### PR TITLE
Typo fixes in 1992/nathan

### DIFF
--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -43,7 +43,7 @@
 	diff nathan.c barfoof.c
 
     WARNING:
-	The judges' make no claim as to the strength or security
+	The judges make no claim as to the strength or security
 	of this program.  It is likely to be nil, or the next
 	best thing to it.  Still, you might consider installing
 	it in /usr/games/nathan.  :-)

--- a/1992/nathan/nathan.c
+++ b/1992/nathan/nathan.c
@@ -11,7 +11,7 @@ static char *text[] =
   "with a subject \"IOCCC request\". If you know that your 'From'",
   "line is incorrect, add a single line",
   "\"replyto you@your.correct.address\" to the body of the message.",
-  "A deamon will autoreply.",
+  "A daemon will autoreply.",
   "WARNING: You must not re-export this out of the USA, or else",
   "the men in black might get you.",
   NULL


### PR DESCRIPTION
In nathan.c there was also a typo fix but since it's not the original entry (or any thing like it) it's okay to do this. This is actually the subject of a discussion to be had on GitHub which I'll be addressing in a bit.

In README.md there was also a typo fixed.