### PR TITLE
Typo fixes in example.dot_winner.json

### DIFF
--- a/1995/cdua/.gitignore
+++ b/1995/cdua/.gitignore
@@ -1,1 +1,2 @@
 cdua
+cdua.alt

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -61,7 +61,7 @@ CDEFINE= -DZ=3000
 
 # Include files that are needed to compile
 #
-CINCLUDE= 
+CINCLUDE= -include stdio.h -include stdlib.h
 
 # Optimization
 #
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -134,6 +134,10 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${ALT_TARGET}: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
 
 # data files
 #

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -18,13 +18,13 @@ would work with macOS. Once it could compile it additionally segfaulted under
 macOS which he also fixed. Thank you Cody for your assistance!
 
 NOTE: on modern systems this was hard to see it solve it in real time because it
-goes so quickly so Cody added a macro `Z` defaulting to 3000 for a call to
-`usleep()` to make it easier to see. The `Z` macro lets you configure it in case
-you find it too slow or too fast. To do that:
+goes so quickly so Cody added an alternate version which makes it easier with
+modern systems to see the maze actually being solved in real time. We encourage
+you to use this version but we keep the original here to both preserve the
+original code (the bug fixes notwithstanding) and it will also let you see just
+how fast your computer is :-) (and you can also use both to see the difference).
+For this alternate, slower version, please see below.
 
-```sh
-make CFLAGS+="-DZ=1500" clobber all
-```
 
 ## To run:
 
@@ -37,11 +37,46 @@ NOTE: sometimes the program needs you to press enter a second time to continue
 solving the maze. See [bugs.md](/bugs.md) for more details.
 
 
-## Judges' remarks
+### Alternate code:
+
+This version uses `usleep(3)` with the `Z` (defined in the Makefile, default
+`3000`) microseconds to make it easier to see the maze being solved in real
+time. You can redefine Z to reconfigure it in case it's going too slow, too
+fast :-) or you're doing some strange experiment like making it 100000 (which
+Cody did for fun :-) ). To compile and use without reconfiguring the 3000
+microseconds, try:
+
+```sh
+make clobber alt
+./cdua.alt # press enter
+```
+
+Use `cdua.alt` as you would `cdua` above.
+
+To use a 1500 for `Z` try something like:
+
+```sh
+make CFLAGS="-DZ=1500" clobber alt
+./cdua.alt # press enter and watch it move a bit slower
+```
+
+Also try:
+
+```sh
+make CFLAGS="-DZ=65000" clobber alt
+./cdua.alt # press enter and watch it go much slower!
+```
+
+Do you see anything strange in this version when `Z` is a high value like
+`65000`? What happens if you use `100000`? Is this strange output still there?
+Why?
+
+
+## Judges' remarks:
 
 This could be used as the basis of an a-maze-ing screen exerciser.
 
-## Author's remarks
+## Author's remarks:
 
 A program that generates a maze, and then solves it, all this being
 seen by the user.  Some highlights of obfuscation are: 3 steps

--- a/1995/cdua/cdua.alt.c
+++ b/1995/cdua/cdua.alt.c
@@ -1,3 +1,7 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
 #define r return 
 
 char*u0="<RET> to begin... ",*u1="Already been here!",*u2="Found a wall! \
@@ -11,6 +15,6 @@ n=main;if(!c)for(srand(l(0)),g=a=1000,--d;++d<1840;b[c=d]=" #\n"[d%80==79?2:d/80
 &&(b[a+2]+b[a-2]+b[a+160]+b[a-160]-4*' ')){while(b[a+(f=(e=k()%4)?e-1?e-2?-1
 :1:-80:80)*2]!='#');b[a]=b[a+f]=b[f+a+f]=' ';printf(v,a/80+1,1+a%80,' ',(a+f)/80+
 1,1+(a+f)%80,' ',(f+a+f)/80+1,1+(f+a+f)%80,' ');n(f+a+f);goto k;}else if(!(g
--a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(printf(w,b[a]=='.'?u1:u2),0)
+-a))c=1,a=162,printf(w,u0),m();if(c-1){}else r b[a]!=' '?(usleep(Z),printf(w,b[a]=='.'?u1:u2),0)
 :(b[a]='.',printf(w,u3),printf(z,a/80+1,1+a%80,'.'),a==1676?(printf(w,u4),printf(o),1):n(a+1)||n
 (a+80)||n(a-80)||n(a-1)?1:(b[a]=' ',printf(w,u5),printf(z,a/80+1,1+a%80,' '),0));r 0;}

--- a/tmp/example.dot_winner.json
+++ b/tmp/example.dot_winner.json
@@ -1,7 +1,7 @@
 {
     "no_comment" : "mandatory comment: because comments were removed from the original JSON spec",
     "winner_version" : "0.0 2023-04-12",
-    "IOCCC_award" : "Best award title",
+    "IOCCC_award" : "Award title",
     "IOCCC_contest" : "IOCCC28",
     "IOCCC_year_dir" : 2024,
     "IOCCC_dirname" : "dirname",
@@ -32,7 +32,7 @@
 	},
 	{
 	    "filename" : "prog.c",
-	    "filetype" : "c",
+	    "filetype" : "C",
 	    "created_by" : null,
 	    "winners.html_show" : true,
 	    "winners.html_display_via" : "GitHub",
@@ -50,7 +50,7 @@
 	},
 	{
 	    "filename" : "prog.alt.c",
-	    "filetype" : "c",
+	    "filetype" : "C",
 	    "created_by" : null,
 	    "winners.html_show" : true,
 	    "winners.html_display_via" : "GitHub",
@@ -85,7 +85,7 @@
 	    "winners.html_rank" : 100
 	},
 	{
-	    "filename" : "spoliler.md",
+	    "filename" : "spoiler.md",
 	    "filetype" : "markdown",
 	    "created_by" : null,
 	    "winners.html_show" : false,
@@ -94,7 +94,7 @@
 	    "winners.html_rank" : null
 	},
 	{
-	    "filename" : "spoliler.html",
+	    "filename" : "spoiler.html",
 	    "filetype" : "html",
 	    "created_by" : "md2html",
 	    "winners.html_show" : true,


### PR DESCRIPTION

Also changed "c" to "C" as it seemed better to honour the language 
(though honour is not really the best word maybe).