### PR TITLE
Fix Westley's entries (dead link, .gitignore)

### DIFF
--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -1,11 +1,13 @@
 # Best Layout
 
-Brian Westley (aka Merlyn Leroy on usenet)  
-Starfire Consulting  
-1121 Hamline Ave. N. #17  
-St. Paul, MN  
-55108  
-USA  
+    Brian Westley (aka Merlyn Leroy on usenet)  
+    Starfire Consulting  
+    1121 Hamline Ave. N. #17  
+    St. Paul, MN  
+    55108  
+    USA  
+
+    http://www.westley.org
 
 ## To build:
 

--- a/1988/westley/README.md
+++ b/1988/westley/README.md
@@ -7,6 +7,8 @@
 	55108
 	U.S.A.
 
+	http://www.westley.org
+
 ## Try:
 
 	make all

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -7,6 +7,8 @@
 	55104  
 	USA
 
+	http://www.westley.org
+
 ## To build:
 
 	make all

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -6,6 +6,8 @@
 	St. Paul, MN  55104  
 	USA
 
+	http://www.westley.org
+
 ## To build:
 
         make all

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -4,6 +4,8 @@
     DigiBoard, Inc.
     1026 Blair Ave.
     St. Paul, MN  55104  USA
+    
+    http://www.westley.org
 
 ## To build:
 

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -6,6 +6,8 @@
 	St. Paul, MN  55104
 	USA
 
+	http://www.westley.org
+
 ## To build:
 
         make all

--- a/1994/westley/README.md
+++ b/1994/westley/README.md
@@ -6,6 +6,8 @@
 	St. Paul, MN  55105
 	USA
 
+	http://www.westley.org
+
 ## To build:
 
         make all

--- a/1996/dalbec/README.md
+++ b/1996/dalbec/README.md
@@ -11,7 +11,19 @@
 
         make all
 
-NOTE: This entry uses non-standard args to main() that do not work with modern compilers.
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) proposed a fix for this
+to compile with clang and Landon implemented it after some discussion. The
+reason Cody did not do it is because he thought it was the wrong output but as
+it happens the try section below was worded a bit confusingly. He looked at
+[Yusuke Endoh's](/winners.html#Yusuke_Endoh) analysis found
+[here](https://mame-github-io.translate.goog/ioccc-ja-spoilers/1996/dalbec.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp)
+but he missed that Yusuke added a '...' after the result which made him think
+the fix was wrong. Cody also made the recommended change of the author to make
+it so that each number is printed on a line by itself rather than having a long
+string of numbers on the same line. Thank you Cody for your assistance and
+thanks to Yusuke for confirming the output is correct!
+
 
 ## To run:
 
@@ -20,9 +32,9 @@ NOTE: This entry uses non-standard args to main() that do not work with modern c
 ## Try:
 
 
-	./dalbec 3
+	./dalbec 3 | head -n 29
 
-Why does it output 121?
+Why does the output end with 121?
 
 
 ## Judges' comments:

--- a/1996/dalbec/dalbec.c
+++ b/1996/dalbec/dalbec.c
@@ -9,7 +9,7 @@ int cain(int I, char **O, int O0, int OO, int l)
 		!(OO-l+!I||I)?l-1:cain(I-!I-!!I,O,OO,OO,l))
 	:(O0+OO)%l
 	:cain(I-I/I-I/I,O,O0,OO+OO/OO,
-		cain(0,O,O0,OO,I-I-I)+I+1?1:printf("%d ",I-I-I)+fflush(stdout))
+		cain(0,O,O0,OO,I-I-I)+I+1?1:printf("%d\n",I-I-I)+fflush(stdout))
 	:cain(I-I-I-I-I,O,I+I-I+I,I,0)
 	:cain(~!!I-!!I,O,atoi(1[O]),1,atoi(0[O]));
 }

--- a/1996/westley/.gitignore
+++ b/1996/westley/.gitignore
@@ -1,1 +1,2 @@
 westley
+westley.alt

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -167,8 +167,8 @@ OBJ= ${PROG}.o
 DATA= clock1 clock2 clock3
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= westley.alt.o
+ALT_TARGET= westley.alt
 
 
 #################

--- a/1996/westley/README.md
+++ b/1996/westley/README.md
@@ -5,7 +5,7 @@
     St. Paul, MN  55105
     USA
 
-    http://www.visi.com/~westley/index.html
+    http://www.westley.org
 
 ## To build:
 

--- a/1996/westley/README.md
+++ b/1996/westley/README.md
@@ -11,26 +11,47 @@
 
         make all
 
-### To run
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed a segfault in
+this entry as well as it displaying environmental variables if argc == 1.
+Although the scripts showed correct output these also segfaulted but with the
+fix they no longer do. Now if argc < 5 (argv[4] is referenced) it will not do
+anything and it will not segfault either (this was caused by the body of the
+for() loop which is now empty (it doesn't appear to be needed at all). Note that
+this does make some of the author's explanations / portability notes no longer
+valid but we have kept them there for the interested. The original is in
+[westley.alt.c](westley.alt.c). Thank you Cody for your assistance!
+
+
+## To run:
 
 	sh ./clock1
 
-## Judges' comments
+
+## Try:
+
+
+	    sh ./clock2
 
 Also try:
+	
+	
+	    sh ./clock2
 
-	sh ./clock2
 
 And for a good time, try:
 
-	sh ./clock3
+
+	    sh ./clock3
+
+## Judges' comments:
 
 Time and time again, Brian Westley seems to come up with a winner!
 We are amazed at how much is being done with only one relatively
 short line.  We think you will as well if you take the time to
 understand it.
 
-## Author's comments
+## Author's comments:
 
 This 1-line program allows various analog ASCII clocks
 to print out the time; the ASCII clock is built from

--- a/1996/westley/westley.alt.c
+++ b/1996/westley/westley.alt.c
@@ -1,0 +1,1 @@
+main(h,m)char**m;{for(time(*m);h/=2;)m[4][m[h][h[(int*)localtime(*m)]]]=m[3][h];puts(m[4]);}

--- a/1996/westley/westley.c
+++ b/1996/westley/westley.c
@@ -1,1 +1,1 @@
-main(h,m)char**m;{for(time(*m);h/=2;)m[4][m[h][h[(int*)localtime(*m)]]]=m[3][h];puts(m[4]);}
+main(h,m)int h;char**m;{if(h>4){for(time(*m);h/=2;);puts(m[4]);}}

--- a/2001/herrmann2/README.md
+++ b/2001/herrmann2/README.md
@@ -14,11 +14,25 @@
 make
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to work with
+clang by changing the args to main() to be `int` and `char **` respectively and
+changing specific references to the `argv` arg, casting to int which was its old
+type. Thank you Cody for your assistance!
+
+
 ### To run:
 
 ```sh
 ./herrmann2
 ```
+
+Cody notes that [Yusuke Endoh](/winners.html#Yusuke_Endoh) does not get a
+segfault with some of the invocations (without fixing it for clang) but Cody
+does get a segfault both before fixing it for clang and after. Yusuke provides
+some interesting thoughts which can be found
+[here](https://mame-github-io.translate.goog/ioccc-ja-spoilers/2001/herrmann2.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp).
+Thank you Yusuke for your interesting thoughts!
+
 
 ### Try:
 
@@ -27,10 +41,37 @@ make
 ./herrmann2 < herrmann2.cup
 ```
 
+Try running each command a few times and notice the different output. Can you
+figure out why each is different?
+
+
+If you use vi(m) you can see a pattern in `hermmann2.cup` and `herrmann2.ioccc`
+by say:
+
+
+	/[pon]                                                                                                                                          
+
+and
+
+	/l
+
+For additional fun in `herrman2.cup` try:
+
+
+	/[po]
+	/q
+
+and in `herrmann2.ioccc` try:
+
+	/n
+
+
+	
 ## Judges' comments:
 
 Be careful when staring at the source code - your eyes might cross, but
 if you concentrate on your focus you will find illumination!
+
 
 ## Author's comments:
 
@@ -65,9 +106,11 @@ new random character, it will take the next one from the
 argument. When it arrives at the end of the argument, it will
 start over at the beginning. Example:
 
+```sh
 ./herrmann2 "234 84 045 5 6765 7487 65190 84 656 254 12 43931 818 0 6542\
 341 45 567 76967 7244 606 976567 895 81898 095 68678 1843 4650547\
 565980691 389 04974" < herrmann2.ioccc
+```
 
 ### Some hints to get better results
 

--- a/2001/herrmann2/herrmann2.c
+++ b/2001/herrmann2/herrmann2.c
@@ -1,7 +1,7 @@
 char*d,A[9876];char*d,A[9876];char*d,A[9876];char*d,A[9876];char*d,A[9876];char
 e;b;*ad,a,c;  te;b;*ad,a,c;  te;*ad,a,c;  w,te;*ad,a,  w,te;*ad,and,  w,te;*ad,
 r,T; wri; ;*h; r,T; wri; ;*h; r; wri; ;*h;_, r; wri;*h;_, r; wri;*har;_, r; wri
-  ;on; ;l ;i(V)  ;on; ;l ;i(V)  ;o ;l ;mai(V)  ;o  ;mai(n,V)    ;main (n,V)    
+;on;l;i(int V);on;l;i(int V);o;l;mai(int n,int V);o;mai(int n,int V);main(int n,char**V)    
    {-!har  ;      {-!har  ;      {har  =A;      {h  =A;ad        =A;read       
 (0,&e,o||n -- +(0,&e,o||n -- +(0,&o||n ,o-- +(0,&on ,o-4,- +(0,n ,o-=94,- +(0,n
 ,l=b=8,!( te-*A,l=b=8,!( te-*A,l=b,!( time-*A,l=b, time)|-*A,l= time(0)|-*A,l= 
@@ -10,7 +10,7 @@ r,T; wri; ;*h; r,T; wri; ;*h; r; wri; ;*h;_, r; wri;*h;_, r; wri;*har;_, r; wri
 )=+ +95>e?(*& c)=+ +95>e?(*& c) +95>e?(*& _*c) +95>(*& _*c) +95>(*&r= _*c) +95>
 5,r+e-r +_:2-195,r+e-r +_:2-195+e-r +_:2-1<-95+e-r +_-1<-95+e-r ++?_-1<-95+e-r 
 |(d==d),!n ?*d||(d==d),!n ?*d||(d==d),!n ?*d||(d==d),!n ?*d||(d==d),!n ?*d||(d=
- *( (char**)+V+ *( (char)+V+ *( (c),har)+V+  (c),har)+ (V+  (c),r)+ (V+  (  c),
+ *( (char**)+(int)V+ *( (char)+(int)V+ *( (c),har)+V+  (c),har)+ (V+  (c),r)+ (V+  (  c),
 +0,*d-7 ) -r+8)+0,*d-7 -r+8)+0,*d-c:7 -r+80,*d-c:7 -r+7:80,*d-7 -r+7:80,*d++-7 
 +7+! r: and%9- +7+! rand%9-85 +7+! rand%95 +7+!!  rand%95 +7+  rand()%95 +7+  r
 -(r+o):(+w,_+ A-(r+o)+w,_+*( A-(r+o)+w,_+ A-(r=e+o)+w,_+ A-(r+o)+wri,_+ A-(r+o)

--- a/2001/westley/.gitignore
+++ b/2001/westley/.gitignore
@@ -1,2 +1,6 @@
 westley
 westley.alt
+westley2
+westley2.c
+westley3
+westley3.c

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -63,7 +63,7 @@ X11_INCDIR= /opt/X11/include
 # Common C compiler warnings to silence
 #
 #CSILENCE=
-CSILENCE= -Wno-trigraphs
+CSILENCE= -Wno-trigraphs -Wno-implicit-function-declaration -Wno-pedantic
 
 # Common C compiler warning flags
 #
@@ -169,6 +169,10 @@ TARGET= ${PROG}
 ALT_OBJ= ${PROG}.alt.o
 ALT_TARGET= ${PROG}.alt
 
+# FORCE use of -trigraphs
+#
+CFLAGS+= -trigraphs
+
 
 #################
 # build the entry
@@ -185,6 +189,12 @@ ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 ${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+westley2: westley2.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+westley3: westley3.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -6,7 +6,8 @@ Best position-independent code:
     St. Paul, MN  55105
     USA
 
-    http://www.firesigntheatre.com
+    http://www.westley.org
+
 
 ## To build:
 
@@ -19,10 +20,10 @@ Best position-independent code:
 ### Try:
 
     	./westley < westley.c > westley2.c
-	cc westley2.c -ansi -o westley2
+	make westley2
 	echo 'Bozos, please deflate shoes before entering the bus!'| ./westley2
 	sort -b < westley2.c > westley3.c
-	cc westley3.c -ansi -o westley3
+	make westley3
 	./westley3 < westley.c | diff - westley.c
 	./westley3 < westley.c | diff - westley2.c
 	./westley3 < westley.c | diff - westley3.c


### PR DESCRIPTION
    
    The main link was dead but looking at the Internet Wayback Machine I
    found that he changed domains and it's still valid. One entry had a
    different URL but with a quick check I could not determine that it had
    anything to do with him so I changed it to his own domain (which I
    verified is his).
    
    The 2001/westley/.gitignore was also updated as it has other source
    files that are generated by the commands in the try section.