### PR TITLE
Fix Makefile missing separator in 2015/hou

### DIFF
--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -167,7 +167,7 @@ ${PROG}: prebuild
 	fi
 
 prebuild: ${CSRC}
-        ${CC} ${CFLAGS} $< -o $@ ${LIBS}
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable
 #


### PR DESCRIPTION
As in there were spaces instead of tabs.