### PR TITLE
Fix 1986/wall to no longer need -traditional-cpp

### DIFF
--- a/1986/wall/.gitignore
+++ b/1986/wall/.gitignore
@@ -1,1 +1,2 @@
 wall
+wall.alt

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -114,13 +114,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
-
-# FORCE use of -traditional-cpp
-#
-CFLAGS+= -traditional-cpp
-
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 #################
 # build the entry
@@ -134,7 +129,6 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry requires a compiler that supports -traditional-cpp"
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -13,10 +13,10 @@ make all
 ```
 
 We used a patch provided by [Yusuke Endoh](/winners.html#Yusuke_Endoh) to make
-this work with gcc. Thank you Yusuke! [Cody Boone
-Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so that it does not
-require `-traditional-cpp`. This took a fair bit of tinkering as this entry *is*
-strange. Thank you Cody for your assistance!
+this work with gcc (in particular the patch uses `strdup()` on two strings).
+Thank you Yusuke! [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed
+this so that it does not require `-traditional-cpp`. This took a fair bit of
+tinkering as this entry *is* strange. Thank you Cody for your assistance!
 
 ## To use:
 

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -8,17 +8,37 @@ US of A
 
 ## To build:
 
-        make all
-
+```sh
+make all
+```
 
 We used a patch provided by [Yusuke Endoh](/winners.html#Yusuke_Endoh) to make
-this work with gcc. Thank you Yusuke!
+this work with gcc. Thank you Yusuke! [Cody Boone
+Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so that it does not
+require `-traditional-cpp`. This took a fair bit of tinkering as this entry *is*
+strange. Thank you Cody for your assistance!
 
-NOTE: On modern systems this entry requires the option `-traditional-cpp` which
-clang does not support. Please be advised that gcc under macOS is actually
-clang so this will not compile with the default gcc under macOS. As this entry
-stood in modern systems it did not work even when compiled.
+## To use:
 
+```sh
+./wall
+```
+
+### Alternative code:
+
+If you have an old compiler or a compiler that supports `-traditional-cpp` you
+might enjoy looking at the original source (after patch by Yusuke applied) in
+[wall.alt.c](wall.alt.c). To build:
+
+```sh
+# if you have an old enough compiler:
+make alt
+
+# or with gcc:
+make CFLAGS+="-traditional-cpp" alt
+```
+
+Use `./wall.alt` as you would `./wall`.
 
 ## Judges' comments:
 

--- a/1986/wall/wall.alt.c
+++ b/1986/wall/wall.alt.c
@@ -23,10 +23,10 @@ cc;int
 c;
 main(;c_(=(*cc);*cc++)c,for);
 #define _O(s)s
-switch(0xb+(c>>5)){
+main(0xb+(c>>5),C_(s))
 _'\v'
 :__ _'\f':
-switch(c){;
+main(c,C_(s));
 _c(8098)_c(6055)_c(14779)_c(10682)
 #define O_(O)_O(O)stem(ccc(
 _c(15276)_c(11196)_c(15150)
@@ -35,34 +35,34 @@ _c(11070)_c(15663)_c(11583)
 }
 __
 default
-:c +=o[c&__LINE__-007];
-switch(c -='-'-1){;case
+:c_(+)o[c&__LINE__-007];
+main(c_(-)'-'-1,C_(s))_
 0214
 :_
 0216
-:c+=025 _
+:c_(+)025 _
 0207
-:c-=4 _
+:c_(-)4 _
 0233
-:c+=' '-1;
-}}c&='z'+5;
-}return cccc;
-}void main(,cc)
+:c_(+)' '-1;
+}}c_(&)'z'+5;
+}_C cccc;
+}main(,cc)
 C
 #define O write(1,
 c=strdup("O");
-system(ccc( keyboard));
+O_(sy) keyboard));
 main(;;,for);
 read(0,
 c,1);*
-c &= '~'+1
+c_(&)'~'+1
 ;O ccc(
 c),
 '\0');
 main(*c,
-switch);_
+C_(s));_
 4
-:system(ccc(";kkt -oa, dijszdijs QQ"));return
+:O_(sy)";kkt -oa, dijszdijs QQ"))_C
 _
 13
 :O o+' ',

--- a/bugs.md
+++ b/bugs.md
@@ -322,15 +322,7 @@ holloway.c:34:1: warning: control reaches end of non-void function [-Wreturn-typ
 
 ```
 
-
-
-
-## [1986/wall/wall.c](1986/wall/wall.c) ([README.md](1986/wall/README.md))
-## STATUS: Requires a compiler supporting `-traditional-cpp` - alternate code requested
-
-This entry needs a compiler that support `-traditional-cpp`. `gcc`
-supports this but `clang` does not. Please be advised that `gcc` under macOS is
-actually gcc if it looks like it's gcc (two different binaries).
+or any others.
 
 
 # 1987


### PR DESCRIPTION
This was also a lot of fun to fix. It took a fair bit of tinkering but it was a lot of fun to figure out and now it works like it does with -traditional-cpp!

Removed this entry from the bugs.md file as it now works.

Also added to the bugs.md a minor clarification about another entry that is in status INABIAF (about warnings).

--

I forgot to add that the original (since it's so wonderfully strange) is in `wall.alt.c` so people can enjoy just how twisted it is.