### PR TITLE
Make 1995/cdua easier to see with modern systems

### DIFF
--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -57,11 +57,11 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DZ=3000
 
 # Include files that are needed to compile
 #
-CINCLUDE= -include stdlib.h -include stdio.h
+CINCLUDE= 
 
 # Optimization
 #

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -1,27 +1,37 @@
 # Best Output
 
-    Carlos Duarte
-    Instituto Superior Tecnico
-    Largo da Igreja, 5 R/C DTo
-    Damaia
-    2720 Amadora 
-    Portugal
+Carlos Duarte  
+Instituto Superior Tecnico  
+Largo da Igreja, 5 R/C DTo  
+Damaia  
+2720 Amadora   
+Portugal  
 
 ## To build:
 
-        make all
+```sh
+make all
+```
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so that it
 would work with macOS. Once it could compile it additionally segfaulted under
 macOS which he also fixed. Thank you Cody for your assistance!
 
+NOTE: on modern systems this was hard to see it solve it in real time because it
+goes so quickly so Cody added a macro `Z` defaulting to 3000 for a call to
+`usleep()` to make it easier to see. The `Z` macro lets you configure it in case
+you find it too slow or too fast. To do that:
 
-## To run
+```sh
+make CFLAGS+="-DZ=1500" clobber all
+```
 
-	./cdua
+## To run:
 
-NOTE: on modern systems this might be hard to see it solve it in running time as
-it goes so quickly but it will still show the result after execution.
+```sh
+./cdua
+```
+
 
 NOTE: sometimes the program needs you to press enter a second time to continue
 solving the maze. See [bugs.md](/bugs.md) for more details.

--- a/1995/cdua/cdua.c
+++ b/1995/cdua/cdua.c
@@ -1,3 +1,7 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
 #define r return 
 
 char*u0="<RET> to begin... ",*u1="Already been here!",*u2="Found a wall! \
@@ -11,6 +15,6 @@ n=main;if(!c)for(srand(l(0)),g=a=1000,--d;++d<1840;b[c=d]=" #\n"[d%80==79?2:d/80
 &&(b[a+2]+b[a-2]+b[a+160]+b[a-160]-4*' ')){while(b[a+(f=(e=k()%4)?e-1?e-2?-1
 :1:-80:80)*2]!='#');b[a]=b[a+f]=b[f+a+f]=' ';printf(v,a/80+1,1+a%80,' ',(a+f)/80+
 1,1+(a+f)%80,' ',(f+a+f)/80+1,1+(f+a+f)%80,' ');n(f+a+f);goto k;}else if(!(g
--a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(printf(w,b[a]=='.'?u1:u2),0)
+-a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(usleep(Z),printf(w,b[a]=='.'?u1:u2),0)
 :(b[a]='.',printf(w,u3),printf(z,a/80+1,1+a%80,'.'),a==1676?(printf(w,u4),printf(o),1):n(a+1)||n
 (a+80)||n(a-80)||n(a-1)?1:(b[a]=' ',printf(w,u5),printf(z,a/80+1,1+a%80,' '),0));r 0;}


### PR DESCRIPTION
As modern systems are so much faster it's hard to see the maze being solved in real time so I added a call to usleep() with a macro defined in the Makefile (a macro in case someone finds it too slow or too fast or wants to do some strange experiment like setting it to 40000 which I actually tried). Called Z it defaults to 3000. To change it do something like:

    make CFLAGS+="-DZ=1500" clobber all

To do this I had to remove the -include ... from the Makefile and instead add the proper #includes to the source code as the += was not concatenating to the CFLAGS.

This makes the entry a bit more enjoyable with current systems. There still is a known issue that I'll look at again another time.