### PR TITLE
Minor fixes to 1989/tromp - now compiles cleanly

### DIFF
--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -63,9 +63,9 @@ X11_INCDIR= /opt/X11/include
 # Common C compiler warnings to silence
 #
 #CSILENCE=
-CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pointer-to-int-cast \
-	-Wno-no-return-type -Wno-builtin-requires-header -Wno-empty-body \
-	-Wno-string-plus-int -Wno-return-type -Wno-unknown-warning-option
+CSILENCE= -Wno-error -Wno-pointer-to-int-cast -Wno-no-return-type -Wno-empty-body \
+	  -Wno-implicit-function-declaration -Wno-string-plus-int -Wno-return-type \
+	  -Wno-unknown-warning-option
 
 # Common C compiler warning flags
 #
@@ -99,7 +99,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE= -include stdio.h -include unistd.h
+CINCLUDE=
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
@@ -172,6 +172,11 @@ TARGET= ${PROG}
 #
 ALT_OBJ= ${PROG}.alt.o
 ALT_TARGET= ${PROG}.alt
+
+
+# FORCE use of -include stdio.h -include unistd.h
+#
+CINCLUDE+= -include stdio.h -include unistd.h -include stdlib.h
 
 
 #################

--- a/1989/tromp/tromp.c
+++ b/1989/tromp/tromp.c
@@ -16,4 +16,4 @@ for(;j%12;q[j--]=0);u();for(;--j;q[j+12]=q[j]);u();}n=f+rand()%7*4;G(x=17)||(c
 8192);printf("\033[H\033[J\033[0m%ld\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
 0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}system("\
 stty cbreak echo");d=popen("cat - HI 2>/dev/null|sort -rn|head -20>/tmp/$$;mv /tmp/$$ HI\
-;cat HI","w");fprintf(d,"%4d by %s\n",w,getlogin());pclose(d);}
+;cat HI","w");fprintf(d,"%4ld by %s\n",w,getlogin());pclose(d);}


### PR DESCRIPTION
Now compiles without any warnings triggered (though it has some -Wno- at the compiler). Some of the -Wno- options were removed from the Makefile as they are no longer needed. I did not check all the ones that are remaining but some are certainly needed (including some I tested).

Also force use of -include stdio.h -include unistd.h -include stdlib.h by minor change to Makefile. The last one, -include stdlib.h, was newly added.