### PR TITLE
Remove now invalid note in 1992/brnstnd/Makefile

### DIFF
--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -6,10 +6,12 @@ Dave Decot
 
         make all
 
-NOTE: On modern systems this entry requires the option `-traditional-cpp` which
-clang does not support. We thank Yusuke Endoh for his patch which allows the
-entry to compile under gcc! Please be advised that gcc under macOS is actually
-clang so this will not compile with the default gcc under macOS.
+NOTE: [Yusuke Endoh](/winners.html#Yusuke_Endoh) supplied a patch so that this
+entry would compile with gcc.
+
+NOTE: this entry requires a compiler that supports `-traditional-cpp`. Note that
+clang does not support it and in macOS gcc is actually clang so this will not
+compile with the default compiler in macOS.
 
 ## To run:
 

--- a/1985/applin/README.md
+++ b/1985/applin/README.md
@@ -11,9 +11,9 @@ Jack Applin [with help from Robert Heckendorn]
 	./applin
 
 
-NOTE: Yusuke Endoh provided a patch to get this to not issue a bus error. Thank
-you Yusuke! We note that this entry does not work under macOS. Try it out and
-see for yourself what happens!
+NOTE: [Yusuke Endoh](/winners.html#Yusuke_Endoh) provided a patch to get this to
+not issue a bus error. Thank you Yusuke! We note that this entry does not work
+under macOS. Try it out and see for yourself what happens!
 
 
 ## Judges' comments:

--- a/1986/holloway/README.md
+++ b/1986/holloway/README.md
@@ -10,7 +10,7 @@ USA
         make all
 
 
-NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
 compile and work with clang (it already worked with gcc).  The problem was that
 clang is more strict about the type of second arg to main(). However simply
 changing it to a `char **` and updating the `*s` to `**s` caused a segfault. By

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -11,11 +11,12 @@ Paoli, PA.
         make all
 
 
-NOTE: Cody Boone Ferguson got this to compile and work with clang. It did not
-work with clang because it is more strict about the second and third args to
-main() and the third arg was an int. He notes that he tried to keep the picture
-as close to the original. The line lengths are the same but some spaces had to
-be changed to non-spaces. Thank you Cody for your help!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) got this to
+compile and work with clang. It did not work with clang because it is more
+strict about the second and third args to main() and the third arg was an int.
+He notes that he tried to keep the picture as close to the original. The line
+lengths are the same but some spaces had to be changed to non-spaces. Thank you
+Cody for your help!
 
 ## Try:
 

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -11,11 +11,14 @@ US of A
         make all
 
 
+We used a patch provided by [Yusuke Endoh](/winners.html#Yusuke_Endoh) to make
+this work with gcc. Thank you Yusuke!
+
 NOTE: On modern systems this entry requires the option `-traditional-cpp` which
 clang does not support. Please be advised that gcc under macOS is actually
 clang so this will not compile with the default gcc under macOS. As this entry
-stood in modern systems it did not work even when compiled. We used a patch
-provided by Yusuke Endoh to make it work. Thank you Yusuke!
+stood in modern systems it did not work even when compiled.
+
 
 ## Judges' comments:
 

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -11,8 +11,9 @@ USA
 
         make all
 
-NOTE: Cody Boone Ferguson fixed this so it could compile on modern systems. For
-the original file see below.
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for
+modern systems. For the original file see below. Thank you Cody for your
+assistance!
 
 
 ## Alternate code:

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -13,7 +13,8 @@
 
 
 NOTE: we were able to get this to compile under modern systems with a patch from
-Yusuke Endoh. Thank you for your assistance Yusuke!
+[Yusuke Endoh](/winners.html#Yusuke_Endoh). Thank you for your assistance
+Yusuke!
 
 ## To run:
 

--- a/1989/tromp/README.md
+++ b/1989/tromp/README.md
@@ -16,12 +16,14 @@ to get this to compile under gcc. Thank you Yusuke for your assistance!
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) got this to work with
 clang by further changing the variable `a` to be not the third argument to
-`main()` and instead be a variable declared in `main()`. Cody also bug fixed it
-so that the high score file would work (it was not even being created) and after
-this making sure the terminal stayed sane (the letter `u` could not be typed and
-echo was disabled outright after the segfault fix / high score file was
-reinstated). We thank you for your assistance Cody (he cynically notes that he
-did it because tetris just has to work)!
+`main()` and instead be a variable declared in `main()`.
+
+Cody also bug fixed it so that the high score file would work (it was not even
+being created) and after this making sure the terminal stayed sane (the letter
+`u` could not be typed and echo was disabled outright after the segfault fix /
+high score file was reinstated). We thank you for your assistance Cody (he
+cynically notes that he did it because tetris just has to work)!
+
 
 ### Alternate code:
 

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -12,7 +12,7 @@
 	make all
 
 
-NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) was able to get
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) was able to get
 this to partially work with clang; clang requires that the second, third and
 fourth args to main() be `char **`. Only `westley.c` and `ver0.c` (see below) will
 compile with clang. It's possible to get ver1.c to compile too but this causes

--- a/1990/cmills/README.md
+++ b/1990/cmills/README.md
@@ -14,8 +14,10 @@
 
     ./cmills [starting_cash]
 
-NOTE: we used a patch from Yusuke Endoh to get this to work in modern systems
-(it resulted in a bus error otherwise). Thank you Yusuke for your assistance!
+We used a patch from [Yusuke Endoh](/winners.html#Yusuke_Endoh) to get this to
+work in modern systems (it resulted in a bus error otherwise). Thank you Yusuke
+for your assistance!
+
 
 ### Try:
 

--- a/1990/dds/README.md
+++ b/1990/dds/README.md
@@ -11,8 +11,8 @@
 	make all
 
 
-Modern compilers could not compile this entry but Yusuke Endoh supplied a patch
-which lets it compile. Thank you Yusuke!
+[Yusuke Endoh](/winners.html#Yusuke_Endoh) fixed this for modern systems. Thank
+you Yusuke!
 
 ### To run
 

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -23,8 +23,9 @@
 
     make all
 
-NOTE: as `btoa` is not common we used a ruby script from Yusuke Endoh. Thank you
-Yusuke for your implementation of `btoa`!
+NOTE: as `btoa` is not common we used a ruby script from [Yusuke
+Endoh](/winners.html#Yusuke_Endoh). Thank you Yusuke for your implementation of
+`btoa`!
 
 ### Try:
 

--- a/1990/scjones/README.md
+++ b/1990/scjones/README.md
@@ -20,7 +20,8 @@ Modern compilers might fail to compile this entry:
 
 
 but we were able to get it to compile with modern compilers by specifying the
-`-ansi` flag with a tip from Yusuke Endoh. Thank you Yusuke!
+`-ansi` flag with a tip from [Yusuke Endoh](/winners.html#Yusuke_Endoh). Thank
+you Yusuke! 
 
 
 ### To run:

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -17,16 +17,28 @@
 
         make all
 
-NOTE: modern compilers had a problem with this entry because the `exit(3)`
-function returns void but [Cody Boone Ferguson](/winners#Cody_Boone_Ferguson)
-got it to work with the use of a comma operator. Thank you Cody!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to work with
+modern computers; `exit(3)` returns void but the function was used in a binary
+expression so this would not even compile. Thank you Cody for your assistance!
 
-### To run
+
+## To run:
 
 	./tbr
+	# enter some shell commands
+
+## Try:
+
+	./tbr
+	ls -l tbr tbr.c
+	# notice how the following does not work:
+	ls tbr*
+	# try figuring out how this entry works in an editor:
+	vi tbr.c
+	# then figure out how to exit vi :-)
 
 
-## Judges' comments
+## Judges' comments:
 
 
 This program touches on a well known Unix utility, the 6th edition Bourne Shell
@@ -53,6 +65,8 @@ of the program which we include below:
 
 
 ## Author's comments
+
+Rot13:
 
     Guvf cebtenz vf n ehqvzragnel furyy. Vg qbrf v/b erqverpgvba, cvcrf
     naq pq. Vg syntf reebef ba snvyrq puqve'f, bcra'f, perng'f

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -11,10 +11,12 @@
 
         make all
 
-NOTE: thanks to Yusuke Endoh for the pointing out that `atof()` nowadays needs
-`#include <stdlib.h>` in order to get this to work. Thanks also to Cody Boone
-Ferguson for fixing some segfaults under modern (and in some cases earlier)
-systems with this entry.
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some segfaults
+under modern (and in some cases earier) systems with this entry. Thank you Cody!
+
+[Yusuke Endoh](/winners.html#Yusuke_Endoh) pointed out that `atof` nowadays
+needs `#include <stdlib.h>` which was used in order to get this to work
+initially. Thank you Yusuke!
 
 
 ## To run:

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -183,7 +183,6 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry might not compile when using modern compilers."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -12,24 +12,30 @@
 
 ### To run
 
-	./westley 1
+	./westley number
 
-NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
-compile under modern systems. Thank you Cody for your assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for modern
+systems. Thank you Cody for your assistance!
 
 NOTE: this entry will segfault without an arg and will enter an infinite loop if
-input is not a number (or is a negative number).
+input is not a positive number.
 
+
+## Try:
+
+	./westley 1
+	./westley 2
+	./westley 3
+	./westley 5
 
 ## Judges' comments
 
-    usage: westley <number>
 
-    If you would rather "Daisy" someone other than Westley, rename 
-    the program as needed.  :-)
+If you would rather "Daisy" someone other than Westley, rename 
+the program as needed.  :-)
 
-    Read each block of code as if it were a piece of correspondence.
-    For example, the first block of code would read:
+Read each block of code as if it were a piece of correspondence.
+For example, the first block of code would read:
 
 	charlie,
 		doubletime me, OXFACE!
@@ -37,30 +43,30 @@ input is not a number (or is a negative number).
 		mainly die, charly, *die*
 			signed charlotte
 
-    The original source had control-L's after each code block.  To 
-    make it easier on news readers, we converted each control-L to 
-    a blank line.
+The original source had control-L's after each code block.  To 
+make it easier on news readers, we converted each control-L to 
+a blank line.
 
-    Some modern compilers will not accept '1s' as a short integer - for
-    these compilers we replaced the instances of `1s` with `1`.
+Some modern compilers will not accept '1s' as a short integer - for
+these compilers we replaced the instances of `1s` with `1`.
 
 
 ## Author's comments
 
-    This is a "Picking the Daisy" simulation.  Now, instead of mangling a 
-    daisy, simply run this program with the number of petals desired as 
-    the argument.
-    
-    This is a good counter-example to peoples' complaints that C doesn't
-    have an "English-like" syntax.
-    
-    Lint complains about everything - null effect, xxx may be used before
-    set, statement not reached, return(e) and return.  Lint dumps core
-    on some systems.  My personal favorite lint complaint is
-    
+This is a "Picking the Daisy" simulation.  Now, instead of mangling a 
+daisy, simply run this program with the number of petals desired as 
+the argument.
+
+This is a good counter-example to peoples' complaints that C doesn't
+have an "English-like" syntax.
+
+Lint complains about everything - null effect, xxx may be used before
+set, statement not reached, return(e) and return.  Lint dumps core
+on some systems.  My personal favorite lint complaint is
+
     	"warning: eroticism unused in function main".
     
-    Also obviously, (char)lotte and (char*)lie are incompatible types...
+Also obviously, `(char)lotte` and `(char*)lie` are incompatible types...
 
 Copyright (c) 1990, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1991/ant/.gitignore
+++ b/1991/ant/.gitignore
@@ -1,1 +1,2 @@
 ant
+hill

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -185,7 +185,6 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry might not compile when using modern compilers."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/1991/brnstnd/README.md
+++ b/1991/brnstnd/README.md
@@ -7,13 +7,13 @@
 
         make all
 
-NOTE: [Cody Boone Ferguson](/winners#Cody_Boone_Ferguson) fixed this for modern
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for modern
 systems. There were two invalid operands to binary expression (`char *` and
-`void` and `int` and `void`) to resolve and a feature of the C pre-processor
-which no longer works had to be changed as well. In particular `#define C =G` in
-a macro to make `+=` and similar operators no longer works. The invalid operands
-to binary expressions were resolved with the comma operator. Thank you Cody for
-your assistance!
+`void` and `int` and `void`) to resolve and additionally a mis-feature of the C
+pre-processor which no longer works had to be changed as well in order to get
+this to compile. In particular the macro `C`, defined as `C =G` to make `+=` and
+similar operators no longer works.  The invalid operands to binary expressions
+were resolved with the comma operator. Thank you Cody for your assistance!
 
 
 ### Try:

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -11,10 +11,9 @@
         make all
 
 
-NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
-work with clang by changing the third and fourth arg of main() to be ints inside
-main(); clang requires args 2 - 4 to be `char **`. Thank you Cody for your
-assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for clang by
+changing the third and fourth arg of main() to be ints inside main(); clang
+requires args 2 - 4 to be `char **`. Thank you Cody for your assistance!
 
 
 ### To run
@@ -29,7 +28,7 @@ assistance!
 
 Where lat and long correspond to your latitude and longitude.
 
-NOTE: you must have a terminal that wraps at 80 columns (!) in order for this to
+NOTE: you **MUST** have a terminal that wraps at 80 columns (!) in order for this to
 show correctly!
 
 

--- a/1993/jonth/README.md
+++ b/1993/jonth/README.md
@@ -10,7 +10,8 @@
 
         make all
 
-	NOTE: This entry might not compile when using modern compilers.
+NOTE: this entry might not compile with modern systems.
+
 
 ### To run
 
@@ -18,24 +19,22 @@
 
 ## Judges' comments
 
-    Use 'h' and 'l' to shift objects left or right.  Use 'k' to
-    rotate and press SPACE to drop.
+Use 'h' and 'l' to shift objects left or right.  Use 'k' to
+rotate and press SPACE to drop.
 
-    This program's output may be even more obfuscated when played 
-    on inverse video.  :-)
+This program's output may be even more obfuscated when played 
+on inverse video.  :-)
 
-    Yusuke Endoh provided a patch which allows this entry to compile on modern
-    systems. Thank you Yusuke!
 
 ## Author's comments
 
-    This is jonth (jon's t(h)etris) for the X Window System.
+This is jonth (jon's t(h)etris) for the X Window System.
 
-    This program is also an example of data abstraction.  The X array is 
-    after initialization hidden by the well defined macros t, u and F.
+This program is also an example of data abstraction.  The X array is 
+after initialization hidden by the well defined macros t, u and F.
 
-    This program is highly portable as it runs on a "Notebook" size SPARC.
-    This program will not work on machines with sizeof(int)!=sizeof(void *).
+This program is highly portable as it runs on a "Notebook" size SPARC.
+This program will not work on machines with sizeof(int)!=sizeof(void *).
 
 Copyright (c) 1993, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1993/jonth/README.md
+++ b/1993/jonth/README.md
@@ -10,7 +10,9 @@
 
         make all
 
-NOTE: this entry might not compile with modern systems.
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so that it
+will work with modern systems. Thank you Cody for your assistance!
 
 
 ### To run
@@ -34,7 +36,7 @@ This program is also an example of data abstraction.  The X array is
 after initialization hidden by the well defined macros t, u and F.
 
 This program is highly portable as it runs on a "Notebook" size SPARC.
-This program will not work on machines with sizeof(int)!=sizeof(void *).
+This program will not work on machines with `sizeof(int)!=sizeof(void *)`.
 
 Copyright (c) 1993, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1993/jonth/jonth.c
+++ b/1993/jonth/jonth.c
@@ -1,22 +1,22 @@
 #include <X11/Xlib.h>
-  G	long i,j
-  K	case
-  R	return 0
-  S(	x,y) for(x=0; x<y; x++)
-  I	S(i,10
-  z	I-6)B[t][u
-  t	(X[m].b[i].i+g)
-  u	(X[m].b[i].j+l)
-  M(	x,y) XFillRectangles(D,p,x,a,y);
-  s	B[i][j
-  W	=XCreateGC(D,p,4,L)
-  E(	W,_) k=0; I)S(j,22)if(W s]){ a[k].x=i*20; a[k].y=j*20+30; a[k].w=a[k].h=_; k++; }M(
-  A(	W,_) &&!B[W]; if(!j){ z]=1; R; } else{ N(m); _; v(0); }
-  Q	]=0; I-6&&j)j=
-  F	I-6)B[X[w].b[i].i+g][X[w].b[i].j+l
-  e(	x) break; K x:q(c,j,x);
-  H	(m){ G; I-6){ a[i].x=t*20; a[i].y=u*20+30; a[i].w=a[i].h=
-  v(	_) d(m); z+_]=1; R+1;
+#define  G	long i,j
+#define  K	case
+#define  R	return 0
+#define  S(	x,y) for(x=0; x<y; x++)
+#define  I	S(i,10
+#define  z	I-6)B[t][u
+#define  t	(X[m].b[i].i+g)
+#define  u	(X[m].b[i].j+l)
+#define  M(	x,y) XFillRectangles(D,p,x,a,y);
+#define  s	B[i][j
+#define  W	=XCreateGC(D,p,4,L)
+#define  E(	W,_) k=0; I)S(j,22)if(W s]){ a[k].x=i*20; a[k].y=j*20+30; a[k].w=a[k].h=_; k++; }M(
+#define  A(	W,_) &&!B[W]; if(!j){ z]=1; R; } else{ N(m); _; v(0); }
+#define  Q	]=0; I-6&&j)j=
+#define  F	I-6)B[X[w].b[i].i+g][X[w].b[i].j+l
+#define  e(	x) break; K x:q(c,j,x);
+#define  H	(m){ G; I-6){ a[i].x=t*20; a[i].y=u*20+30; a[i].w=a[i].h=
+#define  v(	_) d(m); z+_]=1; R+1;
 struct{
 	short x,y,w,h;
 } a[220],C;

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -97,7 +97,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h -include stdlib.h -include time.h
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
@@ -169,6 +169,11 @@ TARGET= ${PROG}
 ALT_OBJ=
 ALT_TARGET=
 
+# FORCE use of -trigraphs
+#
+CFLAGS+= -trigraphs
+
+
 
 #################
 # build the entry
@@ -182,6 +187,7 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	@echo "NOTE: this entry uses gets() so you might get a warning compiling and/or running this."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -10,24 +10,40 @@
 
         make all
 
-### To run
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so it would
+compile and work with modern compilers. Thank you Cody for your assistance!
+
+NOTE: this entry uses `gets()` so you will likely get a warning on compilation
+and/or execution of the program.
+
+
+## To run:
 
 	./ldb < file
 
-    Try:
+	some_command | ./ldb
+
+NOTE: input lines must be under 232 characters long.
+
+## Try:
+
 	./ldb < /etc/passwd
+
+	printf "The International Obfuscated C Code Contest\n
+		Best One-liner\n
+		by Laurion Burchall" | ./ldb
 
 ## Judges' comments
 
-    Tri-graphs are natural obfuscators.  Most C-beautifiers become 
-    C-uglifiers because they don't handle them correctly.
+Trigraphs are natural obfuscators.  Most C-beautifiers become 
+C-uglifiers because they don't handle them correctly.
 
-    Can you figure out how it prints a given random line from stdin?
+Can you figure out how it prints a given random line from stdin?
 
 ## Author's comments
 
-    All input lines must be under 232 characters long.  The compiling
-    platform should be ASCII based.
+All input lines must be under 232 characters long.  The compiling
+platform should be ASCII based.
 
 Copyright (c) 1994, Landon Curt Noll & Larry Bassel.
 All Rights Reserved.  Permission for personal, educational or non-profit use is

--- a/1994/ldb/ldb.c
+++ b/1994/ldb/ldb.c
@@ -1,1 +1,1 @@
-int _,O,__??('}'??);main(){while(O?gets((rand()%O++?':':_)+__)||puts(&__??(_??))&_:srand(time((O+++_)))||O);}
+int _,O,__??('}'??);main(){while(O?gets((rand()%O++?':':_)+__)||puts(&__??(_??))&_:(srand(time((O+++_))),0)||O);}

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -97,7 +97,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdlib.h -include stdio.h
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -11,17 +11,23 @@
 
         make all
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so that it
+would work with macOS. Once it could compile it additionally segfaulted under
+macOS (it did not under linux) which he also fixed. Thank you Cody for your
+assistance!
+
+
 ### To run
 
 	./cdua
 
 ## Judges' comments
 
-    This could be used as the basis of an a-maze-ing screen exerciser.
+This could be used as the basis of an a-maze-ing screen exerciser.
 
 ## Author's comments
 
-   A program that generates a maze, and then solves it, all this being
-   seen by the user.  Some highlights of obfuscation are: 3 steps
-   functions in one - main(), several recursive calls with conditional
-   actions, and just one (big and ugly) statement to solve the maze.
+A program that generates a maze, and then solves it, all this being
+seen by the user.  Some highlights of obfuscation are: 3 steps
+functions in one - main(), several recursive calls with conditional
+actions, and just one (big and ugly) statement to solve the maze.

--- a/1995/cdua/cdua.c
+++ b/1995/cdua/cdua.c
@@ -4,13 +4,13 @@ char*u0="<RET> to begin... ",*u1="Already been here!",*u2="Found a wall! \
     ",*u3="Walking...        ",*u4="Finished.         ",*u5="Going back..\
 .     ",*o="\033[23;1HDone!!\n",*x="\033[2J",*y="\033[1;1H",*z="\033[%d;%\
 dH%c",*w="\033[1;1H%s",*v="\033[%d;%dH%c\033[%d;%dH%c\033[%d;%dH%c",b[1841
-];int c,d,e,f,g;typedef int(*h)();h i,j,k,l,m,n;int printf(),srand(),rand(
-),time(),getchar();int main(int a){i=printf,j=srand,k=rand,l=time,m=getchar,
-n=main;if(!c)for(j(l(0)),g=a=1000,--d;++d<1840;b[c=d]=" #\n"[d%80==79?2:d/80
-&&d%80&&d/80-22&&d%80-78]);if(!(c-1839))++c,i("%s%s%s",x,y,b);k:if(!(c-1840)
+];int c,d,e,f,g;typedef int(*h)();h i,k,l,m,n;rand(
+),time(),getchar();int main(int a){k=rand,l=time,m=getchar,
+n=main;if(!c)for(srand(l(0)),g=a=1000,--d;++d<1840;b[c=d]=" #\n"[d%80==79?2:d/80
+&&d%80&&d/80-22&&d%80-78]);if(!(c-1839))++c,printf("%s%s%s",x,y,b);k:if(!(c-1840)
 &&(b[a+2]+b[a-2]+b[a+160]+b[a-160]-4*' ')){while(b[a+(f=(e=k()%4)?e-1?e-2?-1
-:1:-80:80)*2]!='#');b[a]=b[a+f]=b[f+a+f]=' ';i(v,a/80+1,1+a%80,' ',(a+f)/80+
+:1:-80:80)*2]!='#');b[a]=b[a+f]=b[f+a+f]=' ';printf(v,a/80+1,1+a%80,' ',(a+f)/80+
 1,1+(a+f)%80,' ',(f+a+f)/80+1,1+(f+a+f)%80,' ');n(f+a+f);goto k;}else if(!(g
--a))c=1,a=162,i(w,u0),m();if(c-1){}else r b[a]!=' '?(i(w,b[a]=='.'?u1:u2),0)
-:(b[a]='.',i(w,u3),i(z,a/80+1,1+a%80,'.'),a==1676?(i(w,u4),i(o),1):n(a+1)||n
-(a+80)||n(a-80)||n(a-1)?1:(b[a]=' ',i(w,u5),i(z,a/80+1,1+a%80,' '),0));r 0;}
+-a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(printf(w,b[a]=='.'?u1:u2),0)
+:(b[a]='.',printf(w,u3),printf(z,a/80+1,1+a%80,'.'),a==1676?(printf(w,u4),printf(o),1):n(a+1)||n
+(a+80)||n(a-80)||n(a-1)?1:(b[a]=' ',printf(w,u5),printf(z,a/80+1,1+a%80,' '),0));r 0;}

--- a/1996/gandalf/README.md
+++ b/1996/gandalf/README.md
@@ -14,10 +14,10 @@
 
         make all
 
-NOTE: [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to
-compile with modern systems. As he loved the references in the code that could
-not compile he just commented it out (as little as possible). Thank you Cody for
-your assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile
+and work with modern systems. As he loved the references in the code that could
+not compile he just commented out as little as possible to get this to compile.
+Thank you Cody for your assistance!
 
 ### To run
 

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -164,7 +164,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} ${PROG}.alt
+TARGET= ${PROG}
 #
 ALT_OBJ= ${PROG}.alt.o
 ALT_TARGET= ${PROG}.alt

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -13,9 +13,9 @@
 
         make all
 
-	NOTE: Almost every compiler is supposed to be able to accept the code in
-	schweikh2.c; try compiling schweikh2.alt.c to see if your compiler
-	is fully standard-compliant.
+NOTE: Almost every compiler is supposed to be able to accept the code in
+schweikh2.c; try compiling schweikh2.alt.c to see if your compiler
+is fully standard-compliant.
 
 ### To run
 

--- a/2000/anderson/README.md
+++ b/2000/anderson/README.md
@@ -47,16 +47,17 @@ output as a depiction of a person holding two flags, using only ASCII
 characters (semaphore smileys, if you will).  For example, given the
 input "Hello, world!", the output will be:
 
-	      <>       <>       <>    <>                  <>     <>
-  _()       ()/      ()/      ()/     _\)       ()       (/_     _\)
-[] /^      |^^      /^^      /^^    [] ^^      |^^|      ^^ [] [] ^^
-  <>[      [][     <>][     <>][       ][      [][]      ][       ][
+		  <>       <>       <>    <>                  <>     <>
+      _()       ()/      ()/      ()/     _\)       ()       (/_     _\)
+    [] /^      |^^      /^^      /^^    [] ^^      |^^|      ^^ [] [] ^^
+      <>[      [][     <>][     <>][       ][      [][]      ][       ][
 
 
-	      <>    []
-  _()_      ()/     |()       ()
-[] ^^ []   /^^       ^^|     |^^|
-   ][     <>][       ][]     [][]
+		  <>    []
+      _()_      ()/     |()       ()
+    [] ^^ []   /^^       ^^|     |^^|
+       ][     <>][       ][]     [][]
+
 
 The program is obfuscated without the use of the preprocessor or any
 special compilation parameters.  In fact, the program doesn't even

--- a/2000/bellard/README.md
+++ b/2000/bellard/README.md
@@ -31,12 +31,12 @@ This code is an nice compact example of a Modular Fast Fourier Transform.
 While its output is very specific, the internal FFT has a wide variety
 of uses.
 
-Can you modify this code to produce primes such as 23523*2^70000-1,
-48594^65536+1 or 6917!-1?
+Can you modify this code to produce primes such as `23523*2^70000-1,
+48594^65536+1` or `6917!-1`?
 
 ### Alternate code:
 
-This program prints the biggest known prime number (2^6972593-1)
+This program printed the biggest known prime number (2^6972593-1)
 in base 10. It requires a few minutes. It uses a Modular Fast
 Fourier Transform to compute this number in a reasonable amount
 of time (the usual method would take ages !).

--- a/2000/bmeyer/README.md
+++ b/2000/bmeyer/README.md
@@ -1,12 +1,11 @@
 # Best Utility:
 
-Bernd Meyer
-Monash University, Melbourne, Australia
-1/832 Blackburn Rd
-Clayton, VIC 3168
-Australia
-
-http://byron.csse.monash.edu.au/
+    Bernd Meyer
+    Monash University, Melbourne, Australia
+    1/832 Blackburn Rd
+    Clayton, VIC 3168
+    Australia
+    http://byron.csse.monash.edu.au/
     
 # To build:
 

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -10,6 +10,11 @@
 make
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) made this more
+portable by changing the return type of `main()` to be `int` not `void`. Thank
+you Cody for your assistance!
+
+
 ### To run:
 
 ```sh

--- a/2000/primenum/primenum.c
+++ b/2000/primenum/primenum.c
@@ -1,8 +1,8 @@
-#define BeginProgram void main(int argc, char *argv[])
+#define BeginProgram int main(int argc, char *argv[])
 #define CloseBrace }
 #define CommandLineArgument -1
 #define Declare int i,j,n,Flag=1;
-#define EndOfProgram return;
+#define EndOfProgram return 0;
 #define False 0;
 #define ForLoop ;for
 #define GetCommandLineArgument n=atoi(argv[1]);


### PR DESCRIPTION

As yesterday I fixed the entry to compile with modern systems the 
Makefile does not need a note that it might not compile with modern 
systems.