### PR TITLE
Make 1994/ldb use fgets()

### DIFF
--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -1,20 +1,20 @@
 # Best One-liner:
 
-	Laurion Burchall
-	Brown University
-	Unit 4641
-	Providence RI 02912-4641
-	USA
+Laurion Burchall
+Brown University
+Unit 4641
+Providence RI 02912-4641
+USA
 
 ## To build:
 
         make all
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so it would
-compile and work with modern compilers. Thank you Cody for your assistance!
-
-NOTE: this entry uses `gets()` so you will likely get a warning on compilation
-and/or execution of the program.
+compile and work with modern compilers. The problem was that `srand()` returns
+void but it was used in a `||` expression. Thus the comma operator was needed.
+Cody also changed the entry to use `fgets()` instead of `gets()` to make it
+safe for lines greater than 231 in length. Thank you Cody for your assistance!
 
 
 ## To run:
@@ -23,7 +23,6 @@ and/or execution of the program.
 
 	some_command | ./ldb
 
-NOTE: input lines must be under 232 characters long.
 
 ## Try:
 
@@ -33,14 +32,15 @@ NOTE: input lines must be under 232 characters long.
 		Best One-liner\n
 		by Laurion Burchall" | ./ldb
 
-## Judges' comments
+## Judges' comments:
 
-Trigraphs are natural obfuscators.  Most C-beautifiers become 
-C-uglifiers because they don't handle them correctly.
+Trigraphs are natural obfuscators.  Most C-beautifiers become C-uglifiers
+because they don't handle them correctly.
 
-Can you figure out how it prints a given random line from stdin?
+Can you figure out how it prints a given random line (or if the line is longer
+than 231 characters, part of that line) from stdin?
 
-## Author's comments
+## Author's comments:
 
 All input lines must be under 232 characters long.  The compiling
 platform should be ASCII based.

--- a/1994/ldb/ldb.c
+++ b/1994/ldb/ldb.c
@@ -1,1 +1,1 @@
-int _,O,__??('}'??);main(){while(O?gets((rand()%O++?':':_)+__)||puts(&__??(_??))&_:(srand(time((O+++_))),0)||O);}
+int _,O,__??('}'??);main(){while(O?(fgets((rand()%O++?':':_)+__,232,stdin))||puts(&__??(_??))&_:(srand(time((O+++_))),0)||O);}

--- a/bugs.md
+++ b/bugs.md
@@ -453,7 +453,22 @@ this simply does not work with them. Can you help us?
 
 # 1994
 
-## [1994/schnitzi](1994/schnitzi.c) ([README.md])(1994/schnitzi/README.md))
+## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md))
+## STATUS: known bug - please help us fix
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile
+with modern systems (see the README.md file for what had to change) but the
+entry also used `gets()`. This could overflow long lines. Cody changed it to
+`fgets()` but this introduces another problem namely that newlines can be
+printed if the line length < 231.
+
+This seems like a worthy compromise but it would be ideal for it to never print
+a newline unless that's the line itself (a blank line).
+
+Cody will be looking at this later on.
+
+
+## [1994/schnitzi](1994/schnitzi/schnitzi.c) ([README.md])(1994/schnitzi/README.md))
 ## STATUS: uses gets() - change to fgets() if possible
 
 The original buffer size of this entry is 100 which is very easily overflowed


### PR DESCRIPTION
I had already fixed this entry to compile with modern compilers but a problem existed where lines longer than 231 characters (which generally would not happen but is not impossible) would overflow the buffer. Now it uses fgets() so this does not happen. A couple notes about this though.

It right now does print a newline after the output unless the line length is in fact 231 characters. This seems like a worthy compromise though. In time I hope to address this so that it does not ever print a newline (a blank line notwithstanding which does happen and is part of the entry).

The second thing to be aware of is just a subtlety with the entry: what happens with a line of length 394? What you'll find is that it might print the first 231 characters or it might print the last 163 characters plus the newline (the 231 one does not have a newline).

I've added to bugs.md the part where it will print a newline if the line length < 231.

At the same time I fixed a path in the bugs.md file that I noticed.