### PR TITLE
Update 1988/spinellis/Makefile

### DIFF
--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -127,7 +127,8 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry will not compile with some compilers like clang."
+	@echo "NOTE: this entry will not compile with some compilers like clang."
+	@echo "NOTE: use make alt for clang."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable


### PR DESCRIPTION
Extended the note about clang - use the alt version (make alt) that I made a while back if you have clang and not gcc. It previously only reported that it doesn't work for clang but no note about a version that works.