### PR TITLE
Get 2006/monge to link (won't work on anything but x86/x86_64 or at least not on arm64)

### DIFF
--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -106,7 +106,7 @@ CDEFINE=
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
 #CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11
-CINCLUDE= `${SDL2_CONFIG} --cflags`
+CINCLUDE= `${SDL1_CONFIG} --cflags`
 
 # Optimization
 #
@@ -130,7 +130,7 @@ CFLAGS= ${CSTD} ${CWARN} ${ARCH} ${CDEFINE} ${CINCLUDE} ${OPT}
 #LIBS=
 #LIBS= -lm
 #LIBS= -L ${X11_LIBDIR} -lX11
-LIBS= `${SDL2_CONFIG} --libs`
+LIBS= `${SDL1_CONFIG} --libs`
 
 # C compiler to use
 #

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -9,11 +9,21 @@
 
 # To build:
 
-Make sure you have the SDL2 development environment installed.
+
+Make sure you have the SDL1 (not SDL2!) development environment installed.
 
 ```sh
 make
 ```
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) pointed out that
+without SDL1 (**not** SDL2) this will not link because two functions that are
+used were removed from SDL2. Since SDL1 is still available and since changing
+the code to use SDL2 would be more complicated he decided to change the Makefile
+to use `sdl-config` not `sdl2-config`. Nevertheless he points out that the entry
+segfaults or at least it does under macOS (he has not tested linux yet but will
+in time and then try debugging it). Thank you Cody for your assistance!
+
 
 ### To run:
 
@@ -27,7 +37,7 @@ make
 ./monge "z = 0" "z = z*z*z + c; Abs2(z) < 4"
 ```
 
-## Judges' comments
+## Judges' comments:
 
 For those who are familiar with the previous IOCCC winners, this program
 is best described as "1994/tvr meets 2001/bellard". Here you have
@@ -41,9 +51,9 @@ At the time of judging we were too mesmerized by the graphics
 to realize it; and, after all, this entry does take a special
 effort to work on both i386 and x86_64. Portable it is! :)
 
-## Author's comments
+## Author's comments:
 
-### For the impatients
+### For the impatient:
 
 0. Compile using the Makefile, or just run:
 
@@ -55,7 +65,7 @@ effort to work on both i386 and x86_64. Portable it is! :)
 
 2. Keep clicked with left or right button to zoom in or out.
 
-3. Use the numpad '+' and '-' to increase/decrease the iteration
+3. Use the number pad '+' and '-' to increase/decrease the iteration
    count when needed.
 
 4. Enjoy, unless you're more interested in trying to understand
@@ -67,7 +77,7 @@ This is a fractal generator that supports custom formulas and
 real time zoom.  The program needs to be run with two arguments,
 the first being a semicolon separated list of assignments to
 do once per pixel, and the second a semicolon separated list
-of assignents and conditions that will be executed (and conditions
+of assignments and conditions that will be executed (and conditions
 checked) for each iteration (up to the maximum).  Using the
 left and right mouse buttons you will be able to zoom in and
 out (a la Xaos), the zooming algorithm is a bit slower than
@@ -85,15 +95,17 @@ function 'isspace').
 
 Supported operations and functions are:
 
-> Operation | Description
-> :-------- | :----------
-> +,-,*,/   | Arithmetic operations, priority of *,/ over +,- is respected.
-> <,>       | Compares the real parts of two complex numbers (the imaginary part is ignored). Any number of conditions is allowed, the iteration will just stop as soon as one of them fails.
-> Abs2      | Calculates the squared norm, ie: Abs2(a+b*i) is (a*a+b*b)+0*i
-> Re        | Extract the real part, ie: Re(a+b*i) is a+0*i
-> Im        | Extract the imaginary part, ie: Im(a+b*i) is b+0*i
-> Exp       | Calculates the complex exponential, ie Exp(a+b*i) is e^a*(cos(b)+sin(b)*i)
-> Ln        | Calculates the principal value of the natural logarithm, ie Ln(a+b*i) is ln(a*a+b*b)/2 + atan(b/a)*i 
+Operation | Description
+:-------- | :----------
+> `+,-,*,/`   | Arithmetic operations, priority of `*`,`/` over `+,-` is respected.
+> `<,>`       | Compares the real parts of two complex numbers (the imaginary part is ignored). Any number of conditions is allowed, the iteration will just stop as soon as one of them fails.
+> Abs2      | Calculates the squared norm, ie: `Abs2(a+b*i)` is `(a*a+b*b)+0*i`
+> Re        | Extract the real part, ie: `Re(a+b*i) is a+0*i`
+> Im        | Extract the imaginary part, ie: `Im(a+b*i) is b+0*i`
+> Exp       | Calculates the complex exponential, ie `Exp(a+b*i)` is
+>	      `e^a*(cos(b)+sin(b)*i)`
+> Ln        | Calculates the principal value of the natural logarithm, ie
+>	      `Ln(a+b*i)` is `ln(a*a+b*b)/2` + `atan(b/a)*i`
 
 Here are a few examples of fractals you can draw:
 
@@ -105,15 +117,15 @@ Here are a few examples of fractals you can draw:
 
         ./program "z=c" "z=z*z+c; Abs2(z-c)>0.0001"
 
-- Julia, for c=0.31+i*0.5:
+- Julia, for `c=0.31+i*0.5`:
 
         ./program "z=c; c=0.31+i*0.5" "z=z*z+c; Abs2(z)<4"
 
-- Julia (return time variation), for c=0.31+i*0.5:
+- Julia (return time variation), `for c=0.31+i*0.5`:
 
         ./program "z=c; c=0.31+i*0.5" "z=z*z+c; Abs2(z-c)>0.0001"
 
-- Newton, for x^3-1:
+- Newton, for `x^3-1`:
 
         ./program "z=c" "p=z; z=0.6666*z+0.3333/(z*z); Abs2(p-z) > 0.001"
 
@@ -125,7 +137,7 @@ Here are a few examples of fractals you can draw:
 
         ./program "z=0; q=0" "t=z; z=z*z+Re(c)+Im(c)*q; q=t; Abs2(z)<4"
 
-- Phoenix, Julia version for c=0.56667-i*0.5
+- Phoenix, Julia version for `c=0.56667-i*0.5`
 
         ./program "z=c; c=0.56667-i*0.5; q=0" "t=z; z=z*z+Re(c)+Im(c)*q; q=t; Abs2(z)<4"
 
@@ -134,22 +146,22 @@ Here are a few examples of fractals you can draw:
 This program will only work on x86 (with an x87 FPU) or x86_64 machines,
 and requires the SDL library.
 
-Another system requirement is the mmap function (as #define'd
+Another system requirement is the mmap function (as `#define`d
 at the beginning of the program). If it is not available the
 macro M(a) will have to be replaced with a system dependent
 function that allocates readable, writable *AND* executable
 memory (it will not be possible to make this program run on
 paranoid systems (like OpenBSD IIRC) do not allow rwx memory).
 
-However i was able to compile and make work the program under
+However I was able to compile and make work the program under
 Linux (Debian/x86 and OpenSuSE/x86_64) and under Cygwin/x86. A
-friend of mine was able to make it work under MacOSX too.
+friend of mine was able to make it work under macOS too.
 
 If you want you can change the window width and height, or the default
 number of iterations (that one can be tweaked at runtime, anyway) by
-changing the definitions of W, H and I at the beginnning of the code.
+changing the definitions of W, H and I at the beginning of the code.
 
-### Caveats (i just a selected few of them!)
+### Caveats (I just a selected few of them!)
 
 - The zooming speed depends on the speed of the computer.
 - Incorrect formulas will ungracefully crash the program.
@@ -158,19 +170,19 @@ changing the definitions of W, H and I at the beginnning of the code.
 - Better optimization could be done treating known real numbers as just one
   double, instead of adding a 0 imaginary part to treat them as complex
   numbers.
-- There should be some way to switch from Mandelbrot to Julia with choosen
+- There should be some way to switch from Mandelbrot to Julia with chosen
   parameter.
 
 ### Spoiler 
 
-Sure, i don't want to deprive you of the pleasure of digging
+Sure, I don't want to deprive you of the pleasure of digging
 into the infernal mess created by my corrupted mind (writing
-this remark i noticed that i was ending senteces with ';' instead
-that with '.', and i worried for my sanity), but just in case...
+this remark I noticed that I was ending sentences with ';' instead
+that with '.', and I worried for my sanity), but just in case...
 
 I used many obfuscation techniques, including a few ones that
 are different from the tricks used in most common IOCCC program
-(more 'highlevel', in the sense that they require an understanding
+(more 'high level', in the sense that they require an understanding
 of how all the program works to be worked out).
 
 This program is a formula parser that outputs machine code that

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -21,8 +21,8 @@ without SDL1 (**not** SDL2) this will not link because two functions that are
 used were removed from SDL2. Since SDL1 is still available and since changing
 the code to use SDL2 would be more complicated he decided to change the Makefile
 to use `sdl-config` not `sdl2-config`. Nevertheless he points out that the entry
-segfaults or at least it does under macOS (he has not tested linux yet but will
-in time and then try debugging it). Thank you Cody for your assistance!
+requires x86/x86_64 CPUs. Without it it might very well segfault (for instance
+it segfaulted on his MacBook Pro with the M1 chip).
 
 
 ### To run:

--- a/var.mk
+++ b/var.mk
@@ -170,6 +170,7 @@ SCP= scp
 SCREEN= screen
 SCRIPT= script
 SDIFF= sdiff
+SDL1_CONFIG= sdl-config
 SDL2_CONFIG= sdl2-config
 SED= sed
 SEQ= seq


### PR DESCRIPTION
The problem was that SDL2 removed two functions that are used in this code. Since SDL1 is still available and since changing it to SDL2 is more complicated than it is worth I've decided to keep it as SDL1, changing sdl2-config to sdl-config. Nevertheless it actually segfaults or it does at least in macOS. I have not tested it in linux but I will in time. At this point I will try debugging it but at least now it will link.

Typo fixes in README.md and update the reference to SDL2 to be SDL1. I noted that currently it does not work at least under macOS. I've not yet put it in the bugs.md file but will in time if I don't get it to work (again once I test it under linux).