### PR TITLE
Various README.md files updated

### DIFF
--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -3,7 +3,7 @@
 	Arch D. Robison
 	University of Illinois
 	1304 W. Springfield Ave.
-	Urbana, IL 
+	Urbana, IL
 	61801
 	USA
 
@@ -14,6 +14,27 @@
 
 NOTE: we were able to get this to compile under modern systems with a patch from
 Yusuke Endoh. Thank you for your assistance Yusuke!
+
+## To run:
+
+	./robison
+	# enter valid expressions
+
+
+## Try:
+
+	./robison
+	11x10
+
+	echo 1x10x111 | ./robison
+
+	echo 1+1+10 | ./robison
+
+	echo 100 - 1 | ./robison
+
+	echo -100 x 100 + 1 | ./robison
+
+	echo 100 / 100 | ./robison # <-- what happens here ?
 
 ## Judges' comments:
 
@@ -45,13 +66,13 @@ Extending it to the full APL language should be trivial.
 
 The C-- language improves the C language by removing superfluous
 and confusing features: arithmetic, logical operations, shifts,
-relationals, address-of, and flow control.  In fact, the only 
-expressions retained are function calls, indirection, array 
+relationals, address-of, and flow control.  In fact, the only
+expressions retained are function calls, indirection, array
 assignments, the ',' operator, and sizeof.  Despite these
-restrictions, the C-- program does arithmetic on arbitrarily 
+restrictions, the C-- program does arithmetic on arbitrarily
 large binary numbers.
 
-To obtain a C-- reference, simply rip out the irrelevant pages 
+To obtain a C-- reference, simply rip out the irrelevant pages
 from your K&R C manual.  To obtain a C-- compiler, simply rip
 out the irrelevant bytes from your cc compiler.
 

--- a/1989/westley/.gitignore
+++ b/1989/westley/.gitignore
@@ -1,1 +1,9 @@
+ver0
+ver0.c
+ver1
+ver1.c
+ver2
+ver2.c
+ver3
+ver3.c
 westley

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -94,7 +94,7 @@ ARCH=
 # Defines that are needed to compile
 #
 #CDEFINE=
-CDEFINE= -Dtrgpune=putchar
+CDEFINE= -Dtrgpune=putchar -Dpune=char -Dvag=int
 
 # Include files that are needed to compile
 #

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -1,4 +1,4 @@
-Most algorithms in one program:
+# Most algorithms in one program:
 
 	Merlyn LeRoy (Brian Westley)
 	Starfire Consulting
@@ -7,117 +7,146 @@ Most algorithms in one program:
 	55104  
 	USA
 
-Judges notes:
+## To build:
 
-	There is a secret way to get ONE of the versions to print out
-	"Hello, world!\n".  Can you find how to do it?
+	make all
 
-	Try the following commands:
 
-		westley < westley.c > ver0.c
-		westley 1 < westley.c > ver1.c
-		westley 1 2 < westley.c > ver2.c
-		westley 1 2 3 < westley.c > ver3.c
-	
-	Try compiling and running the 4 resulting programs.
+NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) was able to get
+this to partially work with clang; clang requires that the second, third and
+fourth args to main() be `char **`. Only `westley.c` and `ver0.c` (see below) will
+compile with clang. It's possible to get ver1.c to compile too but this causes
+problems with generating the output of the remaining files so we have opted, at
+least for now, to not do that, as it does not have to output just source code.
+He notes that the original source code sometimes segfaults with `ver2` which
+also happens with the fix but it'll only compile with a compiler that
+does not require the second, third and fourth args of main() to be a `char **`.
+Thank you Cody for your help!
 
-Selected notes from the author:
 
-	This is a filter.  If it is run with no arguments, it copies
-	stdin to stdout.  With one argument, it ROT13's stdin to
-	stdout.  With two arguments, it reverses stdin to stdout.  With
-	three arguments, it does both.  It requires the ASCII character
-	set, with all characters being in 0..255, and EOF must be -1.
-	Also requires two's complement (I think).
+## Try:
 
-	The source code will run if ROT13'ed and/or reversed, using a
-	different algorithm for each version (hereafter referred to as
-	ver0 (original), ver1 (ROT13), ver2 (reversed), and ver3 
-	(ROT13 and reversed)).
 
-	When compiling these versions, one needs to define 'trgpune'
-	in the compile line.  Example:
+		./westley < westley.c > ver0.c
+		./westley 1 < westley.c > ver1.c
+		./westley 1 2 < westley.c > ver2.c
+		./westley 1 2 3 < westley.c > ver3.c
+
+
+Try compiling and running the 4 resulting programs. To compile try:
+
+
+		make ver0
+		make ver1
+		make ver2
+		make ver3
+
+
+
+## Judges notes:
+
+
+There is a secret way to get ONE of the versions to print out
+"Hello, world!\n".  Can you find how to do it?
+
+
+## Selected notes from the author:
+
+This is a filter.  If it is run with no arguments, it copies
+stdin to stdout.  With one argument, it ROT13's stdin to
+stdout.  With two arguments, it reverses stdin to stdout.  With
+three arguments, it does both.  It requires the ASCII character
+set, with all characters being in 0..255, and EOF must be -1.
+Also requires two's complement (I think).
+
+The source code will run if ROT13'ed and/or reversed, using a
+different algorithm for each version (hereafter referred to as
+ver0 (original), ver1 (ROT13), ver2 (reversed), and ver3 
+(ROT13 and reversed)).
+
+When compiling these versions, one needs to define 'trgpune'
+in the compile line (which the Makefile now has).  Example:
 
 		cc -Dtrgpune=putchar ver3.c -o ver3
 
-	"trgpune" is the ROT13 of getchar(), so getchar() and putchar()
-	are exchanged in the ROT13 counterpart.  It is easy to see that
-	this is unavoidable.  I must have a #define for a library
-	function; otherwise I would have an unidentifed extern for the
-	ROT13 version.  If I then define this function, it won't link
-	in the library version for the ORIGINAL code, since my
-	definition will supercede the library function.  Hence, the
-	compiler option gives me putchar(), and allows me to use
-	getchar().  I pass a dummy argument to getchar() to eliminate
-	"variable number of args" from lint (unless it checks against
-	the library).  Otherwise, all versions lint reasonably (main
-	returns random value & constant in conditional context [when I
-	check for ROT13 version] is all it complains about).
+"trgpune" is the ROT13 of getchar(), so getchar() and putchar()
+are exchanged in the ROT13 counterpart.  It is easy to see that
+this is unavoidable.  I must have a #define for a library
+function; otherwise I would have an unidentified extern for the
+ROT13 version.  If I then define this function, it won't link
+in the library version for the ORIGINAL code, since my
+definition will supersede the library function.  Hence, the
+compiler option gives me putchar(), and allows me to use
+getchar().  I pass a dummy argument to getchar() to eliminate
+"variable number of args" from lint (unless it checks against
+the library).  Otherwise, all versions lint reasonably (main
+returns random value & constant in conditional context [when I
+check for ROT13 version] is all it complains about).
 
-	ver0 and ver1 use a range check and a calculation to do ROT13,
-	while ver2 and ver3 use table lookup.  All versions contain
-	main() and it's ROT13 fn, znva().  ver0/ver1 [ver2/ver3] are
-	(of course) syntactically identical, since the syntax is in the
-	non-alphabetic characters.  However, since one program starts
-	at main() while it's ROT13 counterpart starts at znva(), znva()
-	calls main (znva() is also used for output).
+ver0 and ver1 use a range check and a calculation to do ROT13,
+while ver2 and ver3 use table lookup.  All versions contain
+main() and it's ROT13 fn, znva().  ver0/ver1 [ver2/ver3] are
+(of course) syntactically identical, since the syntax is in the
+non-alphabetic characters.  However, since one program starts
+at main() while it's ROT13 counterpart starts at znva(), znva()
+calls main (znva() is also used for output).
 
-	All versions use recursion to work.  If the program is NOT
-	reversing it's output, it prints out the (possibly ROT13'd)
-	character before recursing, otherwise it prints it out
-	afterward (or doesn't recurse at all when EOF is reached).
-	Since most of this code is identical, it is put into znva() and
-	called with a first parameter of 0 as a flag (as "main()", it's
-	first argument (argc) must be at least one).
+All versions use recursion to work.  If the program is NOT
+reversing it's output, it prints out the (possibly ROT13'd)
+character before recursing, otherwise it prints it out
+afterward (or doesn't recurse at all when EOF is reached).
+Since most of this code is identical, it is put into znva() and
+called with a first parameter of 0 as a flag (as "main()", it's
+first argument (argc) must be at least one).
 
-	I can't use any flow control.  If I used if(), I would have a
-	function vs() to define in the ROT13 version.  But a function
-	called vs() turns into a function called if() in the original,
-	so it can't be done.  Therefore, I do:
+I can't use any flow control.  If I used if(), I would have a
+function vs() to define in the ROT13 version.  But a function
+called vs() turns into a function called if() in the original,
+so it can't be done.  Therefore, I do:
 
 		expr1 && expr2 && (expr3=etc);
 
-	which is the same as:
+which is the same as:
 
 		 if (expr1 && expr2) expr3=etc;
 
-	A/UX on the Macintosh doesn't get this right; it evaluates ALL
-	expressions if they aren't in an assignment or conditional
-	statement.  This might warrant a warning, since other compilers
-	may do this.  I found MANY compilers botched:
+A/UX on the Macintosh doesn't get this right; it evaluates ALL
+expressions if they aren't in an assignment or conditional
+statement.  This might warrant a warning, since other compilers
+may do this.  I found MANY compilers botched:
 
 		expr1 && (expr2,expr3);
 
-	expr2 was OFTEN evaluated even if expr1 was false.  I removed
-	such statements to make it more portable.
+expr2 was OFTEN evaluated even if expr1 was false.  I removed
+such statements to make it more portable.
 
-	The variable names are worth noting:
+The variable names are worth noting:
 
 		 'irk' and  'vex' are ROT13 pairs and are synonyms.
 		'Near' and 'Arne' are ROT13 pairs and are anagrams.
 		'NOON' and 'ABBA' are ROT13 pairs and are palindromes.
 		'tang' and 'gnat' are both ROT13 and palindrome pairs!
 
-	Normally (!), a reversible C program is done thus:
+Normally (!), a reversible C program is done thus:
 
 		/**/ forward code /*/ edoc drawkcab /**/
 
-	If your compiler nests comments, it will get this wrong.
-	However, I have made some bits of the code palindromic,
-	(or different, but reversible) so it is more like:
+If your compiler nests comments, it will get this wrong.
+However, I have made some bits of the code palindromic,
+(or different, but reversible) so it is more like:
 
 		/**/forward/*//**/ palindromic /**//*/drawkcab/**/
 
-	The code can therefore be interlaced.  There are eight
-	such palindromic bits.  You can find them within the
-	/*//**/   /**//*/ pairs.
+The code can therefore be interlaced.  There are eight
+such palindromic bits.  You can find them within the
+`/*//**/   /**//*/` pairs.
 
-	The body of the code of ver0 and ver1 is a large lumpy 'K' (for
-	Kernighan); the code of ver2 and ver3 is a flat-topped and
-	lumpier 'R' (for Ritchie).  Judicious use of spaces and tabs
-	helped here.  It barely fits on an 80x24 screen.  Squint.  Note
-	that the code must start with a blank line, or the reversed version
-	will lack a terminating newline.
+The body of the code of ver0 and ver1 is a large lumpy 'K' (for
+Kernighan); the code of ver2 and ver3 is a flat-topped and
+lumpier 'R' (for Ritchie).  Judicious use of spaces and tabs
+helped here.  It barely fits on an 80x24 screen.  Squint.  Note
+that the code must start with a blank line, or the reversed version
+will lack a terminating newline.
 
 Copyright (c) 1989, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1989/westley/westley.c
+++ b/1989/westley/westley.c
@@ -1,7 +1,8 @@
 
 /**//*/};)/**/main(/*//**/tang 	  ,gnat/**//*/,ABBA~,0-0(avnz;)0-0,tang,raeN
-,ABBA(niam&&)))2-]--tang-[kri	  - =raeN(&&0<)/*clerk*/,noon,raeN){(!tang&&
-noon!=-1&&(gnat&2)&&((raeN&&(    getchar(noon+0)))||(1-raeN&&(trgpune(noon
+,ABBA(niam&&)))2-]--tang-[kri	  - =raeN(&&0<)/*clerk*/,noon,raeN)char
+**gnat, **noon, **raeN;{int	gn = gnat, ra = raeN, no = noon; (!tang&&
+no!=-1&&(gn&2)&&((raeN&&(	getchar(no+0)))||(1-ra&&(trgpune(no
 )))))||tang&&znva(/*//**/tang   ,tang,tang/**|**//*/((||)))0(enupgrt=raeN
 (&&tang!(||)))0(rahcteg=raeN(  &&1==tang((&&1-^)gnat=raeN(;;;)tang,gnat
 ,ABBA,0(avnz;)gnat:46+]552&)191+gnat([kri?0>]652%)191+gnat([kri=gnat

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -1,4 +1,4 @@
-Best Output:
+# Best Output:
 
 	Sean Barrett
 	University of Maryland
@@ -16,24 +16,24 @@ Best Output:
 
 ## Judges' comments
 
-    You will be A-mazed.
+You will be A-mazed.
 
-    You are invited to try to cheat, ... if you can figure out how!  :-)
+You are invited to try to cheat, ... if you can figure out how!  :-)
 
 ## Author's comments
 
-    HOW TO PLAY:
+### HOW TO PLAY:
 
-    When the game starts, you are at the far end of the maze from the
-    exit, looking down a corridor.  To move forward, type 'f' and press
-    return.  To turn 90 degrees right, type 'r'; left, 'l'.  You can
-    put multiple commands on one line, and the new view will be drawn
-    after all the moves.
+When the game starts, you are at the far end of the maze from the
+exit, looking down a corridor.  To move forward, type 'f' and press
+return.  To turn 90 degrees right, type 'r'; left, 'l'.  You can
+put multiple commands on one line, and the new view will be drawn
+after all the moves.
 
-    The game ends if you get out the exit (you'll know it when you see
-    it) or when you type ^D.
+The game ends if you get out the exit (you'll know it when you see
+it) or when you type ^D.
 
-    HINTS ON HOW TO CHEAT:  (rot13 to read)
+### HINTS ON HOW TO CHEAT:  (rot13 to read)
 
     Lbh pna, bs pbhefr, purng ol ybbxvat ng gur znmr znc.  Gur dhrfgvba
     lbh arrq gb nfx lbhefrys, gubhtu, vf jung frdhrapr bs punenpgref
@@ -44,7 +44,7 @@ Best Output:
     gura onpxjneq sebz gur pheerag cbfvgvba gb qenj gur yrsg fvqr naq
     gura gur evtug fvqr.
 
-    ADVANCED USAGE NOTES:  (rot13 to read)
+### ADVANCED USAGE NOTES:  (rot13 to read)
 
     Gur cebtenz pna nyfb or eha sebz bgure svyrf pbagnvavat znmrf.  Gur
     znmr fubhyq or ynvq bhg tencuvpnyyl va gur boivbhf sbezng; arjyvarf
@@ -85,6 +85,7 @@ Best Output:
     gb ernpu vagb neovgenel cnepryf bs zrzbel.
 
     Gur cebtenz nffhzrf gung gnof ner frg gb 8 punenpgref.
+
 
 Copyright (c) 1991, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1991/cdupont/README.md
+++ b/1991/cdupont/README.md
@@ -17,20 +17,22 @@
 
 ## Judges' comments
 
-    Why is the following label necessary?
-    
+Why is the following label necessary?
+
+
 	sorryfor_this_unused_but_very_needed_label:
 
-    Notice that if you C beautify (cb) or pre-process this program, it
-    will no longer work correctly, or at all.  (go ahead, try it... :-))
 
-    NOTE: One should remove the final trailing newline to obtain the
-	  original source file.  This step is not needed to compile
-	  this entry.
+Notice that if you C beautify (cb) or pre-process this program, it
+will no longer work correctly, or at all.  (go ahead, try it... :-))
+
+NOTE: One should remove the final trailing newline to obtain the
+original source file.  This step is not needed to compile
+this entry.
 
 ## Author's comments
 
-    Spoiler, rot13 to read:
+Spoiler, rot13 to read:
 
     Gur fbhepr pbqr ubyqf gur yrggref bs gur zrffntr. Rnpu yrggre, pbzovarq
     jvgu nabgure xrl yrggre, vf hfrq gb pbzchgr gur pbbeqvangrf bs gur arkg
@@ -43,6 +45,7 @@
 
     Guvf jnl, nal zrffntr pna or zvkrq vagb n pbqr, fvapr gur xrlf nyybj
     lbh gb cynpr gur zrnavatshy yrggref jurerire lbh jnag.
+
 
 Copyright (c) 1991, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1991/davidguy/README.md
+++ b/1991/davidguy/README.md
@@ -1,4 +1,4 @@
-Best X11 Graphics:
+# Best X11 Graphics:
 
 	David Applegate			Guy Jacobson
 	School of Computer Science	AT&T Bell Laboratories
@@ -10,107 +10,107 @@ Best X11 Graphics:
 
         make all
 
-### To run
+## To run:
 
 	./davidguy ip_address:server.screen
 
-	where 'ip_address' in an IP address of an X server.  For example, try:
+where `ip_address` in an IP address of an X server.
 
-	    davidguy 127.0.0.1:0.0
+## Try:
 
-	Of course, may need to supply a more reasonable address.  :-)
+	    ./davidguy 127.0.0.1:0.0
 
-	Also try:
+Of course, you may need to supply a more reasonable address.  :-)
+
+## Also try:
 
 	    cp -f davidguy guydavid
 	    ./guydavid 127.0.0.1:0.0
 
 ## Judges' comments
 
-    Can you determine why this makes a difference.
+Can you determine why this makes a difference?
 
-    We permitted this type of entry to win because:
+We permitted this type of entry to win because:
 
-	- it did not require X to be on the host system
-	- both BSD and SVR4 have sockets
-    
-    Now that X11 and sockets have become 'standard', we plan to open
-    up the contest to programs that use them.  Future rules will
-    explain this further.
+- it did not require X to be on the host system
+- both BSD and SVR4 have sockets
 
-    We are pleased that this entry has helped bring new 'life' into
-    the contest.
+Now that X11 and sockets have become 'standard', we plan to open
+up the contest to programs that use them.  Future rules will
+explain this further.
+
+We are pleased that this entry has helped bring new 'life' into
+the contest.
 
 ## Author's comments
 
-    The program is a fully-functional X client.  It talks directly to
-    the X server through a socket without using Xlib, Xt or any other
-    wussie toolkit junk.  With no arguments, it will try to run
-    locally using the unix-domain socket (only on BSD :-( ) or you can
-    give it a command line argument identifying a display host address
-    (in dotted octet notation, like 127.0.0.1:0.0) where the X server
-    is running.  It handles color and monochrome displays, and
-    performs whatever byte-swapping and bit-reversal is needed (so
-    that the program works even when the server and the client have
-    different architectures).  It buffers communication to the X
-    server for efficiency.
+The program is a fully-functional X client.  It talks directly to
+the X server through a socket without using Xlib, Xt or any other
+wussie toolkit junk.  With no arguments, it will try to run
+locally using the unix-domain socket (only on BSD :-( ) or you can
+give it a command line argument identifying a display host address
+(in dotted octet notation, like 127.0.0.1:0.0) where the X server
+is running.  It handles color and monochrome displays, and
+performs whatever byte-swapping and bit-reversal is needed (so
+that the program works even when the server and the client have
+different architectures).  It buffers communication to the X
+server for efficiency.
 
-    [[ NOTE: The original source in davidguy.c used only an IP address
-	     argument (assumed :0.0) and assumed the color of black
-	     and white. ]]
+[[ NOTE: The original source in davidguy.c used only an IP address
+argument (assumed :0.0) and assumed the color of black
+and white. ]]
 
-    The program doesn't require any user interaction; you can just sit
-    back and watch it run.  All the action takes place in the root
-    window of the display.
+The program doesn't require any user interaction; you can just sit
+back and watch it run.  All the action takes place in the root
+window of the display.
 
-    We think the program is interesting for these reasons:
+We think the program is interesting for these reasons:
 
-	1) It belongs to a class of programs that programmers make 
-	   the following complaints about:  they require a mountain 
-	   of code to implement even the simplest program; and they 
-	   must be linked with giant libraries of hard-to-understand 
-	   functions.  In contrast to these complaints (made by wimps,
-	   in our humble opinion), our program fits in under 1536 
-	   bytes, doesn't need any external functions except for a few 
-	   system calls, and doesn't need to include any header files.
+1. It belongs to a class of programs that programmers make the following
+complaints about:  they require a mountain of code to implement even the
+simplest program; and they must be linked with giant libraries of
+hard-to-understand functions.  In contrast to these complaints (made by wimps,
+in our humble opinion), our program fits in under 1536 bytes, doesn't need any
+external functions except for a few system calls, and doesn't need to include
+any header files.
 
-	2) It implements an extremely efficient algorithm for the 
-	   computation it performs.  One cool feature of the algorithm 
-	   (at least as far as this contest is concerned) is that its 
-	   obscurity is fundamentally necessary for its efficiency.  
-	   In other words, even if we took steps to present the algorithm 
-	   clearly, (we haven't) the relation of the computation performed 
-	   to the specification of what the program was supposed to do 
-	   would still be hard to understand.
+2. It implements an extremely efficient algorithm for the computation it
+performs.  One cool feature of the algorithm (at least as far as this contest is
+concerned) is that its obscurity is fundamentally necessary for its efficiency.
+In other words, even if we took steps to present the algorithm clearly, (we
+haven't) the relation of the computation performed to the specification of what
+the program was supposed to do would still be hard to understand.
 
-    Quasi-spoiler on internals:
+### Quasi-spoiler on internals:
 
-    The program plays Conway's game of Life in the root window's
-    background pixmap.  It starts by setting the background to random
-    bits, and then plays Life, with one Life cell for each pixel of the
-    screen.  In the game of Life, a cell survives to the next round if
-    2 or 3 of its 8 neighbors are also alive, and a cell is born if
-    exactly 3 of its neighbors are alive.  Otherwise, a cell dies of
-    exposure if it has only 0 or 1 neighbors, and dies of overcrowding
-    if it has 4 or more neighbors.
+The program plays Conway's game of Life in the root window's
+background pixmap.  It starts by setting the background to random
+bits, and then plays Life, with one Life cell for each pixel of the
+screen.  In the game of Life, a cell survives to the next round if
+2 or 3 of its 8 neighbors are also alive, and a cell is born if
+exactly 3 of its neighbors are alive.  Otherwise, a cell dies of
+exposure if it has only 0 or 1 neighbors, and dies of overcrowding
+if it has 4 or more neighbors.
 
-    The algorithm used to compute the next generation is based on the
-    observation that a cell's state in the next generation is a boolean
-    function of its current state, and the states of its 8 neighbors
-    (ie, a boolean function from 9 bits to 1 bit).  This function can
-    be computed by a boolean circuit.  In addition, intermediate values
-    computed by the circuit can be shared between neighboring cells,
-    reducing the number of gates per cell required.  These ideas
-    have been used before, to compute the next generation through a
-    series of bit blits.  Instead of doing this, we map values in the
-    circuit to bits in registers, so that the next generation can be
-    computed efficiently within registers, minimizing memory accesses.
-    As a result, the computation of the next generation is performed
-    with about 1.6 instructions per life cell, consisting of .125
-    memory accesses, .17 shifts, and 1.3 logic operations.  The net
-    result is that the time to transfer the bits to the X server, and
-    for the X server to draw them on the screen, dominates the time to
-    compute the next generation.
+The algorithm used to compute the next generation is based on the
+observation that a cell's state in the next generation is a boolean
+function of its current state, and the states of its 8 neighbors
+(ie, a boolean function from 9 bits to 1 bit).  This function can
+be computed by a boolean circuit.  In addition, intermediate values
+computed by the circuit can be shared between neighboring cells,
+reducing the number of gates per cell required.  These ideas
+have been used before, to compute the next generation through a
+series of bit blits.  Instead of doing this, we map values in the
+circuit to bits in registers, so that the next generation can be
+computed efficiently within registers, minimizing memory accesses.
+As a result, the computation of the next generation is performed
+with about 1.6 instructions per life cell, consisting of .125
+memory accesses, .17 shifts, and 1.3 logic operations.  The net
+result is that the time to transfer the bits to the X server, and
+for the X server to draw them on the screen, dominates the time to
+compute the next generation.
+
 
 Copyright (c) 1991, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -18,33 +18,34 @@
 
 ## Judges' comments
 
-    Make and run as follows:
+Make and run as follows:
     
 	make dds
-    For example, the author suggests trying:
+
+For example, the author suggests trying:
      
 	dds LANDER.BAS
 	a.out
 
-    Notice that a file a.c has been generated.  Can you tell how a.c was
-    produced?  How does a.c relate to LANDER.BAS?
+Notice that a file a.c has been generated.  Can you tell how a.c was
+produced?  How does a.c relate to LANDER.BAS?
 
-    This obfuscated program translates BASIC programs into obfuscated
-    C programs by way of an obfuscated algorithm.
+This obfuscated program translates BASIC programs into obfuscated
+C programs by way of an obfuscated algorithm.
 
-    NOTE: Due to minor problems with some strict ANSI C compilers, we 
-	  have supplied a more portable ANSI version.
+NOTE: Due to minor problems with some strict ANSI C compilers, we 
+have supplied a more portable ANSI version.
 
 
 ## Author's comments
 
-    This program is a companion to the DDS-BASIC interpreter program that
-    was submitted to the contest in 1990.  This compiles BASIC programs into
-    executable commands.  The input format is almost identical to the input
-    format of the DDS-BASIC interpreter.  The program needs an executable C
-    compiler called `cc' in your path in order to work.
+This program is a companion to the DDS-BASIC interpreter program that
+was submitted to the contest in 1990.  This compiles BASIC programs into
+executable commands.  The input format is almost identical to the input
+format of the DDS-BASIC interpreter.  The program needs an executable C
+compiler called `cc' in your path in order to work.
 
-    Program commands:
+Program commands:
 
 	variable names A to Z		variables initialized to 0 on RUN
 	FOR var = exp TO exp		NEXT variable
@@ -54,22 +55,22 @@
 	PRINT exp			var = exp
 	REM any text			END
 
-    Expressions are the same as the expressions of the C language.
-    Many system calls and C library calls can be used.
+Expressions are the same as the expressions of the C language.
+Many system calls and C library calls can be used.
 
-    Input format:
+Input format:
 
-	- Free format positioning of tokens on the line.
-	- No space is allowed before the line number.
-	- Exactly one space is needed after the FOR and NEXT tokens
-	- ALL INPUT MUST BE UPPERCASE.
+- Free format positioning of tokens on the line.
+- No space is allowed before the line number.
+- Exactly one space is needed after the FOR and NEXT tokens
+- ALL INPUT MUST BE UPPERCASE.
 
-    Error checking / error reports:
+Error checking / error reports:
 
-	The compiler silently ignores many errors.
-	Other errors may produce errors in later phases of the compilation.
+The compiler silently ignores many errors.
+Other errors may produce errors in later phases of the compilation.
 
-Can you figure out how the compiler works?  Hint (rot13):
+Can you figure out how the compiler works?  Hint:
 
     The compiler is NOT written in C, so this is really a meta-obfuscated
     program.  The C code is an intepreter for the four register, seven

--- a/1991/fine/README.md
+++ b/1991/fine/README.md
@@ -11,7 +11,7 @@
 
         make all
 
-### To run
+### Try:
 
 	echo "green terra
 vex
@@ -23,24 +23,24 @@ clerk" | ./fine
 
 ## Judges' comments
 
-    This filter, 80 chars plus a newline, fits into a single line on most 
-    terminals (unless your terminal has a line wrap mis-feature :-)).
+This filter, 80 chars plus a newline, fits into a single line on most 
+terminals (unless your terminal has a line wrap mis-feature :-)).
 
-    This entry is likely one of the smallest C implementations of this
-    filter, excluding programs that resort to command line or include 
-    file tricks.
+This entry is likely one of the smallest C implementations of this
+filter, excluding programs that resort to command line or include 
+file tricks.
 
-    How does this program work?  Which 3 bytes of C code can be changed
-    into 2 bytes, allowing the program to still work, but also stripping 
-    the high bit off of some input?
+How does this program work?  Which 3 bytes of C code can be changed
+into 2 bytes, allowing the program to still work, but also stripping 
+the high bit off of some input?
 
 ## Author's comments
 
-    The author wishes to thank J Greely for the last 6 bytes.
+The author wishes to thank J Greely for the last 6 bytes.
 
-    Here's about how it does it:  [rot13 to read]
+Here's about how it does it:  [rot13 to read]
 
-    
+
     ABGR:  Ovgf ner ersreerq gb nf 76543210, uvtu gb ybj.
     
     1.  Trg gur punenpgre va inevnoyr n.  Abgr gur sha jnl jr purpx sbe RBS.

--- a/1991/rince/README.md
+++ b/1991/rince/README.md
@@ -12,20 +12,20 @@
 
         make all
 
-### To run
+### To run:
 
 	./rince
 
-## Judges' comments
+## Judges' comments:
 
-    This entry has been updated to allow most ANSI C compiler.
+This entry has been updated to allow most ANSI C compiler.
 
 ## Author's comments
 
-    This program is a simple puzzle type game. (I'll leave you to play
-    it to see the rest of it .. :-) .)  The general idea was to try and
-    write the smallest playable game, but keep the playability and
-    enjoyment high. 
+This program is a simple puzzle type game. (I'll leave you to play
+it to see the rest of it .. :-) .)  The general idea was to try and
+write the smallest playable game, but keep the playability and
+enjoyment high. 
     
 		    Instructions (rot 13 to read).
 		    ==============================

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -11,19 +11,19 @@
 
 ### To run
 
-    Make and run as follows:
+Make and run as follows:
 
 	./westley [move_location] | tee nextmove.c
     
-    where the 'move_location' is a digit from 1 to 9 that represents
-    a move on a tic-tac-toe board:
+where the 'move_location' is a digit from 1 to 9 that represents
+a move on a tic-tac-toe board:
 
 		1 2 3
 		4 5 6
 		7 8 9
 
-    If you omit 'move_location', then the computer moves first.  For your 
-    next move, recompile nextmove.c and play it again:
+If you omit 'move_location', then the computer moves first.  For your 
+next move, recompile `nextmove.c` and play it again:
 
 	make nextmove
 	./nextmove move_location | tee nextmove.c

--- a/1991/westley/ttt.sh
+++ b/1991/westley/ttt.sh
@@ -61,7 +61,7 @@ if [ ! -f merlyn.c ]; then
     fi
     # check to see if the copy worked
     if [ ! -f merlyn.c ]; then
-	echo "ttt: Darn, coundn't copy westley.c to merlyn.c" 1>&2
+	echo "ttt: Darn, couldn't copy westley.c to merlyn.c" 1>&2
 	exit 4
     fi
 fi
@@ -85,9 +85,9 @@ fi
 if [ ! -w ttt_game.c ]; then
     rm -f ttt_game.c 
     if [ -z "$move" ]; then
-	merlyn | tee ttt_game.c
+	./merlyn | tee ttt_game.c
     else
-	merlyn "$move" | tee ttt_game.c
+	./merlyn "$move" | tee ttt_game.c
     fi
     chmod +w ttt_game.c
 

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -37,8 +37,8 @@ Both albert and albert.orig loop without printing anything, although
 the first factor is 101 and is usually found in an instant.
 ```
 
-The `albert.c` file is the fixed file, where as the `albert.alt.c`
-is file before aookying Leo Broukhis' fix.
+The `albert.c` file is the fixed file, whereas the `albert.alt.c`
+is the file before applying Leo Broukhis' fix.
 
 To compile this alternate version:
 
@@ -48,69 +48,69 @@ Use `albert.alt` as you would `albert` above.
 
 ## Judges' comments
     
-    We were impressed with the speed at which it was able to factor
-    arbitrarily large numbers consisting of factors that fit into
-    a long.
+We were impressed with the speed at which it was able to factor
+arbitrarily large numbers consisting of factors that fit into
+a long.
 
 ## Author's comments
 
-    The Obfuscated version of the Horst algorithm.
+The Obfuscated version of the Horst algorithm.
 
-    This program will factor unlimited length numbers and print the 
-    factors in ascending order. Numbers of one digit (e.g. 8) 
-    are rejected without notice.
-    It quits as soon as there is at most one
-    factor left, but that factor will not be shown. 
-    It accomplishes this efficiently, without resorting to division
-    or multiplication, until the candidate factor no longer fits in 
-    a signed long. 
+This program will factor unlimited length numbers and print the 
+factors in ascending order. Numbers of one digit (e.g. 8) 
+are rejected without notice.
+It quits as soon as there is at most one
+factor left, but that factor will not be shown. 
+It accomplishes this efficiently, without resorting to division
+or multiplication, until the candidate factor no longer fits in 
+a signed long. 
 
-    The nicest way is to rename the program into e.g. 4294967297
-    if you want to factor Fermat's 4th number. Then just run it.
-    Or you may type "prog <some-number>"
-    A nice one is also (30 ones)
-    albert 111111111111111111111111111111
+The nicest way is to rename the program into e.g. 4294967297
+if you want to factor Fermat's 4th number. Then just run it.
+Or you may type "prog <some-number>"
+A nice one is also (30 ones)
+albert 111111111111111111111111111111
 
-    Apart from the foregoing there are no special execution instructions.
+Apart from the foregoing there are no special execution instructions.
 
-    To customize the program into a factorizer of a fixed number, use
-    cc albert.c -o 4294967297
-    or some such.
+To customize the program into a factorizer of a fixed number, use
+cc albert.c -o 4294967297
+or some such.
 
-    There are no data files used, and it is not possible to feed input
-    via stdin.
+There are no data files used, and it is not possible to feed input
+via stdin.
 
-    I think this program is a nice example of algorithmic obfuscation.
-    Several times two similar algorithms are merged into one. Then you 
-    need quite some tricks to get it running, such as long jumps 
-    through recursive subroutines. I felt like a sword smith, 
-    welding the sword very long, folding it again to the proper 
-    length, keep on hammering till it is tight, then fold again.
-    Always keeping it at the proper red hot temperature, but not too
-    hot lest the hardness fades.
-    The strict naming conventions for subroutines did not make things 
-    much clearer after all, but it was not supposed to.
+I think this program is a nice example of algorithmic obfuscation.
+Several times two similar algorithms are merged into one. Then you 
+need quite some tricks to get it running, such as long jumps 
+through recursive subroutines. I felt like a sword smith, 
+welding the sword very long, folding it again to the proper 
+length, keep on hammering till it is tight, then fold again.
+Always keeping it at the proper red hot temperature, but not too
+hot lest the hardness fades.
+The strict naming conventions for subroutines did not make things 
+much clearer after all, but it was not supposed to.
 
-    I would like to draw attention to the robustness of the program
-    with respect to error handling and the nice stopping criterion.
-    The esthetic appeal of some lines is at the expense of clearness, 
-    I apologize.
-    Running the program through the c-beautifier reveals nothing,
-    it will only destroy some of the lay out.
-    Running the program through lint shows the usual remarks for a
-    K&R program. Defeating this through casts does not make a program 
-    cleaner in my opinion.
+I would like to draw attention to the robustness of the program
+with respect to error handling and the nice stopping criterion.
+The aesthetic appeal of some lines is at the expense of clearness, 
+I apologize.
+Running the program through the c-beautifier reveals nothing,
+it will only destroy some of the lay out.
+Running the program through lint shows the usual remarks for a
+K&R program. Defeating this through casts does not make a program 
+cleaner in my opinion.
 
-    Here are some hints, but they may not be too helpful.
-    1. The Horst algorithm is described in the Hobby Computer Club 
-	Newsletter, year 82, part 4, a real Dutch treat.
-       Assembler, c and Forth version have been around for some years.
-    2. Does fractal programming exist after all?
-    3. You remember the ToomCook algorithm in Knuth?
-       It uses iteration instead of recursion and is quite jumpy.
-       This program shares these disadvantages in a modified form.
-    4. The Conversion is to be found in Knuth, not so the Observation.
-       The Observation: "if it ends in a zero, it is divisible by ten"
+Here are some hints, but they may not be too helpful.
+1. The Horst algorithm is described in the Hobby Computer Club 
+Newsletter, year 82, part 4, a real Dutch treat.
+Assembler, c and Forth version have been around for some years.
+2. Does fractal programming exist after all?
+3. You remember the ToomCook algorithm in Knuth?
+It uses iteration instead of recursion and is quite jumpy.
+This program shares these disadvantages in a modified form.
+4. The Conversion is to be found in Knuth, not so the Observation.
+The Observation: "if it ends in a zero, it is divisible by ten"
 
 Copyright (c) 1992, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is


### PR DESCRIPTION
Mostly formatting fixes but some typos were fixed as well. This commit is being made now so I can roll back ad04d21fda51110ce1d6c4ef02bfbb549e65c1ce as it seems to have been a mistake to do. Another way to more easily identify same authors will have to be figured out, perhaps in future files that are yet to be generated. This upcoming commit will hopefully not cause any problems  but if there are any they will be worked out.

Landon and I both came to the same conclusion that although the renaming directories seemed to have been warranted in theory they shouldn't have been renamed after all. This was briefly discussed in issue #3.