### PR TITLE
Partially fix 2001/bellard

### DIFF
--- a/2001/bellard/.gitignore
+++ b/2001/bellard/.gitignore
@@ -1,1 +1,2 @@
 bellard
+bellard.otccex

--- a/2001/bellard/README.md
+++ b/2001/bellard/README.md
@@ -19,6 +19,17 @@ make
 ./bellard file
 ```
 
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) partially fixed this
+but he notes that this will not work without some serious debugging. As he has
+no 32-bit system to test this under it's also unlikely he will be able to
+resolve the remaining problems. He also has no knowledge of the ELF binary
+format so that will also make it harder to work. As it is it segfaults. He fixed
+an earlier segfault so that at least the file can be opened and he also changed
+some of the macro uses to what they expanded to but mostly he kept it the same.
+He also fixed `bellard.otccex.c` so it does not segfault and seemingly works
+okay. Thank you Cody for your assistance!
+
+
 ### Try:
 
 ```sh

--- a/2001/bellard/bellard.c
+++ b/2001/bellard/bellard.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 #define k *(int*)
 #define a if(
 #define c ad()
@@ -10,14 +12,13 @@
 #define f ()
 #define J return
 #define l ae(
-#define n e)
 #define u d!=
 #define F int 
 #define y (j)
 #define r m=
 #define t +4
 F d,z,C,h,P,K,ac,q,G,v,Q,R,D,L,W,M;
-E(n{
+E(int e){
 x D++=e;
 }
 o f{
@@ -131,43 +132,43 @@ x q++=g;
 g=g>>8;
 }
 }
-A(n{
+A(int e){
 F g;
-p n{
+p e){
 g=k e;
 k e=q-e-4;
 e=g;
 }
 }
-s(g,n{
+s(int g,int e){
 l g);
 k q=e;
 e=q;
 q=q t;
 J e;
 }
-H(n{
-s(184,n;
+H(e){
+s(184,e);
 }
-B(n{
-J s(233,n;
+B(e){
+J s(233,e);
 }
-S(j,n{
+S(int j,int e){
 l 1032325);
-J s(132+j,n;
+J s(132+j,e);
 }
-Z(n{
+Z(int e){
 l 49465);
 H(0);
 l 15);
 l e+144);
 l 192);
 }
-N(j,n{
+N(int j,int e){
 l j+131);
-s((e<512)<<7|5,n;
+s((e<512)<<7|5,e);
 }
-T y{
+T (int j){
 F g,e,m,aa;
 g=1;
 a d b 34){
@@ -221,7 +222,7 @@ w f;
 l 89);
 l 392+(e b 256));
 }
-i a n{
+i a e){
 a e b 256)l 139);
 i l 48655);
 q++;
@@ -264,7 +265,7 @@ k r j;
 c;
 a!g){
 e=e t;
-k e=s(232,k n;
+k e=s(232,k e);
 }
 i a g b 1){
 s(2397439,j);
@@ -276,11 +277,11 @@ s(232,g-q-5);
 a j)s(50305,j);
 }
 }
-O y{
+O (int j){
 F e,g,m;
 a j--b 1)T(1);
 i{
-O y;
+O (j);
 r 0;
 p j b C){
 g=d;
@@ -288,17 +289,17 @@ e=z;
 c;
 a j>8){
 r S(e,m);
-O y;
+O (j);
 }
 i{
 l 80);
-O y;
+O (j);
 l 89);
 a j b 4|j b 5){
-Z(n;
+Z(e);
 }
 i{
-l n;
+l e);
 a g b 37)l 146);
 }
 }
@@ -308,7 +309,7 @@ r S(e,m);
 H(e^1);
 B(5);
 A(m);
-H(n;
+H(e);
 }
 }
 }
@@ -319,19 +320,19 @@ U f{
 w f;
 J S(0,0);
 }
-I y{
+I (int j){
 F m,g,e;
 a d b 288){
 c;
 c;
 r U f;
 c;
-I y;
+I (j);
 a d b 312){
 c;
 g=B(0);
 A(m);
-I y;
+I (j);
 A(g);
 }
 i{
@@ -357,7 +358,7 @@ a u 41){
 e=B(0);
 w f;
 B(g-q-5);
-A(n;
+A(e);
 g=e t;
 }
 }
@@ -369,7 +370,7 @@ A(m);
 i a d b 123){
 c;
 ab(1);
-p u 125)I y;
+p u 125)I (j);
 c;
 }
 i{
@@ -386,7 +387,7 @@ i a u 59)w f;
 c;
 }
 }
-ab y{
+ab (int j){
 F m;
 p d b 256|u-1&!j){
 a d b 256){
@@ -428,11 +429,11 @@ k r G;
 }
 }
 }
-main(g,n{
+int main(int g,char **e){
 Q=stdin;
 a g-->1){
-e=e t;
-Q=fopen(k e,"r");
+*e=e[1];
+Q=fopen(*e,"r");
 }
 D=strcpy(R V," int if else while break return for define main ")+48;
 v V;
@@ -441,6 +442,6 @@ P V;
 o f;
 c;
 ab(0);
-J(*(int(*)f)k(P+592))(g,n;
+J(*(int(*)f)k(P+592))(g,e);
 }
 

--- a/2001/bellard/bellard.otccex.c
+++ b/2001/bellard/bellard.otccex.c
@@ -72,13 +72,13 @@ print_num(n, b)
 }
 
 /* 'main' takes standard 'argc' and 'argv' parameters */
-main(argc, argv)
+main(int argc, char **argv)
 {
     /* no local name space is supported, but local variables ARE
        supported. As long as you do not use a globally defined
        variable name as local variable (which is a bad habbit), you
        won't have any problem */
-    int s, n, f, base;
+    int n, f, base;
     
     /* && and || operator have the same semantics as C (left to right
        evaluation and early exit) */
@@ -86,15 +86,14 @@ main(argc, argv)
         /* '*' operator is supported with explicit casting to 'int *',
            'char *' or 'int (*)()' (function pointer). Of course, 'int'
            are supposed to be used as pointers too. */
-        s = *(int *)argv;
-        help(s);
+        help(argv[0]);
         return 1;
     }
     /* Any libc function can be used because OTCC uses dynamic linking */
-    n = atoi(*(int *)(argv + 4));
+    n = atoi(argv[1]);
     base = DEFAULT_BASE;
     if (argc >= 3) {
-        base = atoi(*(int *)(argv + 8));
+        base = atoi(argv[2]);
         if (base < 2 || base > 36) {
             /* external variables can be used too (here: 'stderr') */
             fprintf(stderr, "Invalid base\n");
@@ -118,7 +117,7 @@ main(argc, argv)
 }
 
 /* functions can be used before being defined */
-help(name)
+help(char *name)
 {
     printf("usage: %s n [base]\n", name);
     printf("Compute fib(n) and fact(n) and output the result in base 'base'\n");

--- a/bugs.md
+++ b/bugs.md
@@ -20,7 +20,7 @@ _README.md_ file. If you're a previous winner we will add a link to your winning
 entries in the file (if you're not we can add a link to your personal website if
 you have one if you like).
 
-# List of Statuses - Please read before fixing (you may skip if you're only interested in entries with known issues)
+# List of Statuses - Please read before fixing (you may skip if you're only interested in knowing about entries with known issues)
 
 Entries below have one of the following _Status_ values.
 
@@ -383,6 +383,17 @@ use of the provided source file
 on. Note that it needs to be compiled as a x86 program.
 - The program will to an extent destroy files it is used on. See the author's
 warning in their comments on that.
+
+
+## [2001/bellard](2001/bellard/bellard.c) ([README.md](2001/bellard/README.md))
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed an initial
+segfault and he also fixed the [supplementary
+program](2001/bellard/bellard.otccex.c) to test the entry on to not segfault and
+seemingly work but he has no 32-bit system to test any further fixes and we
+would greatly appreciate anyone's help! It appears that this entry will require
+major debugging and to make it work one might need to have a deep understanding
+of the ELF format.
 
 
 # 2004


### PR DESCRIPTION
This still crashes and may very well not work even if it doesn't but I cannot determine that. I just fixed the initial segfault when opening the file. I believe it will take much debugging, a 32-bit system to test it on and also a knowledge of the ELF format. There might be other things but I believe those are the minimum requirements.

I did fix the supplementary program bellard.otccex.c so it does not segfault and seemingly it works too (I didn't really evaluate that the output is correct but it does process the args anyway).

I updated bugs.md to note that this entry does not work and any help would be appreciated.