### PR TITLE
Go through 2018/ferguson and 2020/ferguson[12]

### DIFF
--- a/2018/burton2/README.md
+++ b/2018/burton2/README.md
@@ -366,7 +366,7 @@ Thus:
 Coda
 ----
 
-Cody Ferguson was relentless in his pursuit of bugs.
+Cody Boone Ferguson was relentless in his pursuit of bugs.
 Thanks to his reports, the version of `unob.sh` is stronger,
 `tac` groks digraphs, `tokenfix` corrects for missing digraphs in `prog.c`,
 and the program `manpage` was added to the corpus.

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -164,7 +164,7 @@ PROG= prog
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG}
+TARGET= ${PROG} ${ALT_TARGET}
 #
 ALT_OBJ= prog-simple.o
 ALT_TARGET= prog-simple

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -166,8 +166,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= prog-simple.o
+ALT_TARGET= prog-simple
 
 
 #################
@@ -183,6 +183,7 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+	${LN} -sf ${PROG} weasel
 
 # alternative executable
 #

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -1,8 +1,10 @@
 # Best use of weasel words
 
-Cody Boone Ferguson <weasel@xexyl.net>  
-<https://ioccc.xexyl.net/2018/weasel>  
-Twitter: @xexyl  
+
+Cody Boone Ferguson <ioccc@xexyl.net>    
+<https://ioccc.xexyl.net>   
+<https://xexyl.net>  
+Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)    
 
 ## To build:
 
@@ -147,11 +149,11 @@ operative phrase is *given enough time*; but even if it's extremely unlikely
 monkey; I thought the monkey had it too easy: unlike his limited keyboard I have
 (besides space) every character in the ASCII range **`0<=126`** that
 **`isprint()`** returns non-zero except that only capital letters are included;
-the file *`prog-simple.c`* has a slightly smaller keyboard. There are some
-additional features I have added (including two Easter eggs); amongst others:
-ability to change the target string and maximum length. See 
-**[How it works](#how)**, **[Hints](#hints)** and **[How to build](#build)** for
-more details.
+the file *`prog-simple.c`* (try `make alt` to compile) has a slightly smaller
+keyboard. There are some additional features I have added (including two Easter
+eggs); amongst others: ability to change the target string and maximum length.
+See **[How it works](#how)**, **[Hints](#hints)** and **[How to build](#build)**
+for more details.
 
 In its simplest invocation this program will work its way (using a genetic
 algorithm) towards the solution of the string **`METHINKS IT IS LIKE A WEASEL`**
@@ -242,10 +244,10 @@ I was quite proud that when the next contest came the judges removed that
 question. Later 2018 and all of 2019 was difficult for me so it was like I won a
 second time for the same entry.
 
-### On user errors
+### On <del>user</del> monkey errors
 
 If the generation reaches **`SIZE_MAX - 1`** I consider it a
-user (or monkey) error; if the user insists on being so petulant enough as to try such
+<del>user</del> monkey error; if the user insists on being so petulant enough as to try such
 a ridiculous set of parameters in an attempt to make it be no more successful
 than a monkey typing *then it shouldn't be any more successful than a monkey; if
 it by chance reaches the target it's because a monkey could too!* Either way
@@ -259,8 +261,8 @@ this program is inspired by the Weasel program *which was inspired by the
 [Infinite Monkey Theorem][]* I opted instead to target the monkey Eric even if
 such a monkey isn't typing or even doesn't exist (because it's not the *Infinite
 Fish Theorem*). So although the user might not be a monkey the program makes the
-assumption that **the user could in fact be a monkey called Eric** *although it
-isn't insolent enough to say the user is a monkey for certain!*
+assumption that **the user could in fact be a monkey called Eric** _although it
+isn't insolent enough to say that the user **is** a monkey for certain!_
 
 [genetic algorithm]: https://web.archive.org/web/20180308131613/http://www.doc.ic.ac.uk/~nd/surprise_96/journal/vol1/hmw/article1.html
 [2018 guidelines]: http://ioccc.org/2018/guidelines.txt
@@ -311,7 +313,7 @@ This means don't print the generation and offspring output; only print (some) of
 the options set (this is always done but wouldn't usually be seen due to verbose
 output) and the final answer.
 
-**Change the mutation rate to `<rate>`:**
+**Change the mutation rate to `<num>`:**
 
 	    -r<num>
 
@@ -1136,7 +1138,8 @@ like to thank my mother for being the best mum anyone could ask for, who's
 always been here for me and whom I also inherit the keen analytical mind from. I
 love you all!
 
-I want to also thank Dave Burton for acknowledging me in his README.md file
+I want to also thank Dave Burton for acknowledging me in his
+[README.md](../burton2/README.md) file
 for as he put it 'being relentless with pursuit of bugs'. To think that it was
 circumstantial to my entry too makes it all the more unlikely but that doesn't
 take away the significance of it; for I am a very symbolic person and being

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -149,11 +149,11 @@ operative phrase is *given enough time*; but even if it's extremely unlikely
 monkey; I thought the monkey had it too easy: unlike his limited keyboard I have
 (besides space) every character in the ASCII range **`0<=126`** that
 **`isprint()`** returns non-zero except that only capital letters are included;
-the file *`prog-simple.c`* (try `make alt` to compile) has a slightly smaller
-keyboard. There are some additional features I have added (including two Easter
-eggs); amongst others: ability to change the target string and maximum length.
-See **[How it works](#how)**, **[Hints](#hints)** and **[How to build](#build)**
-for more details.
+the file *`prog-simple.c`* has a slightly smaller keyboard. There are some
+additional features I have added (including two Easter eggs); amongst others:
+ability to change the target string and maximum length.  See **[How it
+works](#how)**, **[Hints](#hints)** and **[How to build](#build)** for more
+details.
 
 In its simplest invocation this program will work its way (using a genetic
 algorithm) towards the solution of the string **`METHINKS IT IS LIKE A WEASEL`**

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -166,6 +166,7 @@ endif
 #
 ENTRY= ferguson1
 PROG= prog
+EXTRA_PROG= termcaps
 #
 OBJ= ${PROG}.o
 DATA= COMPILING.md HACKING.md bugs.html bugs.md cake.jpg cannibalism.log \
@@ -173,7 +174,7 @@ DATA= COMPILING.md HACKING.md bugs.html bugs.md cake.jpg cannibalism.log \
 	halfwidth_vs_fullwidth.png ioccc-cake.jpg play.sh prog.2.c prog.3-j.c \
 	prog.3.c snake-colours.sh snake.1 spoilers.html spoilers.md \
 	termcaps.c terminals.html terminals.md troubleshooting.html troubleshooting.md
-TARGET= ${PROG}
+TARGET= ${PROG} ${EXTRA_PROG} play snake-colours
 #
 ALT_OBJ= ${PROG}.alt.o
 ALT_TARGET= ${PROG}.alt
@@ -192,6 +193,23 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+# termcaps - test utility for terminal capabilities, size etc.
+${EXTRA_PROG}: ${EXTRA_PROG}.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+
+# play - allows configuring colours and playing pre-configured gameplay modes
+#
+play:	play.sh
+	${CAT} $< > $@
+	${CHMOD} a+x $@
+
+# snake-colours - allows for configuring colours prior to compiling and playing
+#
+snake-colours: snake-colours.sh
+	${CAT} $< > $@
+	${CHMOD} a+x $@
 
 # alternative executable
 #

--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -1,10 +1,9 @@
 # Don't tread on me award
 
-```
-Cody Boone Ferguson <ioccc@xexyl.net>  
-<https://ioccc.xexyl.net>  
-Twitter: @xexyl  
-```
+Cody Boone Ferguson <ioccc@xexyl.net>    
+<https://ioccc.xexyl.net>   
+<https://xexyl.net>  
+Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)    
 
 ## To build:
 
@@ -15,8 +14,11 @@ make
 ### To run:
 
 ```sh
-WAIT=100 WALLS=0 CANNIBAL=0 ./prog
+WAIT=N WALLS=[01] EVADE=N SIZE=N MAXSIZE=N GROW=N SHEDS=N SHED=N CANNIBAL=[01] ./prog
+# Start pressing some arrow keys
 ```
+
+For details on the variables see [gameplay.html](gameplay.html).
 
 ### Try:
 
@@ -34,6 +36,12 @@ CANNIBAL=1 WALLS=1 WAIT=50 EVADE=200 ./prog
 WAIT=75 GROW=-1 SIZE=5 CANNIBAL=1 ./prog
 
 CANNIBAL=1 WALLS=1 WAIT=0 EVADE=1 MAXSIZE=10 ./prog
+
+./play
+# allows you to configure colours and has various pre-configured gameplay modes
+
+./snake-colours
+# allows for configuring colours
 ```
 
 ## Judges' comments:
@@ -43,19 +51,19 @@ This game has a number of configurable pitfalls including walls and snakes.
 
 There is a good deal of useful documentation that is provided with this entry:
 
-* gameplay.md ([gameplay.html][])
+* [gameplay.html][]
 
 Documented game *features*!
 
-* terminals.md ([terminals.html][])
+* [terminals.html][]
 
 Information about terminal capabilities, dimensions (setting and how to restore sanity if it causes any problems) as well as colours (limitations etc.).
 
-* troubleshooting.md ([troubleshooting.html][])
+* [troubleshooting.html][]
 
-Workaround for various game *features*
+Workarounds for various game *features*
 
-* bugs.md ([bugs.html][])
+* [bugs.html][]
 
 Bugs and things that might seem like bugs but are not.
 
@@ -63,16 +71,9 @@ Bugs and things that might seem like bugs but are not.
 
 Because most of us could use some *Double-layered Chocolate Fudge Cake*!
 
-* spoilers.markdown ([spoilers.html][])
+* [spoilers.html][]
 
 Read ***ONLY*** if you really must give up trying to de-obfuscate!
-
-[gameplay.html]: gameplay.html
-[terminals.html]: terminals.html
-[troubleshooting.html]: troubleshooting.html
-[bugs.html]: bugs.html
-[chocolate-cake.html]: chocolate-cake.html
-[spoilers.html]: spoilers.html
 
 ## Author's comments:
 
@@ -82,15 +83,15 @@ Snake has two cheat modes (passable walls and self [cannibalism]), a drawing (or
 practising) mode, *can play by itself (**and win!**)*, is coloured (included
 [snake-colours.sh][] and [play.sh][] scripts compile in player-selected
 colours) and there are many other play modes (many more can be devised with the
-imagination and the environmental variables; see [gameplay.md][] /
-[gameplay.html][] for many examples) and options.  You can pause and there's
-even a built-in test unit for some features!  The following variables change the
-game in the following ways (all can be combined):
+imagination and the environmental variables; see [gameplay.html][] for many
+examples) and options.  You can pause and there's even a built-in test unit for
+some features!  The following variables change the game in the following ways
+(all can be combined):
 
 
-*   The speed of the snake (how many milliseconds to **WAIT** for input before
-    moving; *default 231 milliseconds* and you can move faster by pressing a
-    direction key quicker or even holding it down).
+*   The speed of the snake: how many milliseconds to **WAIT** for input before
+    moving; *default 231 milliseconds*. You can move faster by pressing a
+    direction key quicker or even holding it down.
 
 *   If the bug (to eat) will move (**EVADE**) after user-specified number of snake
     moves (*default 300, 0 disables*).
@@ -100,7 +101,9 @@ game in the following ways (all can be combined):
 
 *   If the snake can go through itself (**CANNIBAL**) (*default 0, no*).
 
-*   The initial **SIZE** of the snake (*default 5*).
+*   The initial **SIZE** of the snake (*default 5*). Note that it grows one by
+    each movement so even if you start at 5 it will take some movements before
+    you are the full length.
 
 *   The size the snake must become in order to win the game (**MAXSIZE**, *default 997*).
 
@@ -115,20 +118,21 @@ game in the following ways (all can be combined):
 
 *   A drawing/practising mode (**WAIT** < 0 makes `timeout()` set blocking read).
 
-*   Computer plays the game (**WAIT=0**) **EPILEPSY/STIMULATION OVERLOAD WARNING**
-    included in the relevant section (this goes for a low **EVADE** value too).
+*   Computer plays the game (**WAIT=0**).  
+	- **EPILEPSY/STIMULATION OVERLOAD WARNING** included in the relevant
+	section (this goes for a low **EVADE** value too).
 
 *   Grow-Shrink mode (Positive and Negative Winning) mode (see
-    [gameplay.md][] for more details).
+    [gameplay.html][] for more details).
 
 *   The dimensions of the game (this is actually a terminal thing but I document
     how to do this and its potential pitfalls) (**LINES** , **COLUMNS**).
 
 There are no complicated command line invocations; it's just a matter of passing
 into the game descriptively named variables and I include a script that sets up
-many different gameplay modes ([gameplay.md][] and [play.sh][]).
+many different gameplay modes (see [gameplay.html][] and [play.sh][]).
 
-The [gameplay.md][] ([gameplay.html][]) file has all the information on
+The [gameplay.html][] file has all the information on
 what the game looks like, how to play, the different types of modes (that I have
 thought of so far) including all those in the above list. Along with the
 [play.sh][] and [snake-colours.sh][] scripts it's probably the most important
@@ -146,18 +150,18 @@ Probably just as important is [chocolate-cake.html][] with an old but wonderful
 recipe (because the judges love chocolate and who can blame them? - also it goes
 with one of the IAQs I include later).
 
-The [troubleshooting.md][] ([troubleshooting.html][]) file has some advice
-on potential problems (and things that might appear to be problems at first
-glance but are not) that I have thought of or encountered.
+The [troubleshooting.html][] file has some advice on potential problems (and
+things that might appear to be problems at first glance but are not) that I have
+thought of or encountered.
 
-The [terminals.md][] ([terminals.html][]) has a variety of information
-specific to terminals from input/directions, dimensions, sanity and colours: a
-sort of troubleshooting guide for terminals with some additional information.
+The [terminals.html][] has a variety of information specific to terminals from
+input/directions, dimensions, sanity and colours: a sort of troubleshooting
+guide for terminals with some additional information.
 
-The [spoilers.markdown][] has a variety of information including some of the
+The [spoilers.html][] has a variety of information including some of the
 obfuscation techniques and a bit of how it works.
 
-The [bugs.md][] ([bugs.html][]) has a list of known bugs and things that
+The [bugs.html][] has a list of known bugs and things that
 look like bugs but aren't as well as documenting a built-in test unit for some
 features.
 
@@ -174,9 +178,8 @@ implemented (and how to/how not to go about some of the things) as well as some
 other information on the entry (some of which is deliberately not true - a
 variation of misleading comments). These files are probably insignificant.
 
-I will have more information about this entry at
-[https://ioccc.xexyl.net/2020/snake][] after the winning entries have been
-published.
+I have more information about this entry at
+[https://ioccc.xexyl.net/2020/snake][].
 
 For the files I recommend looking at the html files with a browser; this
 particularly goes for the [gameplay.html][], [bugs.html][], [terminals.html][]
@@ -205,7 +208,7 @@ and [troubleshooting.html][] - along with the most important one
 
     -	[Do you have any **DELICIOUS CHOCOLATE CAKE** recipes?](#chocolatecake)
 
-    -	[What are the files prog.orig.c, prog.2.c, prog-j.c and prog.alt.c ?](#alt)
+    -	[What are the files prog.alt.c, prog.2.c, prog-j.c and prog.alt.c ?](#alt)
 
 
 *   [Winning thoughts, dedications and thanks](#winning)
@@ -229,7 +232,7 @@ and [troubleshooting.html][] - along with the most important one
     took fewer bytes and the negative shedding is a positive consequence of
     unsigned arithmetic.
 
-On a more serious note look at [bugs.md][] ([bugs.html][]).
+On a more serious note look at [bugs.html][].
 
 
 ### <a name="naqs" href="#toc">NAQs/IAQs (Never/Infrequently Asked Questions)</a>
@@ -309,7 +312,8 @@ I can think of at the least the following:
     would if the grow size was 3. This applies to shedding size too.
 -   If you want to show off keep walls passable and enable cannibalism.  It
     won't be a challenge then but at least you could show your final score?
--   Decrease the max size.
+-   Decrease the max size needed and if you want it even easier increase the
+    terminal size.
 -   And the one that applies to learning new things and getting more things done
     also applies here: remove all sources of distraction; turn the phone off,
     lock yourself in a soundproof room (refusing to get up for anyone or
@@ -360,7 +364,8 @@ And if you're a show-off you can try:
     something I'm capable of...
 -   Watch a film at the same time.
 -   Sneeze and/or cough.
--   Have breakfast, lunch, afternoon tea, dinner or some other meal.
+-   Have breakfast, second breakfast, elevenses, lunch, afternoon tea, dinner or
+    some other meal that you think of.
 -   Get pissed out of your mind to make it difficult to think (please do not
     drive!).
 -   Do more than one or all of the above at the same time (the longer the snake
@@ -449,7 +454,7 @@ out bad!
 #### <a name="alt" href="#toc">What are the files prog.2.c, prog.3.c, prog.3-j.c and prog.alt.c ?</a>
 
 I submitted three Snake versions; these are the other layouts for those few
-(or more likely none) who are interested to see them.
+(more likely none) who are interested to see them.
 
 The prog.2.c has more digraphs but I think no other significant differences.
 
@@ -463,26 +468,6 @@ The prog.alt.c version is the one that allows for customising the bug colour and
 it's used in both [snake-colours.sh][] and [play.sh][]. It also calls `erase()`
 first, clearing the screen, which the play.sh and snake-colours.sh scripts also
 both do.
-
-[COMPILING]: COMPILING
-[HACKING]: HACKING
-[bugs.md]: bugs.md
-[bugs.html]: bugs.html
-[troubleshooting.md]: troubleshooting.md
-[troubleshooting.html]: troubleshooting.html
-[human snakes]: http://www.macroevolution.net/snake-human-hybrids.html
-[chocolate-cake.html]: chocolate-cake.html
-[spoilers.markdown]: spoilers.markdown
-[terminals.md]: terminals.md
-[Surround]: https://en.wikipedia.org/wiki/Surround_(video_game)
-[Snake walk: The physics of slithering]: https://www.bbc.co.uk/news/science-environment-35563941
-[snake-colours.sh]: snake-colours.sh
-[gameplay.md]: gameplay.md
-[gameplay.html]: gameplay.html
-[flying snakes]: https://www.bbc.co.uk/news/science-environment-25943693
-[play.sh]: play.sh
-[great chocolate cake]: cake.jpg
-[https://ioccc.xexyl.net/2020/snake]: https://ioccc.xexyl.net/2020/snake
 
 ## Author's dedication:
 
@@ -504,8 +489,8 @@ Well done and congratulations to all of you again!  Thank you for submitting the
 wonderful entries and I'm honoured to have my two entries beside yours!
 
 To Dave Burton I thank you for your wonderful comments as well as pointing out
-that even with prog.orig.c it probably would be better to make use of the alt
-target instead of naming prog.c prog.orig.c. You're quite right, I had thought
+that even with prog.alt.c it probably would be better to make use of the alt
+target instead of naming prog.c prog.alt.c. You're quite right, I had thought
 of it but you brought it up so I could correct it. Much appreciated mate.
 
 I would like to dedicate this entry to my wonderful mum Dianne Ferguson whom I
@@ -517,9 +502,7 @@ mother.
 
 I also want to dedicate this to Vicky Wilmore who has given me a lot of
 love the past few years and who was there for me in some very dark times. Thank
-you Vicky sweetheart from the bottom of my heart and soul. Although we have
-parted ways, whether for now or for ever, you will always always always have a
-place in my heart and soul xxx
+you Vicky sweetheart from the bottom of my heart and soul.
 
 I would like to thank my dear friend Martijn Schoemaker for encouraging me in my
 programming over the years and who I owe a great deal to. Thank you for
@@ -538,7 +521,29 @@ my entries. It's a huge honour; thank you! I also happen to **love** your
 comments as well as the award titles. And yes indeed 'most of us could use
 *[Double-layered Chocolate Fudge Cake][]*!'
 
+[COMPILING]: COMPILING
+[HACKING]: HACKING
+[bugs.html]: bugs.html
+[troubleshooting.html]: troubleshooting.html
+[human snakes]: http://www.macroevolution.net/snake-human-hybrids.html
+[chocolate-cake.html]: chocolate-cake.html
+[spoilers.markdown]: spoilers.markdown
+[Surround]: https://en.wikipedia.org/wiki/Surround_(video_game)
+[Snake walk: The physics of slithering]: https://www.bbc.co.uk/news/science-environment-35563941
+[snake-colours.sh]: snake-colours.sh
+[gameplay.html]: gameplay.html
+[flying snakes]: https://www.bbc.co.uk/news/science-environment-25943693
+[play.sh]: play.sh
+[great chocolate cake]: cake.jpg
+[https://ioccc.xexyl.net/2020/snake]: https://ioccc.xexyl.net/2020/snake
 [Double-layered Chocolate Fudge Cake]: chocolate-cake.html
+[gameplay.html]: gameplay.html
+[terminals.html]: terminals.html
+[troubleshooting.html]: troubleshooting.html
+[bugs.html]: bugs.html
+[chocolate-cake.html]: chocolate-cake.html
+[spoilers.html]: spoilers.html
+
 
 ## Copyright:
 

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -71,7 +71,7 @@ for the input keys.</p>
 <li><p><a href="#preset">Automate the above gameplay modes</a></p></li>
 </ul>
 </li>
-<li><p><a href="#variables">Game variables</a></p>
+<li><p><a href="#variables">Notes about some of the game variables</a></p>
 
 <ul>
 <li><p><a href="#wait">WAIT         -   Snake speed</a></p></li>
@@ -769,14 +769,14 @@ you choose uses then the script will override what you pass in.</p>
 <pre><code>    WALLS=0 ./play.sh
 </code></pre>
 
-<h1>6. <a name="variables" href="#toc">Game variables</a></h1>
+<h1>6. <a name="variables" href="#toc">Notes about some of the game variables</a></h1>
 
 <p>The game variables can be used for a variety of things including different
-gameplay modes as above but here are some notes about a few of them.</p>
+gameplay modes (as shown above) but here are some notes about a few of them.</p>
 
 <h2><a name="wait" href="#toc">WAIT: Snake speed</a></h2>
 
-<p>Besides the different game modes if you find it too fast/slow you can change it
+<p>Besides the different game modes, if you find it too fast/slow you can change it
 to a value that&rsquo;s better for you. Remember it&rsquo;s a wait time so if you want the
 snake to move slower you have to increase the wait time!</p>
 

--- a/2020/ferguson1/gameplay.md
+++ b/2020/ferguson1/gameplay.md
@@ -52,7 +52,7 @@ for the input keys.
     *	[Automate the above gameplay modes](#preset)
 
 
-6.  [Game variables](#variables)
+6.  [Other game variables](#variables)
 
     * [WAIT		    -	Snake speed](#wait)
 
@@ -743,14 +743,14 @@ Or to make it so walls are an obstacle:
 	    WALLS=0 ./play.sh
 
 
-# 6. <a name="variables" href="#toc">Game variables</a>
+# 6. <a name="variables" href="#toc">Notes about some of the game variables</a>
 
 The game variables can be used for a variety of things including different
-gameplay modes as above but here are some notes about a few of them.
+gameplay modes (as shown above) but here are some general notes about a few of them.
 
 ## <a name="wait" href="#toc">WAIT: Snake speed</a>
 
-Besides the different game modes if you find it too fast/slow you can change it
+Besides the different game modes, if you find it too fast/slow you can change it
 to a value that's better for you. Remember it's a wait time so if you want the
 snake to move slower you have to increase the wait time!
 

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -163,12 +163,13 @@ endif
 #
 ENTRY= ferguson2
 PROG= prog
+EXTRA_PROG= recode
 #
 OBJ= ${PROG}.o
 DATA= chocolate-cake.md enigma.1 input.txt obfuscation.key \
 	obfuscation.md obfuscation.txt recode.1 recode.md \
 	try.this.txt
-TARGET= ${PROG}
+TARGET= ${PROG} ${EXTRA_PROG}
 #
 ALT_OBJ=
 ALT_TARGET=
@@ -186,6 +187,9 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+${EXTRA_PROG}: ${EXTRA_PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -1,10 +1,10 @@
 # Most enigmatic
 
-```
-Cody Boone Ferguson <ioccc@xexyl.net>  
-<https://ioccc.xexyl.net>  
-Twitter: @xexyl  
-```
+Cody Boone Ferguson <ioccc@xexyl.net>    
+<https://ioccc.xexyl.net>   
+<https://xexyl.net>  
+Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)    
+
 
 ## To build:
 
@@ -15,26 +15,71 @@ make
 ### To run:
 
 ```sh
-./prog
+./prog  
+
+# get recode help:
+./recode -h  
+
+# general syntax for recode passing to Enigma machine:  
+./recode [options] | ./prog - 2>/dev/null  
+# general syntax for recode without passing to Enigma machine:  
+./recode [options]  
+  
+# recode prompts for settings; pass to Enigma machine:  
+./recode | ./prog - 2>/dev/null   
+
+# recode reads from input file, prompts for settings; pass to Enigma machine:  
+./recode -finput | ./prog - 2>/dev/null  
+
+# recode reads config from string or file; pass to Enigma machine after
+# prompting for input:
+./recode -R<string|file> | ./prog - 2>/dev/null  
+
+# write config to output file; pass to Enigma machine after prompting for input:  
+./recode -o<config> | ./prog - 2>/dev/null  
+  
+# pseudo-randomly select settings  
+./recode -r
+  
+# show Enigma machine settings after selection / generation:    
+./recode -v  
+
 ```
+
+**NOTE**: in recode no spaces between options and option arguments are allowed.
 
 ### Try:
 
 ```sh
-# IOCCC obfuscated!
-echo IOCCC | ./prog
+# IOCCC obfuscated!  
+echo IOCCC | ./prog  
+  
+# IOCCC obfuscated and de-obfuscated!:  
+echo IOCCC | ./prog | ./prog  
+  
+# more input fun:  
+./prog - < try.this.txt 2>/dev/null  
+  
+# more obfuscated fun:  
+echo testing test tests | ./recode  
+echo testing test tests | ./recode | ./prog - 2>/dev/null  
+echo testing test tests | ./recode | ./prog - 2>/dev/null | ./recode  
+echo testing test tests | ./recode | ./prog - 2>/dev/null | ./recode | ./prog - 2>/dev/null  
 
-# IOCCC obfuscated and de-obfuscated!
-echo IOCCC | ./prog | ./prog
+# even more obfuscated fun saving and reading from files:
+#
+# initial clean up:
+rm -f conf input output output2
+# encrypt "testing test tests" with randomised settings saved in conf, saving
+# original string to input and original output to output:  
+echo testing test tests | tee input | ./recode -r -oconf | ./prog - 2>/dev/null >output
+# configure Enigma machine from conf file and read from output file, thus decrypting:
+./recode -Rconf -foutput | ./prog - 2>/dev/null > output2
+# make sure input and output2 are the same:
+diff -s input output2
+# final clean up
+rm -f conf input output output2
 
-# more input fun
-./prog - < try.this.txt 2>/dev/null
-
-# more obfuscated fun
-echo testing test tests | ./recode
-echo testing test tests | ./recode | ./prog - 2>/dev/null
-echo testing test tests | ./recode | ./prog - 2>/dev/null | ./recode
-echo testing test tests | ./recode | ./prog - 2>/dev/null | ./recode | ./prog - 2>/dev/null
 ```
 
 ## Judges' comments:
@@ -43,21 +88,20 @@ This code is an enigma.  Try to decode it!
 
 There is a good deal of useful documentation that is provided with this entry:
 
-* enigma.1
-
-A useful man page for this entry.  To render, try:
+* [enigma.1](enigma.1)	-  A useful man page for this entry.  To render, try:
 
 ```sh
-man ./enigma.1
+	    man ./enigma.1
 ```
 
-* recode.md ([recode.html][])
+* [recode.html][]	    
+	- Some useful information about recode.c
 
-Some useful information about recode.c
 
-* [chocolate-cake.html][]
+* [chocolate-cake.html][]	
+	-  Because most of us could use some *Double-layered Chocolate Fudge Cake*!
+	-	NOTE: see [recode.html][] for details about how to decrypt this!
 
-Because most of us could use some *Double-layered Chocolate Fudge Cake*!
 
 [recode.html]: recode.html
 [chocolate-cake.html]: chocolate-cake.html
@@ -206,7 +250,7 @@ After that you can input the string and it'll go from there.
 #### <a name="example" href="#toc">Example run</a>
 
 BTW: There's a much more entertaining (and delicious) challenge or exercise in
-[recode.md][] (involves [chocolate-cake.html][]) though one might need a different
+[recode.html][] (involves [chocolate-cake.html][]) though one might need a different
 kind of exercise after taking up the challenge! :-) These however show the
 general program as well as how to use the two winning entries of the Morse code
 that I referred to earlier:
@@ -353,7 +397,7 @@ I didn't think of everything. My entry was meant to be a simulator only as far
 as the ciphering goes but I thought this would make it much more interesting:
 make it more flexible by a wrapper program.
 
-For examples using it (and a delicious challenge) see [recode.md][]. See
+For examples using it (and a delicious challenge) see [recode.html][]. See
 also [recode.1][] and [enigma.1][] man pages.
 
 
@@ -402,7 +446,7 @@ After this it wants Ring 2 and I did similar; for ring 3 I did it each variable
 by itself. However for the reflector I did 1A and it only expects 1 char! So will
 that mean that the plugboard pairs are off? Yes it does seem to be so. This is
 buffering at play I believe but it's useful for allowing the recode program to
-easily configure the Enigma machine. In the other markdown file I give a hint
+easily configure the Enigma machine. In the other markdown/html file I give a hint
 as to how this could be fixed but the caveat is it would necessitate a need for
 rewriting recode.c.
 
@@ -414,7 +458,7 @@ There are two reflectors and the same applies: in C 0-1 but in human it's
 1-2 (technically these were reflectors B and C in the Enigma machine which I
 display by name in recode.c just like with the rotors).
 
-For more information see [recode.md][] or [recode.html][].
+For more information see [recode.html][].
 
 BTW: If you need a reminder to go to the gym just do your Enigma ABCs and it
 should help you remember (though not at this time in our world it might help you
@@ -480,7 +524,7 @@ The file [obfuscation.key][] is the key to decipher/encipher
 For the lazy [obfuscation.md][] has the deciphered version. I am afraid
 I'm not so inclined to do that for the cake recipe: the idea there is to make it
 a fun exercise that when solved unlocks a wonderful double-layered chocolate
-fudge cake recipe. But given that my 'Don't tread on me award' entry also
+fudge cake recipe. But given that my ['Don't tread on me award'](../ferguson1) entry also
 has the recipe, not enciphered, one might just go there instead. Still it's a
 fun way to explore this entry.
 
@@ -503,7 +547,7 @@ machines this would not work because they had to choose from a set of rotors and
 there were no duplicates. This shouldn't be a problem here however except that
 it won't be a possible configuration of the real Enigma machine. The `recode`
 program *however does validate this* (except when reading in settings via the
-`-R` option which I explain in the [recode.md][] / [recode.html][] file).
+`-R` option which I explain in the [recode.html][] file).
 
 *   The way the plugboard - for the machines that had them - is if you connect A
 to B then no other letters can connect to A or B. Earlier there wasn't proper
@@ -710,7 +754,7 @@ that.
 [Interactive Enigma Machine]: http://enigmaco.de/enigma/enigma.html
 [enigma.1]: enigma.1
 [recode.1]: recode.1
-[recode.md]: recode.md
+[recode.html]: recode.html
 [chocolate-cake.html]: chocolate-cake.html
 [recode.c]: recode.c
 [obfuscation.md]: obfuscation.md


### PR DESCRIPTION
Surprise, surprise there are more updates on my entries! :-) But to be fair to me there were some important fixes and I had not really gone through the README files of these entries (I still didn't go through all of them thoroughly and probably won't since I'm far too concise :-) :-)). In fact some of these problems broke some of the features of some of the entries.

I do want to note a few fixes that are important to consider. In 2020/ferguson[12] there is an EXTRA_PROG variable. I'm not sure if this is the right name but it's not an alt target: they're extra tools that are there. For instance in 2020/ferguson2 the recode program was not compiled which is rather a problem. The same could be said for 2020/ferguson1/termcaps: that it was not compiled by make broke some scripts.

There were some typo fixes here and there as well as (I hope) a bit clearer wording.

Some out of date things were changed.

As for 2018/ferguson an important point in the Makefile (besides adding the ALT_TARGET that should have been there) is that the Makefile makes a symlink to prog as weasel. This is because the judges originally did this and to not have it would take fixing a lot in the documentation. Now Landon wrote to me the other day:

    We suspect you might never be finished with your write-up, @xexyl,
but that is OK as the new system is designed to give author's the ability to improve their write-ups via GitHub Pull requests ...

    ... as long as they don't happen too often 😁

...which if I were to fix this there would be yet another update which isn't very desirable, right? :-) Nevertheless if necessary I will go through the files and see if I can find the correct references to weasel to change to prog (unfortunately it's not a simple matter of a global substitution).