### PR TITLE
Point out minor bug in 2014/vik in years.html

### DIFF
--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -9,7 +9,7 @@
 
 ## To build:
 
-        make nathan
+        make all
 
 ### To run
 
@@ -17,42 +17,45 @@
 
 ## Judges' comments
 
-    Try:
+Try:
+
 	./nathan obfuscate < nathan.c > foobarf.c
 	./nathan - obfuscate < foobarf.c > barfoof.c
 	diff nathan.c barfoof.c
 
-    WARNING:
-	The judges make no claim as to the strength or security
-	of this program.  It is likely to be nil, or the next
-	best thing to it.  Still, you might consider installing
-	it in /usr/games/nathan.  :-)
+### WARNING:
 
-    NOTE: 
-	The 'winning' catagory is also open to question.  One could say
-	that it is a 'file obfuscator'.  One could also say that it
-	unintentionally abused the intent of rule #7 (that programs
-	should be freely redistributable).  We suspect that the author
-	may not have intended to do this, but that is the way things go
-	sometimes.
+The judges make no claim as to the strength or security
+of this program.  It is likely to be nil, or the next
+best thing to it.  Still, you might consider installing
+it in /usr/games/nathan.  :-)
 
-	BTW, 'abuse of the rules' entries do not violate the rules.
-	Entries that violate the rules are disqualified.  Abuse of the
-	rules entries are ones that tend to 'stretch' the limits and
-	take the contest into unexpected territory.
+### NOTE:
+
+The 'winning' category is also open to question.  One could say
+that it is a 'file obfuscator'.  One could also say that it
+unintentionally abused the intent of rule #7 (that programs
+should be freely re-distributable).  We suspect that the author
+may not have intended to do this, but that is the way things go
+sometimes.
+
+BTW, 'abuse of the rules' entries do not violate the rules.
+Entries that violate the rules are disqualified.  Abuse of the
+rules entries are ones that tend to 'stretch' the limits and
+take the contest into unexpected territory.
 
 
-### Historical notes for this entry from the judges
+### Historical notes from the judges about this entry
 
-    The US International Traffic in Arms Regulations controls certain
-    exportations going out of the United States.  The U.S.  Munitions
-    List gives the specific categories of restricted exports.  Because
-    this entry at one time appeared to fall under this restricted catagory, the
-    judges originally were not able to distribute winners outside of the USA.
+The US International Traffic in Arms Regulations controls certain exportations
+going out of the United States.  The U.S.  Munitions List gives the specific
+categories of restricted exports.  Because this entry at one time appeared to
+fall under this restricted category, the judges originally were not able to
+distribute winners outside of the USA.
 
-    Nathan Sidwell stated that he was willing to distribute the
-    winning source.  To read HIS instructions of how to obtain his
-    winning program one was able to run:
+Nathan Sidwell stated that he was willing to distribute the winning source.  To
+read HIS instructions of how to obtain his winning program one was able to run:
+
 
 	make nathan
 	./nathan
@@ -60,61 +63,64 @@
 
     to learn how to get a copy of the code.
 
+See the 1992/nathan.c file in the
+[../../archive/archive-1992.tar.bz2](archive/archive-1992.tar.bz2) tarball if
+you're interested in this file.
+
 
 ### Personal note from chongo:
 
-    I think the situation showed just how ridiculous US crypto
-    regulations really were/are.  Certain US federal officials can get away
-    with shipping arms to certain nations in apparent violation of US
-    laws, but I personally can't re-distribute a program contest winner
-    to the network!
+I think the situation showed just how ridiculous US crypto regulations really
+were/are.  Certain US federal officials can get away with shipping arms to
+certain nations in apparent violation of US laws, but I personally can't
+re-distribute a program contest winner to the network!
 
 ## Author's comments
 
-    PROGRAM USE
+### PROGRAM USE
 
-    This program is a hello world text encrypter/decrypter. It uses an
-    enigma (I think) style encryption algorithm, where the encryption
-    key character is modified by a value, determined from the previous
-    character.  Non-printable characters (those with ASCII values < ' '
-    or > 0x7e) are passed unaltered, thus any kind of file may be
-    successfully procesed, but if the original is printable, the
-    processed file will be too. The input is read from stdin, and the
-    output presented to stdout. The key, a text string, is presented as
-    a command argument. This is optional, and if ommitted, the file is
-    self-{de,en}crypted. To specify decryption, a "-" should be given
-    before the key. (Actually encryption and dycryption proper inverse
-    operations, so you can use decrypt to scramble and encrypt to
-    descramble, if you're perverse.)
+This program is a hello world text encryptor/decryptor. It uses an
+enigma (I think) style encryption algorithm, where the encryption
+key character is modified by a value, determined from the previous
+character.  Non-printable characters (those with ASCII values < ' '
+or > 0x7e) are passed unaltered, thus any kind of file may be
+successfully processed, but if the original is printable, the
+processed file will be too. The input is read from stdin, and the
+output presented to stdout. The key, a text string, is presented as
+a command argument. This is optional, and if omitted, the file is
+self-{de,en}crypted. To specify decryption, a "-" should be given
+before the key. (Actually encryption and decryption proper inverse
+operations, so you can use decrypt to scramble and encrypt to
+descramble, if you're perverse.)
 
-    PORTABILITY (A little knowledge is a dangerous thing)
+### PORTABILITY (A little knowledge is a dangerous thing)
 
-    It's written in ANSI C, and doesn't even assume an ASCII character
-    set, (it has an array of the characters to convert), so should be
-    portable across many platforms. It passes gcc -ansi -pedantic -O
-    -Wall with no warnings (You may get assignment in conditional
-    warnings on other platforms though).  Because I've heard that
-    conditional jumps slow down fast processors, I've eliminated all
-    the ifs from the code, indeed, as its only one statement, it should
-    compile to one instruction an a suitably designed CISC machine. To
-    speed compilation, there is only one statement in the loop, so that
-    another scoping level does not need to be opened.
+It's written in ANSI C, and doesn't even assume an ASCII character
+set, (it has an array of the characters to convert), so should be
+portable across many platforms. It passes gcc -ansi -pedantic -O
+-Wall with no warnings (You may get assignment in conditional
+warnings on other platforms though).  Because I've heard that
+conditional jumps slow down fast processors, I've eliminated all
+the ifs from the code, indeed, as its only one statement, it should
+compile to one instruction and a suitably designed CISC machine. To
+speed compilation, there is only one statement in the loop, so that
+another scoping level does not need to be opened.
 
-    Being an encrypter/decrypter, you probably want the source code to
-    be obfuscated, to hide the algorithm.
+Being an encryptor/decryptor, you probably want the source code to
+be obfuscated, to hide the algorithm.
 
-    OBFUSCATION
+### OBFUSCATION
 
-    Inspite of the fact that it looks like a nice friendly hello world
-    program, it isn't (as documented above). (Short lines have been padded,
-    as you'll find if you look at an encrypted copy of the source.)
+In spite of the fact that it looks like a nice friendly hello world
+program, it isn't (as documented above). (Short lines have been padded,
+as you'll find if you look at an encrypted copy of the source.)
 
-    I've also named some of the macros from commonly used functions,
-    just to keep things muddy. Of course, all the variables are
-    misnamed. The program is kept simply (one for statement), by
-    serious overuse of , and ? :. These are really confusing when used
-    together, nested or put in argument lists (is that a comma
-    operator, or argument separator?)
+I've also named some of the macros from commonly used functions,
+just to keep things muddy. Of course, all the variables are
+misnamed. The program is kept simply (one for statement), by
+serious overuse of , and ? :. These are really confusing when used
+together, nested or put in argument lists (is that a comma
+operator, or argument separator?)
 
 Copyright (c) 1992, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -8,28 +8,33 @@ Daniel Vik
 ## Judges' comments:
 ### To build:
 
-    make
+	make all
 
 ### To run:
 
-    ./prog > foo.c
+	./prog > foo.c
 
 ### Try:
 
-    echo 'Want to hear me beep?' | ./prog  > audio_file.raw
+	echo 'Want to hear me beep?' | ./prog > audio_file.raw
 
-    echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
+	echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
+
 
 ### Selected Judges Remarks:
 
-This program sets a new tone for obfuscation.  But do you understand
-what it says about obfuscation?  Perhaps:
+This program sets a new tone for obfuscation. But do you understand
+what it says about obfuscation? Perhaps:
 
-    ./prog < prog.c > prog.raw
 
-might speak to your coding style?  If not, then perhaps:
+	./prog < prog.c > prog.raw
 
-    ./prog < remarks.markdown | mplayer -demuxer rawaudio -
+
+might speak to your coding style? If not, then perhaps:
+
+
+	./prog < remarks.markdown | mplayer -demuxer rawaudio -
+
 
 might help? :-)
 
@@ -42,41 +47,46 @@ I can tell, there are at least six chocolate references in this program.
 This program can convert text to Morse to a raw 44.1kHz stereo audio file.
 Via streaming to mplayer, you can listen to the Morse audio.
 
-Don't forget the last '-' as it makes mplayer read from stdin.)
+Don't forget the last '-' as it makes mplayer read from stdin.
+
 
 ## Convert audio file with Morse signals to text
 
-    $ ./prog e < audio_file.raw
+
+	$ ./prog e < audio_file.raw
+
 
 or alternatively pass a .wav file as input.
 
-The preferred input format 44.1kHz stereo,   but it does  a decent job on mono
-input and different frequencies  as well.
+The preferred input format 44.1kHz stereo, but it does a decent job on mono
+input and different frequencies as well.
+
 
 ### Portability
 
-The program is portable to most platforms. The only system  dependency is that
+The program is portable to most platforms. The only system dependency is that
 the program relies on writing binary data to stdout.
 
-Microsoft compilers adds a carriage  return to  newlines,   and to compile the
-program with this platform,   the following line  can be added  after the main
+Microsoft compilers add a carriage return to newlines, and to compile the
+program with this platform, the following line can be added after the main
 declaration in order for the program to run correctly:
 
-    _setmode(_fileno(stdout), 0x8000);
+
+	_setmode(_fileno(stdout), 0x8000);
 
 ### Known Issues
 
 The program uses a quite simple algorithm for detecting tone on and off events
-in the Morse signal.   Hence the program  does not work well  with noisy input
+in the Morse signal. Hence the program does not work well with noisy input
 signals. I have tested it with several samples of man made Morse recordings as
 well as computer generated ones.
 
-Generally, any recording from ham  radio transmissions  does not decode due to
-noise and echoes.   Other man made recordings may decode,  but some characters
-can be  incorrect  due to too big  variation  in length  of tones  and pauses.
+Generally, any recording from ham radio transmissions does not decode due to
+noise and echoes. Other man made recordings may decode, but some characters
+can be incorrect due to too big variation in length of tones and pauses.
 However I found some man made recordings on that decode reasonable well.
 
-If a recording don't decode,   you could try to  pre-process the input  with a
+If a recording doesn't decode, you could try to pre-process the input with a
 narrow bandpass filter on the frequency of the transmission.
 
 --------------------------------------------------------------------------------

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -81,12 +81,12 @@ I will have more information on this entry at
 published.
 
 <a name="toc"></a>
--   [IOCCC: An Enigma?](#ioccc)
+-   [IOCCC: an Enigma?](#ioccc)
 
 -   [The 1992 Nathan entry](#nathan)
 
 -   [Usage](#usage)
-    *	[An example run](#example)
+    *	[Example run](#example)
 
 -   [The recode.c configurator](#recode)
 
@@ -106,7 +106,7 @@ published.
 
 -   [Resources](#resources)
 
-### <a name="ioccc" href="#toc">IOCCC: An Enigma?</a>
+### <a name="ioccc" href="#toc">IOCCC: an Enigma?</a>
 
 Is there a better single word that could describe the code that is IOCCC?  I'm
 sure there are some other words that are equally as valid but I believe 'Enigma'
@@ -189,12 +189,13 @@ Finally it'll prompt you for the plugboard pairs.
 
 After that you can input the string and it'll go from there.
 
-#### <a name="example" href="#toc">An example run</a>
+#### <a name="example" href="#toc">Example run</a>
 
 BTW: There's a much more entertaining (and delicious) challenge or exercise in
-[recode.md][] (involves [chocolate-cake.html][]). These however show
-the general program as well as how to use the two winning entries of the Morse
-code that I referred to earlier.
+[recode.md][] (involves [chocolate-cake.html][]) though one might need a different
+kind of exercise after taking up the challenge! :-) These however show the
+general program as well as how to use the two winning entries of the Morse code
+that I referred to earlier:
 
 
 	    $ ./prog -
@@ -228,21 +229,21 @@ Notice that all output except the deciphered/enciphered text is sent to stdout.
 If I didn't specify the `-` by e.g. `echo IOCCC | ./prog` then it will use the
 default settings; as the judges suggest this invocation I will not show it here.
 
-You can also type it out like this though:
+But you can also type it out like this:
 
 	    $ ./prog
 	    IOCCC
 	    UUMMX
 
 
-The IOCCC comes from stdin; the UUMMX is stdout.
+The IOCCC comes from stdin; the `UUMMX` is written to stdout.
 
 If I compile the 2014 entry and copy it to my local directory as
 `vik` I might do:
 
 	    $ echo TEST|./prog |./vik | mplayer -demuxer rawaudio -
 
-And you would hear Morse code of the Enigma output of 'TEST' (i.e. KCWV). Or
+And you would hear Morse code of the Enigma output of 'TEST' (i.e. `KCWV`). Or
 perhaps not in this case. I'm not sure: I discovered a bug in that entry
 (Fedora, CentOS and macOS all affected).
 
@@ -289,7 +290,7 @@ Phew! The program redeemed itself after the test failure! :)
 
 (Technically above it didn't print a newline after the output and this is how it
 is with some of the things I pasted in the other file and maybe others here
-too. Notice also how it showed the same output that my program gave it - UUMMX.)
+too. Notice also how it showed the same output that my program gave it - `UUMMX`.)
 
 What about the other Morse code entry?
 

--- a/years.html
+++ b/years.html
@@ -935,6 +935,10 @@ Contest </I></FONT></CENTER>
 <LI><A HREF="2014/vik/Makefile">Makefile</A>
 <LI><A HREF="2014/vik/README.md">README.md</A>
 <LI><A HREF="2014/vik/prog.c">prog.c</A>
+<LI>A minor bug that shows up in some cases was found by
+<a href="winners.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>
+when working on his <a href="#2020_ferguson2">2020 Enigma machine</a>. See his
+README.md file for details (search for vik).
 </UL>
 <A NAME="2014_wiedijk"></A>
 <P><B>wiedijk</B> - Y combinator</P>


### PR DESCRIPTION
    This is to let the viewers know that sometimes the program will display
    invalid input. The note is modelled after some of the other entries that
    have bug reports. Okay it's also some shameless self promotion but never
    mind that! :-)
    
    As well a few minor changes in 2014/vik/README.md mostly being removing
    double spaces in favour of single spaces (particularly in the general
    text). There were some other formatting fixes as well.
    
    In 2020/ferguson2/README.md I made a few adjustments as well (though I'm
    aware of a few more changes in 2020/ferguson[12]/README.md I want to
    make).
