### PR TITLE
Restore alt rule in 1987/heckbert/Makefile

### DIFF
--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -186,6 +186,10 @@ all: ${DATA} ${TARGET}
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
+# alternative executable
+#
+alt: data ${ALT_TARGET}
+	@${TRUE}
 
 # data files
 #


### PR DESCRIPTION
It was removed because it depends on the .orig.c file that no longer exists but it was a mistake to remove it altogether so I have restored it as requested at
https://github.com/ioccc-src/temp-test-ioccc/pull/24#issuecomment-1451367869.