### PR TITLE
Fix 1995/garry/README.md and URL in winners.csv

### DIFF
--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -57,11 +57,11 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DZ=3000
 
 # Include files that are needed to compile
 #
-CINCLUDE= -include stdlib.h -include stdio.h
+CINCLUDE= 
 
 # Optimization
 #

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -1,27 +1,37 @@
 # Best Output
 
-    Carlos Duarte
-    Instituto Superior Tecnico
-    Largo da Igreja, 5 R/C DTo
-    Damaia
-    2720 Amadora 
-    Portugal
+Carlos Duarte  
+Instituto Superior Tecnico  
+Largo da Igreja, 5 R/C DTo  
+Damaia  
+2720 Amadora   
+Portugal  
 
 ## To build:
 
-        make all
+```sh
+make all
+```
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this so that it
 would work with macOS. Once it could compile it additionally segfaulted under
 macOS which he also fixed. Thank you Cody for your assistance!
 
+NOTE: on modern systems this was hard to see it solve it in real time because it
+goes so quickly so Cody added a macro `Z` defaulting to 3000 for a call to
+`usleep()` to make it easier to see. The `Z` macro lets you configure it in case
+you find it too slow or too fast. To do that:
 
-## To run
+```sh
+make CFLAGS+="-DZ=1500" clobber all
+```
 
-	./cdua
+## To run:
 
-NOTE: on modern systems this might be hard to see it solve it in running time as
-it goes so quickly but it will still show the result after execution.
+```sh
+./cdua
+```
+
 
 NOTE: sometimes the program needs you to press enter a second time to continue
 solving the maze. See [bugs.md](/bugs.md) for more details.

--- a/1995/cdua/cdua.c
+++ b/1995/cdua/cdua.c
@@ -1,3 +1,7 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
 #define r return 
 
 char*u0="<RET> to begin... ",*u1="Already been here!",*u2="Found a wall! \
@@ -11,6 +15,6 @@ n=main;if(!c)for(srand(l(0)),g=a=1000,--d;++d<1840;b[c=d]=" #\n"[d%80==79?2:d/80
 &&(b[a+2]+b[a-2]+b[a+160]+b[a-160]-4*' ')){while(b[a+(f=(e=k()%4)?e-1?e-2?-1
 :1:-80:80)*2]!='#');b[a]=b[a+f]=b[f+a+f]=' ';printf(v,a/80+1,1+a%80,' ',(a+f)/80+
 1,1+(a+f)%80,' ',(f+a+f)/80+1,1+(f+a+f)%80,' ');n(f+a+f);goto k;}else if(!(g
--a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(printf(w,b[a]=='.'?u1:u2),0)
+-a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(usleep(Z),printf(w,b[a]=='.'?u1:u2),0)
 :(b[a]='.',printf(w,u3),printf(z,a/80+1,1+a%80,'.'),a==1676?(printf(w,u4),printf(o),1):n(a+1)||n
 (a+80)||n(a-80)||n(a-1)?1:(b[a]=' ',printf(w,u5),printf(z,a/80+1,1+a%80,' '),0));r 0;}

--- a/1995/garry/.gitignore
+++ b/1995/garry/.gitignore
@@ -1,1 +1,2 @@
 garry
+garry.alt

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -114,8 +114,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1995/garry/README.md
+++ b/1995/garry/README.md
@@ -10,6 +10,7 @@ Germany
 make all
 ```
 
+
 ## To run:
 
 ```sh
@@ -25,16 +26,32 @@ make all
 ./garry < README.md
 ```
 
+### Alternate code:
+
+While it may not have been the intention of the author, the
+judges noted that the C pre-processed version (with the `#include`s
+left intact) looked very much like a rat "dropping core".  See
+[garry.alt.c](garry.alt.c) and judge for yourself!
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed it
+so that it will compile with modern compilers. The problem was a missing `int` for
+the `f` variable. He felt it was important that it works because the layout does
+indeed look to him like a rat is dropping core. Thank you Cody!
+
+To use try:
+
+```sh
+make alt
+```
+
+Use `garry.alt` as you would `garry` above.
+
+
 ## Judges' remarks:
 
 
-While it may not have been the intention of the submitter, the
-judges noted that the C pre-processed version (with the `#include`s
-left intact) looked very much like a rat "dropping core".  See
-`garry.cpp` and judge for yourself!
-
 The author was kind enough to provide a less obfuscated version of
-the source called `garry.fmt.c`.
+the source called [garry.fmt.c](garry.fmt.c).
 
 ## Author's remarks:
 

--- a/1995/garry/README.md
+++ b/1995/garry/README.md
@@ -1,28 +1,31 @@
 # Best Utility
 
-    Garry Glendown
-    G\"uldene Kammer 35
-    36251 Bad Hersfeld 
-    Germany
+Garry Glendown
+Germany
+<https://web.archive.org/web/20011221120305/http://insider.regio.net/~garry/>
 
 ## To build:
 
-        make all
+```sh
+make all
+```
 
 ## To run:
 
-
-	./garry <input_file >output_file
+```sh
+./garry <input_file >output_file
+```
 
 ## Try:
 
-	./garry.test.sh
+```sh
 
-	./garry < README.md
+./garry.test.sh
 
-## Judges' remarks
+./garry < README.md
+```
 
-In general, try:
+## Judges' remarks:
 
 
 While it may not have been the intention of the submitter, the
@@ -33,9 +36,9 @@ left intact) looked very much like a rat "dropping core".  See
 The author was kind enough to provide a less obfuscated version of
 the source called `garry.fmt.c`.
 
-## Author's remarks
+## Author's remarks:
 
-This  program is a file filter, designed to do environment-expansion and
+This program is a file filter, designed to do environment-expansion and
 incorporating  the  ability  to  create  binary from escaped data in the
 environment variables.
 

--- a/1995/garry/garry.alt.c
+++ b/1995/garry/garry.alt.c
@@ -16,7 +16,7 @@
 	  !c){return(y);}a=y;b=z;while(*a){if(*a!=D) *b++=*a
 	 ++;else{a++;c=strchr(a,D);if(c){*c=0;;if(strchr(a,32
 	)){*c=D;*b++=D;}else{;v=getenv(a);if(v){while(*v){if(*
-	v!=92)*b++=*v++;else{f=0;v++;if(*v<48||*v>57
+	v!=92)*b++=*v++;else{int f=0;v++;if(*v<48||*v>57
 	)*b++=92;else{f=(*v++)-48;;if(*v<48||*v
 	>57)*b++=f;else{f=(f<<3)+(*v++)-48;;*b++=(
 	 (*v<48||*v>57)?f:((f<<3)+(*v++)-48));}}}

--- a/tmp/winners.csv
+++ b/tmp/winners.csv
@@ -74,7 +74,7 @@ Ferenc Deak,Ferenc_Deak,null,null,null,null,null);
 Francois Boutines,Francois_Boutines,null,null,francois.boutines@gmail.com,Toulouse, France
 Frans van Dorsselaer,Frans van Dorsselaer,null,null,frans@biabv.com,null,null);
 Freek Wiedijk,Freek_Wiedijk,null,null,null,null,null);
-Garry Glendown,Garry_Glendown,http://insider.regio.net/~garry,null,garry@insider.regio.net,null,null);
+Garry Glendown,Garry_Glendown,https://web.archive.org/web/20011221120305/http://insider.regio.net/~garry/,null,garry@insider.regio.net,null,null);
 Gavin Barraclough,Gavin_Barraclough,null,null,gavin@barraclough.name,null,null);
 Gavin Buttimore,Gavin_Buttimore,null,null,gavin.buttimore@creaturelabs.com,null,null);
 Gil Dogon,Gil_Dogon,null,null,gil.jade@gmail.com,null,null);


### PR DESCRIPTION

Formatting fixes.

Remove address as there was a formatting issue. Besides it's probably
inaccurate by now. Kept the country.

There was a stray partial sentence in the judges' remarks that strayed
in (or to be more correct it was never moved properly) when I added the
try section. It's now been removed.

URL is dead so used the Internet Wayback Machine. Updated the URL in the
winners.csv file too. That might need to be done with others that I've
recently fixed but that will have to be checked on another time.

