### PR TITLE
Fixes in 2019/endoh

### DIFF
--- a/2019/endoh/.gitignore
+++ b/2019/endoh/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog2.c

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -65,7 +65,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT= -O3
+OPT=
 
 # Default flags for ANSI C compilation
 #
@@ -129,7 +129,7 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+	${CC} ${CFLAGS} -g $< -o $@ ${LIBS}
 
 # alternative executable
 #

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -1,7 +1,7 @@
 # Most in need of debugging
 
-    Yusuke Endoh  
-    Twitter: @mametter  
+Yusuke Endoh  
+Twitter: @mametter  
 
 ## To build:
 
@@ -18,17 +18,17 @@ make
 ## Try:
 
 ```sh
-gdb ./prog || llvm ./prog
+gdb ./prog || lldb ./prog
 ```
 
 ## Judges' comments:
 
-The purpose of this program is to crash. You'll want to have memorized "man
-ascii" when debugging it to reveal its purpose.
+The purpose of this program is to crash. You'll want to have memorized `man 7
+ascii` when debugging it to reveal its purpose.
 
 ## Author's comments:
 
-### backtrace quine
+### backtrace quine:
 
 Compile prog.c with no optimization.
 
@@ -78,7 +78,7 @@ See the line numbers and lookup the ASCII table.
     101 = 'e'
     ...
 
-### One more thing
+### One more thing:
 
 The original program can be used as a GDB command file.
 


### PR DESCRIPTION
Remove optimisation from Makefile and add -g to compile line as it's a backtrace quine.

Add to .gitignore prog2.c as the author's comments suggest a command that will create it.

I believe that the llvm should be lldb as that's the debugger (macOS) and the llvm tools are not.

Format fixes in README.md.