### PR TITLE
Make 1984/decot compile under linux

### DIFF
--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -104,7 +104,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -traditional-cpp
 #CDEFINE= -DIOCCC=26
 
 # Include files that are needed to compile
@@ -195,7 +195,8 @@ all: ${DATA} ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry may not compile when using modern compilers."
+	@echo "NOTE: This entry will not compile when using clang because it does not support"
+	@echo "      -traditional-cpp but it should compile with gcc."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -10,7 +10,13 @@ NOTE: This entry may not compile when using modern compilers.
 
 ## Judges' comments:
 
-Some new compilers disliked line 15 of the source, so we changed it from:
+NOTE: On modern systems this entry requires the option `-traditional-cpp` which
+clang does not support. We thank Yusuke Endoh for his patch which allows the
+entry to compile under gcc! Please be advised that gcc under macOS is actually
+clang so this will not compile with the default gcc under macOS.
+
+Some new (in 1984) compilers disliked line 15 of the source, so we changed it
+from:
 
 	for(signal=0;*k * x * __FILE__ *i;) do {
 
@@ -21,6 +27,7 @@ to:
 This program prints out a string of garbage.
 
 The judges also offer this one comment: understand comments!
+
 
 Copyright (c) 1984, Landon Curt Noll.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -3,7 +3,6 @@
 #define char k['a']
 #define union static struct
 
-extern int floor;
 double (x1, y1) b,
 char x {sizeof(
     double(%s,%D)(*)())
@@ -24,7 +23,7 @@ _O: while (!(char <<x - dup)) {	/*/*\*/
 
 while(b x 3, i); {
 char x b,i;
-  _0:if(b&&k+
+  _0:if(b&&(int)k+
   sin(signal)		/ *    ((main) (b)-> xO));/*}
   ;
 }


### PR DESCRIPTION
This will not compile with clang which is actually what gcc is under macOS. Unfortunately clang does not support -traditional-cpp which this entry requires for modern systems.