### PR TITLE
Minor fixes to 1994/ldb

### DIFF
--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -132,7 +132,6 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: this entry uses gets() so you might get a warning compiling and/or running this."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -14,7 +14,10 @@ USA
 compile and work with modern compilers. The problem was that `srand()` returns
 void but it was used in a `||` expression. Thus the comma operator was needed.
 Cody also changed the entry to use `fgets()` instead of `gets()` to make it
-safe for lines greater than 231 in length. Thank you Cody for your assistance!
+safe for lines greater than 231 in length. Note that this now prints a newline
+after the output but this seems like a worthy compromise for making it safer
+(fixing it is more problematic than it is worth). Thank you Cody for your
+assistance!
 
 
 ## To run:

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -16,8 +16,10 @@ void but it was used in a `||` expression. Thus the comma operator was needed.
 Cody also changed the entry to use `fgets()` instead of `gets()` to make it
 safe for lines greater than 231 in length. Note that this now prints a newline
 after the output but this seems like a worthy compromise for making it safer
-(fixing it is more problematic than it is worth). Thank you Cody for your
-assistance!
+(fixing it is more problematic than it is worth).  A subtlety about this fix: if
+a line is greater than 231 in length if the program chooses that line it might
+print the first 231 characters or it might print (up to) the next 231 characters
+and so on. Thank you Cody for your assistance!
 
 
 ## To run:


### PR DESCRIPTION
Remove warning from Makefile that this entry uses gets() as this is no longer true.

Update README.md pointing out that this will print a newline after the output.