### PR TITLE
Restore missing 2018/README.md from 2018 preview

### DIFF
--- a/1990/theorem/.gitignore
+++ b/1990/theorem/.gitignore
@@ -3,3 +3,5 @@ fibonacci.c
 mariano
 sorter
 sorter.c
+theorem_bkp
+theorem_bkp.c

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -11,13 +11,19 @@ USA
 
         make all
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some segfaults
-under modern (and in some cases earlier) systems with this entry. Originally we
-noted that the 4 trailing args '0 0 0 0' were required on systems that dump core
-when NULL is dereferenced but this problem showed itself in modern systems even
-with the 4 '0 0 0 0'. Finally he changed this program to use `fgets()` not
-`gets()` to make it safer and to prevent a warning about `gets()` at linking or
-runtime. Thank you Cody for your assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some bugs that
+impacted the usability of this program including some segfaults under modern
+systems (and possibly in some cases earlier systems) with this entry.
+Originally we noted that the 4 trailing args '0 0 0 0' were required on systems
+that dump core when NULL is dereferenced but this problem showed itself in
+modern systems even with the 4 '0 0 0 0'. He also fixed the code so that the
+generated `fibonacci.c` actually works; before it just printed `0` over and over
+again (since it did not work anyway a segfault prevention was added here). He
+also some array addressing (some of which might not be strictly necessary but as
+he was testing the `fibonacci.c` bug he ended up changing it anyway). Finally he
+changed this program to use `fgets()` not `gets()` to make it safer and to
+prevent a warning about `gets()` at linking or runtime. Thank you Cody for your
+assistance!
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh) pointed out that `atof` nowadays
 needs `#include <stdlib.h>` which was used in order to get this to work

--- a/1990/theorem/theorem.c
+++ b/1990/theorem/theorem.c
@@ -21,7 +21,7 @@ if(R=='/')*g/=u;
 if(R=='^')P(g,*g,u);
 C
 w(g,R,u)float*g,u;char R;
-/**/{int b,f;A=atoi(++a);b=atoi(++a);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}
+/**/{int b,f;if(A>2){A=atoi(a[1]);b=atoi(a[2]);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}}
 main(A,a)int A;char*a[];
 o o
 if(!strcmp(*++a,"-r"))S();
@@ -46,14 +46,14 @@ W=D=1;
 ;
 while(W!=1)
 o o
-strcpy(j+m,v);
+strcpy(j[m],v);
 o 
 if((j-=W)<=W)break;
-strcpy(j+m,m+j-W);
+strcpy(j[m],m[j-W]);
 C
-while(strcmp(m+j-W,v)>0)
+while(strcmp(m[j-W],v)>0)
 j=i;
-strcpy(v,i+m);
+strcpy(v,i[m]);
 C
 for(i=(W/=3)-1;++i<n;)
 ;
@@ -78,12 +78,12 @@ return O;
 for(j=0;j<n;puts(j++[m]));
 e("",O,O,a);
 n=j-(O=1);
-while(fgets(j++[m],500,stdin));
+while(fgets(j++[m],99,stdin))(j-1)[m][strlen((j-1)[m])-1]='\0';
 if(!strcmp(++a,"-r"))S();
 C
 /**/main(A,a)int A;char*a[];
 Y
-S(){while(fgets(b++[m],500,stdin));for(b--;b--;puts(b[m]));}
+S(){while(fgets(b++[m],99,stdin))(b-1)[m][strlen((b-1)[m])-1]='\0';for(b--;b--;puts(b[m]));}
 char*f,m[500][99],R,v[99];
 int b,W,n,i,j,z;
 float Q,G,D,M,T,O,B,U,V,N,e();

--- a/2018/README.md
+++ b/2018/README.md
@@ -1,0 +1,113 @@
+# 2018 marked the "The Twenty Fifth International Obfuscated C Code Contest"
+
+Copyright (C) 2018, Landon Curt Noll, Simon Cooper, and Leonid A.
+Broukhis. All Rights Reserved. Permission for personal, educational
+or non-profit use is granted provided this copyright and notice are
+included in its entirety and remains unaltered.  All other uses
+must receive prior permission from the contest judges.
+
+
+## Standard IOCCC stuff
+
+The primary IOCCC web site can be found at,
+
+>	<https://www.ioccc.org/>
+
+Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
+systems the makefile needs to be changed.  See the Makefile for details.
+
+Look at the source and try to figure out what the programs do, and run
+them with various inputs.  If you want to, look at the hints files for
+spoilers - this year we included most of the information included
+by the submitter.
+
+Read over the makefile for compile/build issues.  Your system may require
+certain changes (add or remove a library, add or remove a #define).
+
+Some C compilers are not quite as good as they should be.  If yours is
+lacking, you may need to compile using clang or gcc instead of your local
+compiler.
+
+
+## Remarks on some of the winners
+
+We believe you will again be impressed with this year's winners.
+
+The "Best of show" (mills) is an amazing tribute to winners
+from 1984 and 2015.
+
+Take a close look at the "Most likely to top the charts" (hou) winner.
+Observe that while it contains no variables and no operators, it
+remains functional in what it does.
+
+The "Best one-liner" (burton1), at 109 characters, is a short and sweet
+implementation of a classic utility and a nod to a winner from 1986.
+Sometimes it takes 20 ox years to do things the true IOCCC way.
+
+The color of the remarks text this year was inspired by one of the stars
+of the "Most stellar" winner (poikola).
+
+The "Best use of python" (endoh2) is a not what you might think it is.
+It is something completely different.
+
+The "Most likely to be awarded" (ciura) has an amazing vocabulary!
+
+There are also nods to winners of the years 2000 (bellard), 1989 (yang), ...
+
+...We'll stop spouting spoilers now. Have fun exploring all the entries!
+
+
+## Remarks on some of submissions that did not win
+
+The number of entries that would have made it into the final rounds
+would have been much higher had some people paid attention to rules 2
+and 22 (one third of 666).
+
+Rule 22, now known as "Catch 22" states:
+
+    |  22) Your source code, data files, remarks and program output must NOT
+    |      identify the authors of your code.  The judges STRONGLY prefer to
+    |      not know who is submitting entries to the IOCCC.
+
+    |      The "Peter Honeyman is exempt" guideline also applies to this rule.
+    |      Identifying yourself, in an obvious way in your code, data, remarks
+    |      or program output, unless you are Peter Honeyman or pretending
+    |      to be Peter Honeyman, will be grounds for disqualification of your entry.
+
+A number of other entries were based on iocccsize.c, making derivative works
+rather than original works.
+
+Still other entries were too large, violating the first line of rule 2:
+
+    2) The size of your program source must be <= 4096 bytes in length.
+
+While these entries might have passed under the 2053 limit for iocccsize,
+they were larger than <= 4096 bytes, sometimes by an order or magnitude.
+
+We hope the authors of some of those entries will fix and re-submit
+them for the next IOCCC.
+
+Some entries seemed to have a good idea, but the implementation of
+the idea was limited in scope.
+
+
+## Final Comments
+
+Please feel free to send us comments and suggestions about the
+competition, this README or anything else that you would like to see in
+future contests.
+
+If you use, distribute or publish these entries in some way, please drop
+us a line.  We enjoy seeing who, where and how the contest is used.
+
+If you have problems with any of the entries, AND YOU HAVE A FIX, please
+send us the fix (patch file or the entire changed file).
+
+For the latest information on how to contact the IOCCC Judges please visit
+
+>	<https://www.ioccc.org/contact.html>
+
+For news of the next contest watch:
+
+>	<https://www.ioccc.org/>
+

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -15,7 +15,6 @@ make
 make cpclean
 # Let this run for about about an hour and then kill it:
 ./prog Shakespeare.txt
-./prog < $(< ls -1tr cp* | tail -1) | head -100
 ```
 
 ## Try:
@@ -28,6 +27,10 @@ less IOCCC-Rules-Guidelines.output.txt
 less IOCCC-hints.output.txt
 
 less Eugene_Onegin.output.txt
+
+./prog < IOCCC-Rules-Guidelines.cp98_0.175 |head -n 100
+
+./prog < Shakespeare.cp04_1.633 | head -n 100
 ```
 
 However, as the binary model files used to produce the output are in an

--- a/bugs.md
+++ b/bugs.md
@@ -476,11 +476,6 @@ so it should stay with this note.
 this entry that prevented it from working. However if not enough args are
 specified this program will crash.  This should NOT be fixed.
 
-## STATUS: known bug - please help us fix
-
-On the other hand the `fibonacci` program that is generated prints a string of
-0s over and over again. Can you fix this? See the README.md for details on how
-to generate it.
 
 # 1991
 


### PR DESCRIPTION

For some reason this was missing from the repository. I was certain that 
there was one so I looked at my archive and found in the winner preview
repo for 2018 that there was indeed a README file (README.markdown).
This has been added as 2018/README.md. It felt important that this was 
added back.

I did NOT update the 2018 archive tarball as I'm not sure what to even 
call it - perhaps just README.markdown - but also because I'm not sure
what the status is of my archive/2018 is.

I fixed the formatting to match the style that is being used in this
repo.