### PR TITLE
Update 2006/toledo2/.gitignore

### DIFF
--- a/2006/toledo2/.gitignore
+++ b/2006/toledo2/.gitignore
@@ -22,3 +22,5 @@ WS33/
 toledo2
 toledo2.alt
 DDT.COM
+*.COM
+*.ASM


### PR DESCRIPTION
Added '*.COM' and other globs matching files from the zip file referenced by the author in the README.md file.