### PR TITLE
High score file and other bug fixes in 1989/tromp

### DIFF
--- a/1989/tromp/.gitignore
+++ b/1989/tromp/.gitignore
@@ -1,2 +1,3 @@
 tromp
+tromp.alt
 HI

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -99,7 +99,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h -include unistd.h
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
@@ -170,8 +170,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -192,6 +192,9 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # data files
 #

--- a/1989/tromp/README.md
+++ b/1989/tromp/README.md
@@ -10,25 +10,57 @@
 
         make all
 
-NOTE: we used a patch from Yusuke Endoh to get this to compile under gcc. Thank
-you Yusuke for your assistance! Cody Boone Ferguson got this to work with clang
-by further changing the variable `a` to be not the third argument to `main()` to
-a variable declared in `main()`. We thank you for your assistance Cody (he
-cynically notes that he did it because tetris just has to work)!
+
+We used a patch from [Yusuke Endoh](/winners.html#Yusuke_Endoh) 
+to get this to compile under gcc. Thank you Yusuke for your assistance!
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) got this to work with
+clang by further changing the variable `a` to be not the third argument to
+`main()` and instead be a variable declared in `main()`. Cody also bug fixed it
+so that the high score file would work (it was not even being created) and after
+this making sure the terminal stayed sane (the letter `u` could not be typed and
+echo was disabled outright after the segfault fix / high score file was
+reinstated). We thank you for your assistance Cody (he cynically notes that he
+did it because tetris just has to work)!
+
+### Alternate code:
+
+The author provided an alternate version of the code with some improvements. We
+were unable to see the improvements in modern systems even after fixing it to
+compile (the high score file was not created at all) but if you have an old
+compiler you can try compiling it in its original unmodified form by running:
+
+	make alt
 
 
-### To run
+## To run:
 
 	./tromp [drops_per_sec  [cmd_string]]
 
-NOTE: after this game is finished you will likely get an error along the lines
-of:
+## Try:
 
-    Segmentation fault: 11
-    stty: stdin isn't a terminal
+	./tromp 5
+
+	# fast with vim keys
+	#   h	    - left (left)
+	#   k	    - rotate (arbitrary, in vim k = up)
+	#   l	    - right (right)
+	#   j	    - drop (down)
+	#   space   - pause (literal space in vim)
+	#   q	    - quit (similar to :q in vim)
+	./tromp 10 "hklj q"
+
+NOTE: after this game ends a file called `HI` will be in the directory with the
+high scores (up to 20 runs saved) so one can see who has the highest score. The
+file might look like:
 
 
-and a file `HI` will be in the directory.
+     330 by cody
+     136 by cody
+
+
+.... hey, I haven't played in a very long time and the lower one was hitting
+space (default drop) in rapid succession :-)
 
 ## Judges' comments
 
@@ -56,13 +88,6 @@ character again, which by default is "p".
 As was stated last year, we are likely to be more strict about
 portability in the future.  [ We mean it this time :-) ]
 
-### Bug fix thank you
-
-[Yusuke Endoh](/winners.html#Yusuke_Endoh) provided a patch to get
-this entry to compile with modern compilers.
-
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
-fixed this so it will compile and work under clang.
 
 ## Author's comments
 
@@ -104,25 +129,25 @@ at the start and -raw at the end. This further reduces the size of
 the program, but has the possible disadvantage that the program
 can only by stopped by 'q' or by the `kill -9' command.
 
-long h[4];t(){h[3]-=h[3]/3000;setitimer(0,h,0);}c,d,l,v[]={(int)t,0,2},w,s,I,K
-=0,i=276,j,k,q[276],Q[276],*n=q,*m,x=17,f[]={7,-13,-12,1,8,-11,-12,-1,9,-1,1,
-12,3,-13,-12,-1,12,-1,11,1,15,-1,13,1,18,-1,1,2,0,-12,-1,11,1,-12,1,13,10,-12,
-1,12,11,-12,-1,1,2,-12,-1,12,13,-12,12,13,14,-11,-1,1,4,-13,-12,12,16,-11,-12,
-12,17,-13,1,-1,5,-12,12,11,6,-12,12,24};u(){for(i=11;++i<264;)if((k=q[i])-Q[i]
-){Q[i]=k;if(i-++I||i%12<1)printf("\033[%d;%dH",(I=i)/12,i%12*2+28);printf(
-"\033[%dm  "+(K-k?0:5),k);K=k;}Q[263]=c=getchar();}G(b){for(i=4;i--;)if(q[i?b+
-n[i]:b])return 0;return 1;}g(b){for(i=4;i--;q[i?x+n[i]:x]=b);}main(C,V,a)char*
-*V,*a;{h[3]=1000000/(l=C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i<
-25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo stop u");sigvec(14,v,
-0);t();puts("\033[H\033[J");for(n=f+rand()%7*4;;g(7),u(),g(0)){if(c<0){if(G(x+
-12))x+=12;else{g(7);++w;for(j=0;j<252;j=12*(j/12+1))for(;q[++j];)if(j%12==10){
-for(;j%12;q[j--]=0);u();for(;--j;q[j+12]=q[j]);u();}n=f+rand()%7*4;G(x=17)||(c
-=a[5]);}}if(c==*a)G(--x)||++x;if(c==a[1])n=f+4**(m=n),G(x)||(n=m);if(c==a[2])G
-(++x)||--x;if(c==a[3])for(;G(x+12);++w)x+=12;if(c==a[4]||c==a[5]){s=sigblock(
-8192);printf("\033[H\033[J\033[0m%d\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
-0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}d=popen(
-"stty -cbreak echo stop \023;sort -mnr -o HI - HI;cat HI","w");fprintf(d,
-"%4d from level %1d by %s\n",w,l,getlogin());pclose(d);}
+    long h[4];t(){h[3]-=h[3]/3000;setitimer(0,h,0);}c,d,l,v[]={(int)t,0,2},w,s,I,K
+    =0,i=276,j,k,q[276],Q[276],*n=q,*m,x=17,f[]={7,-13,-12,1,8,-11,-12,-1,9,-1,1,
+    12,3,-13,-12,-1,12,-1,11,1,15,-1,13,1,18,-1,1,2,0,-12,-1,11,1,-12,1,13,10,-12,
+    1,12,11,-12,-1,1,2,-12,-1,12,13,-12,12,13,14,-11,-1,1,4,-13,-12,12,16,-11,-12,
+    12,17,-13,1,-1,5,-12,12,11,6,-12,12,24};u(){for(i=11;++i<264;)if((k=q[i])-Q[i]
+    ){Q[i]=k;if(i-++I||i%12<1)printf("\033[%d;%dH",(I=i)/12,i%12*2+28);printf(
+    "\033[%dm  "+(K-k?0:5),k);K=k;}Q[263]=c=getchar();}G(b){for(i=4;i--;)if(q[i?b+
+    n[i]:b])return 0;return 1;}g(b){for(i=4;i--;q[i?x+n[i]:x]=b);}main(C,V,a)char*
+    *V,*a;{h[3]=1000000/(l=C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i<
+    25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo stop u");sigvec(14,v,
+    0);t();puts("\033[H\033[J");for(n=f+rand()%7*4;;g(7),u(),g(0)){if(c<0){if(G(x+
+    12))x+=12;else{g(7);++w;for(j=0;j<252;j=12*(j/12+1))for(;q[++j];)if(j%12==10){
+    for(;j%12;q[j--]=0);u();for(;--j;q[j+12]=q[j]);u();}n=f+rand()%7*4;G(x=17)||(c
+    =a[5]);}}if(c==*a)G(--x)||++x;if(c==a[1])n=f+4**(m=n),G(x)||(n=m);if(c==a[2])G
+    (++x)||--x;if(c==a[3])for(;G(x+12);++w)x+=12;if(c==a[4]||c==a[5]){s=sigblock(
+    8192);printf("\033[H\033[J\033[0m%d\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
+    0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}d=popen(
+    "stty -cbreak echo stop \023;sort -mnr -o HI - HI;cat HI","w");fprintf(d,
+    "%4d from level %1d by %s\n",w,l,getlogin());pclose(d);}
 
 Copyright (c) 1989, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1989/tromp/tromp.alt.c
+++ b/1989/tromp/tromp.alt.c
@@ -1,19 +1,19 @@
-long h[4];t(){h[3]-=h[3]/3000;setitimer(0,h,0);}FILE *d;long c,v[]={0,0,2},w,s,I,K
+long h[4];t(){h[3]-=h[3]/3000;setitimer(0,h,0);}c,d,l,v[]={(int)t,0,2},w,s,I,K
 =0,i=276,j,k,q[276],Q[276],*n=q,*m,x=17,f[]={7,-13,-12,1,8,-11,-12,-1,9,-1,1,
 12,3,-13,-12,-1,12,-1,11,1,15,-1,13,1,18,-1,1,2,0,-12,-1,11,1,-12,1,13,10,-12,
 1,12,11,-12,-1,1,2,-12,-1,12,13,-12,12,13,14,-11,-1,1,4,-13,-12,12,16,-11,-12,
 12,17,-13,1,-1,5,-12,12,11,6,-12,12,24};u(){for(i=11;++i<264;)if((k=q[i])-Q[i]
-){Q[i]=k;if(i-++I||i%12<1)printf("\033[%ld;%ldH",(I=i)/12,i%12*2+28);printf(
+){Q[i]=k;if(i-++I||i%12<1)printf("\033[%d;%dH",(I=i)/12,i%12*2+28);printf(
 "\033[%dm  "+(K-k?0:5),k);K=k;}Q[263]=c=getchar();}G(b){for(i=4;i--;)if(q[i?b+
-n[i]:b])return 0;return 1;}g(b){for(i=4;i--;q[i?x+n[i]:x]=b);}main(C,V)char**
-V;{char *a;*v=(long)t;h[3]=1000000/(C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i<
-25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo");sigaction(14,v,
+n[i]:b])return 0;return 1;}g(b){for(i=4;i--;q[i?x+n[i]:x]=b);}main(C,V,a)char*
+*V,*a;{h[3]=1000000/(l=C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i<
+25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo stop u");sigvec(14,v,
 0);t();puts("\033[H\033[J");for(n=f+rand()%7*4;;g(7),u(),g(0)){if(c<0){if(G(x+
 12))x+=12;else{g(7);++w;for(j=0;j<252;j=12*(j/12+1))for(;q[++j];)if(j%12==10){
 for(;j%12;q[j--]=0);u();for(;--j;q[j+12]=q[j]);u();}n=f+rand()%7*4;G(x=17)||(c
 =a[5]);}}if(c==*a)G(--x)||++x;if(c==a[1])n=f+4**(m=n),G(x)||(n=m);if(c==a[2])G
 (++x)||--x;if(c==a[3])for(;G(x+12);++w)x+=12;if(c==a[4]||c==a[5]){s=sigblock(
-8192);printf("\033[H\033[J\033[0m%ld\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
-0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}system("\
-stty cbreak echo");d=popen("cat - HI 2>/dev/null|sort -rn|head -20>/tmp/$$;mv /tmp/$$ HI\
-;cat HI","w");fprintf(d,"%4d by %s\n",w,getlogin());pclose(d);}
+8192);printf("\033[H\033[J\033[0m%d\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
+0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}d=popen(
+"stty -cbreak echo stop \023;sort -mnr -o HI - HI;cat HI","w");fprintf(d,
+"%4d from level %1d by %s\n",w,l,getlogin());pclose(d);}


### PR DESCRIPTION
Previously after the game ran the game segfaulted and the high score file HI was not created. Now the file is created and sorted so that the highest score is at the top. This file was not even created because 'd' was an int and not a FILE * (to show how much has changed over the years!) which popen() returns.

It seemed that popen() could not have the stty re-enabling of echo either so it's now in a system() call (it might have been because of a problem I later fixed as described below).

But reinstating echo did not work right and in fact one could not even type the character 'u'. The important changes here are:

```diff
- 25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo stop u");sigaction(14,v,
+ 25||i%12<2?7:0;srand(getpid());system("stty cbreak -echo");sigaction(14,v,
```

and

```diff
-0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}d=popen( -"stty -cbreak echo stop \023;cat - HI|sort -rn|head -20>/tmp/$$;mv /tmp/$$ HI\ -;cat HI","w");fprintf(d,"%4d on level %1d by %s\n",w,l,getlogin());pclose(d);} +8192);printf("\033[H\033[J\033[0m%ld\n",w);if(c==a[5])break;for(j=264;j--;Q[j]= 
+0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}system("\ +stty cbreak echo");d=popen("cat - HI 2>/dev/null|sort -rn|head -20>/tmp/$$;mv /tmp/$$ HI\ +;cat HI","w");fprintf(d,"%4d by %s\n",w,getlogin());pclose(d);}
```

Now a word about these changes and in particularly the assignment to l and the fprintf(d, ...):

```diff
-V;{char *a;*v=(long)t;h[3]=1000000/(l=C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i< 
+V;{char *a;*v=(long)t;h[3]=1000000/(C>1?atoi(V[1]):2);for(a=C>2?V[2]:"jkl pq";i;i--)*n++=i<
```

and

```diff
-;cat HI","w");fprintf(d,"%4d on level %1d by %s\n",w,l,getlogin());pclose(d);} 
+;cat HI","w");fprintf(d,"%4d by %s\n",w,getlogin());pclose(d);}
```

If you notice in the fprintf() call the 'l' is no longer referenced - no level is noted. Why? This is because it was never changed aside from the initial assignment of

	 l=C>1?atoi(V[1]):2

so there was no point in having the level as the argv was not for a level but rather drops per second and command string. Thus the high score (that is now created and updated - up to 20 entries) looks like:

	N by user

where N is the score and user is that from getlogin(). I noted this in the README.md file.

I also gave a 'Try:' section in the README.md and noted the additional bug fixes. As well I noted the alternative code which is put in tromp.alt.c but the unmodified original alternate code which will not work with modern compilers. Why not fixed? Because doing so the high score file still was not created even when made to compile okay so I did not see the point. Perhaps an older compiler will work anyway.

There were two include files that needed to be added which is done via the compiler option -include: stdio.h and unistd.h.

Now 1989/tromp should work without a segfault, without disabling echo (or the u key) and with a high score file with up to 20 entries!

One other change with the README is I removed the section 'Bug fix thank you' as that was redundant: it was already at the top in the how to build section which seems to be a better place. If nothing else it is consistent with the others. However I added the links to both Yusuke and me in the winners.html file like Landon had put int (the other files with fixes needs the links as well). Of course if it's ideal to have a separate section (maybe a subsection of how to compile) I will be happy to find the files that need to be changed and do that.