### PR TITLE
Reapply segfault fixes in 1998/schnitzi

### DIFF
--- a/1988/spinellis/README.md
+++ b/1988/spinellis/README.md
@@ -1,9 +1,10 @@
 ## Best abuse of the rules:
 
-    	Diomidis Spinellis (currently at Imperial College, London, England)
-	1 Myrsinis Str.
-	GR-145 62 Kifissia
-	GREECE
+Diomidis Spinellis (currently at Imperial College, London, England)  
+1 Myrsinis Str.  
+GR-145 62 Kifissia  
+Greece  
+<https://www.spinellis.gr/>  
 
 ## To build:
 

--- a/1990/dds/README.md
+++ b/1990/dds/README.md
@@ -5,6 +5,7 @@ Imperial College, University of London
 Myrsinis 1  
 GR-145 62 Kifissia  
 Greece  
+<https://www.spinellis.gr/>
 
 ## To build:
 

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -115,7 +115,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} sorter fibonacci
+TARGET= ${PROG} sorter fibonacci theorem_bkp
 #
 ALT_OBJ=
 ALT_TARGET=
@@ -133,7 +133,6 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: this entry will segfault on no arg specified."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 sorter.c: ${PROG} ${PROG}.c
@@ -147,6 +146,12 @@ fibonacci.c: sorter ${PROG}.c
 
 fibonacci: fibonacci.c
 	${CC} ${CFLAGS} fibonacci.c -o $@
+
+theorem_bkp: sorter theorem_bkp.c
+	${CC} ${CFLAGS} theorem_bkp.c -o $@
+
+theorem_bkp.c:
+	-./sorter -r 0 0 0 0 < sorter.c > theorem_bkp.c
 
 # alternative executable
 #

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -18,14 +18,14 @@ impacted the usability of this program including some segfaults under modern
 systems (and possibly in some cases earlier systems) with this entry.
 Originally we noted that the 4 trailing args '0 0 0 0' were required on systems
 that dump core when NULL is dereferenced but this problem showed itself in
-modern systems even with the 4 '0 0 0 0'. He also fixed the code so that the
-generated `fibonacci.c` actually works; before it just printed `0` over and over
-again (since it did not work anyway a segfault prevention was added here). He
-also some array addressing (some of which might not be strictly necessary but as
-he was testing the `fibonacci.c` bug he ended up changing it anyway). Finally he
-changed this program to use `fgets()` not `gets()` to make it safer and to
-prevent a warning about `gets()` at linking or runtime. Thank you Cody for your
-assistance!
+modern systems even with the 4 '0 0 0 0'. He also fixed a segfault if not enough
+args are specified and fixed the code so that the generated `fibonacci.c`
+actually works; before it just printed `0` over and over again (since it did not
+work anyway a segfault prevention was added here). He also some array addressing
+(some of which might not be strictly necessary but as he was testing the
+`fibonacci.c` bug he ended up changing it anyway). Finally he changed this
+program to use `fgets()` not `gets()` to make it safer and to prevent a warning
+about `gets()` at linking or runtime. Thank you Cody for your assistance!
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh) pointed out that `atof` nowadays
 needs `#include <stdlib.h>` which was used in order to get this to work
@@ -46,7 +46,6 @@ where:
 	h - step size
 	y1 - initial value  (y(x1) == y1)
 
-NOTE: this entry will segfault on no arg specified.
 
 ## Try:
 
@@ -54,6 +53,11 @@ NOTE: this entry will segfault on no arg specified.
 ./theorem y 0 1 0.1 1
 ```
 
+### Known bug with `fibonacci.c` and `theorem_bkp.c`:
+
+If the two args added up equals 0 the program will enter an infinite loop,
+printing 0 over and over again. Cody fixed another condition where this happens
+but this has not been fixed. See [bugs.md](/bugs.md) for more details.
 
 ## Judges' comments:
 

--- a/1990/theorem/theorem.c
+++ b/1990/theorem/theorem.c
@@ -23,7 +23,9 @@ C
 w(g,R,u)float*g,u;char R;
 /**/{int b,f;if(A>2){A=atoi(a[1]);b=atoi(a[2]);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}}
 main(A,a)int A;char*a[];
-o o
+o
+o
+if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;
 if(!strcmp(*++a,"-r"))S();
 D=atof(*++a);
 T=atof(*++a);

--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -5,7 +5,7 @@ Imperial College, University of London
 Myrsinis 1  
 GR-145 62 Kifissia  
 Greece  
-
+<https://www.spinellis.gr/>  
 
 ## To build:
 

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -1,47 +1,56 @@
-# Best Flow Control:
+# Best Flow Control
 
-    Mark Schnitzius
-    ISX Corporation
-    1280 West Peachtree St. Apt. 1507
-    Atlanta, GA 30309
-    USA
-
-    http://east.isx.com/~schnitzi/
+Mark Schnitzius
+ISX Corporation
+1280 West Peachtree St. Apt. 1507
+Atlanta, GA 30309
+USA
+<http://computronium.org/ioccc.html>
 
 ## To build:
 
-        make all
+```sh
+make all
+```
 
-## To run
+## To run:
 
-	./schnitzi 5 > sort.c
-	make sort
+```sh
+./schnitzi 5 > sort.c
+make sort
+```
 
 ## Try:
 
-	./schnitzi 3 > sort.c
-	make sort
-	echo 123 > data
-	echo 234 >> data
-	echo 413 >> data
-	echo 134 >> data
-	echo 324 >> data
-	./sort < data
+```sh
+./schnitzi 3 > sort.c
+make sort
+echo 123 > data
+echo 234 >> data
+echo 413 >> data
+echo 134 >> data
+echo 324 >> data
+./sort < data
+```
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed invalid data
-types which prevented this entry from working. There are two other segfaults
-that should not be fixed and they are discussed in [bugs.md](/bugs.md). Thank
-you Cody for your assistance!
+types which prevented this entry from working, causing a segfault. This showed
+itself in two parts which required two fixes, one for linux and further changes
+for macOS. He also fixed a segfault (after printing garbage) when the arg
+specified evaluated to 0.  Thank you Cody for your assistance!
 
-NOTE: the larger the number the number of lines of output can become
-substantially higher as well. Doing `./schnitzi 9` will actually print 771999
+### INABIAF - it's not a bug it's a feature
+
+NOTE: the larger the number given to the program the longer the output becomes
+and quite substantially so.  Doing `./schnitzi 9` will actually print 771999
 lines!
 
 
-## Judges' comments
+## Judges' remarks:
 
-This is a beautiful program.  How can a program with no conditional
-behavior at all have output which depends on anything?
+This is a beautiful program.  How can a program with no conditional (except for
+the fixes for modern systems made by Cody) behavior at all have output which
+depends on anything?
 
 For hints on deciphering this, see below past the Author's Comments;
 they're a nice summary, but they leave the mystery intact.
@@ -52,7 +61,7 @@ letter E in the story. He did not note this but it has over 50000 (50 thousand)
 (!!) words without the letter E which is one of the most common letters!
 
 
-## Author's comments
+## Author's remarks:
 
 In literary circles, there is a poetic form called a "lipogram",
 which is a poem in which a specific letter has been distinctly
@@ -87,15 +96,19 @@ a depth of one.
 So what does it do?  Give it an integer (1 < n < 27) on the command
 line, such as
 
-    	./schnitzi 5
+```sh
+./schnitzi 5
+```
 
 The output will itself be a lipographic program, one which inputs
 (in this case) five numbers and prints them out sorted.  It sorts
 them, however, using only "if/else" statements, without arrays or
 looping.  To see the resulting program run, redirect the output from
-"schnitzi" into another file, like this
+`schnitzi` into another file, like this
 
-    	schnitzi 4 > sort.c
+```sh
+schnitzi 4 > sort.c
+```
 
 and then compile it.
 
@@ -105,10 +118,10 @@ The big key to this program is figuring out what the names of the
 functions ought to be; a bit of research may allow you to guess at
 a few crucial ones.
 
-The only function ever called is "O", but "O" is just set to point to
+The only function ever called is `O`, but `O` is just set to point to
 other functions all the time.  Or, almost all the time.
 
-So how does 'h' get set, and what to?
+So how does `h` get set, and what to?
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/1998/schnitzi/schnitzi.c
+++ b/1998/schnitzi/schnitzi.c
@@ -52,5 +52,6 @@ void x_(){ O=g; *r=y[k-2]; _=r; j=o_; }
 void d (){ O=g; *r=y[k]; _=r; k=k+1; m=k<z; w=_t; l=p_; j=p; }
 void y_(){ O=g; *r=x[17][1]+k; _=r; j=q_; }
 void r_(){ O=_b; _=x[17]; s=(char**)_d; s=s+1; i=*s; q=0; }
-main(int v,char **V){ O=r_; _d=V;
-  x: (O)(); goto x; }
+main(int v,char **V){ if (V[1]) {if(atoi(V[1])!=0) {
+ q=0; O=r_; _d=V;
+  x: (O)(); goto x; }}}

--- a/bugs.md
+++ b/bugs.md
@@ -764,15 +764,6 @@ $ ./schnitzi 9|wc -l
   771999
 ```
 
-There are two segfaults that were initially fixed but the fixes were undone to
-make the entry as close to possible as the original. These should not be fixed
-either:
-
-- if one does not specify an arg the program will crash.
-- if the arg had any characters that were not digits 1 - 9 it will show invalid
-output and then crash. If it starts with 0 it can work as long as another digit
-follows it and there are no other non-digits.
-
 
 # 1999
 

--- a/bugs.md
+++ b/bugs.md
@@ -27,6 +27,16 @@ format is consistent and clean.
 
 THANK YOU!
 
+## To the winning authors:
+
+If you're the author of an entry that has been fixed and you find it against
+your liking **PLEASE** let us know and we'll be happy to undo any fixes even if
+it takes away some instructional value or even usability. _In this case we're
+**VERY SORRY_** about it: it's a fine line, we know, and we tried to use careful
+judgement but invariably some might have been the wrong decision. Thank you for
+understanding!
+
+
 ### ON **ALL** FIXES / IMPROVEMENTS / CHANGES
 
 Make **ABSOLUTE CERTAIN** that you test the entry _BEFORE_ **AND** _AFTER_ your
@@ -121,6 +131,11 @@ when formatting code.
 
 Entries with this status have one or more bugs that need to be fixed. Are you
 able to fix it? We welcome your help!
+
+An important point to note is that there is a very fine line when fixing bugs
+where it might sometimes border on tampering with the program. And after all,
+these are not meant to be maintainable or even good programming style! Use
+careful judgement when fixing bugs please!
 
 ## STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
 
@@ -239,19 +254,19 @@ An example where a crash is not a bug: [2019/endoh](2019/endoh/endoh.c) is
 supposed to crash. There are others that are also supposed to crash or that are
 known to segfault but are considered features.
 
-As of 07 April 2023 the definition changed where just because an entry segfaults
-because of (for example) invalid input does not mean it's a bug that should be
-fixed. [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some of the
-entries but he felt this is tampering with the entries (that after all are not
-meant to be maintainable or even good programming style!); thus the definition
-of this status was changed and the 'fixes' were rolled back. There might be some
-exceptions where the entry did not actually work or compile under some systems;
-in this case depending on how complicated the fix is it might not have been
-rolled back.
+As of 10 April 2023 the definition changed for a second time (the first time was
+07 April 2023). If something is noted by the author as a known bug or limitation
+it need not be fixed unless it impacts the usability of the program or removes
+instructional value. An example where a crash undocumented needn't be fixed is
+[1984/laman](1984/laman/laman.c).  On the other hand the fixes made by [Cody
+Boone Ferguson](/winners.html#Cody_Boone_Ferguson) in
+[1990/theorem](1990/theorem/theorem.c) were useful.
 
-We challenge you to fix them for educational/instructional value and/or
-enjoyment but we kindly request that you **DO NOT** submit a pull request! If
-you can't figure it out you're invited to look at the git diffs if you wish.
+Nonetheless we challenge you to fix these entries for educational/instructional
+value and/or enjoyment but we kindly request that you **DO NOT** submit a pull
+request! If you can't figure it out you're invited to look at the git diffs,
+where there are some (some were fixed earlier on but rolled back due the fix
+feeling like tampering).
 
 NOTE: in the case of `gets()` we've fixed some to avoid the warning of the
 compiler, linker or even during runtime, depending on the system. In [one
@@ -470,11 +485,47 @@ so it should stay with this note.
 
 
 ## [1990/theorem](1990/theorem/theorem.c) ([README.md](1990/theorem/README.md))
-## STATUS: INABIAF - please **DO NOT** fix
+## STATUS: known bug - please help us fix
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some segfaults in
-this entry that prevented it from working. However if not enough args are
-specified this program will crash.  This should NOT be fixed.
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed many bugs that
+prevented this from working properly (including segfaults) but one bug known to
+exist remains: if `theorem_bkp` or `fibonacci` is passed two zeros the program
+will enter an infinite loop, printing 0 over and over again (another condition
+where this occurred was fixed).
+
+Cody provides some hints here:
+
+0. The function in `theorem.c` that matters is `w` (see below for definition).
+1. However adding checks for the value being > 0 does not work due to the way the
+code is generated. See below.
+
+`w()` looks like this:
+
+```c
+w(g,R,u)float*g,u;char R;
+/**/{int b,f;if(A>2){A=atoi(a[1]);b=atoi(a[2]);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}}
+```
+
+But as far as point 1 above changing it to be:
+
+```c
+/**/{int b,f;if(A>2){A=atoi(a[1]);b=atoi(a[2]);while(f!=0&&(f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}}
+```
+
+and similar (like checking `>0`, doing a `do..while`, doing an `if` before the
+while etc.) cause compilation errors.
+
+Can you fix this? We welcome your help!
+
+BTW: one of the important fixes for `fibonacci` to work is:
+
+```diff
+-/**/{int b,f;A=atoi(++a);b=atoi(++a);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}
++/**/{int b,f;if(A>2){A=atoi(a[1]);b=atoi(a[2]);while((f=A+b)<15000){printf("%d\n",f);A=b;b=f;}}}
+```
+
+Observe the check for the number of args and the calls to `atoi()` have been
+changed a bit too.
 
 
 ## [1990/westley](1990/westley/westley.c) ([README.md](1990/westley/README.md))


### PR DESCRIPTION

After discussing it with Landon it was recommended that these fixes be
reapplied.

Updated bugs.md wrt this.

README.md has had formatting fixes as well.

Updated URL for author as it has changed. It's very little on his page
and the only page that suggests it is his is the ioccc.html page. I
couldn't find anything else.