### PR TITLE
Add entry to faq.md about terminal sanity

### DIFF
--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -20,31 +20,38 @@ make all
 ./a.out
 ```
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed some segfaults in
-this entry as well as making it so `a` (was `a.out`, see below) can be generated
-(as in the program did not work, at least with clang). The alternative code,
-described below, is what is needed for clang. Reading it might be instructive
-even if you have gcc.
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed a segfault that
+prevented this entry from working at all and made an alternate version
+that works with `clang`. The alternate code, described below, is what is needed
+for clang. Reading it might be instructive even if you have gcc.
 
-The first segfault which was always triggered was due to the code `*q>'
-'&&(*q)--;`. This seems odd at first glance but it's pointing to `s` which was
-read-only memory as a `char *s`.  It's now a `char s[]`. The second and third
-segfaults were caused if a file was not specified (or it the one specified did
-not exist or couldn't be opened for some reason) and if the output file could
-not be opened for writing.
+The segfault which was always triggered was due to the code `*q>' '&&(*q)--;`.
+This seems odd at first glance but it's pointing to `s` which was read-only
+memory as a `char *s`.  It's now a `char s[]`.
 
 Thank you Cody for your assistance!
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+Please note that if the BASIC file cannot be opened for reading or the output
+file cannot be opened for writing then this program will crash. These crashes
+are a mild nuisance but are considered a feature not a bug. We challenge you to
+fix it for learning if you wish. See also [bugs.md](/bugs.md).
 
 ## Try:
 
 With gcc, make and run as follows:
-    
-	make dds
+
+```sh
+make dds
+```
 
 For example, the author suggests trying:
-     
-	./dds LANDER.BAS
-	./a.out
+    
+```sh
+./dds LANDER.BAS
+./a.out
+```
 
 ### Alternative code:
 
@@ -55,7 +62,7 @@ not messing with the `s` string which is quite complicated. For all Cody knows
 even changing the length could break functionality and indeed the length would
 have to be longer for this to work with clang.
 
-How does it work? The code, which you will see in `dds.c`, `return system(q-6);`
+How does it work? The code, which you will see in [dds.c](dds.c), `return system(q-6);`
 equates to `return system("cc a.c");` but clang by default, at least in macOS,
 has default -Werror and there were some warnings. This means that the
 compilation failed with clang. In particular it would fail (at least with

--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -53,6 +53,15 @@ For example, the author suggests trying:
 ./a.out
 ```
 
+What happens if you give the program a C program like itself? Try:
+
+```sh
+./dds dds.c
+```
+
+You'll get errors yes but what does the generated file look like? What about
+other types of files?
+
 ### Alternative code:
 
 The alternative code, provided by Cody, allows this entry to work successfully
@@ -62,10 +71,11 @@ not messing with the `s` string which is quite complicated. For all Cody knows
 even changing the length could break functionality and indeed the length would
 have to be longer for this to work with clang.
 
-How does it work? The code, which you will see in [dds.c](dds.c), `return system(q-6);`
-equates to `return system("cc a.c");` but clang by default, at least in macOS,
-has default -Werror and there were some warnings. This means that the
-compilation failed with clang. In particular it would fail (at least with
+How does it work? The code (which you will see in [dds.c](dds.c)) does a `return
+system(q-6);` which equates to `return system("cc a.c");` but clang by default,
+at least in macOS, has default -Werror and there were some warnings. This means
+that the compilation failed with clang (because it didn't use `make` so no
+[Makefile](Makefile) was used). In particular it would fail (at least with
 `LANDER.BAS`) due to a return from `main()` without a return value and the use
 of functions not yet declared.
 

--- a/1991/dds/dds.alt.c
+++ b/1991/dds/dds.alt.c
@@ -10,8 +10,8 @@ R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
 aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)hfut)c**aHb%JD12JON1!Qjg)a%LN1UP1D12JIQUa\
 P1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!b/d";int k;char R[4][99]
 ;main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*q)--;{FILE*i=fopen(v
-[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p++)switch(*p++){B'M':
-Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return
-system("make a");}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);
-p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G
-B'G':k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}
+[1],"r"),*o=fopen(q-3,"w");for(p=s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF
+&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return system("make a");}*r=0
+B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0'
+)(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(
+*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}

--- a/1991/dds/dds.c
+++ b/1991/dds/dds.c
@@ -10,8 +10,8 @@ R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
 aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)hfut)c**aHb%JD12JON1!Qjg)a%LN1UP1D12JIQUa\
 P1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!b/d";int k;char R[4][99]
 ;main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*q)--;{FILE*i=fopen(v
-[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p++)switch(*p++){B'M':
-Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return
-system(q-6);}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);
-p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G
-B'G':k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}
+[1],"r"),*o=fopen(q-3,"w");for(p=s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF
+&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return system(q-6);}*r=0
+B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0'
+)(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(
+*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}

--- a/bugs.md
+++ b/bugs.md
@@ -542,6 +542,23 @@ This will be fixed in time but it's noted here for now.
 
 # 1991
 
+## [1991/dds](1991/dds/dds.c) ([README.md)(1991/dds/README.md))
+## [1991/dds.alt](1991/dds/dds.alt.c) ([README.md)(1991/dds/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+If the BASIC file cannot be opened for reading or the output file cannot be
+opened for writing the program will crash. This is not a bug but a feature.
+Please do not fix this except for the challenge.
+
+Please also note that for `clang` you have to use [dds.alt](1991/dds/dds.alt.c) not
+[dds.c](1991/dds/dds.c).
+
+## STATUS: uses gets() - change to fgets() if possible
+
+That being said the compiled code uses `gets()` not `fgets()`. Can you fix this?
+You might find that the `s` array is relevant but if you do change it please
+make sure to test all functionality!
+
 ## [1991/westley](1991/westley/westley.c) ([README.md](1991/westley/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
@@ -551,6 +568,7 @@ you're caught'. :-)
 
 Please don't try and fix it as it's not a bug and was actually documented as a
 possibility. Can you find out how?
+
 
 
 # 1992

--- a/faq.md
+++ b/faq.md
@@ -172,6 +172,12 @@ fix. If it is accepted we'll be happy to credit you in the entry's _README.md_
 file. If you're a previous winner we will happily link to your entries; if
 you're not we can link to your website if you wish.
 
+## Q: After running a program my terminal is all messed up! How do I restore my terminal?
+
+The simplest way to do this is to type `reset`. If echo was disabled you can get
+away with `stty echo`. Sometimes you can also get away with `stty sane`. `reset`
+does the most but note that it will clear the screen (`clear` will not work).
+
 ## Q: Are there types of entries that are submitted so frequently that the judges get tired of them?
 
 Yes, there are types of entries that show up over and over again.


### PR DESCRIPTION

In other words after running a curses program (ANSI escape codes can 
also cause problems) the terminal can be quite insane; echo might be
disabled as a simpler example but many worse more annoying problems can
occur.

The simplest way is to run reset. This will restore everything though 
it'll clear the screen (clear command will not fix any problems but just
clear the screen). For echo disabled stty echo should work. Sometimes
you can get away with doing stty sane.

Now these are in the faq.md. I wrote more about this in 2020/ferguson1 
but that doesn't really matter other than it was the inspiration for 
this entry (which I think is a good idea to include).