### PR TITLE
Get 2005/giljade to work

### DIFF
--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -92,7 +92,7 @@ CSTD= -std=gnu99
 #
 # By default we assume nothing:
 #
-ARCH=
+ARCH= -m32
 
 # Defines that are needed to compile
 #
@@ -101,7 +101,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
@@ -119,7 +119,7 @@ CINCLUDE=
 #OPT= -O
 #OPT= -O1
 #OPT= -O2
-OPT= -O3
+OPT=
 
 # Default flags for ANSI C compilation
 #
@@ -188,6 +188,7 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	@echo "NOTE: this entry requires 32-bit architecture in order to run properly"
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -12,6 +12,18 @@
 make
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) discovered that there
+are two things that are needed in order to get this to work in modern systems.
+First it needs 32-bit architecture so the Makefile now has `-m32`. It appears
+it's because of the size of ints being different which affects the bitwise
+operations though this is just a hunch. Second is the optimiser cannot be
+enabled for this to work. Both changes made and it works. This does prove a
+problem for macOS as it no longer easily allows for compiling with 32-bit
+possibly even if you have the Intel chip (it certainly does not work with arm64
+macOS). It might be possible to get the entry to work with 64-bit by changing
+the int size but this is currently unknown.
+
+
 ### To run:
 
 ```sh


### PR DESCRIPTION
I've discovered that this entry has to have the optimiser disabled and it also requires 32 bit. I believe the 32-bit is to do with the many bitwise operations but the size of the ints are different. This is just a hunch though from what I saw earlier when debugging it. The fact it's 32-bit only (at this time?) means it won't easily compile under macOS as Apple has made it hard to compile 32-bit programs.

It might be possible to change the size of the ints to fix this problem but it of course could also be entirely true that I'm wrong here. I've not added this to the bugs file but perhaps it should be added.