### PR TITLE
Update chocolate cake files (2020/ferguson[12])

### DIFF
--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -425,12 +425,18 @@ to the pandemic but maybe next time (or they can do on their own).
 
 Do make sure to pay attention to all notes!
 
-##### A note on the icing and room temperature
+##### Reiterating the notes about the cake and the icing
 
-Please be advised that the note there that talks about the icing being difficult
-in too warm room is rather significant; unfortunately with SARS-CoV-2 this might
-be more of a problem depending on how long it lasts and where you reside. If
-necessary use the refrigerator or else air conditioner to cool down the place.
+The following notes are so important that they are worth repeating here.
+
+- The icing being difficult in warmer rooms is rather significant. If necessary
+use the refrigerator or else air conditioner to cool down the place. This might
+or might not work well enough.
+- Do **NOT** use imitation vanilla!
+- Do **NOT** use butter even if you think it'll come out better; it will come
+out bad!
+- Pay attention to the rest of the notes as well! They're crucial.
+
 
 
 #### <a name="alt" href="#toc">What are the files prog.2.c, prog.3.c, prog.3-j.c and prog.alt.c ?</a>

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -24,9 +24,6 @@
     <P><FONT size="6"><B>Supplemental Info</B></FONT></P>
 </CENTER>
 
-
-
-
 <h1>Double-layered Chocolate Fudge Cake</h1>
 
 <p>Here's a delicious double-layered chocolate fudge cake that is
@@ -86,22 +83,23 @@ recipe notes because they're really important!</strong></p>
 <p><strong>PAY CLOSE ATTENTION TO THESE:</strong></p>
 
 <ul>
-<li><p><strong>USE MARGARINE</strong>. Butter does not work well.</p></li>
+<li><p><strong>USE MARGARINE</strong>. Butter does not work well. If you think it will come out
+better by using butter you're very mistaken; it will come out badly!</p></li>
 <li><p>Over the years they changed the size of the unsweetened chocolate squares;
 they used to be one ounce each now they are 1/4 ounce each square so be sure to
 note the amount is by ounce not squares as listed. See the measurements link
 if there's any doubt.</p></li>
-<li><p>Pay careful attention to <strong>cook for only the indicated time</strong>.</p></li>
-<li><p><strong>Remove the cake from the pans 2 minutes after removing from oven</strong>. Then allow
+<li><p>Pay careful attention to <strong>COOK FOR ONLY THE INDICATED TIME</strong>.</p></li>
+<li><p><strong>REMOVE THE CAKE FROM THE PANS 2 MINUTES AFTER REMOVING FROM OVEN</strong>. Then allow
 to fully cool on racks. The important point is that they don't overcook.</p></li>
 <li><p>When the recipe was first written they sold powdered sugar in a box; now
 it's confectioners sugar in a bag. My mum experimented with the amount and
 found that 4 cups seems about right.</p></li>
-<li><p>She uses <strong>whole milk</strong> for this recipe; she doesn't know if it really matters
+<li><p>She uses <strong>WHOLE MILK</strong> for this recipe; she doesn't know if it really matters
 but given that she and I both prefer skim milk except for here and in
 chocolate milk I would recommend whole milk for this recipe too. In any case
-it turns out great!</p></li>
-<li><p>Use only <strong>pure vanilla extract</strong>! Do <strong>not use imitation vanilla!</strong></p></li>
+it turns out great <strong>if you follow <em>everything</em> to a T!</strong></p></li>
+<li><p>Use only <strong>PURE VANILLA EXTRACT</strong>! Do <strong>NOT USE imitation vanilla!</strong></p></li>
 </ul>
 
 
@@ -203,5 +201,3 @@ This work is licensed under a <a rel="license" href="https://creativecommons.org
 </TR></TABLE>
 </body>
 </html>
-
-

--- a/2020/ferguson1/chocolate-cake.md
+++ b/2020/ferguson1/chocolate-cake.md
@@ -57,28 +57,29 @@ recipe notes because they're really important!**
 
 **PAY CLOSE ATTENTION TO THESE:**
 
-*   **USE MARGARINE**. Butter does not work well.
+*   **USE MARGARINE**. Butter does not work well. If you think it will come out
+    better by using butter you're very mistaken; it will come out badly!
 
 *   Over the years they changed the size of the unsweetened chocolate squares;
     they used to be one ounce each now they are 1/4 ounce each square so be sure to
     note the amount is by ounce not squares as listed. See the measurements link
     if there's any doubt.
 
-*   Pay careful attention to **cook for only the indicated time**.
+*   Pay careful attention to **COOK FOR ONLY THE INDICATED TIME**.
 
-*   **Remove the cake from the pans 2 minutes after removing from oven**. Then allow
+*   **REMOVE THE CAKE FROM THE PANS 2 MINUTES AFTER REMOVING FROM OVEN**. Then allow
     to fully cool on racks. The important point is that they don't overcook.
 
 *   When the recipe was first written they sold powdered sugar in a box; now
     it's confectioners sugar in a bag. My mum experimented with the amount and
     found that 4 cups seems about right.
 
-*   She uses **whole milk** for this recipe; she doesn't know if it really matters
+*   She uses **WHOLE MILK** for this recipe; she doesn't know if it really matters
     but given that she and I both prefer skim milk except for here and in
     chocolate milk I would recommend whole milk for this recipe too. In any case
-    it turns out great!
+    it turns out great **if you follow *everything* to a T!**
 
-*   Use only **pure vanilla extract**! Do **not use imitation vanilla!**
+*   Use only **PURE VANILLA EXTRACT**! Do **NOT USE imitation vanilla!**
 
 
 ## Cake Ingredients

--- a/2020/ferguson2/.gitignore
+++ b/2020/ferguson2/.gitignore
@@ -1,2 +1,4 @@
 prog
 recode
+chocolate-cake.dat
+chocolate-cake.key

--- a/2020/ferguson2/chocolate-cake.html
+++ b/2020/ferguson2/chocolate-cake.html
@@ -24,9 +24,6 @@
     <G><ZUGQ tknd="6"><K>Zxdohfunvftm Vgbs</T></IPOE></L>
 </XCJFRM>
 
-
-
-
 <q1>Fuvkkv-usgqjgx Qcaizhkzs Pclwj Rema</q1>
 
 <j>Paey'f q uhaovhamb nyxkuq-jyixvbm baaimvgzx xqnlp kvns pidw rp
@@ -86,122 +83,121 @@ kkhpba sryyo pawgbix meph'nm ctsvak ecbjlrdbk!</dkcmen></a>
 <v><jrjcky>JJE RFDCH JVVUQXCKL NK LQGUO:</oghdad></r>
 
 <ku>
-<zp><g><prqear>LZV XKXRMAKDW</qstdzw>. Jejeuc uctt zdd lklw fbzb.</g></xh>
-<fm><c>Mosi sgu ggtch zcxd pmrgsxr xom onmn ql oug fabpmowsdyb gsawevjar feoifbh;
-qrdk elbb xk hv gil umetu lqxz qmj rpys osc 1/4 ixhac oyvi kgckma od pi mlen af
-zbxb pna hprkbv gc wc gzfqh knr vaerdhv lf nngicu. Tvy bmw ysdjghhtmyii elic
-ey bfdvk'q oaq tramc.</t></ql>
-<qg><v>Huf mueshwc dvzagitcw vz <hygzuy>tjgz blv vkai msm xxxrfmnas yvgv</cwbtlt>.</e></bj>
-<rs><u><kplirc>Bdghsr ewr nkxa xscs krt imcj 2 hrraofm wdwhc gxwqkrmm yaex dnqg</wojnhb>. Wknz wtzbu
-hh cjrpb exwr qt uuimd. Hdy rjkwthmzo ufpaa wy mosb abgu cnw'q vnrgstdu.</d></yr>
-<dh><s>Mzmj zih uzmcvu vhb ebubl blpdgjm apka hxmy swgklfrf fauyg zt r fbj; ykn
-sd'c utxnshccvlpwv pcorw se f kqh. Gt vkx hckgdfwbvbqk yjcs lpf mfnxum huo
-kfyfu piec 4 vyxi hagjd tjqpx tdpli.</u></ir>
-<hu><v>Dsf nfuc <zwbqxv>eilmd wegp</rnjazu> uju zksp ydsbvz; wgu lysqh'b atay db uy zudkvo ymoyjbu
-fgc dqptw wtle xcz qla U jkdp qgqmsv zjps rjxz xnukab ajh dshs bfc os
-rnxvuhhys qohn T rvgff qtygkfqfh oktvs sgdj aqk fzsf qovvls rzp. Mk smd zknn
-ju ifkph lpp qgreh!</u></cm>
-<kk><o>Lnb fdhe <wxnxfb>hwsw chvjvou jbfipqm</noygxy>! Zb <kafzvk>qaf taq qeqmemqyt uzghpbw!</uewxbf></h></ja>
-</kq>
+<zp><g><prqear>LZV XKXRMAKDW</qstdzw>. Jejeuc uctt zdd lklw fbzb. Ku tkr xjaud mj rarx rbxs pcb
+vxqvxd hx conwr vcoxgc onn'ao isge wahqijiw; vb nlqd dxuv tjn cukpk!</y></gd>
+<wn><s>Uenw qzp kqpuk rpys kwvsapm mub mhqs sv ioy adfptrzcliv bzxakxkhc vnlkyrm;
+vohd ipun yj zn lzx qfion cyuo ziq fksi gju 1/4 saxma osel nwcpgd tf uu meiv qh
+iwuz ofz kzqjql pn gv mmjmd ghq kjpkanc jz vsickm. Yql hxi nmeevixaaoof zqlw
+je obsth'q zwg hjcpd.</e></wm>
+<hc><n>Wgk awddppj hekqxhqkb ij <vxciah>QFFL KYB QXPT WVG DUOWJOQZZ QTCF</uqdzbi>.</h></bs>
+<tl><a><cacmav>LTGCJS RBV KGYZ GNCS ZEJ UTEV 2 OWXEABI TCHFU CDBVNUEE HAHF CKJG</pplxjk>. Xepx nxziv
+fz ehiwc aucw vi ztiei. Gjw xjbhowylv qlydn zu kjeo ojhn tra'o jusjtkvt.</e></uk>
+<rh><u>Osfe zjb kympgb kow ospjv qacpzlp jwll qwzn ayfjkjtn idijo fg d ime; kuy
+aa'h hibcvwetychvl yncca dj y hhe. Zv jfg nboibwzltvsw eblx zko eehyqs imx
+wrqyw mokn 4 darz tsslu ucyhl fvclg.</g></wa>
+<aq><v>Qvf yntx <oshxup>XJVAA ZZJM</ukltzx> nzo jrky txryii; ers twnks'y vmgj cn hz zkwpef xxvmgkb
+vzk pstrl oprb ain fcz C omnk dntcst lnmu rgrf lzonei ueo sbim xhy bm
+ivfowdhdb pchq M dhfsc ddjsgvldw gtnrq fnxh hty zixc txpprp jaa. Lf svz osca
+ua kjxfr kjy uitcv <dxeekr>nq gtn ocjskz <jz>yztgvlpztu</mh> ol s L!</lgydik></d></og>
+<pk><y>Ihk efhi <brnzey>IKUG EQDFHOZ QTOOGKX</emwqdi>! Hu <vcwzwq>YRR QQU tuzjkzaqz suoubyg!</azdjca></z></vw>
+</wa>
 
 
-<p2>Xbch Zyhvdohyhei</a2>
+<e2>Vrda Fdzsyqrmfwe</v2>
 
-<dn>
-<js>3 fv dlcmbcgtphz (Oywhb'h) qsglrhlaq</ij>
-<gs>2 uqf 1/4 fdyi ihled</jh>
-<ey>2 nsea vpogum vqhg</bk>
-<gg>1/2 rlx fhts</vz>
-<qa>2 zzt 1/4 nzqp fgxsny rietf twwxa</bh>
-<oe>3 ooca</tb>
-<wm>1 fis 1/2 zqv dwraexl</wa>
-<vt>1/2 yqeq gqkeduphr</op>
-<ol>1 lfd (resmlum) rellb</zr>
-<gd>1 hdv vgqy smbeo</xt>
-</bx>
-
-
-<y2>Qguq Sqnfvfkxpsd</y2>
-
-<rd>
-<zo><b>Vtyalyz xcozuz ecs 9 h 1.5 lbho tksvt bssy; aakvgmv fvzl klnw rfdjt.</a></ww>
-<tp><x>Rtbdmkl awxe fg 350 S (176.67 Y).</a></mz>
-</tq>
+<zm>
+<fe>3 iv lpucryvwjwk (Wyjfk'f) ekaugohin</ce>
+<sd>2 zep 1/4 nnnv rtmle</cx>
+<yq>2 fcvl yeffyq qtfw</xn>
+<to>1/2 vhs owgz</xp>
+<yp>2 qdc 1/4 yybc bemfpg eqyfx qsnnm</bk>
+<iv>3 vcpz</cu>
+<pn>1 ssk 1/2 cme hlegnnp</tc>
+<ij>1/2 gwbw ijvfhxpil</dx>
+<op>1 srd (dkvdfgl) mrviu</ux>
+<ph>1 glt dzpz uwcmb</zs>
+</dm>
 
 
-<s2>Bcba Zgknosavsi</c2>
+<l2>Onat Mwigkegkmbi</i2>
 
-<mo>
-<xw><e>Hlze <jnssjm>3 vq yxlzqqvxfmh ftnvaizzv</vboyri> vk lmccow hunaog py vnpjs mqmb kwhb
-<oiczds>lpn (<vp>iei tkh wvlkofi</wb>) trjlo</bhfegu>; jhp wfqf fwlyex ggpoywmggr.</n></iu>
-<de><b>Onbu <mhlkmz>2 1/4 edrw cfnqf</vykbqp>, <ppvnzy>2 jcj llcfzv qnxz</gbdioe>, oyj <hrispq>1/2 mwe aujq</pitncy></j></tf>
-<qs><f>Htyo <ncjdts>1 lkyjc qsgzynacn</tlojyj> uw qystx xngb <jn>vzmdc zups</kp>.</w></bf>
-<nb><r>Ngz <eamrjh>2 1/4 obfh gcsigi qante cxovy</ohyxox> yfi <ypqfmf>3 oxhv</rkmacl>. Xpyb shnwh psdju hpy
-ifhent.</i></rh>
-<ky><l>Kgqn ld <ieujvq>1 1/2 gwu dczojst</zeoglp> car <jmaggn>eaekyu lqtiwm pidjkordb</cpcyby>.</e></ag>
-<jy><y>Acpp cj sqt atdxpndmpbb hypmvxtqjdj pbuj <wutysh>1 pil ezkv bnhmc</usqsmv>; pzjxpw vkqb
-ixpzz ynrdxe.</k></wl>
-<kn><u>Jpgv dp <gcjijn>1 qmr pmvbgfa lpvjx</hybfes>.</v></ar>
-<ap><m>Cnrf vgza xzkeytmz yejg.</v></ou>
-<te><w>Ttrr lhb <ugssih>IPTB 35 dbqvzwj</jeszmn> (JS DLEADC) sl 350 B (176.67 M).</k></ua>
-<ia><q>Gqou ufb itbt mlm hjxa lbe ypp wqw btjx zvgw lr k abaqhqe oxdl jhv <uohehl>OQI
-UKVFMMQ EYWA DFC XVUX UXXCQMFGBMO HYEJ LSBUW ICO FI HG CYOF</jhjiyh>. Egf huqq
-yaryqcdtkp.</q></ka>
-</yv>
-
-
-<d2>Xhkjx Ytnhbezkkva</p2>
-
-<oq>
-<yd>4 bj rggmzpultoq jxmqwxrxo (Xmdgf'n hvumqbmgf)</ju>
-<ax>1/2 kjf oxgheizqg</gu>
-<no>4 lxnu brgknhcx gkxnc</az>
-<fv>1/2 yko gkcqr fwhf</ju>
-<kt>2 dbg zqgxitz</rp>
-</sd>
-
-
-<h>Iyr hsap jkek iflp e fevelp ezb wg cmei qflf ouq ggca guj hlarp qbfu jcw woncy
-kfrw pfl bhf ou.</s>
-
-<t2>Mrftror fvfwk syc egw vfscz</s2>
-
-<f><ambwab>VTI FYSRN PDRJRILFS GI ZSYKF:</vxcfss></c>
-
-<ce>
-<fk><g>Onhu ezff raln jjn kpfikb iqrlpadrq oss agmwgwueu kdgf uqf cne lcscq.</s></yx>
-<gs><x>Geq fftm #4 wnv <rcwcbv>8 nm 10 bwu jnlgj</khprsn> ul l ynl de mez pafh (mbzo'v axe
-gtgzhm ogoq chrycdv ubqg ipr djj yh xg). Sef ql ohmc jn hsgka jsw kxsk khm
-bxi zdui vtls rwn pmyit yv lav feo dq uslk ri mba jocgu. <uryndl>Fs evr kck rfi
-hauhf vtx xwp!</vgmlwl></x></bw>
-<tn><d>Rp dhf hxp axudm xxy lij qdmyx.</j></tz>
-<xk><c>Vgw <jxhdtw>yeewf rfiw.</rfjxbf></j></fh>
-<jj><o>Ddq rres <ubhgyf>gvmr boehitg zmdmjpa</lzdbwp>! Bu <vcqfde>tqp kaa mlgjeqtuz hxvpfqz!</iuigwv></r></ij>
-</eo>
-
-
-<d2>Fouxq Nfdjicbrvp</z2>
-
-<ep>
-<od><k>Ngyrccw <mnuphk>4 ap xckvufpibmi pjfvscrhq</lhjfpn> ncm <khhelt>1/2 xby qzgvzhphf</lgzheb> lq kkj.
-Xvsy kcf wsxhrv mife dbhc. <qmkiph>QJ IHL VBL KV TYY WDADE.</ioqzly></r></ys>
-<nr><s>Ymqatfu <yezwjn>3 1/4 tgju vlgyrbtp afjbl</kilkkf>, <ajtkzk>1/2 rtii dxyqp njyq</aduefi> dgv <acyhza>2 szj
-mtdynit</voqwwn> eawi z vgtp. <ohdxww>Wdun yvwbi ioktls</luflwx>.</c></vb>
-<ed><o>Cai xehvjqivr jlquqgg.</t></mz>
-<fk><z>Ome zvcx vd wzl/fjpm fu uiu nhs rxktb. Qosu szaf jwiqv/ivrro dtowq gm'e
-dvvqs PBH mih hxf epqrw. Dvdp hyvu fubbp qkkdp'g ehc mtq! Mif zxwz ee mb
-<wexrmo>AEAJ WPJ OTHY KN'Y DA XUII <ih>mpx vxh guh uob uwddu rog tvj</ut></jeilth>.</u></jz>
+<dk>
+<jp><b>Utstgsx dqiuvq yuz 9 t 1.5 vkvi shaqt mcrb; ynakajt ykun uqoe iknsl.</v></ay>
+<zb><d>Mkumqvh yojw eg 350 X (176.67 T).</g></fy>
 </le>
 
-<LWLEV><WZ>
-<WQ><m uaw="vafipih" dewk="avzwy://epvdpcevsprulga.cze/bxuogjxl/tb-ml/3.0/"><qwn kfa="Husbaqwf Gqxzvsv Kyjxtvg" lremh="hrwpzg-dhyxm:0" dia="/xao/io-te-3.0-88q31.ckp" /></m></AP>
-<MO><L>&lyri; Syfrhacgo 1984-2020,
-<I CNKV="/ivcjle.akvf">Bls Tisqdwky, Xsbnv Ofrrkj, Olzxyj Vgcv Wdhs</U>
-- Dvz yrwudg qgmtjxbx<LE>
-Pdbl uzim jp zfdxeoia vimmz r <q wtx="fngmpgx" xoas="xsbhe://nkrugmyilzcaeat.qdj/ypxotykg/ki-wt/3.0/">Oliqudlm Wekadum Mznxlmhwjjo-KqqymKjmrc 3.0 Qieagcct Xxohghl</e>.</T></QI>
-<ET>&xghb;<!--<w tpvx="onwxy://yiwfqsyqn.s3.gfd/mwamb?seq=pvcgdxl"><kvm viq="jemqm://dee.c3.qpt/Rdxvf/ozmyi-ccgc401" eui="Nvjrl KSNC 4.01 Ciytkdvxdlvo" zuuwtu="31" zcqog="88"></f>--></RC>
-</DL></VWAOH>
-</tucd>
-</uank>
+
+<t2>Mrmo Bxchujaqxt</w2>
+
+<ky>
+<fk><g>Hzkn <dkffvz>3 qv gzofloubupp pbngxrsdt</tczqyn> hf xzjxqi wvubbh bo xcjhm thcy nqdu
+<zitwgz>dxx (<ph>zgq kvr jqtuuws</nw>) rrffl</fnyuvq>; bki klqe dtagkl inrfrrnfuo.</k></eb>
+<rb><l>Pcel <emgkce>2 1/4 trrf rbwjn</xgnfgr>, <tecpbn>2 zhg xmiace vnml</cqkfzp>, vjf <cowavo>1/2 pgr gojs</zpsnam></f></gk>
+<tc><m>Hzmj <cfjxdj>1 wxzwb wozqjlhzo</fnzutb> mz bkajl qfbf <gi>eyisc xraa</rn>.</u></ox>
+<vx><r>Vam <puvnbd>2 1/4 gjfy ldtjux yaqui iyjtv</jqhzqd> smh <ykqrej>3 dzdy</vvzkpl>. Suvp xfamo yuiky zvq
+lgbrbl.</e></pq>
+<tm><f>Cfrj tq <tlteqe>1 1/2 gqr xyltxkl</kpbqfv> bfz <bnkqdo>bacsqi vczlvp bfgvlxgns</duewms>.</k></iu>
+<te><r>Guwi ja iof akelsrjifrc wurffjqindu uybm <oqwhij>1 yqz qxzc wwcls</kzvnuq>; yrgjto pfgr
+gqoqm pzkqpp.</q></pm>
+<bg><c>Kktk tq <pvjudz>1 uyr qhrrngp dtsxl</lsdlrb>.</k></er>
+<qh><i>Xrll cyry knkjebjx meau.</l></vp>
+<fy><i>Gyfm skg <bfqgiv>LBTF 35 qvcsork</nugndm> (QT IVYOXJ) er 350 K (176.67 L).</d></fx>
+<st><o>Ecgh fth fbdc dqz oflj yqs qky wup eqxb xswo ei n hsmtqoz jrei zft <rvnerr>EOU
+IGWNRVQ YSSK EGJ WCIM TDHHSMQPQSJ FPHQ ONFFQ QXH ES IS WLPI</trvyae>. Atu rrcc
+nsgovhhbsi.</d></kt>
+</lk>
 
 
+<w2>Tnayk Cuptxlddiov</p2>
+
+<cp>
+<mr>4 ij mdbbanqjwlt sxvgcrygw (Drjvg'r zgyvcaigg)</ar>
+<ks>1/2 unt wndntuncv</tz>
+<xz>4 prdb wmtbdcvw admol</ms>
+<ek>1/2 fkr ioams yszi</fw>
+<bh>2 yyb qixyuyr</nx>
+</mw>
+
+
+<m>Zgy tuwc cohn zfbe d uksbvg hgv mz nrxw crmf dsv jvip xgk qupnw mzdr jvu roocw
+qqpd bwp tkx ji.</v>
+
+<b2>Rdgqcpn xtblf geq qqt allji</r2>
+
+<c><ukjkkp>YVG OBIJG MFWWGPPDS UT CDDJR:</zzvaed></v>
+
+<vm>
+<ex><v>Rjxy elau jkcs nfg pnpgfh ilmmvdteh jpe bqmmuomdd ngvw diw fyr efuaq.</c></ze>
+<tb><j>Xky yuqy #4 dcs <ghqvvu>8 xj 10 lud tfuwj</bytwgd> lm d yfc zy lsl jsup (rwqk'q tef
+ucuivu xkbp qsjrrnt lrrc ubu iaf zi om). Opn jc zfhw jx rgsfk vkc fedr xqx
+jns xvzx lrds srv ndsbf zs ayv ohf go fbcm rc zhc aslrj. <wulkqa>Ok mum wre zwu
+enrwh elc ogn!</bpaiux></y></qb>
+<to><h>El edl yki tgmso mak ovg zdfom.</z></wu>
+<nq><r>Wqw <twkruv>qknwa ysai.</voppbr></j></na>
+<ap><e>Iff rdmi <vrzfwa>gifq nlbqian wnrsxrd</wllshy>! Im <kkbtgd>dls jhb xfrmfyqhd tioaqwj!</yeifhw></o></ds>
+</we>
+
+
+<d2>Omngu Aanfnlkrmu</a2>
+
+<bt>
+<ad><b>Etseest <vecyth>4 mg xwdjotskjbv lkdfltpdp</dquguv> vaq <krytpz>1/2 oim nfkhwyazb</gikrde> ap jvj.
+Skel kfs wuzaqu cbkh jnco. <ngvlmi>JI YMM KWJ QA RQI WWBKV.</jwermc></i></mr>
+<fo><m>Ilxexbp <ogsxjv>3 1/4 xozk wmxyrvcv wqrww</beyrrm>, <retvrd>1/2 qtwi xdjuw shzq</twstso> mdw <rgidje>2 ajk
+ambqnrn</ubeslt> ejmp r mjpt. <mvqerc>Acya iowqu djjxjs</wpqabp>.</x></ns>
+<yg><y>Qxb lbhuvmbiw petmqgt.</h></ut>
+<ju><f>Pjw ssgh gd sbl/wbqz kj ebd shb creua. Hjyv cdor qbazh/lswxu ecnxh qp'y
+cykjf DJC pgr xrf opvze. Bter xeci aszki rjiry'd xgu yjo! Fnw oeum qw hq
+<lbntmh>WVAZ ACS FREX CJ'Y RO AVCI <qd>uin qsn uyg vbv yjptu ecx zzs</hi></dwcyjv>.</h></mu>
+</ae>
+
+<AKHAG><HC>
+<HT><o aqg="iagwqqs" zzrk="suyse://gsfjdkxqkstljry.muo/rpoavfke/pd-lb/3.0/"><var kwv="Bzttwmlc Qeiactt Thovlfb" znaqn="vzvfwb-dkqnu:0" xpy="/bfx/vo-mr-3.0-88f31.mfi" /></s></WV>
+<PC><Q>&rkgq; Njnplnsvv 1984-2020,
+<U ODLA="/xbrjol.fxqr">Ylb Niqxhtyw, Khwwv Faixax, Fmsaqj Bcxx Ldmu</Y>
+- Inb zzatbe kclrbsyw<UM>
+Emqa xayr dr ykoszhim dyrwu l <n fkk="krroqnv" mnrr="upsxt://szrdcndgawgrzxv.hhn/kofikbwa/ah-cc/3.0/">Dsqulncv Juighzp Fbfirucscem-BfmdlIwefx 3.0 Zdjfphqo Wxwljih</r>.</M></VB>
+<SQ>&rtbu;<!--<p uxzm="ussmo://kijtuxitw.o3.ass/hbkum?see=gmhrvcg"><jpv wli="sdpea://zgb.l3.lji/Dlfkp/rjhfs-tdjj401" wgj="Tgjbx EHCS 4.01 Icspwmheqizx" pohton="31" xmvjw="88"></n>--></OA>
+</ZU></NCDUM>
+</vqxz>
+</uxix>

--- a/2020/ferguson2/chocolate-cake.md
+++ b/2020/ferguson2/chocolate-cake.md
@@ -57,136 +57,137 @@ bzvxrd uvgch pkimwnw lezx'cz omlgpw skqqdrshm!**
 
 **CZJ HFUAG QXKUAFKQM CG RFAKY:**
 
-*   **IMS YKPVJGKMI**. Fxgovg tita two hkmw usyw.
+*   **IMS YKPVJGKMI**. Fxgovg tita two hkmw usyw. Cu vww ceqyr zi zwgj mbwg frc
+    jxupdk xo gydsi nwcxwc uth'qz bmsa cjfyhxyp; rk zztn rmfl yko dhvwv!
 
-*   Hluc koh msnce keht mqrmlzx kqp cknt yy jxk tbqumwfopre dptqggpmx btmrize;
-    gqbm pzlv ft dr uvj rwdlw nsyi bsa vufd hjv 1/4 gyhsg himz mfdbut hi qb yoii kb
-    bxjb fci ehzlpu ct ak maeza kpk jaeqjmk mw vhrrtu. Ehr znu xvceahsoqasz edcf
-    ps reacw'q wkg zzyye.
+*   Rxjo jvv cxmmr vufd ldhiaki qev zjqp qx qux cmyqpyvlwol nwzhbvenq tboetmp;
+    ztrm olrb dj hu tfz gyrdd tpme fqt vwve wvd 1/4 nrtib tgwj ldkmfa bu ep umfa zu
+    lzmc fel xqmecb bx se eyztk vwh fubmxhm gf xjiojt. Pti yvw lccudpjpheql etad
+    vp zxzxx'v vkn psdiq.
 
-*   Mna kbbbswp dbhjxhkkz ci **hwid znj zvyl lcw scxoqgkwb xkiw**.
+*   Jec hqihpwp rfpgjfpdy qp **ILQN CZM YOBJ BSJ YKNNLKMDV VWYP**.
 
-*   **Aodkgh hfg vohi qinw ogx mvkp 2 cdlqqyf gpvxq dyqhufoi tsdb prvc**. Gcqi nxrmx
-    bd tzdgj ljlc ee mwjql. Obv lxnyunrvb jwqfn qr kiri qets qqi'd nqojzett.
+*   **JVZFEJ BCT JJIC DAWC VAP FYFW 2 UZCQOIZ LZFTX JXJTQATS QYNQ SRZW**. Bafw dfmbb
+    ja pgizr abxm ah srguh. Avk ujwjwftbr hdnpd sm hnvz emcb axa'e htmoaslh.
 
-*   Jbmz egg uukvfr nvu lktdj bxokyxe djti xaip lpzcksfr kgetz md s mei; rws
-    rg'i vqkwsswphamom ogwnn df q vux. Dl xmc yckdsgwdboxg obhp woa nyveki tdh
-    eipuf ieuv 4 jzel xzxig djfdd pqulq.
+*   Kfkf usj mifain gsn inlic yjfream yidd vscn fkznfdmi pxalh mh r xhs; yko
+    wi'u jgewflxctoxig asflb ue p hkt. Tb vcv rkkazszkwyqm tfjd cwy yctsaj zsg
+    cgkts kvdh 4 hxum gnbrx fzxnu ljhnc.
 
-*   Xvx lgdu **yflbn hunn** eiu rkkt oaissk; zpq mgleq'c fhpv qv kj nghxqg cqkbvdz
-    npk sphuu ontf htg mhz P fyiv ipnpdz yqze xltr xswlmf jhv xtjm itu hh
-    vacvghmbq dgcl K mxonp ayazvawpc rpdiz fuoa cvk ojkv cmvegs hci. Lw vbo iznk
-    lp qijoq wop txyhn!
+*   Ynj awnw **TXNSK AZRC** vpk nyeg oblmwa; jsm ccvrh'j nveb au ac icpkdz dqeyyxf
+    ksc dushf yyul zvu qll R esiq viikso qtlh twkf tfpdtq otl msvk vdh lt
+    kawxvfkpp upns O mjewx jwtqcjhws xompq ypvj ytn xgyc jwrsen dzd. Bk lpz mhys
+    ka hyzoi xpx nmark **kz zkk iktwrl *ozshpcnwmn* rg h G!**
 
-*   Vpf dxfn **tknt hnpxvad iqxyfmv**! Sx **yvi ahq fucprogft agecekf!**
-
-
-## Bhcc Bkjgklqdayg
-
-*   3 ad woidmmzobjl (Dopty'p) sontcsqgj
-*   2 uag 1/4 tksx ajroq
-*   2 sjmy mhohjr bklf
-*   1/2 qqi wlmb
-*   2 twx 1/4 xear gsgdlt qddkk phevn
-*   3 cjxi
-*   1 cep 1/2 ctl nijkxcu
-*   1/2 hgvh hrwsgdkcm
-*   1 rtx (dqxnatp) ufgma
-*   1 lob cnyg dbosr
+*   Oao xjur **LDDK CMCKCNN LLQEVNQ**! Xa **OKX HAM xxhucfqyr ahhwdfn!**
 
 
-## Mdeq Atiwekclssq
+## Pcxs Rbhwqqkjrze
 
-1.  Xeulobp jbaoad qab 9 c 1.5 uqte tatvi yvsk; xhhuzyu blos lrnc ukyle.
-
-2.  Ozrjzzq xyaq yr 350 V (176.67 L).
-
-
-## Szau Ojgbqmunov
-
-1.  Huxi **3 ln klbtfnhcgvr vmswucgiu** to pijpec cwersg iv lzorb grnu hlay
-    **wjj (*waa zsl luacepy*) byigu**; bly vbbx koozic jagmlcwemj.
-
-2.  Yhcv **2 1/4 fngt jbgnk**, **2 xuh wvpcvw kqnn**, ctw **1/2 dqd pwko**
-
-3.  Ftpf **1 kysma ghllggpdv** zr bujbf oeie *nbuag piay*.
-
-4.  Jry **2 1/4 rnhc goujiv yavpe xsfyg** mci **3 krmg**. Ycnn qpnmq hjnto gsl
-    ggsrgu.
-
-5.  Yqtc xu **1 1/2 ayo lslqrkb** zoe **yvqdnq rppgxb siyanszzq**.
-
-6.  Jvps cq xfs chcuaojxsdj mfaqgqlrwwt oqmd **1 miw flgo lxgrz**; euqrmi mzno
-    hfxos lshfku.
-
-7.  Pqna vv **1 syi eahxplo komgd**.
-
-8.  Rxzm emps uwpcfpba tjup.
-
-9.  Eseq ogg **KLGS 35 ueevuxx** (QU OJMFKH) pk 350 D (176.67 K).
-
-10. Jvuy bmg cqvm mtv qhsn qyb rhs boi zixx fozr pk d vqekdaf wctj pgo **PCM
-    TPBARHB NJCU HYE MCFQ NFXVJMKCNKC EESL ZNAQT MCY DY SV BEXG**. Jsq hdtc
-    nmbjicqkvz.
+*   3 po wclroxbdcmz (Xuzca'r) ozvtnbrzr
+*   2 tdr 1/4 jyui jccls
+*   2 btaa ohzbpm fhru
+*   1/2 yfn ivbi
+*   2 whr 1/4 jovl qqxtyb gtabv pckgf
+*   3 pvhg
+*   1 yok 1/2 eef fnqawhw
+*   1/2 rlqv vhtxzfsha
+*   1 yeu (mmduvmx) lqzhl
+*   1 wxi vxea szglg
 
 
-## Tnptw Ncqknabuhlr
+## Tqwn Noiaoxcfjuf
 
-*   4 ud meebkqyllst qjcfduykq (Hlsdk'a iuqozgzbz)
-*   1/2 nvr xinftwyws
-*   4 tmje uumpnppm tpdpt
-*   1/2 yjd mxdaz tmki
-*   2 cfw jrdojej
+1.  Ztvemjn ralxxb hkf 9 t 1.5 oyzi dkeai vsij; qlbfjep bjol nxls hccos.
 
-Qxp jtzo dzwk dqmc c xztlij crs gg ridd azwi bop oefq qoj femsa npzl mqm kzdsj
-nicj pti jbo tw.
-
-## Tifgysk isepg kgy nbm ziqdn
-
-**QWR QSYQW CNPURMQEF CU AMOGN:**
-
-*   Buuw adhg vlhc sdw ndvxsz kekoaincl gws ultzkotyn zfxm hcd otd pekev.
-
-*   Qjb oqnm #4 cwp **8 iy 10 qjs bjjya** rf h rfi fo ueu hxfe (uvov'f lfb
-    pwssvv ukoi qffidka zuuf hxu elx sa dk). Bbi eb gtuj tk ztwam oqp ufvz hbh
-    xif mmug rjot afa tntqv kd duu yzl ih tsvi yl ukh tzdsu. **Zm zwx ind zoj
-    oucdw ckg ssr!**
-
-*   Zj qsf vlr xpphp fxn chg cavkw.
-
-*   Hvc **aoain kpbx.**
-
-*   Wgc xkzf **hdnp knfuaab bozhyhi**! Vn **kgv lhm tiogoklwf egfgbds!**
+2.  Ufvvlkd buuu ri 350 U (176.67 T).
 
 
-## Vukyj Kmuwtzgeqy
+## Tlbu Aodjhitkxi
+
+1.  Cxen **3 nk njlszgzvlsx tvexrrcnk** et pzxvkr xxnvhy do rxngc ajzd ylcn
+    **btd (*ofp sfy zyngoyi*) tgloy**; gbb tmta xnpiuq mikknnpdxr.
+
+2.  Cunk **2 1/4 uzbg azztt**, **2 waa njoyrl mifi**, fjs **1/2 wxh yhvu**
+
+3.  Tsnh **1 djtsl sjermmvrc** vz dquns tpsf *rhskx birf*.
+
+4.  Ljl **2 1/4 xgqq fuvejo zutzp wgbnj** vbh **3 tphf**. Mpyn wtktx udzex ldb
+    kzvhun.
+
+5.  Tzfj sb **1 1/2 aru ppvdgfq** oon **ycgmlo nhscbi jaqxyxkll**.
+
+6.  Clhu ou xcx qpdwcugmlca deuxtqbekqn hjrf **1 wry rwdv xxqqw**; rofyrj rnlc
+    fzmvx fabvhg.
+
+7.  Qvls bk **1 ewl jxdgmqj dgcuo**.
+
+8.  Tvrw pbna optegzua gxbt.
+
+9.  Phrj cmn **RHAT 35 suwqhpq** (VS KMLBNT) pd 350 C (176.67 I).
+
+10. Jxba ofc oeiu fnx ebey iwm iwn qkw pksh nimr us h qjfmukq wfon dck **GSN
+    FSFBBDD IVKZ FEM DAZC SKXOHVTQHSB CMMM TLAGH BTI ZV WV TOYB**. Qrh iyer
+    owneybwohe.
 
 
-1.  Mungrxv **4 qq wugbqyivsru owfxdhhiq** vjf **1/2 kkr nrcdznybl** dp yjh.
-    Hfjo fbw swhlra ljih nazq. **MJ GUM INF EM LLJ QDGNP.**
+## Mbghw Ukmswhqldyi
 
-2.  Pivxskz **3 1/4 bxeo cqblszfs lvcxc**, **1/2 sizf durzl zjmn** stp **2 hwi
-    tubunkk** xpxw s znho. **Jrtk bylfq iwylfv**.
+*   4 rw iypjiakfsic etbimqwiu (Uosat'h lvwsxftkp)
+*   1/2 goa tbwuhoyik
+*   4 kghe jrnejshv ukcjc
+*   1/2 ujj bzdtb fsvx
+*   2 kdb fjajmrt
 
-3.  Geb akluijomc zkjhmdz.
+Obb kxxk ojfe fwnm o yjlyoe lsk wx ztpq sdyq twd cpbh uoy pncli ezij rof jwoew
+dftt ojc muz uw.
 
-4.  Wol tjcd uw xyu/kufs hi csg ffi ailzu. Adlw opvz uefqe/rdwrj buzsr we'k
-    afmub XOQ xfe bbm jtbph. Kfuj ywvo yrxfi uamph'l xxd krj! Xjx snph bw vc
-    **WOPI DQT MEGG XG'D LD HPDV *mog crx zyy fbw ubelj pvm avm***.
+## Ajnxlgi esssu ryo xri mudkd
 
-[nzhcoyo]: mdvy.ieo
-[xfur://qin.llgsifrybrppjrpq.rvu/gghvhoq.xxw]: xvns://gyy.drxcfzjlhgxuzkwj.bqi/vmfxbfp.tke
-[OZNMY bhn vuyidgzpd]: jdbk://lua.wpnk.rrp/mswfjuodt/200103068.xic
-[Yulvsgbvqlhgb Mxlsrmij Nkfvcdsgd Ynat Gmkfveu zjkpj]: vdryj://ybtwkvs.osh/yiarhszankqik/kpsfxk/1290520266087571458?x=20
-[kkvuby LTIWY cbpzyu Qmbf Otxmlxpez]: mzkgv://iyevhkg.thj/ejpygddnqjjpk
-[MhyClg]: wxyvq://jhlbzv.zhq/dqucfxuxtmiji
-[FAVQJ hyfm fkaiof lxlbp]: enyen-fvyt.rcr
-[qmiutighcn WEX]: ohhge://dqs.qzsyjevihwrdu.acr/uvypuojyu-cwld/
+**WHZ OCFPD ULGMPVVQS VP IZHGR:**
+
+*   Gqrg grmj iahi fni wnfqfu jiuubeokz chj omgozyulb zmqv quu yvv hwxuo.
+
+*   Euh ayfc #4 gka **8 di 10 tnv rrabv** tz l mjg qm lkz njke (lmzd'e dpf
+    glymtc zowe xlvnwkm xfet zhy tni ag wa). Kip it viwo fu egoai wgj yidg pns
+    qnc rfgo iwfm cmt tjeym qt kcj muk go mkoc ys svn kzzvi. **Pr azx tvm gwx
+    mynfv iow bwa!**
+
+*   Su dbl vcz qioji uvf bhc qjsar.
+
+*   Efq **ltyzj tosl.**
+
+*   Vtg kbek **nofo lhgmbyi ansbdjr**! Qi **epx sdw gkfmtxebr jbvejgw!**
+
+
+## Ypooc Qoqhdsdebu
+
+
+1.  Twjvcxd **4 hw augvbfcvolp mrqlyyedd** kie **1/2 feb eswccolon** ym gfc.
+    Nbta eeg wtstqd wyuj zhzi. **QL UFU IJW GL ZCB YSDUR.**
+
+2.  Rglkbca **3 1/4 xjrc rmbiuxgy ttyle**, **1/2 zjwx ocfkn rdib** ygw **2 zik
+    nhpdrff** eews j gdjx. **Ujxd tfrpr gxdamz**.
+
+3.  Xyw swanfqgmx wdjjwex.
+
+4.  Imu ywsr qq yov/sgpk es awy mrn pviia. Kxdm rohx oyyyh/jherq ppmqe zz'i
+    xgqmv NNO fgf fvq lkaif. Rfjf wzjw bygtj gbrau'k ktl ddn! Xjp cimz db pu
+    **BTAZ ANJ OHPM KX'W YZ RXYS *hnr uzk wfn juj vwxmv ejp ddp***.
+
+[itobipn]: vfdw.qli
+[enmf://yxr.afsghgexkemjvazd.fbw/dcsfrms.irf]: yywi://rik.gaxlocesguputmco.lqq/atkrtee.djt
+[YUGXU rik yxswxmdlq]: pfvj://gez.tcgi.oto/grikrqswc/200103068.ioa
+[Nspfbqrugzqyf Hdlvgdsq Tolhguypj Lfhl Apehjwy dlnly]: zfsxx://jbchrab.vmw/qgcthmxlcawdt/rmyvcf/1290520266087571458?f=20
+[suzdgc DLURM fvcyfe Rcww Hjzmfxudq]: mgyjj://huomxld.bnr/yqcojmfvzzlcu
+[NaxGof]: cywaj://ymwnby.xsz/nijyeyzubbhsd
+[RFQVG wksp xwoaoo galew]: kiumm-rkni.cvn
+[rexfnuxeuv HON]: veosq://fvd.wuzlkakqexsnh.rqr/yoropdvxr-byed/
 
 -----------------------------------------------------------------------------------------------------
-(m) Uqwpipwpn 1984-2020, [Qks Oplbhakt, Rfker Jzmfpp, Euwyij Vsxu Xuus][qgkzqo] - Lbw zhnmek lcfgwdvz
-Mtko dqof yb qkjkljyq bbqbo n [Lsdkzoxq Mgeknpu Ezihazelwnf-UjqovPmson 3.0 Qfwkjplp Qlnjwoh][su].
+(j) Gzsbgoprj 1984-2020, [Ror Plnvljdq, Uglvg Zcawnj, Wfthgc Hozd Dspi][lgetwr] - Ram gdjgrw nzmjpckn
+Exxx msdh wm omrgbcki rlzgb q [Tjjzybjh Pbldjqk Cbgsxuwbsmp-HsskkEvrrd 3.0 Srksshxt Gambglg][la].
 
-[mpsudh]: xqpu://svb.tehvo.mot/ndqytw.bpwh
-[hi]: exeq://rflkjdebpsopklq.ypz/wrppfill/pq-fy/3.0/
+[icbrfv]: pfnv://jqq.jxlir.ggj/pzskje.bnex
+[og]: nwia://lmlgjjowaniljub.gda/auwulwgf/ju-cj/3.0/
 -----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
There were some things I wanted to reiterate and stress even more that are important notes about the cake.

Of course the ferguson2 files are still encrypted with a specific key for the Enigma machine (one of the keys I provided in recode.md / recode.html but which is a challenge though probably pointless since it's also in ferguson1 unencrypted).

Updated 2020/ferguson2/.gitignore: added data files specific to the encryption of the cake files so I can more easily fix it should I need to update the files under 2020/ferguson2 (unlikely as that might be).