### PR TITLE
Format fix 2012/vik/README.md + add alt code

### DIFF
--- a/2012/endoh2/README.md
+++ b/2012/endoh2/README.md
@@ -27,25 +27,31 @@ gcc -o e e.c
 ./e > 271.c
 ```
 
+...
+
 ## Try:
 
 ```sh
-make pi
-make e
-make everything
+./everything.sh
 ```
 
 ## Judges' remarks:
 
-A pi/e printing quasi-quine in ASCII art with a compressed font in it;
-what else to wish for in this program? Virtual machine emulation?
+A
+[pi](https://en.wikipedia.org/wiki/Pi)/[e](https://en.wikipedia.org/wiki/E_(mathematical_constant))
+printing quasi-[quine](https://en.wikipedia.org/wiki/Quine_(computing) in [ASCII
+art](https://en.wikipedia.org/wiki/ASCII_art) with a compressed font in it; what
+else to wish for in this program? [Virtual
+machine](https://en.wikipedia.org/wiki/Virtual_machine) emulation?
 
 ## Author's remarks:
 
 Yeah, "Again".  Sorry.  But I don't feel guilty or uncomfortable.
 
 This entry is based on 'over-used themes' such as self reproducing
-program and pi or e computation.  I know you're tired of them.
+program and [pi](https://en.wikipedia.org/wiki/Pi) or
+[e](https://en.wikipedia.org/wiki/E_(mathematical_constant))) computation.  I
+know you're tired of them.
 
 But have you ever seen **all-in-one**?
 
@@ -54,57 +60,58 @@ But have you ever seen **all-in-one**?
 This program generates a new program in the shape of the Greek letter
 `pi`.  Then, the generated program:
 
-- computes 3 digits of pi and prints it as a ASCII-art program that:
-- computes 4 digits of pi and prints it as a ASCII-art program that:
-- computes 5 digits of pi and prints it as a ASCII-art program that:
-- computes 6 digits of pi and prints it as a ASCII-art program that:
-- etc.
+- computes 3 digits of pi and prints it as an ASCII-art program that:
+- computes 4 digits of pi and prints it as an ASCII-art program that:
+- computes 5 digits of pi and prints it as an ASCII-art program that:
+- computes 6 digits of pi and prints it as an ASCII-art program that:
+- ...
 
-One more thing...  When you give a command line option "e" to the
-first program, the generated one will compute Napier's constant
+One more thing...  When you give a command line argument `e` to the
+first program, the generated one will compute [Napier's
+constant](https://en.wikipedia.org/wiki/E_(mathematical_constant)))
 rather than pi.
 
 
 ### Obfuscation
 
-This program itself is in the shape of a spigot.  This is derived
-from analogy with "spigot algorithm" which infinitely computes the
-value of a mathematical constant such as `pi` or `e`.
+This program itself is in the shape of a
+[spigot](https://en.wikipedia.org/wiki/Tap_(valve)).  This is derived from
+analogy with [spigot algorithm](https://en.wikipedia.org/wiki/Spigot_algorithm)
+which infinitely computes the value of a mathematical constant such as
+[pi](https://en.wikipedia.org/wiki/Pi) or
+[e](https://en.wikipedia.org/wiki/E_(mathematical_constant)).
 
-<http://en.wikipedia.org/wiki/Spigot_algorithm>
+The two sets of programs, `314*.c` and `271*.c`, are almost the same
+except their shape and constant computational part.  I tailored the
+common part to parse in both shapes (`3.14...` and `2.71...`), by
+tweaking the computational order and adding meaningless code fragments.
 
-The two sets of programs, 314\*.c and 271\*.c, are almost the same
-except its shape and constant computation part.  I tailored the
-common part to parse in both shapes ("3.14..." and "2.71..."), by
-tweaking the computation order and adding meaningless code fragment.
-
-On the other hand, to make it fit inside one screen (80 x 25), my
-program is shortened properly, more than it looks.  (As you may
-know, Quine needs to make its program size doubled.)
-For example, this program involves 3x5 bitmap font data of ten
-characters ('0' -- '9'), as just 20 bytes: "G1%xJ{;Q7wunmuGuu%uu".
-We can decode character n as `275*s[n+10] - 8*s[n] - 8`.  I solved the
-system of Bezout's identities to find the magic string, with the
-aid of a brute force.  See `find-font-table.rb` in detail.
-
-<http://en.wikipedia.org/wiki/B%C3%A9zout's_identity>
+On the other hand, to make it fit inside one screen (80 x 25), my program is
+shortened properly, more than it looks.  (As you may know,
+[quines](https://en.wikipedia.org/wiki/Quine_(computing)) need to make its
+program size doubled.) For example, this program involves 3x5 bitmap font data
+of ten characters (`0` -- `9`), as just 20 bytes: `G1%xJ{;Q7wunmuGuu%uu`.  We
+can decode character `n` as `275*s[n+10] - 8*s[n] - 8`.  I solved the system of
+[Bézout's identity](https://en.wikipedia.org/wiki/B%C3%A9zout%27s_identity) to
+find the magic string, with the aid of a brute force.  See `find-font-table.rb`
+in detail.
 
 I used many other tricks for short coding.
 
-I'm sorry that many ASCII-art-style winning entries of IOCCCs
-ignore preprocessor directives.  In my program, #include is a part
-of ASCII-art with comment padded.
+I'm sorry that many ASCII-art-style winning entries of
+[IOCCC](https://www.ioccc.org/years.html) ignore [C preprocessor
+directives](https://en.wikipedia.org/wiki/C_preprocessor).  In my program,
+`#include` is a part of ASCII-art with comments padded.
 
 These design requirements made my program well-obfuscated
 willy-nilly.
 
 ### Portability
 
-I expect it to work in any major environment and C compiler.
-To build with no warning, it requires two C99 features: string
-literal more than 509 characters and omissible return in main
-function.  In fact, recent compilers with "-std=c99 -Wall -W
--Wextra -pedantic" would say nothing.
+I expect it to work in any major environment and C compiler.  To build with no
+warning, it requires two C99 features: string literal more than 509 characters
+and not requiring a return in `main()` function.  In fact, recent compilers with
+`-std=c99 -Wall -W -Wextra -pedantic` would say nothing.
 
     gcc -std=c99 -Wall -W -Wextra -pedantic spigot.c
     clang -std=c99 -Wall -W -Wextra -pedantic spigot.c
@@ -141,7 +148,7 @@ etc...
 You can do `make everything` for the process (with no `cat`).
 
 Note: The executable may return a failure (non-zero) exit status
-unless -std=c99 option is given.
+unless `-std=c99` option is given.
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2012/endoh2/endoh2.c
+++ b/2012/endoh2/endoh2.c
@@ -1,4 +1,4 @@
-#include<stdio.h> /******** SpigotQuine -- usage: ./spigot [pi or e] ********/
+#include<stdio.h> /******** SpigotQuine -- usage: ./endoh2 [pi or e] ********/
 char*s="G1%%xJ{;Q7wunmuGuu%%uu#include<stdio.h>/*Spigot_Quine*/#include<stdli"
 "b.h>/*_IOCCC2012_*/int*e,"    "i,j,k,n"     ";char*q"    ",*a,*d,*z,*p=%s%c;"
 "int" "%cmain(){a=calloc("                                 "1,1e4+n*2);;for(*"

--- a/2012/endoh2/everything.sh
+++ b/2012/endoh2/everything.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+make everything || exit 1
+
+run()
+{
+    local program="$1"
+    echo "" 1>&2
+    echo -n "$ ./${program}" 1>&2
+    sleep 2
+    "./${program}" | less -K -e
+}
+echo "running everything with $(type -P less): " 1>&2
+echo 1>&2
+run pi
+run 314
+run 3141
+run 31415
+run 314159
+run 3141592
+run 31415926
+run 314159265
+run 3141592653
+run 31415926535
+run e 271
+run 2718
+run 27182
+run 271828
+run 2718281
+run 27182818
+run 271828182
+run 2718281828
+run 27182818284

--- a/2012/vik/.gitignore
+++ b/2012/vik/.gitignore
@@ -5,3 +5,4 @@ restored-chocolate.png
 restored-ioccc.png
 restored.png
 vik
+vik.alt

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA= chocolate.png ioccc.png
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -1,8 +1,8 @@
 # Best use of cocoa - Bronze award
 
-    Daniel Vik  
-    <daniel@vik.cc>  
-    <http://danielvik.com/>  
+Daniel Vik  
+<daniel@vik.cc>  
+<http://danielvik.com/>  
 
 ## To build:
 
@@ -10,7 +10,8 @@
 make
 ```
 
-This entry requires [Zlib](http://www.zlib.net/).
+This entry requires [Zlib](https://www.zlib.net).
+
 
 ## To run:
 
@@ -44,6 +45,16 @@ To extract the embedded PNG:
 ./vik d encodedimg.png > restored.png
 ```
 
+There is an alternate version which might work for Windows. See Alternate code
+section below.
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+The author stated that the program will crash if no argument is passed to the
+program or if invalid arguments or images of mismatching sizes or unsupported
+pixel formats though we note that your computer might also [halt and catch
+fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)) :-)
+
 ## Try:
 
 ```sh
@@ -53,45 +64,65 @@ To extract the embedded PNG:
 ./vik d ioccc-in-chocolate.png > restored-ioccc.png
 ```
 
+### Alternate code:
+
+Based on the author's description it should be able to get this entry to work
+for Windows. With his instructions [Cody Boone
+Ferguson](/winners.html#Cody_Boone_Ferguson) added the alternate version that
+does this for the few who might use Windows. To compile:
+
+```sh
+make alt
+```
+
+Use `vik.alt` as you would `vik` above.
+
+We're not sure whether we want to thank Cody or not for this :-) and he's not
+sure if he wants to be thanked either :-) but we appreciate it nonetheless.
+
 ## Judges' remarks:
 
 References to chocolate had no effect on judging this entry. We
 guarantee it.
 
-Can you discern hidden pieces of chocolate in `chocolate-in-ioccc.png`?
+Can you discern hidden pieces of chocolate in
+[chocolate-in-ioccc.png](chocolate-in-ioccc.png)?
+
+![chocolate in ioccc](chocolate-in-ioccc.png "Chocolate in IOCCC")
 
 ## Author's remarks:
 
 ### Introduction
 
-This program is a  steganography application for embedding an image or text
-into another image as well as extracting  the embedded image  or text back.
-The program stores  the embedded  image or text in  the low bits of the RGB
-values.
+This program is a [steganography](https://en.wikipedia.org/wiki/Steganography)
+application for embedding an image or text into another image as well as
+extracting the embedded image or text back.  The program stores the embedded
+image or text in the low bits of the RGB values.
 
-The program supports any 8 bit true color PNG images (RGB, RGBA, grayscale,
-and grayscale+alpha). The output image is always 8 bit RGB.  When embedding
+The program supports any 8 bit true color PNG images (RGB, RGBA, greyscale,
+and greyscale+alpha). The output image is always 8 bit RGB. When embedding
 one image into another, the width and height needs to be the same.
 
-The program only updates the IDAT and IHDR chunks of the source image.  Any
+The program only updates the `IDAT` and `IHDR` chunks of the source image. Any
 additional chunks are copied into the resulting image.
 
 ### Bonus Extractor:
 
-For some reason the chocolate image seems to have some  special properties.
-Apart from  being quite big  and a little bit noisy,  it appears  that when
-embedded into  another image and extracted, the bitmap data is also a valid
-brain$#@$ program. It is of course possible to get the bitmap data from the
-extracted image, and run it through  any of the previous  winning brain$#@$
-interpreters, but I thought it would be easier to include an interpreter in
-the program  to avoid the hassle:
+For some reason the chocolate image seems to have some special properties.
+Apart from being quite big and a little bit noisy, it appears that when embedded
+into another image and extracted, the bitmap data is also a valid
+[brain$#@$](https://en.wikipedia.org/wiki/Brainfuck) program. It is of course
+possible to get the bitmap data from the extracted image, and run it through any
+of the previous winning brain$#@$ interpreters, but I thought it would be easier
+to include an interpreter in the program to avoid the hassle:
 
 ```sh
 ./vik e ioccc.png chocolate.png > encodedimg.png
 ./vik b encodedimg.png
 ```
 
-It is of course also possible  to embed a brain$#@$ program  as a text file
+It is of course also possible to embed a
+[brain$#@$](https://en.wikipedia.org/wiki/Brainfuck) program as a text file
 (as explained above) and decode it, e.g.:
 
 ```sh
@@ -101,26 +132,25 @@ It is of course also possible  to embed a brain$#@$ program  as a text file
 
 ### Obfuscation
 
-I really wanted to keep  the program simple,  so instead of adding multiple
-macros or helper methods that can be confusing,  I placed all functionality
-in the main function. Main is called recursively and quite extensively, but
-it gives  the benefit  that all  invocations of  the function  has the same
-parameters, argv and argc.   This really helps readability, as a programmer
-doesn't need to remember several variable or function names.   I also tried
-to reduce the number of keywords,  and the program only  has four for-loops
-followed by a single return statement.  There is a little bit of use of the
-question mark operator,   but this is really  there to keep  the program as
-simple as possible.
+I really wanted to keep the program simple, so instead of adding multiple macros
+or helper methods that can be confusing, I placed all functionality in the
+`main()` function. `main()` is called recursively and quite extensively, but it
+gives the benefit that all invocations of the function have the same parameters,
+`argv` and `argc`. This really helps readability, as a programmer doesn't need
+to remember several variable or function names. I also tried to reduce the
+number of keywords, and the program only has four for-loops followed by a single
+return statement. There is a little bit of use of the ternary (`?:`) operator,
+but this is really there to keep the program as simple as possible.
 
 ### Portability
 
-The program is portable to most platforms that  have zlib  available.   The
-only system dependency is that the program relies on writing binary data to
-stdout.
+The program is portable to most platforms that have [zlib](https://www.zlib.net)
+available. The only system dependency is that the program relies on writing
+binary data to stdout.
 
-By default, Microsoft compilers adds carriage returns to new lines,  and to
+By default, Microsoft compilers adds carriage returns to new lines, and to
 compile the program on this platform, the following line can be added after
-the  variable  declarations  in  the  main  declaration  in  order  to  run
+the variable declarations in the main declaration in order to run
 correctly:
 
 ```c
@@ -129,31 +159,33 @@ _setmode(_fileno(stdout), 0x8000);
 
 ### Limitations
 
-The program doesn’t have many error checks so passing in  invalid arguments
+The program doesn't have many error checks so passing in invalid arguments
 or images of mismatching sizes, or unsupported pixel formats will cause the
 program to crash.
 
 
 ### Extendability
 
-Since a lot of care was taken to keep the code simple,  it turned out to be
-quite easy to extend functionality. I did include a small brain$#@$ after I
+Since a lot of care was taken to keep the code simple, it turned out to be
+quite easy to extend functionality. I did include a small
+[brain$#@$](https://en.wikipedia.org/wiki/Brainfuck) after I
 realized that the chocolate image had some interesting properties.
 
-But there  is more functionality  I added that didn’t  fit within  the size
-limits and could not remain included.   For example,  I added  a method  to
-format source code based on a PNG image.   So the format  of the program is
+But there is more functionality I added that didn't fit within the size
+limits and could not remain included. For example, I added a method to
+format source code based on a PNG image. So the format of the program is
 actually done by the program itself.
 
-And to be honest,   the chocolate  image  did not have  a brain$#@$ program
-embedded to begin with.   I added functionality to the  program to  embed a
-brain$#@$  into a  PNG image and used it  to create the image provided with
+And to be honest, the chocolate image did not have a
+[brain$#@$](https://en.wikipedia.org/wiki/Brainfuck) program
+embedded to begin with. I added functionality to the program to embed a
+brain$#@$ into a PNG image and used it to create the image provided with
 the entry.
 
-I also added a method to analyze PNG images,  to print the size and format,
+I also added a method to analyze PNG images, to print the size and format,
 as well as the scan line filters.
 
-All these features  were quite easy to add,   much thanks to  the (actually
+All these features were quite easy to add, much thanks to the (actually
 pretty good) design of the code.
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2012/vik/vik.alt.c
+++ b/2012/vik/vik.alt.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <io.h>
+#include "zlib.h"
+
+
+
+
+      int
+    i,j,k,l
+  ,m,n,Q,W,H,
+ B,Z,Y,X,O=1<<24
+  ; char*A[999],x[
+   1<<24],z[1<<24],
+     s[1<<24],t[2<<24
+         ],w[2<<24],*E;
+           uLong N;  FILE
+             *f ; int  main(
+                int c,char**v){
+                  unsigned char**V
+                     =(unsigned char
+                        **)v;_setmode(
+			_fileno(stdout),
+			0x8000); for(m=0;
+                            c==-11&&m<H
+                              ; m++, (*v)
+                                +=m%3==0&&
+                                (B&4) ,V[4]
+                                 ++) n=m%W,
+                                  l=n?l:*(*V
+                                  )++,*V[4]=
+                                   !(B&2)&&
+                                    n%3?V[4
+                                    ][-1]:
+                                     (i=
+                                    n<3?0:
+                                  V[4][-3],j
+                                =m/W?V[4][-W
+                               ]:0,Z=k=!(m/W)
+                              ||n<3?0:V[4][-3
+                             -W],*(*V)+++(l?l
+                             -1?l-2?l-3?(X=j-
+                             Z,X=X>0?X:-X,Y=i-
+                            Z,Y=Y>0?Y:-Y,Z=i+j
+                            -Z-Z,Z=Z>0?Z:-Z,X>Y
+                           ||X>Z?Y   >Z?k:j:i):
+                           (i+j)    /2:j:i:0));
+                          for(     E=t+O; *v-1[v]
+                         &&c==   -16; ++*v)n=**v,n
+                         -62?   n-60?n  -91?n-93||!
+                        m||    !*E?*    v:(*v=A[--m+9
+                       ]):    (A[9+    m++]=*v-1):--E
+                      :++       E      ,n-43?n-44?n-45?
+                     n-        46    ?0:putchar(*E):--*E
+                   :(*       E=     getchar()):++*E; for(;
+                   7<       -c     &&11>-c&&*v!=5[v]; ++*v)
+                 **V      =c     +8?c+9?*V[1]++<<6|56:**V|~3
+                &*V     [1]     ++:**V>>6; for(; m<n*2; m+=2)c
+              +18?    c+19      ?0:(V[1][m/8]+=(*V[0] ++-56)>>m
+             %8)     :(*       V[1]++=V[0][m/8]<<m%8 ); return !
+           c?c:     c>0       ?n=main(-7,(Q=**++v,N=0x49444154,*A
+         =s+4,    main      (-128   ,A),A[1]=*++v,A  [4]=z,*A=x,A))
+        ,c=A[    6]         -x-    12,Q-101?main(-19,(main(-10,(A[5]=
+       t+n,    *A=          t,   A[1]=z,A)),*A=t,A  [1]=w,A)):main(-9,(
+      main(   -8                ,((n=main(-7,(A[1]   =*++v,A[4]=t,*A=s+4,
+    A)))<0               ?      main     (-18,(n=  -n,*A=s,A[1]=t,A)):0,A[
+    5]=t+n            ,*A=     t,A)      ),*A=t,  A[1]=z,A)),98-Q?E=memcmp(
+   w,s,4              )?      n+=       main(-22  ,(*A=z,A[1    ]=t,A[2]=t+n
+  ,A)),            N=n=     main     (-23,(*A=t, A[1]=z,A[2       ]=z+n,A)),
+  memmove         (x+      c+n+12   ,x+c,12),memcpy(x+c+8,t,     n),main(-128
+  ,(*A=          x+c       +4,A))   ,N=crc32(    0,memcpy(x       +c+4,s,4),n
+ +4),           main       (-128,   (*A=x+c+     n+12,A)),n       +=c+24,x:(n=
+ strlen         (w        +4),w+4),fwrite(E     ,1,n,stdout):  main(-16,(*A=w,
+ A[1]=w    +H, A))       :-c>31?main(c+=32     ,(*--*v=N,N>>=8,v)):-++c<4?(-c)
+ [*V]+256*main(c,v    ):c+23?c+22?c+21?c+6?c+5?c+4?0:(N=O,uncompress(*v=s+4,&N
+  ,v[3],v[2]-v[3]   ),main(c-7,v),H):(n-=l=main(-4,v)+12,5[*v]-68?(v[6]=(*v+=
+  l)):(memcpy(v[2],*v+8,l-12),v[2]+=l-12,memmove(*v,*v+l,n)),main(c-(n>8),v))
+  :(n=  main(-24,v),main(-4,v)-0x89504e47?-H:main(c,(*v+=16,W=main(-4,v)*3,*v
+   +=       4,H=main(-4,v)*W,B=(*v)[5],(*v)[5]=2,N=crc32(0,*v-    8,17),*v+=
+    13         ,main(-128,v),v[3]=v[2]=w+O,*v-=21,v))):(*      *v=0,memcpy
+     (++*v            ,v[1],W),*v+=W,v[1]+=W,                1+main((v[1]
+      !=v[2])                                            *--c,v)):(N=O
+         ,compress(*v,&N,                    v[1],v[2]-v[1]),N):(f=
+              fopen(v[1],"rb"))?fclose((n=fread(*v,1,O,f),f)),
+                      n[*v]=0,n:(strcpy(*v,v[1]),0); }

--- a/2012/zeitak/README.md
+++ b/2012/zeitak/README.md
@@ -15,8 +15,8 @@ make
 ./zeitak < file.c
 ```
 
-where file.c is the file to be checked for nesting errors. For example, you may
-try incorrect.c and the program itself.
+where `file.c` is the file to be checked for nesting errors. For example, you may
+try [incorrect.c](incorrect.c) and the program itself.
 
 ## Try:
 
@@ -25,10 +25,13 @@ try incorrect.c and the program itself.
 ./zeitak < incorrect.c
 ```
 
+NOTE: it prints an error and exits on the first nesting error so it will not
+detect multiple issues!
+
 ### Alternate code
 
-An alternate version of this entry, `zeitak.alt.c`, is provided.
-The file `zeitak.alt.c` provides a version that has been slightly
+An alternate version of this entry, [zeitak.alt.c](zeitak.alt.c), is provided.
+The file [zeitak.alt.c](zeitak.alt.c) provides a version that has been slightly
 deobfuscated.  You may find reading that file helpful in your attempt
 to understand this extremely subtle entry.
 
@@ -40,13 +43,14 @@ make alt
 
 Use `zeitak.alt` as you would `zeitak` above.
 
-## Judges' remarks
+## Judges' remarks:
 
 This is an extremely subtle and twisted piece of Gold award winning code!
 
 The judges had spent a considerable amount of time analyzing this entry.
 At one point we spent
-[18 minutes](https://twitter.com/ioccc/status/252162898800033792)
+[18
+minutes](https://web.archive.org/web/20130925190722/https://twitter.com/ioccc/status/252162898800033792)
 just to understand 18 key characters of this code.
 
 ## Author's remarks
@@ -58,8 +62,8 @@ just to understand 18 key characters of this code.
 As you have probably understood by looking at the source\*, this program has
 something to do with parenthesis (and equality of opening and closing
 parenthesis, if you look close enough). It goes over the file given to it and
-checks that every opening (, [, or { has a matching closing one and
-vice versa. It also checks that every " or ' is closed.
+checks that every opening `(`, `[`, or `{` has a matching closing one and
+vice versa. It also checks that every `"` or `'` is closed.
 
 If an error is detected, an error message will be printed. If the problem
 is a superfluous closing bracket, it will even print a few characters
@@ -74,7 +78,7 @@ around it's position.
 
         printf(")");
 
-*   Doesn't get confused by the 1984/anonymous entry!
+*   Doesn't get confused by the [1984/anonymous](/1984/anonymous/anonymous.c) entry!
 
 #### Mis-Features
 
@@ -92,14 +96,14 @@ even more limited source, that is:
 *   Without any digits.
 *   Without any character constants.
 *   Without using functions from headers other than stdio.
-*   Without any control-flow keywords (not even the ?: operator).
+*   Without any control-flow keywords (not even the `?:` operator).
 *   Without any arithmetic or logic operators!
 
 So, what's left? Parenthesis, and lots of them, as looking at the source will
 reveal immediately. The main obfuscation is building the whole algorithm using
 only function calls, typecasts, array lookups and pointer operators.
 
-Additional obfuscations include:
+##### Additional obfuscations include:
 
 *   Extensive reuse of identifiers: Macros share names with variables, inner
     curly braces scopes contain variables with names identical to those in the
@@ -109,16 +113,15 @@ Additional obfuscations include:
 *   Mostly one-letter identifiers.
 *   Complex recursion: A function might call itself once, twice, or not at all.
 
-#### Compilation/Running Notes
+#### Compilation/Portability/Running Notes
 
 *   The program requires `char` to be one byte and pointers to be
     at least two bytes long.
 
 *   The program was tested on the following platforms:
-
-**  Ubuntu 9.04 32-bit with GCC
-**  Windows 7 32-bit with GCC
-**  Windows 7 32-bit with OpenWatcom
+	- Ubuntu 9.04 32-bit with GCC
+	- Windows 7 32-bit with GCC
+	- Windows 7 32-bit with OpenWatcom
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/bugs.md
+++ b/bugs.md
@@ -1977,7 +1977,7 @@ where `o` is a `void`.
 
 Do you have a fix? We welcome it!
 
-## [2011/vik](2012/vik/vik.c) ([README.md](2012/vik/README.md))
+## [2011/vik](2011/vik/vik.c) ([README.md](2011/vik/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
 The author stated that the program will crash if no argument is passed to the

--- a/bugs.md
+++ b/bugs.md
@@ -1987,6 +1987,15 @@ fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)) :-)
 
 # 2012
 
+## [2012/vik](2012/vik/vik.c) ([README.md](2012/vik/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+The author stated that the program will crash if no argument is passed to the
+program or if invalid arguments or images of mismatching sizes or unsupported
+pixel formats though we note that your computer might also [halt and catch
+fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)) :-)
+
+
 
 # 2013
 

--- a/bugs.md
+++ b/bugs.md
@@ -1980,7 +1980,7 @@ Do you have a fix? We welcome it!
 ## [2011/vik](2012/vik/vik.c) ([README.md](2012/vik/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
-The author stated that the program will crash if no argument is passed tot he
+The author stated that the program will crash if no argument is passed to the
 program though we note that your computer might also [halt and catch
 fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)) :-)
 


### PR DESCRIPTION

Based on the author's description I made an alt version that should 
theoretically work in Windows though of course (thank goodness) I have 
no way to actually test it.

Just like with 2011/vik I've only done this because part of issue #1 is
to make entries work on as many systems as possible though it's not 
entirely clear to me that 'Windows' should even be considered a 'system'
at all let alone one worthy of consideration :-)

Updated .gitignore.
