### PR TITLE
Fix 2000/dlowe for more recent perl versions

### DIFF
--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -19,6 +19,11 @@ The following bit of perl may help determining the values you need:
 perl -MConfig -e 'print "$Config{archlibexp}/CORE\n"'
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile
+with more recent perl versions; the symbol now `PL_na` was once `na`. He notes
+that this entry crashes under macOS but it works under linux after this change.
+
+
 ### To run:
 
 ```sh

--- a/2000/dlowe/dlowe.c
+++ b/2000/dlowe/dlowe.c
@@ -6,7 +6,7 @@
 #define                            cc                            (((3)))
 #define                     ZZ(YY,WW) XS(YY)                     {AV*gg\
 = perl_get_av(              "SS",cc-cc); SV*              Ss,*uu; char \
-ii=*(SvPV(                  perl_get_sv("_",                  0*cc),na)\
+ii=*(SvPV(                  perl_get_sv("_",               0*cc),PL_na)\
 ) %(36+cc); (               av_len(gg) <1)?(               perl_call_pv\
 ("__",0/cc)):(Ss            =av_pop(gg), uu=            av_pop(gg),(((i\
 i==pow(2,cc))||(            ii==(40-cc)))&&(            SvNV(Ss)==0))?(\


### PR DESCRIPTION
The problem was that they renamed 'na' to 'PL_na' so the code did not compile. I note that it segfaults in macOS but I've not had a chance to look into that yet. It works fine in linux.