### PR TITLE
Remove no longer true comment in big/sgit

### DIFF
--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -43,7 +43,7 @@
 	diff nathan.c barfoof.c
 
     WARNING:
-	The judges' make no claim as to the strength or security
+	The judges make no claim as to the strength or security
 	of this program.  It is likely to be nil, or the next
 	best thing to it.  Still, you might consider installing
 	it in /usr/games/nathan.  :-)

--- a/1992/nathan/nathan.c
+++ b/1992/nathan/nathan.c
@@ -11,7 +11,7 @@ static char *text[] =
   "with a subject \"IOCCC request\". If you know that your 'From'",
   "line is incorrect, add a single line",
   "\"replyto you@your.correct.address\" to the body of the message.",
-  "A deamon will autoreply.",
+  "A daemon will autoreply.",
   "WARNING: You must not re-export this out of the USA, or else",
   "the men in black might get you.",
   NULL

--- a/bin/sgit
+++ b/bin/sgit
@@ -13,10 +13,6 @@
 # how it is and I don't think it would do good to add any additional features
 # except perhaps allowing for one to specify path to sed.
 #
-# A limitation is that if the sed command has spaces it will be a problem.
-# Whether this will be fixed is not yet decided. I have some ideas of how it
-# might happen but it might not be worth it.
-#
 # - Cody Boone Ferguson (@xexyl)
 #
 


### PR DESCRIPTION
Spaces haven't been a problem for some time but I neglected to copy the script to the bin/ directory here.