### PR TITLE
Fixes to 2018/mills/README.md

### DIFF
--- a/2018/mills/README.md
+++ b/2018/mills/README.md
@@ -1,7 +1,7 @@
 # Best of show
 
-    Christopher Mills <mrxo@sonic.net>  
-    Twitter: @MisterXopher  
+Christopher Mills <mrxo@sonic.net>  
+Twitter: @MisterXopher  
 
 ## To build:
 
@@ -21,13 +21,13 @@ make
 ./prog
 ```
 
-At the ">boot" prompt, type return
+At the `>boot` prompt, type return
 
-At the ":" prompt, type "rk(0,0)rkunix"
+At the `:` prompt, type `rk(0,0)rkunix`
 
-NOTE: To quit, press Control-E
+NOTE: To quit, press Control-E.
 
-### Selected Judges Remarks:
+### Selected Judges' Remarks:
 
 Do small machines only need small programs?  This program weighs in at just
 3636 bytes, which is considerably lighter than the original machine it can replace.
@@ -39,7 +39,7 @@ run v0. Just type:
 ./v0
 ```
 
-NOTE: To quit v0, press Control-E
+NOTE: To quit v0, press Control-E.
 
 You will be greeted with a familiar prompt of "login". The username and
 password are "dmr" and "dmr". To make things more familiar you'll need to
@@ -49,9 +49,9 @@ create '.' as it hasn't been invented yet on this image!
 @ ln dd dmr .
 ```
 
-An "ls" will reveal that C hasn't been invented yet! IOBCC anyone? The
-compiler is "bc". It producess assembly, which will then need to be assembled
-together in this order "ops.s bl.s hello.s bi.s" to produce a.out!
+An `ls` will reveal that C hasn't been invented yet! IOBCC anyone? The
+compiler is `bc`. It produces assembly, which will then need to be assembled
+together like `ops.s bl.s hello.s bi.s` (in that order) to produce a.out!
 
 But wait, we said this was the start of it all! This program can also run a
 program that replaces an even larger machine that can run BSD 2.9. To start this,
@@ -64,10 +64,10 @@ At the ">boot" prompt, type return
 
 At the ":" prompt, type "rk(0,0)rkunix"
 
-NOTE: To quit prog, press Control-E
+NOTE: To quit prog, press Control-E.
 
 This should now be very familiar and it is possible to compile and run one of
-the very first IOCCC entires "mullender.c"
+the very first IOCCC entires "mullender.c".
 
 But wait, there is even more!  Try:
 
@@ -75,20 +75,21 @@ But wait, there is even more!  Try:
 ./v6
 ```
 
-At the "@" prompt, type "rkunix"
+At the "@" prompt, type `rkunix`. You might want to type `stty -lcase` as
+otherwise the output will be in all caps.
 
-NOTE: To quit v6, press Control-E
+NOTE: To quit v6, press Control-E.
 
 ## Author's comments:
 
 >   *This IOCCC entry is dedicated to the late Dennis M. Ritchie*
 
-### The Program
+### The Program:
 
 Since this is the 25th "annual" IOCCC, I thought I should mark the occasion
 with a look back to its earliest roots.  At the same time the contest enters
 its 34th year of providing a safe forum for poor C code, the C language
-itself is fast approching its 50th anniversary, along with the UNIX operating
+itself is fast approaching its 50th anniversary, along with the UNIX operating
 system whose history is so entwined with.
 
 The program delivered here is both a full machine emulation of the original
@@ -96,13 +97,13 @@ PDP-7 that Ken Thompson used to write the first version of UNIX and a full
 machine emulation of the PDP-11/40 used by subsequent UNIXes.  The `Makefile`
 can build versions that can run each of the following:
 
-  1. UNIX v0 for the PDP-7 (circa 1969)
-  2. Research UNIX Version 6 (circa 1975)
-  3. BSD 2.9 (circa 1983)
+1. UNIX v0 for the PDP-7 (circa 1969)
+2. Research UNIX Version 6 (circa 1975)
+3. BSD 2.9 (circa 1983)
 
 For reasons to be described in a bit, the last (BSD 2.9) is the default.
 
-### Building and Running BSD 2.9
+### Building and Running BSD 2.9:
 
 To run BSD 2.9, do `make` to build `prog` and then `./prog` to run it.
 
@@ -110,13 +111,13 @@ You should see a prompt from the first-stage bootloader that looks like
 
         >boot
 
-Type `RETURN` at this point and you will get to the second-stage boot loader
+Hit enter/return at this point and you will get to the second-stage boot loader
 that looks like
 
         40Boot
         :
 
-The 40 in the prompt indicates that the bootloder has correctly determined
+The 40 in the prompt indicates that the bootloader has correctly determined
 that we are running on a PDP-11/40.
 
 At this point, type the rather cryptic command `rk(0,0)rkunix` -- this tells
@@ -169,7 +170,7 @@ Let's try some:
         # df
         Filesystem  Mounted on  kbytes    used    free  % used
         /dev/rk0    /             1958    1688     270     86%
-        # cc mullender.c
+        # bin/cc mullender.c
         # ./a.out
 
 The program you've just run was the [winner of the first IOCCC contest from
@@ -178,7 +179,7 @@ tightly bound to running on either a PDP-11 or a VAX.  Now you have one.
 
 Hitting Control-C will return you to the BSD UNIX prompt.  Hitting Control-D
 will log you out of the single-user session and get you back to the `:login:`
-prompt.  Here you can log in as `root` and get a full timesharing session.
+prompt.  Here you can log in as `root` and get a full time-sharing session.
 Feel free to try things like `vi`.  I've taken the liberty of editing the
 `.login` and `.profile` files to set the console to a less traditional setup
 so that you don't have to wait for the Model 33 KSR teletype to move its
@@ -193,8 +194,7 @@ possible, but I didn't get around to it...  As the Judges can no doubt attest,
 
 Once you've had enough fun in BSD 2.9, type Control-E to exit the emulation.
 
-Building and Running Research UNIX v6
--------------------------------------
+### Building and Running Research UNIX v6:
 
 Research UNIX v6 and BSD 2.9 use the same executable, but require a different
 disk image.  Type `make v6` to build it, then type `./prog` to run it.
@@ -248,6 +248,7 @@ Assuming you're more careful than that, we can try a few commands:
         {
             printf("Hello, World!\n");
         }
+	^D
         # cc foo.c
         # ./a.out
         Hello, World!
@@ -255,24 +256,24 @@ Assuming you're more careful than that, we can try a few commands:
 Why is Version 6 interesting?  Well, it was the oldest version that I could
 find a boot image of that had a C compiler...  This C compiler is recognizably
 C, but not quite the same syntax as we have today.  It's much closer to the
-[B language] [3] from which it is derrived.  In particular, this C compiler
+[B language] [3] from which it is derived.  In particular, this C compiler
 would not be able to compile `mullender.c` (as simple as it is), because the
 following syntax features don't exist yet:
 
-  * The `short` data type doesn't exist yet.  Only `int` (`short` will show
-    up when `long` comes, and the port to the Interdata 7/32 starts to make
-    the idea of portability become important).
-  * Hexidecimal constants don't exist yet.  Digital's computers all used
-    octal.
-  * The array initializer syntax hasn't yet moved to using `=`.  It still uses
-    the older form taken from B, which looks like `array[] { 1, 2, 3 };`
+* The `short` data type doesn't exist yet.  Only `int` (`short` will show
+up when `long` comes, and the port to the Interdata 7/32 starts to make
+the idea of portability become important).
+* Hexadecimal constants don't exist yet.  Digital's computers all used
+octal.
+* The array initializer syntax hasn't yet moved to using `=`.  It still uses
+the older form taken from B, which looks like `array[] { 1, 2, 3 };`
 
 It can still compile "Hello World!" (note that you must type a Control-D after
 you finish entering the code, to let `cat` see an end-of-file).
 
 This version of UNIX doesn't go into multi-user mode if you do a Control-D.
 Single-user mode was entered because the front-panel console switches were
-set to the magic number 0173030 (this can be changed with a re-compile).
+set to the magic number 0173030 (this can be changed with a recompile).
 
 Once you are done with Version 6, Type Control-E to exit the simulation.
 
@@ -281,20 +282,20 @@ code, and they use the same name for the disk (`rk05.fs`), if you want to go
 back to the BSD simulation, you should either delete `rk05.fs` or do a
 `make clean` before you do a `make`.
 
-### Building and Running UNIX v0
+### Building and Running UNIX v0:
 
 We now set the Wayback Machine to the very start of it all, 1969.
 
 [The story] [4] here is interesting and well worth a read.  Bell Labs was
-pulling out of the Multics project and Ken Thompson and his collegues had
+pulling out of the Multics project and Ken Thompson and his colleagues had
 become accustomed to the relatively nice programming environment.  They also
 enjoyed the early computer game [*Space Travel*] [5] and wanted another system
 to run it on.  They found a PDP-7 which was already obsolete at the time to
 port *Space Travel* to.  The primitive programming environment influenced
 Thompson to recreate parts of the Multics experience in the much more
-hardware-constrained PDP-7 environemnt.  In the summer of 1969, with his wife
-out on a month-long vacation, Thompson re-wrote a filesystem emulation he had
-been experementing with to include an assembler, a shell, an editor and an
+hardware-constrained PDP-7 environment.  In the summer of 1969, with his wife
+out on a month-long vacation, Thompson rewrote a filesystem emulation he had
+been experimenting with to include an assembler, a shell, an editor and an
 operating system kernel and hence created the first version of UNIX (although
 it hadn't been named that yet).
 
@@ -329,10 +330,10 @@ filesystem paths yet*.  In other words, we can't say something like
 We also haven't invented `.` or `..` yet.  In fact, the filesystem isn't even
 the traditional UNIX tree structure, it's a directed graph of hard links...
 
-`ls` needs to be able to read '`.`', the current directory.  `dmr`'s home
+`ls` needs to be able to read `.`, the current directory.  `dmr`'s home
 directory doesn't have that yet, but we can make it, because the home
 directory has a hard link to `dd`, which is the directory that holds all
-of the user home directories (this will eventually become ``/``, the root
+of the user home directories (this will eventually become `/`, the root
 path).  We can do
 
         @ ln dd dmr .
@@ -384,10 +385,10 @@ Now `ls` will work, and we can try some other things while we are here:
         Hello, World!
         @ 
 
-The last command is invoking the compiler for an exteremely early version of
+The last command is invoking the compiler for an extremely early version of
 the [B programming language] [3], the predecessor to C.  Thompson missed the
-convinience of writing code in a high-level language -- Multics was written
-a version of PL/1 -- and wanted the same convinience on UNIX.  He preferred
+convenience of writing code in a high-level language -- Multics was written
+a version of PL/1 -- and wanted the same convenience on UNIX.  He preferred
 BCPL (a typeless language) to PL/1.  As Dennis Ritchie [wrote] [6]:
 
 > B can be thought of as C without types; more accurately,
@@ -407,42 +408,42 @@ on the command line, concatenated together and assembled, producing a single
 remained the default name of the binary generated by the linker (and hence
 also by `cc`).
 
-This system is still has the familiarity of UNIX, with all the two- and
-three-letter commands, device files, shell redirection, the same core system
+This system is still has the familiarity of UNIX, with all the two and
+three letter commands, device files, shell redirection and the same core system
 calls (`read`, `write`, `open`, `close`, `creat`, `fork`, etc.).  There are a
 number of differences still:
 
-  * As noted, there are no file paths
-  * `read` and `write` do I/O on (18-bit) words.  Character I/O to files needs
-    to unpack those to bytes, and of course deal with `NUL` characters.
-  * `exec` was performed by the shell directly.  Arguments are passed as
-    four words (eight bytes), and space padded.  This matches the format for
-    file names for `open` and `creat`.
-  * `wait` does not yet exist.  A more complicated mechanism for sending and
-    recieving messages (`smes` and `rmes`) are used instead.
-  * File permission bits are all different, since groups don't exist yet.
-  * User programs are not allowed to run during disk I/O.  This is because the
-    disk controller's "data break" (DMA) accesses were so fast relative to the
-    CPU that transfers would be dropped if an instruction that used
-    "deferred" mode (indirection) was executed.  This also meant that the
-    "program break" (interrupt) routine in the kernel had to specifically
-    avoid deferred accesses by using self-modifying code to do indirection
-    through pointers.
-  * Although the PDP-7 suppoted a "trap mode" (a primitive supervisor mode),
-    the UNIX kernel doesn't use it.  This means that user programs could alter
-    or crash the kernel at will (in fact, there is a system call that returns
-    addresses of useful kernel routines so that user code can call them
-    directly).
+* As noted, there are no file paths.
+* `read` and `write` do I/O on (18-bit) words.  Character I/O on files need
+to unpack those bytes, and of course deal with `NUL` characters.
+* `exec` was performed by the shell directly.  Arguments are passed as
+four words (eight bytes), and space padded.  This matches the format for
+file names for `open` and `creat`.
+* `wait` does not yet exist.  A more complicated mechanism for sending and
+receiving messages (`smes` and `rmes`) are used instead.
+* File permission bits are all different, since groups don't exist yet.
+* User programs are not allowed to run during disk I/O.  This is because the
+disk controller's "data break" (DMA) accesses were so fast relative to the
+CPU that transfers would be dropped if an instruction that used
+"deferred" mode (indirection) was executed.  This also meant that the
+"program break" (interrupt) routine in the kernel had to specifically
+avoid deferred accesses by using self-modifying code to do indirection
+through pointers.
+* Although the PDP-7 supported a "trap mode" (a primitive supervisor mode),
+the UNIX kernel doesn't use it.  This means that user programs could alter
+or crash the kernel at will (in fact, there is a system call that returns
+addresses of useful kernel routines so that user code can call them
+directly).
 
 As usual, when you are done exploring UNIX v0, type Control-E to exit the
 simulator.
 
-### About the Program
+### About the Program:
 
 The program came about when I was looking for something to honor the pending
 50th anniversary of the C language (because of the mercurial nature of IOCCC
 contest scheduling, I chose not to wait for the actual 50th anniversary).
-I had though of writing self-hosting compilers for a stripped-down version of
+I had thought of writing self-hosting compilers for a stripped-down version of
 C, or maybe even a version of the B language...  At the same time, I was
 obsessed with the idea of allowing `mullender.c` from 1984 to run.  Although
 that was still a possibility on an interpreted version of B or a stripped-down
@@ -457,7 +458,7 @@ Thompson's PDP-7 that allowed them to get the system up and running.  Although
 source for the entire kernel and about half of the user-space commands were
 present (including the runtime and libraries for the B compiler), the
 remainder needed to be written from scratch, including the shell.  The final
-results of the project are [available on github] [9].
+results of the project are [available on GitHub] [9].
 
 None of this was remotely easy (as I was to discover myself).  The PDP-7 is
 long gone, and the documentation for it is less complete than one would like.
@@ -473,43 +474,43 @@ I decided that implementing this PDP-7 would be possible as an IOCCC entry.
 
 The emulator emulates the full machine:
 
-  * PDP-7 Central Processor
-  * Core Memeory Module Type 147 -- extends the core to 8,192 18-bit words
-  * Extended Arithmetic Element Type 177 -- adds one's-complement
-    multiplication, division and shifting
-  * Real Time Clock
-  * Teletype Model 33 KSR
-  * Perforated Tape Reader Type 444
-  * RB09 Fixed Disk Controller
+* PDP-7 Central Processor
+* Core Memory Module Type 147 -- extends the core to 8,192 18-bit words
+* Extended Arithmetic Element Type 177 -- adds one's-complement multiplication,
+division and shifting
+* Real Time Clock
+* Teletype Model 33 KSR
+* Perforated Tape Reader Type 444
+* RB09 Fixed Disk Controller
 
 The [PDP-7] [10] is an odd duck by modern computer standards:
 
-  * 18 bit words, with no byte addressing.
-  * Both one's and two's complement math (there is `ADD` for one's complement
-     and `TAD` for two's complement).  The EAE is entirely one's-complement.
-  * "Microcoded" instructions.
-  * Auto-increment memory locations.
-  * Non-reentrant function calls (the return address is stored at the indicated
-    address and the PC jumps to the location after it).
-  * The `XCT` instruction, that executes the word loaded from memory as an
-    instruction.
-  * An instruction `LAW` that loads the instruction opcode into the
-    accumulator.
-  * Heavy use of "inline" operands.  For instance the `MUL` instruction expects
-    the second operand to be stored in memory after the instruction.  This
-    pretty much requires the use of self-modifying code.
-  * No immediates.  Almost all constants have to live in memory locations and
-    be referenced by address.
-  * Common operations, like "subtract" and "inclusive OR" are not directly
-    supported on the machine and require multiple instructions and some spare
-    memory locations to support.  Being clever also helps.
-  * Single accumulator architecture.  No direct support for things like stacks.
-  * I/O is done with dedicated I/O instructions (which are also microcoded).
-  * The RB09 disk controller gets a special mention here because of its
-    particularly annoying encoding of track and sector offsets in
-    [packed BCD] [11].  A non-trivial amount of code space in the simulator
-    is needed to convert into and out of BCD, along with an equivalent amount
-    of code in the UNIX kernel itself.
+* 18 bit words, with no byte addressing.
+* Both one's and two's complement math (there is `ADD` for one's complement and
+`TAD` for two's complement).  The EAE is entirely one's-complement.
+* "Microcoded" instructions.
+* Auto-increment memory locations.
+* Non-reentrant function calls (the return address is stored at the indicated
+address and the PC jumps to the location after it).
+* The `XCT` instruction, that executes the word loaded from memory as an
+instruction.
+* An instruction `LAW` that loads the instruction opcode into the
+accumulator.
+* Heavy use of "inline" operands.  For instance the `MUL` instruction expects
+the second operand to be stored in memory after the instruction.  This
+pretty much requires the use of self-modifying code.
+* No immediates.  Almost all constants have to live in memory locations and
+be referenced by address.
+* Common operations, like "subtract" and "inclusive OR" are not directly
+supported on the machine and require multiple instructions and some spare
+memory locations to support.  Being clever also helps.
+* Single accumulator architecture.  No direct support for things like stacks.
+* I/O is done with dedicated I/O instructions (which are also microcoded).
+* The RB09 disk controller gets a special mention here because of its
+particularly annoying encoding of track and sector offsets in
+[packed BCD] [11].  A non-trivial amount of code space in the simulator
+is needed to convert into and out of BCD, along with an equivalent amount
+of code in the UNIX kernel itself.
 
 The simulation handles everything I was able to discover about the PDP-7, even
 things that the UNIX code itself doesn't use.  For instance, it correctly
@@ -545,13 +546,13 @@ this problem in two ways:
 First, I didn't submit the source code or binary image for v0 UNIX as part of
 my IOCCC entry.  I merely submitted a `Makefile` that can issue a `curl`
 command to fetch a prebuilt v0 disk image from the github repository.  I am
-hoping this is considered part of "Legal abose of the rules" which is supposed
+hoping this is considered part of "Legal abuse of the rules" which is supposed
 to be "somewhat encouraged".  As per RULE 12, I am justifying said abuse here,
 in the remarks file.
 
 Secondly, the choice to run the UNIX v0 code is optional.  If you are worried
 about Nokia's lawyers running you to ground for running a 50-year old copy
-of a binary image for a machine that is almost completely nonexistant, you
+of a binary image for a machine that is almost completely non-existent, you
 can just not do so.  Delete the lines from the `Makefile` and sleep well.
 You still have two other UNIXes to play with.
 
@@ -571,22 +572,22 @@ So if I have a PDP-7 emulator, how do I run operating systems that expect a
 PDP-11?  Simple...  *I emulate a PDP-11/40 on the PDP-7*.  I have written
 PDP-7 assembler code to emulate a PDP-11/40 with the following equipment:
 
-  * PDP-11/40 (KD11-A)
-  * EIS instruction set (KE11-E)
-  * Memory management unit (KJ11-A)
-  * Line time clock (KT11-D)
-  * 124 Kwords of memory (244 Kbytes)
-  * RK05 fixed disk drive (RK11)
-  * Console TTY (DL11)
+* PDP-11/40 (KD11-A)
+* EIS instruction set (KE11-E)
+* Memory management unit (KJ11-A)
+* Line time clock (KT11-D)
+* 124 Kwords of memory (244 Kbytes)
+* RK05 fixed disk drive (RK11)
+* Console TTY (DL11)
 
 This required a few tweaks to the emulator.  The first problem is that the
 RK05 disk is about 2.5 MB, but the RB09 is only about 2 MB.  That's easily
-solveable -- just add more tracks to the RB09.  UNIX v0 is unlikely to notice
+solvable -- just add more tracks to the RB09.  UNIX v0 is unlikely to notice
 (although the number of tracks is a compile time parameter, and the `v0`
 build commands set it to the correct value).
 
 The second problem is that we are simulating a system that can have up to
-124 Kwords of memory on a system with only 8 Kwords total.  That meant I needed
+124K words of memory on a system with only 8K words total.  That meant I needed
 to virtualize the PDP-11/40's physical memory (and add a few more tracks to
 the disk to hold the virtualization).
 
@@ -609,7 +610,7 @@ PDP-11's disk is 16-bit, but the PDP-7's is 18-bit (which the emulator stores
 in 32-bit `int`s), a conversion program is needed to unpack the binary disk
 images from 16 bits per word to 32.  This in turn needs to be done in the
 `Makefile` using standard POSIX tools, which aren't exactly good with binary.
-I had a wierdly clever way to do this with `od`, `awk` and `uudecode` that
+I had a weirdly clever way to do this with `od`, `awk` and `uudecode` that
 I will leave as an exercise for the curious, but I decided it would be easier
 to do it with the PDP-7 emulator itself, feeding a simple program in on its
 boot tape.  This required an additional tweak to the emulator, since by default
@@ -620,8 +621,8 @@ parity).  This is also enabled by a compile-time setting (used only for the
 
 Despite the complexity of the PDP-11 instruction set and its emulated I/O
 devices and the corresponding primitiveness of the PDP-7's instruction set,
-the emulation itself is a suprisingly small amount of code, not really taxing
-the 8 Kword memory, with about 2.25 Kwords of actual code and a similar
+the emulation itself is a surprisingly small amount of code, not really taxing
+the 8K word memory, with about 2.25 Kwords of actual code and a similar
 amount of space for the memory virtualization cache and disk block buffer,
 leaving nearly half (3.5 Kwords) of the memory unused.  The simulator executes
 somewhere around 250 PDP-7 instructions per PDP-11 instruction.  On my laptop,
@@ -638,37 +639,37 @@ window on the dawn of the UNIX era.  I feel that someone should complete the
 circle here by emulating a VAX 780 on the PDP-11 and run 4.2BSD on it, so that
 we can get the [original runtime environment used for the first IOCCC] [13].
 
-### Compile-time Options
+### Compile-time Options:
 
 The following command flags control the compilation:
 
-  * `-DI="image.fs"`: Name of the disk image file.  This must be created
-     offline, and be of the correct size to avoid segmentation violations.
-  * `-DA=4096`: Setting of the console address switches.  This tells the RIM
-    bootloader where to load the boot image.
-  * `-DS=0`: Setting of the console data switches.  The PDP-7 emulation can
-    read these with the microcoded `OAS` (OR switches into AC) instruction.
-    By proxy, the PDP-11 emulation can read them via the `CSW` device.
-  * `-DW=MAP_PRIVATE`: This sets the memory mapping for `mmap`.  Setting to
-    `MAP_PRIVATE` makes the disk image be copy-on-write.  Setting it to
-    `MAP_SHARED` makes the disk image be sharable.  Do the latter if you want
-    to preserve the disk contents between sessions.
-  * `-DT=`: List of initializers for the `termios` structure.  The v0 UNIX
-    expects the terminal to be in half-duplex mode, echoing its input, with
-    swapped CR and NL.  The PDP-11 UNIXes don't.
-  * `-DX=5`: The ASCII code of the control character that causes the simulation
-    to abort.  If set to 0, there is no abort code.
-  * `-DY=128`: Controls console I/O parity.  If set to zero, the console is
-    eight-bit clean.  If set to 128, the high bit is set on keyboard reads and
-    masked off on printer output ("mark" parity).  UNIX v0 expects the latter.
-  * `-DV=270`: The size of the disk, in tracks.  The UNIX v0 disk has 200
-    tracks (each has 80 sectors of 64 18-bit words).  The PDP-11 UNIXes
-    increase this to 270, to allow for the larger RK05 disk emulation
-    (406 tracks of twelve 256-word sectors), plus the space for the 124 Kwords
-    of virtualized memory and the 8 Kwords of emulator code.
-  * `-DP="xxx"`: RIM bootstrap program paper tape image.  Be careful with the
-    quoting here -- there is at least three levels going on.  In particular,
-    you will need to escape `$` as `$$` to protect it from `make`.
+* `-DI="image.fs"`: Name of the disk image file.  This must be created
+ offline, and be of the correct size to avoid segmentation violations.
+* `-DA=4096`: Setting of the console address switches.  This tells the RIM
+bootloader where to load the boot image.
+* `-DS=0`: Setting of the console data switches.  The PDP-7 emulation can
+read these with the microcoded `OAS` (OR switches into AC) instruction.
+By proxy, the PDP-11 emulation can read them via the `CSW` device.
+* `-DW=MAP_PRIVATE`: This sets the memory mapping for `mmap`.  Setting to
+`MAP_PRIVATE` makes the disk image be copy-on-write.  Setting it to
+`MAP_SHARED` makes the disk image be shareable.  Do the latter if you want
+to preserve the disk contents between sessions.
+* `-DT=`: List of initializers for the `termios` structure.  The v0 UNIX
+expects the terminal to be in half-duplex mode, echoing its input, with
+swapped CR and NL.  The PDP-11 UNIXes don't.
+* `-DX=5`: The ASCII code of the control character that causes the simulation
+to abort.  If set to 0, there is no abort code.
+* `-DY=128`: Controls console I/O parity.  If set to zero, the console is
+eight-bit clean.  If set to 128, the high bit is set on keyboard reads and
+masked off on printer output ("mark" parity).  UNIX v0 expects the latter.
+* `-DV=270`: The size of the disk, in tracks.  The UNIX v0 disk has 200
+tracks (each has 80 sectors of 64 18-bit words).  The PDP-11 UNIXes
+increase this to 270, to allow for the larger RK05 disk emulation
+(406 tracks of twelve 256-word sectors), plus the space for the 124K words
+of virtualized memory and the 8K words of emulator code.
+* `-DP="xxx"`: RIM bootstrap program paper tape image.  Be careful with the
+quoting here -- there is at least three levels going on.  In particular,
+you will need to escape `$` as `$$` to protect it from `make`.
 
 ### What is the ASCII art supposed to be?
 
@@ -678,23 +679,23 @@ The ASCII art represents a torn piece of [paper tape] [14].
 
 None of this could have been possible without the hard work of
 
-  * Warren Toomey and the other members of the
-    [The Unix Heratage Society] [15]
-  * Robert M. Supnik and the other contributors to [SimH] [16], the simulator
-    for historic computer architectures.  The number of times I needed to
-    "Use the Source, Luke" on SimH to unravel some dark corner of these
-    machines was uncountable.
-  * [Bitsavers] [17], which acquired, scanned and preserved all the manuals
-    I spent many hours squinting at.
-  * Ken Thompson, Dennis Ritchie, Brian Kernigan, M\. D\. McIlroy, J\. F\.
-    Osssanna, Rudd Canaday and the other members of the Bell Labs
-    Computing Science Research Center who were responsible for the invention
-    of UNIX, the C programming language, and the innumerable other innovations
-    that we now take for granted as part of the modern software landscape.
-    In particular, the [home page of the late Dennis Ritchie] [18] contained
-    a trove of useful information on the evolution of UNIX and C and is
-    recommended for perusal by others who share my peculiar retrocomputing
-    affectations.
+* Warren Toomey and the other members of the
+[The Unix Heritage Society] [15]
+* Robert M. Supnik and the other contributors to [SimH] [16], the simulator
+for historic computer architectures.  The number of times I needed to
+"Use the Source, Luke" on SimH to unravel some dark corner of these
+machines was uncountable.
+* [Bitsavers] [17], which acquired, scanned and preserved all the manuals
+I spent many hours squinting at.
+* Ken Thompson, Dennis Ritchie, Brian Kernigan, M\. D\. McIlroy, J\. F\.
+Osssanna, Rudd Canaday and the other members of the Bell Labs
+Computing Science Research Center who were responsible for the invention
+of UNIX, the C programming language, and the innumerable other innovations
+that we now take for granted as part of the modern software landscape.
+In particular, the [home page of the late Dennis Ritchie] [18] contained
+a trove of useful information on the evolution of UNIX and C and is
+recommended for perusal by others who share my peculiar retrocomputing
+affectations.
 
 Finally, thanks to my spouse for putting up with the many hours I spent on this
 nonsense, and treating "I'm working on my IOCCC entry" as an acceptable answer

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -118,6 +118,7 @@ TARGET= ${PROG}
 ALT_OBJ=
 ALT_TARGET=
 
+DOCS= poikola.tex
 
 #################
 # build the entry
@@ -142,6 +143,10 @@ alt: data ${ALT_TARGET}
 #
 data: ${DATA}
 	@${TRUE}
+
+docs: ${DOCS}
+	pdflatex ${DOCS}
+
 
 # both all and alt
 #

--- a/2018/poikola/README.md
+++ b/2018/poikola/README.md
@@ -9,10 +9,11 @@
 make
 ```
 
-NOTE: this entry requires `X11/Xlib.h` header file and the X11 library to
-compile. macOS users running Mountain Lion and later will need to download and
-install [XQuartz](https://www.xquartz.org) in order to compile and run this
-entry.
+NOTE: some have reported that Terminal.app in macOS does not work and one might
+need a different terminal emulator like that from
+[XQuartz](https://www.xquartz.org) but [Cody Boone
+Ferguson](/winners.html#Cody_Boone_Ferguson) reported that this works fine in
+macOS Ventura with Terminal.app. YMMV of course.
 
 
 ## To run:
@@ -42,7 +43,7 @@ And those in the deep south might wish to go north for a better view.
 
 ## Author's comments:
 
-### How to build
+### How to build:
 
 ```sh
 cc -o prog -std=gnu11 -O3 prog.c
@@ -54,67 +55,91 @@ or
 make
 ```
 
-### Poster
+### Poster:
 
-You can generate an A3 sized poster by _make docs_. This command creates a pdf file _poikola.pdf_.
+You can generate an A3 sized poster by _make docs_. This command creates a pdf
+file _poikola.pdf_.
 
-### What this entry does
-#### Introduction
-It was a starry night when my wife pointed her finger up and asked: "What is this star and may I have some Easter eggs?"
+### What this entry does:
 
-So I had to sit down and solve those tricky questions with Nano and a C compiler.
+#### Introduction:
+It was a starry night when my wife pointed her finger up and asked: "What is
+this star and may I have some Easter eggs?"
 
-#### Little spoilers
-Basically, the program draws animated ASCII art of the Big Dipper using Annie Jump Cannon's spectral classification system of stars and I think the
-colors of the output are as accurate as possible.
+So I had to sit down and solve those tricky questions with Nano and a C
+compiler.
 
-This program also tells once in a year if it is correct time to find and eat some Easter eggs.
+#### Little spoilers:
+
+Basically, the program draws animated ASCII art of the Big Dipper using Annie
+Jump Cannon's spectral classification system of stars and I think the colors of
+the output are as accurate as possible.
+
+This program also tells once in a year if it is correct time to find and eat
+some Easter eggs.
 
 The program has also at least three other functions, obvious and not so obvious.
 
 #### Technical jargon
-This program has been tested on xterm and Konsole and also Linux virtual terminal. Color support in the terminal is not necessary, but the effect is better with it.
-This entry has partial support for terminals with a white background but the best viewing experience is achieved when the terminal in use supports 24-bit colors,
-has a black background and the size is at least 125x38.
+This program has been tested on xterm and Konsole and also Linux virtual
+terminal. Color support in the terminal is not necessary, but the effect is
+better with it.
 
-Special note for Mac users: __Terminal__ does not work as expected you might need xterm from XQuartz or some other
-working terminal. Thanks to [Dave Burton](/winners.html#Dave_Burton) for spotting this problem.
+This entry has partial support for terminals with a white background but the
+best viewing experience is achieved when the terminal in use supports 24-bit
+colors, has a black background and the size is at least 125x38.
 
-The main reason for the header `unistd.h` is `getdelim()` but once I included it I also abused other functions and defines. This header is mutually exclusive with _-std=c11_.
+Special note for Mac users: __Terminal__ does not work as expected you might
+need xterm from XQuartz or some other working terminal. Thanks to [Dave
+Burton](/winners.html#Dave_Burton) for spotting this problem.
 
-The program was developed with little-endian machines; I tried to support big-endian too, but this support is somewhat limited.
+The main reason for the header `unistd.h` is `getdelim()` but once I included it
+I also abused other functions and defines. This header is mutually exclusive
+with _-std=c11_.
+
+The program was developed with little-endian machines; I tried to support
+big-endian too, but this support is somewhat limited.
 
 This program has been compiled in
 
 1. i386 (Debian Stretch) with gcc and clang
 2. amd64 (Debian Buster) with gcc and clang
 3. Raspberry Pi 3 (Debian stretch) with gcc and clang
-4. Lego Mindstorms EV3 Intelligent Brick (Debian Jessie) with gcc and clang (in this case, compiling time with clang-3.5 12 seconds and with gcc 27 seconds)
+4. Lego Mindstorms EV3 Intelligent Brick (Debian Jessie) with gcc and clang (in
+this case, compiling time with clang-3.5 12 seconds and with gcc 27 seconds)
 
-### Warnings and restrictions required by law
+### Warnings and restrictions required by law:
 Please do not feed little babies chocolate.
 
-### Major spoilers
+### Major spoilers:
 <div style="margin-bottom:61em;">&nbsp;</div>
 
-I incorporated the Fletcher 16 checksum algorithm into the source for security reasons; it might be challenging to make changes without breaking the main functionality of the code.
+I incorporated the Fletcher 16 checksum algorithm into the source for security
+reasons; it might be challenging to make changes without breaking the main
+functionality of the code.
+
 The space after `#define p return` is necessary.
 
-The computus uses an algorithm described in the journal Nature in 1876. It should be valid for Gregorian calendars.
+The computus (method to determine the date of Easter) uses an algorithm
+described in the journal Nature in 1876. It should be valid for Gregorian
+calendars.
 
-#### Some obfuscation techniques used
+### Some obfuscation techniques used:
 
-1. I tried to use meaningless or misleading variable names. For example, this program draws the Big Dipper with the correct colors, but variables
-like `o`, `b`, and `a` are used in totally unrelated tasks.
+1. I tried to use meaningless or misleading variable names. For example, this
+program draws the Big Dipper with the correct colors, but variables like `o`,
+`b`, and `a` are used in totally unrelated tasks.
 2. I reused and recycled variables almost every time when possible.
 3. Unnecessary use of predefined stuff like `__ATOMIC_SEQ_CST`.
-4. When I was a kid, my favorite programming language was Pascal. In Pascal, there are things like `begin;` and `end;` instead of curly brackets.
-They are used also in my code, but I had to shorten them to meet size requirements.
-5. I also have strong Perl background,
-and therefore I added some dollar signs to the code. One of the first ideas was to
-write all variables with prefixed `$`, but then I rejected it.
+4. When I was a kid, my favorite programming language was Pascal. In Pascal,
+there are things like `begin;` and `end;` instead of curly brackets. They are
+used also in my code, but I had to shorten them to meet size requirements.
+5. I also have strong Perl background, and therefore I added some dollar signs
+to the code. One of the first ideas was to write all variables with prefixed
+`$`, but then I rejected it.
 
-If you think you understand how this program works, can you answer these questions:
+If you think you understand how this program works, can you answer these
+questions:
 
 1. What is the value of `aI_` after line 21?
 2. Why are there some big numbers on line 47?
@@ -124,7 +149,8 @@ If you think you understand how this program works, can you answer these questio
 
 ### Rot18 part
 
-Because the rot13 is too easy to decode with the plain eyes, I decided to use the Caesar cipher with the key 18.
+Because the rot13 is too easy to decode with the plain eyes, I decided to use
+the Caesar cipher with the key 18.
 
     Lzw xajkl tsffwj ak wfugvwv mkafy AWWW 754 xdgslk gf dafw 47. Al ak hjaflwv
     gfdq gf dalldw-wfvasf esuzafwk.

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -1,7 +1,7 @@
 # Most connected
 
-    Scott Vokes  
-    Twitter: @silentbicycle  
+Scott Vokes  
+Twitter: @silentbicycle  
 
 ## To build:
 
@@ -34,7 +34,7 @@ answer you seek with no hocus pocus.
 
 ## Author's comments:
 
-### Introduction
+### Introduction:
 
 This program reads a directed graph (as lines with integer node IDs),
 and prints the graph's nodes in reverse-topologically sorted order,
@@ -82,7 +82,7 @@ implementation of counting sort, which sorts each group.
 For other details about the input format, see "Issues and
 Limitations".
 
-### Building
+### Building:
 
 To build:
 
@@ -99,7 +99,7 @@ may also be necessary -- the function pointer declarations for
 `_` and `B` may get warnings otherwise, for reasons described
 under "Obfuscations".
 
-### Obfuscations
+### Obfuscations:
 
 - This entry uses functions that have a variable number of arguments,
   but despite what the rules say, there is no need to be careful about
@@ -115,8 +115,8 @@ under "Obfuscations".
 
 - It uses `_` in three different scopes: as a goto label (function
   scope), as an enum name, and a `_` function pointer (which is required
-  to have file scope, since it starts with '_'). There are also other
-  `_`s: it appears in a string, obscured by a headecimal escape sequence
+  to have file scope, since it starts with `_`). There are also other
+  `_`s: it appears in a string, obscured by a hexadecimal escape sequence
   (`\x5f`), and the cauldron is supported by a giant underscore.
   (Does this program qualify for Best One Liner?)
 
@@ -168,7 +168,7 @@ under "Obfuscations".
 - Oh, and the program is squashed into the shape of a bubbling cauldron,
   on top of a giant underscore, so there's that.
 
-### Issues and Limitations
+### Issues and Limitations:
 
 - Despite appearances, it does not handle numbers in hex, or provide
   a `curses(3)`-based interface.

--- a/2018/yang/.gitignore
+++ b/2018/yang/.gitignore
@@ -4,9 +4,10 @@ generated3.c
 generated4.c
 generated5.c
 left
-msg0
-msg1
-msg2
+msg[0-9]
 prog
 right
 shift
+rotated_counterclockwise.txt
+rotated_clockwise.txt
+no_leading_space.txt

--- a/2018/yang/README.md
+++ b/2018/yang/README.md
@@ -39,15 +39,14 @@ this program left and recompiling will reveal other tools including a right rota
 and a shift program.
 
 Strange things happen when the world is upside down! It is entirely possible
-that this is remark is completely misleading.
+that this remark is completely misleading.
 
 What exactly does the shift program do?
 
-Like a great sliding puzzle (hint) this entry has 6 more programs that will
-reveal messages and one more tool that can be used to reveal the final
-message hidden in the original source.  All of these can be created using
-combinations of ./left, ./right and ./shift and the additionally generated
-programs.
+Like a great sliding puzzle (hint) this entry has six more programs that will
+reveal messages and one more tool that can be used to reveal the final message
+hidden in the original source.  All of these can be created using combinations
+of `./left`, `./right` and `./shift` and the additionally generated programs.
 
 The final message can be revealed using
 
@@ -55,12 +54,12 @@ The final message can be revealed using
 ./msg9 < prog.c
 ```
 
-But what combinations will generate ./msg3, ./msg4, ./msg5, ./msg6, ./msg7,
-./msg8 and finally ./msg9?
+But what combinations will generate `./msg3`, `./msg4`, `./msg5`, `./msg6`,
+`./msg7`, `./msg8` and finally `./msg9`?
 
 ## Author's comments:
 
-### Tools usage
+### Tools' usage:
 
 Nuko is a text rotator: given some text in stdin, Nuko will write the
 same text to stdout, but rotated 90 degrees counterclockwise.
@@ -108,7 +107,7 @@ Where this might be useful, besides ruining the formatting of certain
 files, is that it completes the set of tools needed to solve the
 puzzle that is embedded in prog.c
 
-### Puzzle box
+### Puzzle box:
 
 Notice how the edges of prog.c contain two notches.  By rotating
 prog.c and removing leading space, the code would be shifted one space
@@ -135,20 +134,20 @@ in prog.c, all you need is a C compiler.
 
 ### Features
 
-   - Code compiles when rotated 4 ways.  This required a bit of
-     patience to achieve.  Code still compiles even with one column of
-     text shifted.  This required even more patience.
+- Code compiles when rotated 4 ways.  This required a bit of patience to
+achieve.  Code still compiles even with one column of text shifted.  This
+required even more patience.
 
-   - All rotated and shifted variants compiles without warnings.  This
-     involves various tweaks to satisfy cases where compiler is overly
-     protective, including but not limited to the "1125" at line 4 as
-     opposed to "1025", to satisfy -Waggresive-loop-optimizations.
+- All rotated and shifted variants compiles without warnings.  This involves
+various tweaks to satisfy cases where compiler is overly protective, including
+but not limited to the "1125" at line 4 as opposed to "1025", to satisfy
+`-Waggresive-loop-optimizations`.
 
-   - CRC32 of the code is embedded in the code itself.
+- CRC32 of the code is embedded in the code itself.
 
-   - Process for writing prog.c is available in spoiler.html
+- Process for writing prog.c is available in spoiler.html
 
-### Compatibility
+### Compatibility:
 
 Nuko and the rotated tools accepts only ASCII files where each
 character maps to exactly one byte.  Also, end-of-line sequence is
@@ -158,18 +157,18 @@ will look weird after rotation, for example.
 
 Nuko has been verified to work with these compiler / OS combinations:
 
-   - gcc 4.8.4 on Linux
-   - gcc 4.9.2 on Linux
-   - gcc 6.1.0 on JS/Linux
-   - gcc 6.3.0 on Linux
-   - gcc 6.4.0 on Cygwin
-   - clang 3.5.0 on Linux
-   - clang 3.8.1 on Linux
-   - clang 5.0.1 on Cygwin
-   - tcc 0.9.25 on JS/Linux
+- gcc 4.8.4 on Linux
+- gcc 4.9.2 on Linux
+- gcc 6.1.0 on JS/Linux
+- gcc 6.3.0 on Linux
+- gcc 6.4.0 on Cygwin
+- clang 3.5.0 on Linux
+- clang 3.8.1 on Linux
+- clang 5.0.1 on Cygwin
+- tcc 0.9.25 on JS/Linux
 
 Nuko compiles without warnings with all compilers above, even with
-"-Wall -Wextra -pedantic" for gcc and clang.
+`-Wall -Wextra -pedantic` for gcc and clang.
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/faq.md
+++ b/faq.md
@@ -50,10 +50,13 @@ Thank you Cody!
 
 See also [Yusuke Endoh](/winners.html#Yusuke_Endoh)'s entry
 [2015/endoh3](/2015/endoh3/README.md) entry which lets one compile it and run
-it.
+it. Another entry that you can enjoy it under is [Christopher
+Mill](/winners.html#Christopher_Mills)'s entry
+[2018/mills](/2018/mills/README.md) which is a PDP-7 emulator as well as a
+PDP-11/40 emulator. 
 
 Others are not so easy though we're working on this and over time have added
-alternative code and in some cases replaced the original code with code that
+alternative code. In some cases we replaced the original code with code that
 works for modern systems.
 
 


### PR DESCRIPTION

Typo fixes, formatting fixes and other things.

Updated faq.md with a note that this entry can also be used to run 
1984/mullender.
