### PR TITLE
Fix 1992/westley to compile with clang

### DIFF
--- a/1992/westley/.gitignore
+++ b/1992/westley/.gitignore
@@ -1,1 +1,2 @@
 westley
+whereami

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -183,7 +183,7 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry might not compile when using modern compilers."
+	@echo "NOTE: your terminal must wrap at 80 columns for this to work right!"
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 whereami: ${PROG}

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -10,7 +10,12 @@
 
         make all
 
-	NOTE: This entry might not compile when using modern compilers.
+
+NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
+work with clang by changing the third and fourth arg of main() to be ints inside
+main(); clang requires args 2 - 4 to be `char **`. Thank you Cody for your
+assistance!
+
 
 ### To run
 
@@ -22,14 +27,25 @@
 
 	./whereami lat long
 
-## Judges' comments
-    
-    Where lat and long correspond to your latitude and longitude.
+Where lat and long correspond to your latitude and longitude.
 
-    To find the approximate place where this entry was judged, type:
+NOTE: you must have a terminal that wraps at 80 columns (!) in order for this to
+show correctly!
+
+
+## Try:
+
+	./whereami 47 -122	(- means west of meridian)
+	./whereami 47 122
+
+
+## Judges' comments:
+
+To find the approximate place where this entry was judged, type:
 
 	./whereami 37 -122	(- means west of meridian)
-    
+
+   
 ## Author's comments
 
     Run the program with your latitude & longitude as integer

--- a/1992/westley/westley.c
+++ b/1992/westley/westley.c
@@ -1,5 +1,5 @@
            main(l
-      ,a,n,d)char**a;{
+   ,a)char**a;{int n;int d;
   for(d=atoi(a[1])/10*80-
  atoi(a[2])/5-596;n="@NKA\
 CLCCGZAAQBEAADAFaISADJABBA^\


### PR DESCRIPTION
Since the third and fourth args of main() were being used as ints I have made them ints inside main() as clang does not allow the second, third or fourth args to main() to be anything but char **. An important note (which the author noted but which I put in the Makefile as well as under the 'To run:' section) is that the terminal must wrap at 80 columns in order for this to work right. I had to shrink down the terminal size to get to show that this change worked okay - it was the simplest way I could think of to do it.