### PR TITLE
Remove alt target from TARGETS in 1998/schweikh2

### DIFF
--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -164,7 +164,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} ${PROG}.alt
+TARGET= ${PROG}
 #
 ALT_OBJ= ${PROG}.alt.o
 ALT_TARGET= ${PROG}.alt

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -13,9 +13,9 @@
 
         make all
 
-	NOTE: Almost every compiler is supposed to be able to accept the code in
-	schweikh2.c; try compiling schweikh2.alt.c to see if your compiler
-	is fully standard-compliant.
+NOTE: Almost every compiler is supposed to be able to accept the code in
+schweikh2.c; try compiling schweikh2.alt.c to see if your compiler
+is fully standard-compliant.
 
 ### To run
 

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -10,6 +10,11 @@
 make
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) made this more
+portable by changing the return type of `main()` to be `int` not `void`. Thank
+you Cody for your assistance!
+
+
 ### To run:
 
 ```sh

--- a/2000/primenum/primenum.c
+++ b/2000/primenum/primenum.c
@@ -1,8 +1,8 @@
-#define BeginProgram void main(int argc, char *argv[])
+#define BeginProgram int main(int argc, char *argv[])
 #define CloseBrace }
 #define CommandLineArgument -1
 #define Declare int i,j,n,Flag=1;
-#define EndOfProgram return;
+#define EndOfProgram return 0;
 #define False 0;
 #define ForLoop ;for
 #define GetCommandLineArgument n=atoi(argv[1]);


### PR DESCRIPTION

This is because it doesn't compile in all systems though it is supposed 
to I think.
