### PR TITLE
Fixes in 2018/poikola

### DIFF
--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -118,6 +118,7 @@ TARGET= ${PROG}
 ALT_OBJ=
 ALT_TARGET=
 
+DOCS= poikola.tex
 
 #################
 # build the entry
@@ -142,6 +143,10 @@ alt: data ${ALT_TARGET}
 #
 data: ${DATA}
 	@${TRUE}
+
+docs: ${DOCS}
+	pdflatex ${DOCS}
+
 
 # both all and alt
 #

--- a/2018/poikola/README.md
+++ b/2018/poikola/README.md
@@ -9,10 +9,11 @@
 make
 ```
 
-NOTE: this entry requires `X11/Xlib.h` header file and the X11 library to
-compile. macOS users running Mountain Lion and later will need to download and
-install [XQuartz](https://www.xquartz.org) in order to compile and run this
-entry.
+NOTE: some have reported that Terminal.app in macOS does not work and one might
+need a different terminal emulator like that from
+[XQuartz](https://www.xquartz.org) but [Cody Boone
+Ferguson](/winners.html#Cody_Boone_Ferguson) reported that this works fine in
+macOS Ventura with Terminal.app. YMMV of course.
 
 
 ## To run:
@@ -42,7 +43,7 @@ And those in the deep south might wish to go north for a better view.
 
 ## Author's comments:
 
-### How to build
+### How to build:
 
 ```sh
 cc -o prog -std=gnu11 -O3 prog.c
@@ -54,67 +55,91 @@ or
 make
 ```
 
-### Poster
+### Poster:
 
-You can generate an A3 sized poster by _make docs_. This command creates a pdf file _poikola.pdf_.
+You can generate an A3 sized poster by _make docs_. This command creates a pdf
+file _poikola.pdf_.
 
-### What this entry does
-#### Introduction
-It was a starry night when my wife pointed her finger up and asked: "What is this star and may I have some Easter eggs?"
+### What this entry does:
 
-So I had to sit down and solve those tricky questions with Nano and a C compiler.
+#### Introduction:
+It was a starry night when my wife pointed her finger up and asked: "What is
+this star and may I have some Easter eggs?"
 
-#### Little spoilers
-Basically, the program draws animated ASCII art of the Big Dipper using Annie Jump Cannon's spectral classification system of stars and I think the
-colors of the output are as accurate as possible.
+So I had to sit down and solve those tricky questions with Nano and a C
+compiler.
 
-This program also tells once in a year if it is correct time to find and eat some Easter eggs.
+#### Little spoilers:
+
+Basically, the program draws animated ASCII art of the Big Dipper using Annie
+Jump Cannon's spectral classification system of stars and I think the colors of
+the output are as accurate as possible.
+
+This program also tells once in a year if it is correct time to find and eat
+some Easter eggs.
 
 The program has also at least three other functions, obvious and not so obvious.
 
 #### Technical jargon
-This program has been tested on xterm and Konsole and also Linux virtual terminal. Color support in the terminal is not necessary, but the effect is better with it.
-This entry has partial support for terminals with a white background but the best viewing experience is achieved when the terminal in use supports 24-bit colors,
-has a black background and the size is at least 125x38.
+This program has been tested on xterm and Konsole and also Linux virtual
+terminal. Color support in the terminal is not necessary, but the effect is
+better with it.
 
-Special note for Mac users: __Terminal__ does not work as expected you might need xterm from XQuartz or some other
-working terminal. Thanks to [Dave Burton](/winners.html#Dave_Burton) for spotting this problem.
+This entry has partial support for terminals with a white background but the
+best viewing experience is achieved when the terminal in use supports 24-bit
+colors, has a black background and the size is at least 125x38.
 
-The main reason for the header `unistd.h` is `getdelim()` but once I included it I also abused other functions and defines. This header is mutually exclusive with _-std=c11_.
+Special note for Mac users: __Terminal__ does not work as expected you might
+need xterm from XQuartz or some other working terminal. Thanks to [Dave
+Burton](/winners.html#Dave_Burton) for spotting this problem.
 
-The program was developed with little-endian machines; I tried to support big-endian too, but this support is somewhat limited.
+The main reason for the header `unistd.h` is `getdelim()` but once I included it
+I also abused other functions and defines. This header is mutually exclusive
+with _-std=c11_.
+
+The program was developed with little-endian machines; I tried to support
+big-endian too, but this support is somewhat limited.
 
 This program has been compiled in
 
 1. i386 (Debian Stretch) with gcc and clang
 2. amd64 (Debian Buster) with gcc and clang
 3. Raspberry Pi 3 (Debian stretch) with gcc and clang
-4. Lego Mindstorms EV3 Intelligent Brick (Debian Jessie) with gcc and clang (in this case, compiling time with clang-3.5 12 seconds and with gcc 27 seconds)
+4. Lego Mindstorms EV3 Intelligent Brick (Debian Jessie) with gcc and clang (in
+this case, compiling time with clang-3.5 12 seconds and with gcc 27 seconds)
 
-### Warnings and restrictions required by law
+### Warnings and restrictions required by law:
 Please do not feed little babies chocolate.
 
-### Major spoilers
+### Major spoilers:
 <div style="margin-bottom:61em;">&nbsp;</div>
 
-I incorporated the Fletcher 16 checksum algorithm into the source for security reasons; it might be challenging to make changes without breaking the main functionality of the code.
+I incorporated the Fletcher 16 checksum algorithm into the source for security
+reasons; it might be challenging to make changes without breaking the main
+functionality of the code.
+
 The space after `#define p return` is necessary.
 
-The computus uses an algorithm described in the journal Nature in 1876. It should be valid for Gregorian calendars.
+The computus (method to determine the date of Easter) uses an algorithm
+described in the journal Nature in 1876. It should be valid for Gregorian
+calendars.
 
-#### Some obfuscation techniques used
+### Some obfuscation techniques used:
 
-1. I tried to use meaningless or misleading variable names. For example, this program draws the Big Dipper with the correct colors, but variables
-like `o`, `b`, and `a` are used in totally unrelated tasks.
+1. I tried to use meaningless or misleading variable names. For example, this
+program draws the Big Dipper with the correct colors, but variables like `o`,
+`b`, and `a` are used in totally unrelated tasks.
 2. I reused and recycled variables almost every time when possible.
 3. Unnecessary use of predefined stuff like `__ATOMIC_SEQ_CST`.
-4. When I was a kid, my favorite programming language was Pascal. In Pascal, there are things like `begin;` and `end;` instead of curly brackets.
-They are used also in my code, but I had to shorten them to meet size requirements.
-5. I also have strong Perl background,
-and therefore I added some dollar signs to the code. One of the first ideas was to
-write all variables with prefixed `$`, but then I rejected it.
+4. When I was a kid, my favorite programming language was Pascal. In Pascal,
+there are things like `begin;` and `end;` instead of curly brackets. They are
+used also in my code, but I had to shorten them to meet size requirements.
+5. I also have strong Perl background, and therefore I added some dollar signs
+to the code. One of the first ideas was to write all variables with prefixed
+`$`, but then I rejected it.
 
-If you think you understand how this program works, can you answer these questions:
+If you think you understand how this program works, can you answer these
+questions:
 
 1. What is the value of `aI_` after line 21?
 2. Why are there some big numbers on line 47?
@@ -124,7 +149,8 @@ If you think you understand how this program works, can you answer these questio
 
 ### Rot18 part
 
-Because the rot13 is too easy to decode with the plain eyes, I decided to use the Caesar cipher with the key 18.
+Because the rot13 is too easy to decode with the plain eyes, I decided to use
+the Caesar cipher with the key 18.
 
     Lzw xajkl tsffwj ak wfugvwv mkafy AWWW 754 xdgslk gf dafw 47. Al ak hjaflwv
     gfdq gf dalldw-wfvasf esuzafwk.

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -1,7 +1,7 @@
 # Most connected
 
-    Scott Vokes  
-    Twitter: @silentbicycle  
+Scott Vokes  
+Twitter: @silentbicycle  
 
 ## To build:
 
@@ -34,7 +34,7 @@ answer you seek with no hocus pocus.
 
 ## Author's comments:
 
-### Introduction
+### Introduction:
 
 This program reads a directed graph (as lines with integer node IDs),
 and prints the graph's nodes in reverse-topologically sorted order,
@@ -82,7 +82,7 @@ implementation of counting sort, which sorts each group.
 For other details about the input format, see "Issues and
 Limitations".
 
-### Building
+### Building:
 
 To build:
 
@@ -99,7 +99,7 @@ may also be necessary -- the function pointer declarations for
 `_` and `B` may get warnings otherwise, for reasons described
 under "Obfuscations".
 
-### Obfuscations
+### Obfuscations:
 
 - This entry uses functions that have a variable number of arguments,
   but despite what the rules say, there is no need to be careful about
@@ -115,8 +115,8 @@ under "Obfuscations".
 
 - It uses `_` in three different scopes: as a goto label (function
   scope), as an enum name, and a `_` function pointer (which is required
-  to have file scope, since it starts with '_'). There are also other
-  `_`s: it appears in a string, obscured by a headecimal escape sequence
+  to have file scope, since it starts with `_`). There are also other
+  `_`s: it appears in a string, obscured by a hexadecimal escape sequence
   (`\x5f`), and the cauldron is supported by a giant underscore.
   (Does this program qualify for Best One Liner?)
 
@@ -168,7 +168,7 @@ under "Obfuscations".
 - Oh, and the program is squashed into the shape of a bubbling cauldron,
   on top of a giant underscore, so there's that.
 
-### Issues and Limitations
+### Issues and Limitations:
 
 - Despite appearances, it does not handle numbers in hex, or provide
   a `curses(3)`-based interface.

--- a/2018/yang/.gitignore
+++ b/2018/yang/.gitignore
@@ -4,9 +4,10 @@ generated3.c
 generated4.c
 generated5.c
 left
-msg0
-msg1
-msg2
+msg[0-9]
 prog
 right
 shift
+rotated_counterclockwise.txt
+rotated_clockwise.txt
+no_leading_space.txt

--- a/2018/yang/README.md
+++ b/2018/yang/README.md
@@ -39,15 +39,14 @@ this program left and recompiling will reveal other tools including a right rota
 and a shift program.
 
 Strange things happen when the world is upside down! It is entirely possible
-that this is remark is completely misleading.
+that this remark is completely misleading.
 
 What exactly does the shift program do?
 
-Like a great sliding puzzle (hint) this entry has 6 more programs that will
-reveal messages and one more tool that can be used to reveal the final
-message hidden in the original source.  All of these can be created using
-combinations of ./left, ./right and ./shift and the additionally generated
-programs.
+Like a great sliding puzzle (hint) this entry has six more programs that will
+reveal messages and one more tool that can be used to reveal the final message
+hidden in the original source.  All of these can be created using combinations
+of `./left`, `./right` and `./shift` and the additionally generated programs.
 
 The final message can be revealed using
 
@@ -55,12 +54,12 @@ The final message can be revealed using
 ./msg9 < prog.c
 ```
 
-But what combinations will generate ./msg3, ./msg4, ./msg5, ./msg6, ./msg7,
-./msg8 and finally ./msg9?
+But what combinations will generate `./msg3`, `./msg4`, `./msg5`, `./msg6`,
+`./msg7`, `./msg8` and finally `./msg9`?
 
 ## Author's comments:
 
-### Tools usage
+### Tools' usage:
 
 Nuko is a text rotator: given some text in stdin, Nuko will write the
 same text to stdout, but rotated 90 degrees counterclockwise.
@@ -108,7 +107,7 @@ Where this might be useful, besides ruining the formatting of certain
 files, is that it completes the set of tools needed to solve the
 puzzle that is embedded in prog.c
 
-### Puzzle box
+### Puzzle box:
 
 Notice how the edges of prog.c contain two notches.  By rotating
 prog.c and removing leading space, the code would be shifted one space
@@ -135,20 +134,20 @@ in prog.c, all you need is a C compiler.
 
 ### Features
 
-   - Code compiles when rotated 4 ways.  This required a bit of
-     patience to achieve.  Code still compiles even with one column of
-     text shifted.  This required even more patience.
+- Code compiles when rotated 4 ways.  This required a bit of patience to
+achieve.  Code still compiles even with one column of text shifted.  This
+required even more patience.
 
-   - All rotated and shifted variants compiles without warnings.  This
-     involves various tweaks to satisfy cases where compiler is overly
-     protective, including but not limited to the "1125" at line 4 as
-     opposed to "1025", to satisfy -Waggresive-loop-optimizations.
+- All rotated and shifted variants compiles without warnings.  This involves
+various tweaks to satisfy cases where compiler is overly protective, including
+but not limited to the "1125" at line 4 as opposed to "1025", to satisfy
+`-Waggresive-loop-optimizations`.
 
-   - CRC32 of the code is embedded in the code itself.
+- CRC32 of the code is embedded in the code itself.
 
-   - Process for writing prog.c is available in spoiler.html
+- Process for writing prog.c is available in spoiler.html
 
-### Compatibility
+### Compatibility:
 
 Nuko and the rotated tools accepts only ASCII files where each
 character maps to exactly one byte.  Also, end-of-line sequence is
@@ -158,18 +157,18 @@ will look weird after rotation, for example.
 
 Nuko has been verified to work with these compiler / OS combinations:
 
-   - gcc 4.8.4 on Linux
-   - gcc 4.9.2 on Linux
-   - gcc 6.1.0 on JS/Linux
-   - gcc 6.3.0 on Linux
-   - gcc 6.4.0 on Cygwin
-   - clang 3.5.0 on Linux
-   - clang 3.8.1 on Linux
-   - clang 5.0.1 on Cygwin
-   - tcc 0.9.25 on JS/Linux
+- gcc 4.8.4 on Linux
+- gcc 4.9.2 on Linux
+- gcc 6.1.0 on JS/Linux
+- gcc 6.3.0 on Linux
+- gcc 6.4.0 on Cygwin
+- clang 3.5.0 on Linux
+- clang 3.8.1 on Linux
+- clang 5.0.1 on Cygwin
+- tcc 0.9.25 on JS/Linux
 
 Nuko compiles without warnings with all compilers above, even with
-"-Wall -Wextra -pedantic" for gcc and clang.
+`-Wall -Wextra -pedantic` for gcc and clang.
 
 ## Copyright and CC BY-SA 4.0 License:
 


### PR DESCRIPTION

I had put in the README.md that the entry needs XQuartz for macOS
because it uses X11 but this is not true (I should have known as this
was my favourite entry that year in the preview and it still is). The
point was that Terminal.app of macOS might not work. This has been
corrected.

As it happens it appears to work fine for me which I noted in the 
README.md. 

Formatting fixes, slight improvements and possibly typo fixes.

Add missing make rule docs that was referred to in the README.md but was
missing from the Makefile. It was found in the 
archive/2020/poikola/Makefile.