### PR TITLE
Minor fixes + alt code in 1990/baruch

### DIFF
--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -1,25 +1,59 @@
 # Best Small Program
 
-	Doron Osovlanski
-	CADTECH - CAD/CAM Systems Ltd
-        24 Ben-Yosef st.
-        Givat-Shmuel   51905
-	Israel
+Baruch Nissenbaum
+Tel-Aviv University
+The Faculty of Engineering
+Tel-Aviv
+Israel
 
-	Baruch Nissenbaum
-	Tel-Aviv University
-	The Faculty of Engineering
-	Tel-Aviv
-	Israel
+Doron Osovlanski
+CADTECH - CAD/CAM Systems Ltd
+24 Ben-Yosef st.
+Givat-Shmuel   51905
+Israel
 
 ## To build:
 
-        make all
+```sh
+make all
+```
 
 ## To run:
 
-	echo 4 | ./baruch
-	echo 7 | ./baruch
+```sh
+echo 4 | ./baruch
+echo 7 | ./baruch
+```
+
+## Try:
+
+```sh
+echo 2 | ./baruch
+echo 3 | ./baruch
+```
+
+Why is there no output?
+
+### Alternate code:
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) provided alternate code
+for users using Turbo-C or MSC, based on the authors' comments below, except
+that he did not change the `" #Q"` string as that showed worse looking output
+instead of improved output though he has no way to test the compilers in
+question. YMMV. Thank you Cody (though we all think <strike>[no
+one](https://en.wiktionary.org/wiki/no_one#Pronoun)</strike> [very
+few](https://en.wikipedia.org/wiki/0)
+[users](https://en.wikipedia.org/wiki/Microsoft_Windows)
+[here](https://www.ioccc.org) will need it :-) )!
+
+To compile:
+
+```sh
+make alt
+```
+
+Use `baruch.alt` as you would `baruch`.
+
 
 ## Judges' comments:
 
@@ -30,44 +64,38 @@ added a final newline to the file to make unpacking easy.
 
 ## Authors' comments:
 
-The goal of this work was to write a program that solves the
-classic n-queen problem, with a board size of up to 99x99, while
-keeping the program as short as possible.
+The goal of this work was to write a program that solves the classic [n-queens
+problem](https://en.wikipedia.org/wiki/Eight_queens_puzzle), with a board size
+of up to 99x99, while keeping the program as short as possible.
 
-The program finds all possibilities to place N chess queens on
-a NxN chess board so that no queen is in range of any other queen
-(not in the same column row or diagonal).  For each solution the
-chess board and the place of the queens is printed to stdout.
+The program finds all possibilities to place N chess queens on a NxN
+[chessboard](https://en.wikipedia.org/wiki/Chessboard) so that no queen is in
+range of any other queen (not in the same column row or diagonal).  For each
+solution the chess board and the place of the queens is printed to stdout.
 
+This program is about as simple and as readable as possible.  To make things
+even more simple we used a very limited subset of C:
 
-This program is about as simple and as readable as possible.
-To make things even more simple we used a very limited subset of C:
+- No pre-processor statements
+- Only one, harmless, `for` statement
+- No `if`s
+- No `break`s
+- No `case`s
+- No functions outside the standard C library
+- No `goto`s
+- No structures
 
-     No pre-processor statements
-     Only one, harmless, 'for' statement
-     No ifs
-     No breaks
-     No cases
-     No functions
-     No gotos
-     No structures
-
-In short, it contains no C language that might confuse the
-innocent reader.  :-)
-
+In short, it contains no C language that might confuse the innocent reader. :-)
 
 This program demonstrates the claim that in C, any program
 can be written using a single 'for' statement, as long as it is
 long enough..
 
-The authors' further note:
+### For PC users:
 
-For PC users:
-
-In order to compile the program under Turbo-C or MSC, 'int '
-should be inserted at the beginning of the program.
-For better looking results it is recommended to replace the " #Q"
-string with " \261\2".
+In order to compile the program under Turbo-C or MSC,  `'int '` should be inserted
+at the beginning of the program.  For better looking results it is recommended
+to replace the `" #Q"` string with `" \261\2"`.
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/1990/baruch/baruch.c
+++ b/1990/baruch/baruch.c
@@ -2,5 +2,5 @@ int v,i,j,k,l,s,a[99];
 main()
 {
 	for(scanf("%d",&s);*a-s;v=a[j*=v]-a[i],k=i<s,j+=(v=j<s&&(!k&&!!printf(2+"\n\n%c"-(!l<<!j)," #Q"[l^v?(l^j)&1:2])&&++l||a[i]<s&&v&&v-i+j&&v+i-j))&&!(l%=s),v||(i==j?a[i+=k]=0:++a[i])>=s*k&&++a[--i])
-		;
+		;puts("");
 }

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -9,7 +9,9 @@ USA
 
 ## To build:
 
-        make all
+```sh
+make all
+```
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some bugs that
 impacted the usability of this program including some segfaults under modern
@@ -32,7 +34,9 @@ initially. Thank you Yusuke!
 
 ## To run:
 
-	./theorem expression x1 x2 h y1
+```sh
+./theorem expression x1 x2 h y1
+```
 
 where:
 
@@ -46,8 +50,9 @@ NOTE: this entry will segfault on no arg specified.
 
 ## Try:
 
-	./theorem y 0 1 0.1 1
-
+```sh
+./theorem y 0 1 0.1 1
+```
 
 
 ## Judges' comments:
@@ -70,54 +75,62 @@ left to right.  (i.e., parenthesis aren't supported).
 
 Try running the program with the following args:
 
-	./theorem y 0 1 0.1 1
-	./theorem 1/x 1 2 0.1 0
-	./theorem 'x^2/y+x' 0 1 0.1 6
+```sh
+./theorem y 0 1 0.1 1
+./theorem 1/x 1 2 0.1 0
+./theorem 'x^2/y+x' 0 1 0.1 6
+```
 
 But wait, there is more!  You also get, free of charge, a 
 reversing filter!  Try:
 
-	./theorem -r 0 0 0 0 < theorem.c > sorter.c
+```sh
+./theorem -r 0 0 0 0 < theorem.c > sorter.c
+```
 
 Still not impressed?  The author throws in for free, a 
 sort program! Try:
 
-	make sorter
-	ls | ./sorter
+```sh
+make sorter
+ls | ./sorter
+```
 
 This program is safe for home use as well.  The author has
 included a safety feature in case you misplace the original
 program source:
 
-    ./sorter -r 0 0 0 0 < sorter.c > theorem_bkp.c
+```sh
+./sorter -r 0 0 0 0 < sorter.c > theorem_bkp.c
+```
 
 And finally, as a special offer to users of this entry,
 the author provides a Fibonacci sequence generator!  Try:
 
-    ./sorter 0 0 0 0 < theorem.c > fibonacci.c
-    make fibonacci
-    ./fibonacci 1 1
-    ./fibonacci 2 1
+```sh
+./sorter 0 0 0 0 < theorem.c > fibonacci.c
+make fibonacci
+./fibonacci 1 1
+./fibonacci 2 1
+```
 
-Program available 9 track and cartridge cassette.  Gensu knife
-not included!  :-)
+Program available on 9 track and cartridge cassette.  Neither [Ginsu
+knife](https://ginsu.com) nor [Swiss army
+knife](https://en.wikipedia.org/wiki/Swiss_Army_knife) included! :-)
 
-When this program was first shown at the 1990 Summer Usenix 
-conference, it received a standing ovation; a first for
-a contest entry.
+When this program was first shown at the 1990 Summer Usenix conference, it
+received a standing ovation; a first for a contest entry.
 
+## Author's comments:
 
-
-## Author's comments
-
-Differential equations are solved via the Runge-Kutta method, 
-which guarantees local error proportional to h^5, and total
-error across a finite interval is at most a constant times h^4.
+Differential equations are solved via the Runge-Kutta method, which guarantees
+local error proportional to h^5, and total error across a finite interval is at
+most a constant times `h^4`.
 
 Sorting is accomplished with a standard shell sort.
 
-Note that the sorting and reversing is limited to files with 
-fewer than 500 lines, each less than 99 characters long.  
+Note that the sorting and reversing is limited to files with fewer than 500
+lines, each less than 99 characters long.
 
 ## Copyright and CC BY-SA 4.0 License:
 


### PR DESCRIPTION

Fixed formatting in README.md.

Add alt code based on authors' suggestion except that the string
replacement was not done because it seems like the output would be not
better but worse. There's a joke in the alternate code section of the
README.md file.
