### PR TITLE
Fix bugs in 1990/theorem

### DIFF
--- a/1990/theorem/.gitignore
+++ b/1990/theorem/.gitignore
@@ -3,3 +3,5 @@ fibonacci.c
 mariano
 sorter
 sorter.c
+theorem_bkp
+theorem_bkp.c

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -11,13 +11,19 @@ USA
 
         make all
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some segfaults
-under modern (and in some cases earlier) systems with this entry. Originally we
-noted that the 4 trailing args '0 0 0 0' were required on systems that dump core
-when NULL is dereferenced but this problem showed itself in modern systems even
-with the 4 '0 0 0 0'. Finally he changed this program to use `fgets()` not
-`gets()` to make it safer and to prevent a warning about `gets()` at linking or
-runtime. Thank you Cody for your assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some bugs that
+impacted the usability of this program including some segfaults under modern
+systems (and possibly in some cases earlier systems) with this entry.
+Originally we noted that the 4 trailing args '0 0 0 0' were required on systems
+that dump core when NULL is dereferenced but this problem showed itself in
+modern systems even with the 4 '0 0 0 0'. He also fixed the code so that the
+generated `fibonacci.c` actually works; before it just printed `0` over and over
+again (since it did not work anyway a segfault prevention was added here). He
+also some array addressing (some of which might not be strictly necessary but as
+he was testing the `fibonacci.c` bug he ended up changing it anyway). Finally he
+changed this program to use `fgets()` not `gets()` to make it safer and to
+prevent a warning about `gets()` at linking or runtime. Thank you Cody for your
+assistance!
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh) pointed out that `atof` nowadays
 needs `#include <stdlib.h>` which was used in order to get this to work

--- a/1990/theorem/theorem.c
+++ b/1990/theorem/theorem.c
@@ -21,7 +21,7 @@ if(R=='/')*g/=u;
 if(R=='^')P(g,*g,u);
 C
 w(g,R,u)float*g,u;char R;
-/**/{int b,f;A=atoi(++a);b=atoi(++a);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}
+/**/{int b,f;if(A>2){A=atoi(a[1]);b=atoi(a[2]);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}}
 main(A,a)int A;char*a[];
 o o
 if(!strcmp(*++a,"-r"))S();
@@ -46,14 +46,14 @@ W=D=1;
 ;
 while(W!=1)
 o o
-strcpy(j+m,v);
+strcpy(j[m],v);
 o 
 if((j-=W)<=W)break;
-strcpy(j+m,m+j-W);
+strcpy(j[m],m[j-W]);
 C
-while(strcmp(m+j-W,v)>0)
+while(strcmp(m[j-W],v)>0)
 j=i;
-strcpy(v,i+m);
+strcpy(v,i[m]);
 C
 for(i=(W/=3)-1;++i<n;)
 ;
@@ -78,12 +78,12 @@ return O;
 for(j=0;j<n;puts(j++[m]));
 e("",O,O,a);
 n=j-(O=1);
-while(fgets(j++[m],500,stdin));
+while(fgets(j++[m],99,stdin))(j-1)[m][strlen((j-1)[m])-1]='\0';
 if(!strcmp(++a,"-r"))S();
 C
 /**/main(A,a)int A;char*a[];
 Y
-S(){while(fgets(b++[m],500,stdin));for(b--;b--;puts(b[m]));}
+S(){while(fgets(b++[m],99,stdin))(b-1)[m][strlen((b-1)[m])-1]='\0';for(b--;b--;puts(b[m]));}
 char*f,m[500][99],R,v[99];
 int b,W,n,i,j,z;
 float Q,G,D,M,T,O,B,U,V,N,e();

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -15,7 +15,6 @@ make
 make cpclean
 # Let this run for about about an hour and then kill it:
 ./prog Shakespeare.txt
-./prog < $(< ls -1tr cp* | tail -1) | head -100
 ```
 
 ## Try:
@@ -28,6 +27,10 @@ less IOCCC-Rules-Guidelines.output.txt
 less IOCCC-hints.output.txt
 
 less Eugene_Onegin.output.txt
+
+./prog < IOCCC-Rules-Guidelines.cp98_0.175 |head -n 100
+
+./prog < Shakespeare.cp04_1.633 | head -n 100
 ```
 
 However, as the binary model files used to produce the output are in an

--- a/bugs.md
+++ b/bugs.md
@@ -476,11 +476,6 @@ so it should stay with this note.
 this entry that prevented it from working. However if not enough args are
 specified this program will crash.  This should NOT be fixed.
 
-## STATUS: known bug - please help us fix
-
-On the other hand the `fibonacci` program that is generated prints a string of
-0s over and over again. Can you fix this? See the README.md for details on how
-to generate it.
 
 # 1991
 


### PR DESCRIPTION

In this case these were not features.

The most important bug fix actually prevented the entry from working
properly: the generated code for the Fibonacci sequence just printed 0
over and over again. Added a segfault prevention here as it seemed like
if I'm going to fix it I might as well fix it properly. Removed this bug
from bugs.md.

A set of possible issues with the char m[][] array was also including 
the size limit in the fgets() calls (that was my fault due to missing 
the proper type of m at the time). Still might be good to test with 
longer lines of input. Commands with known output are correct 
nonetheless.

The other bug was due to the gets() to fgets() change where blank lines
were added where they shouldn't be. Now one can do ls | ./sorter and get
no blank lines after each file in the listing.
