### PR TITLE
Minor updates to 2005/mynx

### DIFF
--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -92,7 +92,7 @@ CSTD= -std=gnu99
 #
 # By default we assume nothing:
 #
-ARCH=
+ARCH= -m32
 
 # Defines that are needed to compile
 #
@@ -101,7 +101,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h
 #CINCLUDE= -include stdio.h
 #CINCLUDE= -include stdlib.h -include stdio.h
@@ -119,7 +119,7 @@ CINCLUDE=
 #OPT= -O
 #OPT= -O1
 #OPT= -O2
-OPT= -O3
+OPT=
 
 # Default flags for ANSI C compilation
 #
@@ -188,6 +188,7 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	@echo "NOTE: this entry requires 32-bit architecture in order to run properly"
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -12,6 +12,18 @@
 make
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) discovered that there
+are two things that are needed in order to get this to work in modern systems.
+First it needs 32-bit architecture so the Makefile now has `-m32`. It appears
+it's because of the size of ints being different which affects the bitwise
+operations though this is just a hunch. Second is the optimiser cannot be
+enabled for this to work. Both changes made and it works. This does prove a
+problem for macOS as it no longer easily allows for compiling with 32-bit
+possibly even if you have the Intel chip (it certainly does not work with arm64
+macOS). It might be possible to get the entry to work with 64-bit by changing
+the int size but this is currently unknown.
+
+
 ### To run:
 
 ```sh

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -16,14 +16,29 @@ make
 ### To run:
 
 ```sh
-./prog
+./mynx http://<domain>
 ```
+
+You can specify a port by appending to the domain `:port`. See notes below on
+the issue of https.
 
 ### Try:
 
 ```sh
-./mynx http://www.ioccc.org/
+./mynx http://www.textfiles.com
 ```
+
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) pointed out that this
+will not work for https initially for two reasons. First it scanned for http://.
+Cody changed it to scan for both http:// and https:// but the problem is a
+secure connection needs to be set up before http commands can be sent. One would
+also have to specify a port in the URL. Fortunately or unfortunately many more
+websites use https nowadays so this entry will not work as well as it used to.
+If one were to try and connect to `http://www.ioccc.org` with this entry they'll
+just get a 301 error. Perhaps someone can come up with a pipeline that will make
+this work with the change made.  Otherwise just enjoy it for what it was.
+
 
 ## Judges' comments
 

--- a/2005/mynx/mynx.c
+++ b/2005/mynx/mynx.c
@@ -147,7 +147,7 @@ main(I V, c *v)
 		struct sockaddr_in A;
 		L = 0;
 		B = 1;
-		Q !sscanf(t, "http://%255[^/]%n", h, &n) && !*h) {
+		Q (!sscanf(t, "http://%255[^/]%n", h, &n)&&!sscanf(t,"https://%255[^/]%n",h, &n) && !*h)) {
 			Q !(f = fopen(t, "rb")))
 				k 1;
 			goto e;

--- a/bugs.md
+++ b/bugs.md
@@ -226,6 +226,16 @@ is true on both linux and macOS, with `k` being equal to 22.
 Should the entry use `perror()`? Perhaps not but we're not sure of its purpose
 so it can stay for now with this note.
 
+### [2005/mynx](2005/mynx/mynx.c) ([README.md](2005/mynx/README.md))
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) notes that, though
+probably obvious, this entry will not work with https. He changed the code to
+scan for https too (it exited before) in case someone comes up with a clever
+command line to make it work but the problem is a secure connection has to first
+be set up in order to give http commands. This is not a bug but it's worth
+pointing out as it won't work on as many websites as it used to including the
+[IOCCC website](https://www.ioccc.org) itself.
+
 
 ### [2019/endoh](2019/endoh/prog.c) ([README.md](2019/endoh/README.md))
 

--- a/bugs.md
+++ b/bugs.md
@@ -102,6 +102,15 @@ needless cast to `char *` from gets(). This cast remains in the code however.
 however.
 
 
+### [2005/giljade](2005/giljade/giljade.c) ([README.md](2005/giljade/README.md))
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) noted that this
+requires both 32-bit CPUs (data size?) and also cannot have optimiser enabled.
+It might be that it can be fixed, perhaps by changing the int sizes and bitwise
+operations, but if not this will not work with some systems like modern Macs as
+Apple has made it hard to compile 32-bit applications.
+
+
 ### [2014/vik](2014/vik/prog.c) ([README.md](2014/vik/README.md))
 
 
@@ -182,7 +191,7 @@ the judges and needn't be fixed.
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed the scripts to
 work in modern systems. He notes however that the command in the try section,
-the one to test the official C entry, appear to not work with macOS, giving:
+the one to test the official C entry, appears to not work with macOS, giving:
 
 
 	$ echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
@@ -216,14 +225,6 @@ is true on both linux and macOS, with `k` being equal to 22.
 
 Should the entry use `perror()`? Perhaps not but we're not sure of its purpose
 so it can stay for now with this note.
-
-
-### [1996/westley](1996/westley/westley.c) ([README.md](1996/westley/README.md))
-
-
-This entry will possibly segfault even when showing the proper output in the
-`clock1`, `clock2` and `clock3` scripts. Though this doesn't need to be fixed as
-long as it works right it wouldn't hurt to fix it either.
 
 
 ### [2019/endoh](2019/endoh/prog.c) ([README.md](2019/endoh/README.md))
@@ -295,13 +296,16 @@ XXX - .. more entries to be added later ..
 This entry is likely to fail and/or dump core on any computer other than a
 Vax-11 or pdp-11. In 1984 machine dependent code was allowed.
 
-Perhaps what is needed is for someone to supply a Vax-11 or pdp-11 emulator for this entry.
+To see this entry in action check out [Yusuke
+Endoh](/winners.html#Yusuke_Endoh)'s [2015/endoh3](2015/endoh3) entry. Otherwise
+a Vax-11 or pdp-11 emulator would be necessary.
 
 
 ### [2004/gavin](2004/gavin/gavin.c) ([README.md](2004/gavin//README.md))
 
 
-Segmentation fault occurs when running `gavin` to produce the kernel:
+Segmentation fault will occur in some systems. For instance on macOS with the
+arm64 chip:
 
 ```sh
 ./gavin > kernel
@@ -318,13 +322,10 @@ ld: symbol(s) not found for architecture arm64
 ```
 
 
-#### Recent for 2004/gavin mods:
+#### Recent 2004/gavin mods:
 
-
-In case recent modification are part of the problem, here is a full disclosure
-of what was changed:
-
-To compile on modern C compilers, the following patch was applied to `gavin.c`:
+Although not related some recent changes were made to 2004/gavin to let it
+compile under clang. The following patch was applied:
 
 ```patch
 diff --git a/2004/gavin/gavin.c b/2004/gavin/gavin.c


### PR DESCRIPTION

Though this will not work as is I have changed the code to scan for
https as well (it exited before). This is so if someone comes up with a
clever command line to make it work it can. A secure connection has to
be established before http commands can be given but now it at least can
connect (though it's been a while since I've played with sockets so
maybe I'm forgetting some detail - one does have to specify the port but
I gave an example in the README.md file for that).

In the README.md I pointed out that one has to specify http:// (or else
https though with the caveat noted above). I also explained how to 
specify an alternative port.

I also noted the https issue in the bugs.md file in the INABIAF section 
('it's not a bug it's a feature').

As well I changed the try command in the entry README.md file to refer
to a page that does not use https as trying it on the ioccc website
(what it used to) will just return a 301 error.

--

.. not in the log but I also fixed a typo in the README.md: referring to `prog` instead of `mynx`. Not the only README.md file with this problem and I've fixed some already.