### PR TITLE
Inconsistent state fix in winners.html

### DIFF
--- a/winners.html
+++ b/winners.html
@@ -95,11 +95,6 @@ Contest </I></FONT></CENTER><BR>
 <LI TYPE=square>Best 3D puzzle (<A HREF="years.html#2005_anon">2005 anon</A>)
 </UL><BR>
 
-<LI TYPE=none><A NAME="Anonymous_2015"></A><B>Someone Anonymous</B>
-<UL>
-<LI TYPE=square>Most Diffused Reaction (<A HREF="years.html#2015_endoh1">2015 endoh1</A>)
-</UL><BR>
-
 <LI TYPE=none><A NAME="David_Applegate"></A><B><a href="&#x6D;&#97;&#105;&#108;&#116;o&#x3A;&#x64;&#97;vi&#x64;&#x61;&#64;&#x63;&#97;&#97;&#109;&#46;&#114;&#x69;&#99;&#x65;&#x2E;&#101;d&#x75;">David Applegate</a></B> -- <A HREF="http://www.caam.rice.edu/~davida">http://www.caam.rice.edu/~davida</a>
 <UL>
 <LI TYPE=square>Best X11 Graphics (<A HREF="years.html#1991_davidguy">1991 davidguy</A>)


### PR DESCRIPTION
Originally 2015/endoh1 was submitted anonymously but it was changed. The winners.html file has under Endoh the entry but it still was under A as 'Someone Anonymous'.