### PR TITLE
Remove LESSECHO from Makefiles (including var.mk)

### DIFF
--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -133,7 +133,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln

--- a/var.mk
+++ b/var.mk
@@ -117,7 +117,6 @@ KILL= kill
 KSH= ksh
 LAST= last
 LD= ld
-LESSECHO= lessecho
 LEX= len
 LINK= link
 LN= ln


### PR DESCRIPTION
As per a request on GitHub the LESSECHO variable has been removed from all the Makefiles. It was only in the 2019 and 2020 Makefiles as well as var.mk.