### PR TITLE
1988/dale requires -traditional-cpp to compile

### DIFF
--- a/1985/README.md
+++ b/1985/README.md
@@ -1,5 +1,4 @@
-1985 marked the second year of the Obfuscated C Code Contest.
-
+1985 marked the second year of the International Obfuscated C Code Contest.
 
 Look at the README.md file for the given winner for information
 on how to compile the winner and how to run the winning program.

--- a/1985/shapiro/.gitignore
+++ b/1985/shapiro/.gitignore
@@ -1,1 +1,2 @@
 shapiro
+shapiro.alt

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -167,8 +167,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1986/holloway/README.md
+++ b/1986/holloway/README.md
@@ -10,12 +10,13 @@ USA
         make all
 
 
-NOTE: Cody Boone Ferguson fixed this to compile with clang (it worked with gcc).
-The problem was that clang is more strict about the type of second arg to
-main(). However simply changing it to a `char **` and updating the `*s` to `**s`
-caused a segfault. By adding a new variable, `char *t`, initialising it to `s`
-and then using `t` instead of `s` it compiles and runs successfully under clang
-and gcc. Thank you Cody for your assistance!
+NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
+compile and work with clang (it already worked with gcc).  The problem was that
+clang is more strict about the type of second arg to main(). However simply
+changing it to a `char **` and updating the `*s` to `**s` caused a segfault. By
+adding a new variable, `char *t`, initialising it to `s` and then using `t`
+instead of `s` it compiles and runs successfully under clang and gcc. Thank you
+Cody for your assistance!
 
 ## Try:
 

--- a/1987/biggar/README.md
+++ b/1987/biggar/README.md
@@ -35,7 +35,7 @@ One vendor's lint got hung in an infinite loop over this entry!
 > FYI:  We will let Mark get away with this truly sick entry this time, but 
 > for the future on we have placed a limit on the size of a compile line.
 
-NOTE: originally there we made a comment in [Larry Wall's
+NOTE: originally we made a comment in [Larry Wall's
 entry](../wall/README.md) regarding Mark's contribution but it seems to have
 been lost in time. If anyone knows about its whereabouts we'd appreciate letting
 us know. Thanks!

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -28,6 +28,9 @@ and input the following:
 	c^2
 	m*m
 
+	# can you figure out what this does?
+	500
+
 ### Also try:
 
 	./wall | bc

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -170,6 +170,9 @@ TARGET= ${PROG}
 ALT_OBJ=
 ALT_TARGET=
 
+# FORCE use of -traditional-cpp
+#
+CFLAGS+= -traditional-cpp
 
 #################
 # build the entry
@@ -183,16 +186,13 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	@echo "NOTE: this entry requires a compiler that supports -traditional-cpp."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
-
-${PROG}.orig: ${PROG}.orig.c
-	@echo "NOTE: The original source might not compile using modern compilers."
-	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # data files
 #

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -16,24 +16,12 @@ NOTE: for modern compilers we had to change the C pre-processor lines like:
 	    #define _ define
 	    -#_ foo bar
 
-to be
+to be:
 
 	    #define foo bar
 
-Even so this entry will not compile under macOS. If we change the
-
-
-	    #define a(x)get/***/x/***/id())
-
-to
-
-
-	    #define a(x)get/***/##x##/***/id())
-
-it almost works under macOS but there will still be a compilation error. There
-need not be any other changes under linux.
-
-NOTE: this program will likely dump core.
+Even so this entry requires a compiler that supports the `-traditional-cpp`
+option.
 
 ## Try:
 

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -63,9 +63,9 @@ X11_INCDIR= /opt/X11/include
 # Common C compiler warnings to silence
 #
 #CSILENCE=
-CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pointer-to-int-cast \
-	-Wno-no-return-type -Wno-builtin-requires-header -Wno-empty-body \
-	-Wno-string-plus-int -Wno-return-type -Wno-unknown-warning-option
+CSILENCE= -Wno-error -Wno-pointer-to-int-cast -Wno-no-return-type -Wno-empty-body \
+	  -Wno-implicit-function-declaration -Wno-string-plus-int -Wno-return-type \
+	  -Wno-unknown-warning-option
 
 # Common C compiler warning flags
 #
@@ -99,7 +99,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE= -include stdio.h -include unistd.h
+CINCLUDE=
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
@@ -172,6 +172,11 @@ TARGET= ${PROG}
 #
 ALT_OBJ= ${PROG}.alt.o
 ALT_TARGET= ${PROG}.alt
+
+
+# FORCE use of -include stdio.h -include unistd.h
+#
+CINCLUDE+= -include stdio.h -include unistd.h -include stdlib.h
 
 
 #################

--- a/1989/tromp/tromp.c
+++ b/1989/tromp/tromp.c
@@ -16,4 +16,4 @@ for(;j%12;q[j--]=0);u();for(;--j;q[j+12]=q[j]);u();}n=f+rand()%7*4;G(x=17)||(c
 8192);printf("\033[H\033[J\033[0m%ld\n",w);if(c==a[5])break;for(j=264;j--;Q[j]=
 0);while(getchar()-a[4]);puts("\033[H\033[J\033[7m");sigsetmask(s);}}system("\
 stty cbreak echo");d=popen("cat - HI 2>/dev/null|sort -rn|head -20>/tmp/$$;mv /tmp/$$ HI\
-;cat HI","w");fprintf(d,"%4d by %s\n",w,getlogin());pclose(d);}
+;cat HI","w");fprintf(d,"%4ld by %s\n",w,getlogin());pclose(d);}

--- a/1990/stig/README.md
+++ b/1990/stig/README.md
@@ -13,7 +13,7 @@
 
 	make all
 
-NOTE: that's not a typo but one can also do:
+NOTE: that's not a typo or mistake but one can also do:
 
 	./o
 

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -17,9 +17,14 @@
 
         make all
 
+NOTE: modern compilers had a problem with this entry because the `exit(3)`
+function returns void but [Cody Boone Ferguson](/winners#Cody_Boone_Ferguson)
+got it to work with the use of a comma operator. Thank you Cody!
+
 ### To run
 
 	./tbr
+
 
 ## Judges' comments
 
@@ -45,10 +50,6 @@ of the program which we include below:
 	    1),e(creat(i[2],438)):2,e(execvp(*u,u))):e(chdir(u[1])*2):6;}
 	    e(x){x<0?write(2,"?\n$ "-x/4,2),x+1||(exit(1),0):5;}
 
-
-Modern compilers had a problem with this entry because the exit(3) function
-returns void but we were able to get it to compile by using the comma
-operator which we also did in the smaller version.
 
 
 ## Author's comments

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -10,11 +10,12 @@
 
         make all
 
-NOTE: This entry might not compile when using modern compilers.
-
 ### To run
 
 	./westley 1
+
+NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
+compile under modern systems. Thank you Cody for your assistance!
 
 NOTE: this entry will segfault without an arg and will enter an infinite loop if
 input is not a number (or is a negative number).

--- a/winners.html
+++ b/winners.html
@@ -626,9 +626,9 @@ Contest </I></FONT></CENTER><BR>
 
 <LI TYPE=none><A NAME="Anthony_C._Howe"></A><B><a href="&#x6D;&#x61;&#x69;&#x6C;t&#111;&#58;&#97;&#99;&#x68;&#111;&#119;&#x65;&#64;&#115;&#110;&#x65;r&#x74;&#46;&#99;&#111;&#109;">Anthony C. Howe</a></B> -- <A HREF="http://www.snert.com/">http://www.snert.com/</a>
 <UL>
-<LI TYPE=square>Best Utility (<A HREF="years.html#1991_ant">1991 ant</A>)
-<LI TYPE=square>Best Utility (<A HREF="years.html#1992_ant">1992 ant</A>)
-<LI TYPE=square>Best Utility (<A HREF="years.html#1993_ant">1993 ant</A>)
+<LI TYPE=square>Best Utility (<A HREF="years.html#1991_howe">1991 howe</A>)
+<LI TYPE=square>Best Utility (<A HREF="years.html#1992_howe">1992 howe</A>)
+<LI TYPE=square>Best Utility (<A HREF="years.html#1993_howe">1993 howe</A>)
 <LI TYPE=square>Best Abuse of the Guidelines (<A HREF="years.html#2004_hibachi">2004 hibachi</A>)
 <LI TYPE=square>Best use of the WWW (<A HREF="years.html#2005_mynx">2005 mynx</A>)
 <LI TYPE=square>Most Different (<A HREF="years.html#2015_howe">2015 howe</A>)


### PR DESCRIPTION
Thus one can now enjoy it as long as they have a compiler that supports
    it. Unfortunately clang does not but gcc does.