### PR TITLE
Fix in 1991/westley/ttt.sh

### DIFF
--- a/1989/westley/.gitignore
+++ b/1989/westley/.gitignore
@@ -1,1 +1,9 @@
+ver0
+ver0.c
+ver1
+ver1.c
+ver2
+ver2.c
+ver3
+ver3.c
 westley

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -94,7 +94,7 @@ ARCH=
 # Defines that are needed to compile
 #
 #CDEFINE=
-CDEFINE= -Dtrgpune=putchar
+CDEFINE= -Dtrgpune=putchar -Dpune=char -Dvag=int
 
 # Include files that are needed to compile
 #

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -1,4 +1,4 @@
-Most algorithms in one program:
+# Most algorithms in one program:
 
 	Merlyn LeRoy (Brian Westley)
 	Starfire Consulting
@@ -7,117 +7,146 @@ Most algorithms in one program:
 	55104  
 	USA
 
-Judges notes:
+## To build:
 
-	There is a secret way to get ONE of the versions to print out
-	"Hello, world!\n".  Can you find how to do it?
+	make all
 
-	Try the following commands:
 
-		westley < westley.c > ver0.c
-		westley 1 < westley.c > ver1.c
-		westley 1 2 < westley.c > ver2.c
-		westley 1 2 3 < westley.c > ver3.c
-	
-	Try compiling and running the 4 resulting programs.
+NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) was able to get
+this to partially work with clang; clang requires that the second, third and
+fourth args to main() be `char **`. Only `westley.c` and `ver0.c` (see below) will
+compile with clang. It's possible to get ver1.c to compile too but this causes
+problems with generating the output of the remaining files so we have opted, at
+least for now, to not do that, as it does not have to output just source code.
+He notes that the original source code sometimes segfaults with `ver2` which
+also happens with the fix but it'll only compile with a compiler that
+does not require the second, third and fourth args of main() to be a `char **`.
+Thank you Cody for your help!
 
-Selected notes from the author:
 
-	This is a filter.  If it is run with no arguments, it copies
-	stdin to stdout.  With one argument, it ROT13's stdin to
-	stdout.  With two arguments, it reverses stdin to stdout.  With
-	three arguments, it does both.  It requires the ASCII character
-	set, with all characters being in 0..255, and EOF must be -1.
-	Also requires two's complement (I think).
+## Try:
 
-	The source code will run if ROT13'ed and/or reversed, using a
-	different algorithm for each version (hereafter referred to as
-	ver0 (original), ver1 (ROT13), ver2 (reversed), and ver3 
-	(ROT13 and reversed)).
 
-	When compiling these versions, one needs to define 'trgpune'
-	in the compile line.  Example:
+		./westley < westley.c > ver0.c
+		./westley 1 < westley.c > ver1.c
+		./westley 1 2 < westley.c > ver2.c
+		./westley 1 2 3 < westley.c > ver3.c
+
+
+Try compiling and running the 4 resulting programs. To compile try:
+
+
+		make ver0
+		make ver1
+		make ver2
+		make ver3
+
+
+
+## Judges notes:
+
+
+There is a secret way to get ONE of the versions to print out
+"Hello, world!\n".  Can you find how to do it?
+
+
+## Selected notes from the author:
+
+This is a filter.  If it is run with no arguments, it copies
+stdin to stdout.  With one argument, it ROT13's stdin to
+stdout.  With two arguments, it reverses stdin to stdout.  With
+three arguments, it does both.  It requires the ASCII character
+set, with all characters being in 0..255, and EOF must be -1.
+Also requires two's complement (I think).
+
+The source code will run if ROT13'ed and/or reversed, using a
+different algorithm for each version (hereafter referred to as
+ver0 (original), ver1 (ROT13), ver2 (reversed), and ver3 
+(ROT13 and reversed)).
+
+When compiling these versions, one needs to define 'trgpune'
+in the compile line (which the Makefile now has).  Example:
 
 		cc -Dtrgpune=putchar ver3.c -o ver3
 
-	"trgpune" is the ROT13 of getchar(), so getchar() and putchar()
-	are exchanged in the ROT13 counterpart.  It is easy to see that
-	this is unavoidable.  I must have a #define for a library
-	function; otherwise I would have an unidentifed extern for the
-	ROT13 version.  If I then define this function, it won't link
-	in the library version for the ORIGINAL code, since my
-	definition will supercede the library function.  Hence, the
-	compiler option gives me putchar(), and allows me to use
-	getchar().  I pass a dummy argument to getchar() to eliminate
-	"variable number of args" from lint (unless it checks against
-	the library).  Otherwise, all versions lint reasonably (main
-	returns random value & constant in conditional context [when I
-	check for ROT13 version] is all it complains about).
+"trgpune" is the ROT13 of getchar(), so getchar() and putchar()
+are exchanged in the ROT13 counterpart.  It is easy to see that
+this is unavoidable.  I must have a #define for a library
+function; otherwise I would have an unidentified extern for the
+ROT13 version.  If I then define this function, it won't link
+in the library version for the ORIGINAL code, since my
+definition will supersede the library function.  Hence, the
+compiler option gives me putchar(), and allows me to use
+getchar().  I pass a dummy argument to getchar() to eliminate
+"variable number of args" from lint (unless it checks against
+the library).  Otherwise, all versions lint reasonably (main
+returns random value & constant in conditional context [when I
+check for ROT13 version] is all it complains about).
 
-	ver0 and ver1 use a range check and a calculation to do ROT13,
-	while ver2 and ver3 use table lookup.  All versions contain
-	main() and it's ROT13 fn, znva().  ver0/ver1 [ver2/ver3] are
-	(of course) syntactically identical, since the syntax is in the
-	non-alphabetic characters.  However, since one program starts
-	at main() while it's ROT13 counterpart starts at znva(), znva()
-	calls main (znva() is also used for output).
+ver0 and ver1 use a range check and a calculation to do ROT13,
+while ver2 and ver3 use table lookup.  All versions contain
+main() and it's ROT13 fn, znva().  ver0/ver1 [ver2/ver3] are
+(of course) syntactically identical, since the syntax is in the
+non-alphabetic characters.  However, since one program starts
+at main() while it's ROT13 counterpart starts at znva(), znva()
+calls main (znva() is also used for output).
 
-	All versions use recursion to work.  If the program is NOT
-	reversing it's output, it prints out the (possibly ROT13'd)
-	character before recursing, otherwise it prints it out
-	afterward (or doesn't recurse at all when EOF is reached).
-	Since most of this code is identical, it is put into znva() and
-	called with a first parameter of 0 as a flag (as "main()", it's
-	first argument (argc) must be at least one).
+All versions use recursion to work.  If the program is NOT
+reversing it's output, it prints out the (possibly ROT13'd)
+character before recursing, otherwise it prints it out
+afterward (or doesn't recurse at all when EOF is reached).
+Since most of this code is identical, it is put into znva() and
+called with a first parameter of 0 as a flag (as "main()", it's
+first argument (argc) must be at least one).
 
-	I can't use any flow control.  If I used if(), I would have a
-	function vs() to define in the ROT13 version.  But a function
-	called vs() turns into a function called if() in the original,
-	so it can't be done.  Therefore, I do:
+I can't use any flow control.  If I used if(), I would have a
+function vs() to define in the ROT13 version.  But a function
+called vs() turns into a function called if() in the original,
+so it can't be done.  Therefore, I do:
 
 		expr1 && expr2 && (expr3=etc);
 
-	which is the same as:
+which is the same as:
 
 		 if (expr1 && expr2) expr3=etc;
 
-	A/UX on the Macintosh doesn't get this right; it evaluates ALL
-	expressions if they aren't in an assignment or conditional
-	statement.  This might warrant a warning, since other compilers
-	may do this.  I found MANY compilers botched:
+A/UX on the Macintosh doesn't get this right; it evaluates ALL
+expressions if they aren't in an assignment or conditional
+statement.  This might warrant a warning, since other compilers
+may do this.  I found MANY compilers botched:
 
 		expr1 && (expr2,expr3);
 
-	expr2 was OFTEN evaluated even if expr1 was false.  I removed
-	such statements to make it more portable.
+expr2 was OFTEN evaluated even if expr1 was false.  I removed
+such statements to make it more portable.
 
-	The variable names are worth noting:
+The variable names are worth noting:
 
 		 'irk' and  'vex' are ROT13 pairs and are synonyms.
 		'Near' and 'Arne' are ROT13 pairs and are anagrams.
 		'NOON' and 'ABBA' are ROT13 pairs and are palindromes.
 		'tang' and 'gnat' are both ROT13 and palindrome pairs!
 
-	Normally (!), a reversible C program is done thus:
+Normally (!), a reversible C program is done thus:
 
 		/**/ forward code /*/ edoc drawkcab /**/
 
-	If your compiler nests comments, it will get this wrong.
-	However, I have made some bits of the code palindromic,
-	(or different, but reversible) so it is more like:
+If your compiler nests comments, it will get this wrong.
+However, I have made some bits of the code palindromic,
+(or different, but reversible) so it is more like:
 
 		/**/forward/*//**/ palindromic /**//*/drawkcab/**/
 
-	The code can therefore be interlaced.  There are eight
-	such palindromic bits.  You can find them within the
-	/*//**/   /**//*/ pairs.
+The code can therefore be interlaced.  There are eight
+such palindromic bits.  You can find them within the
+`/*//**/   /**//*/` pairs.
 
-	The body of the code of ver0 and ver1 is a large lumpy 'K' (for
-	Kernighan); the code of ver2 and ver3 is a flat-topped and
-	lumpier 'R' (for Ritchie).  Judicious use of spaces and tabs
-	helped here.  It barely fits on an 80x24 screen.  Squint.  Note
-	that the code must start with a blank line, or the reversed version
-	will lack a terminating newline.
+The body of the code of ver0 and ver1 is a large lumpy 'K' (for
+Kernighan); the code of ver2 and ver3 is a flat-topped and
+lumpier 'R' (for Ritchie).  Judicious use of spaces and tabs
+helped here.  It barely fits on an 80x24 screen.  Squint.  Note
+that the code must start with a blank line, or the reversed version
+will lack a terminating newline.
 
 Copyright (c) 1989, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1989/westley/westley.c
+++ b/1989/westley/westley.c
@@ -1,7 +1,8 @@
 
 /**//*/};)/**/main(/*//**/tang 	  ,gnat/**//*/,ABBA~,0-0(avnz;)0-0,tang,raeN
-,ABBA(niam&&)))2-]--tang-[kri	  - =raeN(&&0<)/*clerk*/,noon,raeN){(!tang&&
-noon!=-1&&(gnat&2)&&((raeN&&(    getchar(noon+0)))||(1-raeN&&(trgpune(noon
+,ABBA(niam&&)))2-]--tang-[kri	  - =raeN(&&0<)/*clerk*/,noon,raeN)char
+**gnat, **noon, **raeN;{int	gn = gnat, ra = raeN, no = noon; (!tang&&
+no!=-1&&(gn&2)&&((raeN&&(	getchar(no+0)))||(1-ra&&(trgpune(no
 )))))||tang&&znva(/*//**/tang   ,tang,tang/**|**//*/((||)))0(enupgrt=raeN
 (&&tang!(||)))0(rahcteg=raeN(  &&1==tang((&&1-^)gnat=raeN(;;;)tang,gnat
 ,ABBA,0(avnz;)gnat:46+]552&)191+gnat([kri?0>]652%)191+gnat([kri=gnat

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -11,19 +11,19 @@
 
 ### To run
 
-    Make and run as follows:
+Make and run as follows:
 
 	./westley [move_location] | tee nextmove.c
     
-    where the 'move_location' is a digit from 1 to 9 that represents
-    a move on a tic-tac-toe board:
+where the 'move_location' is a digit from 1 to 9 that represents
+a move on a tic-tac-toe board:
 
 		1 2 3
 		4 5 6
 		7 8 9
 
-    If you omit 'move_location', then the computer moves first.  For your 
-    next move, recompile nextmove.c and play it again:
+If you omit 'move_location', then the computer moves first.  For your 
+next move, recompile `nextmove.c` and play it again:
 
 	make nextmove
 	./nextmove move_location | tee nextmove.c

--- a/1991/westley/ttt.sh
+++ b/1991/westley/ttt.sh
@@ -61,7 +61,7 @@ if [ ! -f merlyn.c ]; then
     fi
     # check to see if the copy worked
     if [ ! -f merlyn.c ]; then
-	echo "ttt: Darn, coundn't copy westley.c to merlyn.c" 1>&2
+	echo "ttt: Darn, couldn't copy westley.c to merlyn.c" 1>&2
 	exit 4
     fi
 fi
@@ -85,9 +85,9 @@ fi
 if [ ! -w ttt_game.c ]; then
     rm -f ttt_game.c 
     if [ -z "$move" ]; then
-	merlyn | tee ttt_game.c
+	./merlyn | tee ttt_game.c
     else
-	merlyn "$move" | tee ttt_game.c
+	./merlyn "$move" | tee ttt_game.c
     fi
     chmod +w ttt_game.c
 


### PR DESCRIPTION

Don't assume '.' is in the path.

I note that at least under macOS this game does not work. I'll be
looking at the entries of this year at another time. I just need this
commit in to make some other changes unrelated.

The README.md was also updated - formatting fixes to turn it into a 
markdown file proper.
