### PR TITLE
Add author comments to 2018/endoh2/README.md

### DIFF
--- a/2018/endoh2/README.md
+++ b/2018/endoh2/README.md
@@ -40,6 +40,35 @@ This is an EX-tremely obfuscated program!
 
 ## Author's comments:
 
+
+A high-context work that combines parrots that new hackers like and parrots that
+old hackers like. One is an internet meme called [Party
+Parrot](https://cultofthepartyparrot.com). The other is a
+sketch (comte) called ["Dead
+Parrot"](https://en.wikipedia.org/wiki/Dead_Parrot_sketch) from the British
+comedy TV show ["Monty Python's Flying Circus"](https://en.wikipedia.org/wiki/Monty_Python%27s_Flying_Circus)
+The "_Python_" in the award name refers to Monty Python, **not** the
+[programming language Python (the name of the programming language Python is
+derived from Monty
+Python)](https://en.wikipedia.org/wiki/Python_(programming_language).
+
+
+The shape of prog.c is "Undead Parrot" based on "dead parrot". The message that
+appears in the bottom line of the output source code is the subject of the
+dialogue that appears in "Dead Parrot" and explains in various expressions that
+the parrot died. Also, the second **__<-_Source_of_Parrots__** line from the bottom
+<http://cultofthepartyparrot.com/> has a hidden URL (hidden by the parrot's body).
+
+Although it is a boring Quine story, it is quite difficult to have 10 parrot
+pictures and 10 lines of data. Only the outline data of the parrot picture is
+saved, and the body is filled in at runtime. These data are probably compressed
+with [byte pair encoding](https://en.wikipedia.org/wiki/Byte_pair_encoding).
+
+The parrot ASCII art below is the opening line of the Monty Python show. The judge's
+comment ["And now for something completely
+different"](https://en.wikipedia.org/wiki/And_Now_for_Something_Completely_Different) is also used in the
+opening.
+
 ```
                              ___-----__
                           _--          --__


### PR DESCRIPTION
These were found on Yusuke Endoh's analysis of all the IOCCC winning entries. I kept the ASCII art he had for the comments but his comments for the entry seem like a good idea to include especially as he wrote them himself and they add to the entry itself.