### PR TITLE
Move 2014/vik bug notice from years to README.md

### DIFF
--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -38,6 +38,10 @@ might speak to your coding style? If not, then perhaps:
 
 might help? :-)
 
+NOTE: In 2020 Cody Boone Ferguson found a minor bug when working on his [Enigma
+machine entry](../../2020/ferguson2); see his
+[README.md](../../2020/ferguson2/README.md) for details (search for `vik`).
+
 ## Author's comments:
 ### Remarks
 

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -305,7 +305,7 @@ If I compile the 2014 entry and copy it to my local directory as
 $ echo TEST|./prog |./vik | mplayer -demuxer rawaudio -
 ```
 
-And you would hear Morse code of the Enigma output of 'TEST' (i.e. `KCWV`). Or
+And you would hear Morse code of the Enigma output of 'TEST' (i.e. `KCWV`)! Or
 perhaps not in this case. I'm not sure: I discovered a bug in that entry
 (Fedora, CentOS and macOS all affected).
 

--- a/years.html
+++ b/years.html
@@ -903,10 +903,6 @@ Contest </I></FONT></CENTER>
 <LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/Makefile">Makefile</A>
 <LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/README.md">README.md</A>
 <LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/prog.c">prog.c</A>
-<LI>A minor bug that shows up in some cases was found by
-<a href="winners.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>
-when working on his <a href="#2020_ferguson2">2020 Enigma machine</a>. See his
-README.md file for details (search for vik).</LI>
 </UL>
 <A NAME="2014_wiedijk"></A>
 <P><B>wiedijk</B> - Y combinator</P>


### PR DESCRIPTION
As the years.html file will be generated with a tool (yet to be written) having the bug notice will (greatly)? complicate the generation. Thus the bug notice (which I discovered when working on 2020/ferguson2) was moved to 2014/vik/README.md.

But why? Because it is a good idea, I think, to note that although mostly correct, there is a minor problem with it. I don't have a fix for it but whether I ever look at that I do not know.

I also made a minor change in 2020/ferguson2/README.md: changed a full stop to an exclamation mark as it seemed better.