### PR TITLE
Fix 1990/stig/Makefile to use ${SH}, not ${ZSH}

### DIFF
--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -127,7 +127,7 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "source stig.sh ; source stig.c" | ${ZSH}
+	@echo "source stig.sh ; source stig.c" | ${SH}
 
 # alternative executable
 #


### PR DESCRIPTION
This is because not all systems have zsh installed. Why not bash? Because it returned a syntax error. It might be possible to get it to work with bash but there's a chance that a system might not have bash. Of course SHELL is set to bash so that might be an irrelevant point. I know not all sh implementations are good so that's another thing to consider but for now it'll do.