### PR TITLE
Fix consistency of award titles

### DIFF
--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -1,4 +1,4 @@
-# The Grand Prize
+# Grand Prize
 
 Sjoerd Mullender<br />
 <https://github.com/sjoerdmullender>

--- a/1985/august/README.md
+++ b/1985/august/README.md
@@ -1,4 +1,4 @@
-# The most obscure program
+# Most obscure program
 
 Lennart Augustsson  
 <https://web.archive.org/web/20090831055828/http://www.cs.chalmers.se/~augustss>

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -1,4 +1,4 @@
-# The strangest appearing program 
+# Strangest appearing program 
 
 Ed Lycklama  
 

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -1,4 +1,4 @@
-# The worst abuse of the C preprocessor
+# Worst abuse of the C preprocessor
 
 Col. G. L. Sicherman  
 

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -1,4 +1,4 @@
-# The grand prize in most well-rounded in confusion
+# Grand prize in most well-rounded in confusion
 
 Larry Wall  
 US 

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -1,4 +1,4 @@
-## Best abuse of system calls
+# Best abuse of system calls
 
 Paul Dale  
 University of Queensland  

--- a/1988/litmaath/README.md
+++ b/1988/litmaath/README.md
@@ -1,4 +1,4 @@
-## Best small program
+# Best small program
 
 Maarten Litmaath  
 Free University (VU) Amsterdam  

--- a/1988/phillipps/README.md
+++ b/1988/phillipps/README.md
@@ -1,4 +1,4 @@
-## Least likely to compile successfully
+# Least likely to compile successfully
 
 Ian Phillipps  
 Cambridge Consultants Ltd  

--- a/1988/reddy/README.md
+++ b/1988/reddy/README.md
@@ -1,4 +1,4 @@
-## Most useful Obfuscated C program
+# Most useful Obfuscated C program
 
 Amperif Corporation  
 9232 Eton Avenue  

--- a/1988/robison/README.md
+++ b/1988/robison/README.md
@@ -1,4 +1,4 @@
-## Best abuse of C constructs
+# Best abuse of C constructs
 
 Arch D. Robison  
 University of Illinois at Urbana-Champaign  

--- a/1988/spinellis/README.md
+++ b/1988/spinellis/README.md
@@ -1,4 +1,4 @@
-## Best abuse of the rules
+# Best abuse of the rules
 
 Diomidis Spinellis  
 Greece  

--- a/1988/westley/README.md
+++ b/1988/westley/README.md
@@ -1,4 +1,4 @@
-## Best layout
+# Best layout
 
 Merlyn LeRoy (Brian Westley)  
 Rosemount, Inc.  

--- a/1989/jar.2/README.md
+++ b/1989/jar.2/README.md
@@ -1,4 +1,4 @@
-## Best of show
+# Best of show
 
 Jari Arkko, Ora Lassila, Esko Nuutila  
 Laboratory of Information Processing Science  

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -1,4 +1,4 @@
-## Most humorous output
+# Most humorous output
 
 Oskar von der Luehe  
 Institut fuer Astronomie  

--- a/1989/paul/README.md
+++ b/1989/paul/README.md
@@ -1,4 +1,4 @@
-## Most complex algorithm
+# Most complex algorithm
 
 Paul E. Black  
 CIRRUS LOGIC, Inc.  

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -1,4 +1,4 @@
-## Best minimal use of C
+# Best minimal use of C
 
 Arch D. Robison  
 University of Illinois  

--- a/1989/roemer/README.md
+++ b/1989/roemer/README.md
@@ -1,4 +1,4 @@
-## Best layout
+# Best layout
 
 Lievaart, Roemer B.  
 VU-Informatica, Amsterdam  

--- a/1989/vanb/README.md
+++ b/1989/vanb/README.md
@@ -1,4 +1,4 @@
-## Best one liner
+# Best one liner
 
 David Van Brackle  
 Department of Computer Science  

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -1,4 +1,4 @@
-# Most likely to amaze
+# Dishonorable mention
 
 The author wishes to remain anonymous  
 Great Britain  

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -1,4 +1,4 @@
-# Best primal ASCII graphics
+# Best of Show
 
 Nicolas Ollinger
 France

--- a/2004/kopczynski/README.md
+++ b/2004/kopczynski/README.md
@@ -1,4 +1,4 @@
-# Best one-liner
+# Best One-Liner
 
 Eryk Kopczynski  
 Poland  

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -1,4 +1,4 @@
-# Best use of the www
+# Best use of the WWW
 
 Anthony Howe  
 <achowe@snert.com>  

--- a/2005/persano/README.md
+++ b/2005/persano/README.md
@@ -1,4 +1,4 @@
-# Best of show
+# Best of Show
 
 Mauro Persano  
 Brazil  

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -1,4 +1,4 @@
-# Best emulator
+# Best Emulator
 
 Stephen Sykes  
 <sds@maxisat.fi>  

--- a/2005/toledo/README.md
+++ b/2005/toledo/README.md
@@ -1,4 +1,4 @@
-# Best game
+# Best Game
 
 Oscar Toledo G.  
 Familia Toledo  

--- a/2006/toledo2/.gitignore
+++ b/2006/toledo2/.gitignore
@@ -22,3 +22,5 @@ WS33/
 toledo2
 toledo2.alt
 DDT.COM
+*.COM
+*.ASM

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -64,7 +64,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE= `${SDL2_CONFIG} --cflags`
+CINCLUDE= `${SDL1_CONFIG} --cflags`
 
 # Optimization
 #
@@ -76,7 +76,7 @@ CFLAGS= ${CSTD} ${CWARN} ${ARCH} ${CDEFINE} ${CINCLUDE} ${OPT}
 
 # Libraries needed to build
 #
-LIBS= `${SDL2_CONFIG} --libs`
+LIBS= `${SDL1_CONFIG} --libs`
 
 # C compiler to use
 #

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -6,66 +6,16 @@
 
 ## To build:
 
-This entry requires SDL to be installed.
+This entry requires SDL to be installed. See the [faq.md](/faq.md) if you don't
+know how to do this for your system.
 
 ```sh
 make
 ```
 
-### To install SDL and SDL2:
-
-#### macOS users
-
-If you have not aleady do so, install Homebrew.  See the following for information:
-
-    https://brew.sh
-
-Then to install SDL and SDL2, execute the following command:
-
-```sh
-brew install sdl2 sdl12-compat
-eval "$(/opt/homebrew/bin/brew shellenv)"
-```
-
-#### Linux users:
-
-To install SDL and SDL2, execute the following command as root:
-
-```sh
-dnf install SDL2 SDL2-devel sdl12-compat sdl12-compat-devel
-```
-
-Use make as follows:
-
-```sh
-make ... SDL2_INCLUDE_ROOT=/usr
-```
-
-or set the following environment variable:
-
-```sh
-export SDL2_INCLUDE_ROOT=/usr
-```
-
-#### Debian users
-
-To install SDL and SDL2, execute the following command as root:
-
-```sh
-apt install libsdl1.2debian libsdl1.2-dev libsdl2-dev
-```
-
-Use make as follows:
-
-```sh
-make ... SDL2_INCLUDE_ROOT=/usr
-```
-
-or set the following environment variable:
-
-```sh
-export SDL2_INCLUDE_ROOT=/usr
-```
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed the build for
+this entry: it does not require SDL2 but SDL1 so there were linking errors.
+Thank you Cody!
 
 ## To run:
 
@@ -78,162 +28,299 @@ cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679
 ```sh
 cat giana.level | ./prog 320 200 1000 300 192 168 giana.rgba giana8.wav 5459393
 
-cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet towel.blinkenlights.nl
+cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet telehack.com 23
+
 ```
+
+If you end up telnetting to the server you can try:
+
+```
+ls # show files including games
+wumpus.bas # play Hunt the Wumpus
+advent.gam # you know what this is! :-)
+starwars # animated Star Wars 'film'
+```
+
+NOTE: the author stated that the sky colour is incorrect in some versions of
+macOS, offering a workaround. Cody tested this out in the most recent macOS
+version and this does not seem to be a problem any more. As he played (and beat)
+the entire series many times years ago he can confirm that the sky is more or
+less correct though it's possible that because he's practically blind he might
+have missed something :-) He guesses that the problem might have been the
+version of `SDL1` but he does not know this either way.
+
+Cody notes ironically that the author stated that in Super Mario Bros one cannot
+go through walls but there are known glitches where you can in some areas (as he
+recalls this also applied to the arcade version, Mario Bros, but he cannot
+confirm this now) :-)
+
 
 ## Judges' remarks:
 
 A classic for a particular generation. Like all good programs, being data
 driven means you can do fun things in small spaces.
 
+NOTE: the author states to use `tabsize=4` to see the magic of the formatting of
+the code. In `vim` you can do:
+
+```
+:set tabstop=4
+```
+
+in command mode to see this effect. You don't need to modify your `.vimrc` file!
+You can also use `expand` as described below if your terminal has enough rows
+and you don't want to move about in the code. The vim command should immediately
+take effect.
+
+
 ## Author's remarks:
 
 ### Remarks
 
-Use tabsize=4 to see the magic
+Use `tabsize=4` to see the magic.
 
 ```sh
-./expand -t 4 < prog.c
+expand -t 4 prog.c
 ```
 
-The program returns 0 if the user win or *not-zero* if loose so you can test it and make something useful (or not), like that:
+The program returns 0 if the player wins or *non-zero* if the player loses so
+you can test it and make something useful (or not), like this:
 
 ```sh
-cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet towel.blinkenlights.nl
+cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet telehack.com 23
 ```
 
-This is an engine for **Platform Games**. It can be used to create games like the legendary [Super Mario Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.).
-With this simple and clear sourcecode you can create all the games you want, for free!
+and type in: `starwars`
 
-In my two tests i tried to create one level of [Super Mario Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.) and one of [The Great Giana The Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters).
-Both games are classic *platform games* and both share the same fundamental rules:
 
-- there is a player
-- there is a powerup that can change the look of the player and/or give to him/her more power!
-- there are walls, floors and ceilings. the player can move and jump over these type of obstacles but cannot walk through them
-- there are enemies and, if the player collides with an enemy, the player dies or loses its powers
+This is an engine for [platform
+game](https://en.wikipedia.org/wiki/Platform_game). It can be used to create
+games like the legendary [Super Mario
+Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.).
 
-### Regards running under Mac OS X
+With this simple and clear source code you can create all the games you want,
+for free!
 
-The color of the sky is wrong on MacOS. You need to flip some bytes from the last parameter of the program:
+In my two tests I tried to create one level of [Super Mario
+Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.) and one of [The Great
+Giana The Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters).
 
-	MARIO LAST PARAMETER: 4292124159
+Both games are classic [platform
+games](https://en.wikipedia.org/wiki/Platform_game) and both share the same
+fundamental rules:
 
-	GIANA LAST PARAMETER: 3243070463
+- There is a character.
+
+- There are power-ups that can change the look of the character and/or give the
+character more or different powers or abilities!
+
+- There are walls, floors and ceilings. The character can move and jump over
+these type of obstacles but cannot walk through them.
+
+- There are enemies and; if the character collides with an enemy, the character
+dies or loses its powers.
+
+###  Running under macOS
+
+[NOTE: this seems to no longer be the case as of 2023 and most likely much
+earlier. However one can change the look of the game doing this anyway:]
+
+The color of the sky is wrong on macOS. You need to flip some bytes from the
+last parameter of the program:
+
+* MARIO LAST PARAMETER: `4292124159`
+
+* GIANA LAST PARAMETER: `3243070463`
 
 ### Regarding how to compile
 
-The code requires libSDL1.X.
+The code requires `SDL1`.
 
 The build process will generate some warnings  (60~ on clang) about:
 
-- **incompatible pointer types**: because all pointers are declared to *int* or *char*, to save tokens
-- **type specifier missing, defaults to 'int'**: because i need to save tokens
-- **using the result of an assignment as a condition without parentheses**: because while(c=getchar()) is not evil
+- `incompatible pointer types`: because all pointers are declared to `int` or
+`char`, to save bytes.
+- `type specifier missing, defaults to 'int'`: because I need to save bytes.
+- `using the result of an assignment as a condition without parentheses`:
+because `while(c=getchar())` is not evil.
 
 ### How it works
 
 ## Parameters
 
-1. Window width
-2. Window height
-3. Level width
-4. Level height
-5. Sprites image width
-6. Sprites image height
-7. Filename of the sprites image (raw RGBA image)
-8. Filename of the music (WAVE 8000 Hz 8bit Mono)
-9. Sky color. This number depends on the system where you run the program. See **NOTE on MacOS**
+1. Window width.
+2. Window height.
+3. Level width.
+4. Level height.
+5. Sprites image width.
+6. Sprites image height.
+7. Filename of the sprites image (raw RGBA image).
+8. Filename of the music (WAVE 8000 Hz 8bit Mono).
+9. Sky color. This number depends on the system where you run the program. See
+note on macOS.
 
 ## Sprites
 
-The program read a single image that contains all the game sprites. The image must be a grid of 8xN sprites. The size of a single sprite must be square. The program calculates the size in this way:
+The program read a single image that contains all the game sprites. The image
+must be a grid of 8xN sprites. The size of a single sprite must be square. The
+program calculates the size in this way:
 
-	sprite_size = image_width / 8
+```
+sprite_size = image_width / 8
+```
 
-Each sprite is identified by its position inside the grid, counting line by line, from left to right (for example sprite 0 is the top left sprite in the grid, sprite 8 is the first sprite of the second row of the grid).
+Each sprite is identified by its position inside the grid, counting line by
+line, from left to right (for example sprite 0 is the top left sprite in the
+grid, sprite 8 is the first sprite of the second row of the grid etc.).
 
 Some positions of the grid have a predefined purpose:
 
+```
 Position          | Description
 :-----------------|:--------------
-0                 | Player stand right
-1                 | Player walk right frame 0
-2                 | Player walk right frame 1
-3                 | Player jump right
-4                 | Player stand left
-5                 | Player walk left frame 0
-6                 | Player walk left frame 1
-7                 | Player jump left
-8 *(second row)*  | Super player stand right
-9                 | Super player walk right frame 0
-10                | Super player walk right frame 1
-11                | Super player jump right
-12                | Super player stand left
-13                | Super player walk left frame 0
-14                | Super player walk left frame 1
-15                | Super player jump left
+0                 | Player standing right
+1                 | Player walking right frame 0
+2                 | Player walking right frame 1
+3                 | Player jumping right
+4                 | Player standing left
+5                 | Player walking left frame 0
+6                 | Player walking left frame 1
+7                 | Player jumping left
+8 *(second row)*  | Super player standing right
+9                 | Super player walking right frame 0
+10                | Super player walking right frame 1
+11                | Super player jumping right
+12                | Super player standing left
+13                | Super player walking left frame 0
+14                | Super player walking left frame 1
+15                | Super player jumping left
 24                | Player dead
-32                | Player win
-40                | Super player win
+32                | Player won
+40                | Super player won
+```
 
-All the others sprites can be used as you want, depending on the game you want to create.
+All the others sprites can be used as you want, depending on the game you want
+to create.
 
 ## Levels
 
-The program reads the level description from **stdin**.
+The program reads the level description from `stdin`.
 
-The level description is a sequence of rows where each row describe an object. You can input as many objects as you want but the maximum number of objects handled by the program is 333. You can modify this value by editing the source here:
+The level description is a sequence of rows where each row describe an object.
+You can input as many objects as you want but the maximum number of objects
+handled by the program is 333. You can modify this value by editing the source
+here:
 
 ```c
 C[333*7],d=333;
 ```
 
-Each row have six columns:
+Each row has six columns:
 
-1. Screen X: x position of the object in the level
-2. Screen Y: y position of the object in the level
-3. Sprite: id of the sprite to be used for the object
-4. CLASSFLAGS: a bitmask that describe how the object behaves
-5. CLASSPARAM0: a parameter that depends on CLASSFLAGS
-6. CLASSPARAM1: a parameter that depends on CLASSFLAGS
+1. `Screen X`	: `x` position of the object in the level.
+2. `Screen Y`	: `y` position of the object in the level.
+3. `Sprite`	: `id` of the sprite to be used for the object.
+4. `CLASSFLAGS`	: a bitmask that describe how the object behaves.
+5. `CLASSPARAM0`: a parameter that depends on `CLASSFLAGS`.
+6. `CLASSPARAM1`: a parameter that depends on `CLASSFLAGS`.
 
-CLASSFLAGS must be a combination (bitwise or) of some of these constants:
+`CLASSFLAGS` must be a combination (bitwise OR) of some of these constants:
 
-NAME       | CONSTANT  | CLASS
-:----------|:----------|:---------
-ENEMY      | 1         | An enemy. CLASSPARAM0 can be 0 if the enemy don't move, 1 if the initial move direction is right, -1 if direction is left. All enemies that walk will change its direction after 20 pixels. The sprite of an enemy must have 2 others adjacent sprites: SPRITE-1, used when the enemy die, and SPRITE+1, used when it walks
-BLOCK      | 2         | A wall. Player can walk over the object but can not pass through it
-GIFT BLOCK | 4         | When the player hits the object from below, a new object is created. CLASSFLAGS of the new object is defined in CLASSPARAM0. The sprite used for the new object is defined in CLASSPARAM1. The sprite of the gift object must have an adjacent sprite: SPRITE+1, used when the block is hit
-POWERUP    | 8         | This is the classic Mario's mushroom. When the player hit the powerup object, the player become  *Super player*. If CLASSFLAGS has the bit ZOOM, the player height will be doubled.<br>The *Super player* can hit the enemies without die, but when this happens, the *Super player* goes back to being normal
-END         | 16       | When the player hits this object the level ends. Player win
-ZOOM        | 32       | This flag can be used with POWERUP to indicate a powerup that will doubles the size of the player (like Mario's mushroom)
-DESTROY     | 64       | When the player hits the object the object disappear. This is the classic Mario's coin, but the engine does not counts the points, so, from the user point of view, this object is useless
-DESTROYUP   | 128      | This object is like a BLOCK but when the player hits the object from below, the object disappear
+* `ENEMY` (`1`)
 
-If CLASSFLAGS is zero the object has only an aesthetic function.
+	    An enemy. CLASSPARAM0 can be 0 if the enemies don't move, 1 if the
+	    initial move direction is right, -1 if that direction is left. All
+	    enemies that walk will change their direction after 20 steps. The
+	    sprite of an enemy must have 2 other adjacent sprites: SPRITE-1,
+	    used when the enemy dies, and SPRITE+1, used when it moves.
 
-The last row of the level descriptor must have all its columns set equal to -1.
+* `BLOCK` (`2`)
+
+	    A wall. Player can walk over the object but can not pass through it.
+
+* `OBJECT BLOCK` (`4`)
+
+	    When the player hits the object from below, a new object is created.
+	    CLASSFLAGS of the new object is defined in CLASSPARAM0. The sprite
+	    used for the new object is defined in CLASSPARAM1. The sprite of the
+	    new object must have an adjacent sprite: SPRITE+1, used when the
+	    block is hit.
+
+* `POWERUP` (`8`)
+
+	    This is a power-up like the classic Mario mushroom. When the
+	    character hits the power-up object, the character becomes the Super
+	    character. If CLASSFLAGS has the bit ZOOM, the character height will
+	    be doubled.  The Super character can hit the enemies without dying,
+	    but when this happens, the Super character goes back to being
+	    normal.
+
+* `END` (`16`)
+
+	    When the player hits this object the level ends; the player wins.
+
+* `ZOOM` (`32`)
+
+	    This flag can be used with POWERUP to indicate a power-up that
+	    will double the size of the player (like the Mario mushroom).
+
+* `DESTROY` (`64`)
+
+	    When the player hits the object (e.g. the classic Mario coin) the
+	    object disappears but the engine does not counts the points, so,
+	    from the player point of view, this object is useless.
+
+* `DESTROYUP` (`128`)
+
+	    This object is like a BLOCK but when the player hits the object
+	    from below, the object disappears.
+
+If `CLASSFLAGS` is `0` the object only has an aesthetic function.
+
+The last row of the level descriptor must have all its columns set equal to
+`-1`.
 
 ### Limitations
 
-Some classical features are missing: throw objects, shoot, multiple lives, points counter. You can add those features if you want!
+Some classical features are missing: throwing objects, shooting, multiple lives,
+score tracking. You can add those features if you want!
 
-The program allow to run one level only. It's easy to add a menu and multiple levels but the size of the engine will grow too much.
+The program allows only one level. It's easy to add a menu and multiple levels
+but the size of the engine would too big for the contest.
 
-When the *Super player* become bigger (ZOOM flag), the player can collide with blocks and get stuck inside them. This is a KNOWN BUG. When your player become bigger, stay away from blocks!
+When the `Super character` becomes bigger (`ZOOM` flag), the character can
+collide with blocks and get stuck inside them. This is a KNOWN BUG. When your
+player become bigger, stay away from blocks!
 
-There is one audio track only (game effects are missing).
+There's only one audio track (game effects are missing).
 
 ### Credits
 
-Some of the sprites used in the examples are identical to those of the original games, others were designed by me.
+Some of the sprites used in the examples are identical to those of the original
+games; the others were designed by me.
 
-The music used in the examples have been resampled, starting from the original versions for the [Commodore Amiga](http://en.wikipedia.org/wiki/Amiga) and [Nintendo NES](http://en.wikipedia.org/wiki/Nintendo_Entertainment_System).
+The music used in the examples have been
+[resampled](https://en.wikipedia.org/wiki/Sample-rate_conversion), starting from
+the original versions for the [Commodore
+Amiga](http://en.wikipedia.org/wiki/Amiga) and [Nintendo
+NES](http://en.wikipedia.org/wiki/Nintendo_Entertainment_System).
 
-[Super Mario Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.) is a game created by Nintendo Entertainment, my use of the sprites does not intend to infringe the intellectual property of Nintendo but only demonstrate the operation of the program. From my point of view this is a tribute to the legendary game [Super Mario Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.)!
+[Super Mario Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.) is a game
+created by [Nintendo Co., Ltd](https://en.wikipedia.org/wiki/Nintendo). My use
+of the [sprites](https://en.wikipedia.org/wiki/Sprite_(computer_graphics)) does
+not intend to infringe the [intellectual
+property](https://en.wikipedia.org/wiki/Intellectual_property) of Nintendo but
+only demonstrates the operation of the program. From my point of view this is a
+tribute to the legendary game [Super Mario
+Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.)!
 
-[The Great Giana The Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters) is the game created by Time Warp Productions and also for this game worth my previous notes. Long live [The Great Giana The Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters) !! :)
+[The Great Giana The
+Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters) is the game
+created by [Time Warp
+Productions](https://www.ign.com/games/producer/time-warp-productions) and my
+justification for the sprites for Mario are the same for this game. Long live
+[The Great Giana The
+Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters) !! :)
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/bin/check_awards.sh
+++ b/bin/check_awards.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+grep -Hc "^# Dishonorable mention" 1984/anonymous/README.md
+grep -Hc "^# Second place" 1984/decot/README.md
+grep -Hc "^# Third place" 1984/laman/README.md
+grep -Hc "^# Grand Prize" 1984/mullender/README.md
+grep -Hc "^# Best one liner" 1985/applin/README.md
+grep -Hc "^# Most obscure program" 1985/august/README.md
+grep -Hc "^# Strangest appearing program" 1985/lycklama/README.md
+grep -Hc "^# Grand prize for most well-rounded in confusion" 1985/shapiro/README.md
+grep -Hc "^# Worst abuse of the C preprocessor" 1985/sicherman/README.md
+grep -Hc "^# Most adaptable program" 1986/applin/README.md
+grep -Hc "^# Best complex task done in a complex way" 1986/august/README.md
+grep -Hc "^# Most useful obfuscation" 1986/bright/README.md
+grep -Hc "^# Worst abuse of the C preprocessor" 1986/hague/README.md
+grep -Hc "^# Best simple task performed in a complex way" 1986/holloway/README.md
+grep -Hc "^# Best layout" 1986/marshall/README.md
+grep -Hc "^# Most illegible code" 1986/pawka/README.md
+grep -Hc "^# Best one liner" 1986/stein/README.md
+grep -Hc "^# Grand prize in most well-rounded in confusion" 1986/wall/README.md
+grep -Hc "^# Best Abuse of the Rules" 1987/biggar/README.md
+grep -Hc "^# Best Obfuscator of Programs" 1987/heckbert/README.md
+grep -Hc "^# Worst Style" 1987/hines/README.md
+grep -Hc "^# Best One Liner" 1987/korn/README.md
+grep -Hc "^# Grand Prize" 1987/lievaart/README.md
+grep -Hc "^# Most Useful Obfuscation" 1987/wall/README.md
+grep -Hc "^# Best Layout" 1987/westley/README.md
+grep -Hc "^# Best of show" 1988/applin/README.md
+grep -Hc "^# Best abuse of system calls" 1988/dale/README.md
+grep -Hc "^# Best visuals" 1988/isaak/README.md
+grep -Hc "^# Best small program" 1988/litmaath/README.md
+grep -Hc "^# Least likely to compile successfully" 1988/phillipps/README.md
+grep -Hc "^# Most useful Obfuscated C program" 1988/reddy/README.md
+grep -Hc "^# Best abuse of C constructs" 1988/robison/README.md
+grep -Hc "^# Best abuse of the rules" 1988/spinellis/README.md
+grep -Hc "^# Best layout" 1988/westley/README.md
+grep -Hc "^# Best self-modifying program" 1989/fubar/README.md
+grep -Hc "^# Strangest abuse of the rules" 1989/jar.1/README.md
+grep -Hc "^# Best of show" 1989/jar.2/README.md
+grep -Hc "^# Most humorous output" 1989/ovdluhe/README.md
+grep -Hc "^# Most complex algorithm" 1989/paul/README.md
+grep -Hc "^# Best minimal use of C" 1989/robison/README.md
+grep -Hc "^# Best layout" 1989/roemer/README.md
+grep -Hc "^# Best game" 1989/tromp/README.md
+grep -Hc "^# Best one liner" 1989/vanb/README.md
+grep -Hc "^# Most algorithms in one program" 1989/westley/README.md
+grep -Hc "^# Best Small Program" 1990/baruch/README.md
+grep -Hc "^# Best Game" 1990/cmills/README.md
+grep -Hc "^# Best Language Tool" 1990/dds/README.md
+grep -Hc "^# Best Abuse of the C Preprocessor" 1990/dg/README.md
+grep -Hc "^# Best Entropy-reducer" 1990/jaw/README.md
+grep -Hc "^# Most Unusual Data Structure" 1990/pjr/README.md
+grep -Hc "^# ANSI Committee's Worst Abuse of C" 1990/scjones/README.md
+grep -Hc "^# Strangest Abuse of the Rules" 1990/stig/README.md
+grep -Hc "^# Best Utility" 1990/tbr/README.md
+grep -Hc "^# Best of Show" 1990/theorem/README.md
+grep -Hc "^# Best Layout" 1990/westley/README.md
+grep -Hc "^# Best Utility" 1991/ant/README.md
+grep -Hc "^# Best Of Show" 1991/brnstnd/README.md
+grep -Hc "^# Best Output" 1991/buzzard/README.md
+grep -Hc "^# Most Useful Label" 1991/cdupont/README.md
+grep -Hc "^# Best X11 Graphics" 1991/davidguy/README.md
+grep -Hc "^# Most Well Rounded" 1991/dds/README.md
+grep -Hc "^# Best One Liner" 1991/fine/README.md
+grep -Hc "^# Best Game" 1991/rince/README.md
+grep -Hc "^# Grand Prize" 1991/westley/README.md
+grep -Hc "^# Most Educational" 1992/adrian/README.md
+grep -Hc "^# Most Useful Program" 1992/albert/README.md
+grep -Hc "^# Best Utility" 1992/ant/README.md
+grep -Hc "^# Most Obfuscated Algorithm" 1992/buzzard.1/README.md
+grep -Hc "^# Best Language Tool" 1992/buzzard.2/README.md
+grep -Hc "^# Most Humorous Output" 1992/gson/README.md
+grep -Hc "^# Best Output" 1992/imc/README.md
+grep -Hc "^# Best X Program" 1992/kivinen/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor" 1992/lush/README.md
+grep -Hc "^# Best Game" 1992/marangon/README.md
+grep -Hc "^# Worst Abuse of the Rules" 1992/nathan/README.md
+grep -Hc "^# Best of Show" 1992/vern/README.md
+grep -Hc "^# Best Small Program" 1992/westley/README.md
+grep -Hc "^# Best Utility" 1993/ant/README.md
+grep -Hc "^# \"Bill Gates\" Award" 1993/cmills/README.md
+grep -Hc "^# Best Abuse of the C Preprocessor" 1993/dgibson/README.md
+grep -Hc "^# Best Obfuscated Algorithm" 1993/ejb/README.md
+grep -Hc "^# Most Obfuscated X Program" 1993/jonth/README.md
+grep -Hc "^# Best Game" 1993/leo/README.md
+grep -Hc "^# Most Versatile Source" 1993/lmfjyh/README.md
+grep -Hc "^# Best One Liner" 1993/plummer/README.md
+grep -Hc "^# Most Well Rounded" 1993/rince/README.md
+grep -Hc "^# Obfuscated Intelligence Award" 1993/schnitzi/README.md
+grep -Hc "^# Most Irregular Expression" 1993/vanb/README.md
+grep -Hc "^# Best Game" 1994/dodsond1/README.md
+grep -Hc "^# Most Obfuscated Packaging" 1994/dodsond2/README.md
+grep -Hc "^# Best Utility" 1994/horton/README.md
+grep -Hc "^# Most Obfuscated Algorithm" 1994/imc/README.md
+grep -Hc "^# Best One-liner" 1994/ldb/README.md
+grep -Hc "^# Best Layout" 1994/schnitzi/README.md
+grep -Hc "^# Most Well Rounded Obfuscation" 1994/shapiro/README.md
+grep -Hc "^# Worst Abuse of the Rules" 1994/smr/README.md
+grep -Hc "^# Best X11 Program" 1994/tvr/README.md
+grep -Hc "^# Best Short Program" 1994/weisberg/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor" 1994/westley/README.md
+grep -Hc "^# Best Output" 1995/cdua/README.md
+grep -Hc "^# Most Humorous" 1995/dodsond1/README.md
+grep -Hc "^# Best Game" 1995/dodsond2/README.md
+grep -Hc "^# Interesting Algorithm" 1995/esde/README.md
+grep -Hc "^# Best Utility" 1995/garry/README.md
+grep -Hc "^# Best Layout" 1995/heathbar/README.md
+grep -Hc "^# Best Use of Obfuscation" 1995/leo/README.md
+grep -Hc "^# Best Short Program" 1995/makarios/README.md
+grep -Hc "^# Most Obfuscated Syntax" 1995/savastio/README.md
+grep -Hc "^# Best One Liner" 1995/schnitzi/README.md
+grep -Hc "^# Abusing The Rules" 1995/spinellis/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor and Most Likely To Amaze" 1995/vanschnitz/README.md
+grep -Hc "^# Best of Show" 1996/august/README.md
+grep -Hc "^# Best Numerical Obfuscation" 1996/dalbec/README.md
+grep -Hc "^# Best Output" 1996/eldby/README.md
+grep -Hc "^# Best Layout" 1996/gandalf/README.md
+grep -Hc "^# Best Obfuscated Character Set Utility" 1996/huffman/README.md
+grep -Hc "^# Best X11 Entry" 1996/jonth/README.md
+grep -Hc "^# Best RFC Obfuscation" 1996/rcm/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor" 1996/schweikh1/README.md
+grep -Hc "^# Best Algorithm" 1996/schweikh2/README.md
+grep -Hc "^# Best Utility" 1996/schweikh3/README.md
+grep -Hc "^# Best One Liner" 1996/westley/README.md
+grep -Hc "^# Best of Show" 1998/banks/README.md
+grep -Hc "^# Best Encapsulation" 1998/bas1/README.md
+grep -Hc "^# Best Small Program" 1998/bas2/README.md
+grep -Hc "^# Best Object Orientation" 1998/chaos/README.md
+grep -Hc "^# Best Data Hiding" 1998/df/README.md
+grep -Hc "^# Best Utility" 1998/dlowe/README.md
+grep -Hc "^# Most Fun" 1998/dloweneil/README.md
+grep -Hc "^# Obsolescent Feature" 1998/dorssel/README.md
+grep -Hc "^# Most Obfuscated Translator" 1998/fanf/README.md
+grep -Hc "^# Best Flow Control" 1998/schnitzi/README.md
+grep -Hc "^# CPP Abuse" 1998/schweikh1/README.md
+grep -Hc "^# Most Erratic Behavior" 1998/schweikh2/README.md
+grep -Hc "^# Most Space Efficient" 1998/schweikh3/README.md
+grep -Hc "^# Best Self-Documenting" 1998/tomtorfs/README.md
+grep -Hc "^# Best Use of Flags" 2000/anderson/README.md
+grep -Hc "^# Most Specific Output" 2000/bellard/README.md
+grep -Hc "^# Best Utility" 2000/bmeyer/README.md
+grep -Hc "^# Best Abuse of User" 2000/briddlebane/README.md
+grep -Hc "^# Best Layout" 2000/dhyang/README.md
+grep -Hc "^# Worst Abuse of the Rules" 2000/dlowe/README.md
+grep -Hc "^# Best of Show" 2000/jarijyrki/README.md
+grep -Hc "^# Best Small Program" 2000/natori/README.md
+grep -Hc "^# Best Abuse of CPP" 2000/primenum/README.md
+grep -Hc "^# Astronomically Obfuscated" 2000/rince/README.md
+grep -Hc "^# Best game" 2000/robison/README.md
+grep -Hc "^# Most Timely Output" 2000/schneiderwent/README.md
+grep -Hc "^# Most Portable Output" 2000/thadgavin/README.md
+grep -Hc "^# Most Complete Program" 2000/tomx/README.md
+grep -Hc "^# Dishonorable mention" 2001/anonymous/README.md
+grep -Hc "^# Best abuse of the rules" 2001/bellard/README.md
+grep -Hc "^# Best short program" 2001/cheong/README.md
+grep -Hc "^# Most obfuscated sound" 2001/coupard/README.md
+grep -Hc "^# Worst Driver" 2001/ctk/README.md
+grep -Hc "^# Best AI" 2001/dgbeards/README.md
+grep -Hc "^# Best abuse of the C preprocessor" 2001/herrmann1/README.md
+grep -Hc "^# Most eye-crossing" 2001/herrmann2/README.md
+grep -Hc "^# Best Of Show" 2001/jason/README.md
+grep -Hc "^# Best Curses Game" 2001/kev/README.md
+grep -Hc "^# Best of Show" 2001/ollinger/README.md
+grep -Hc "^# Best abuse of the user" 2001/rosten/README.md
+grep -Hc "^# Best one-liner" 2001/schweikh/README.md
+grep -Hc "^# Best position-independent code" 2001/westley/README.md
+grep -Hc "^# Best Graphic Game" 2001/williams/README.md
+grep -Hc "^# Best use of \"Precious\" Lines" 2004/anonymous/README.md
+grep -Hc "^# Best use of Vision" 2004/arachnid/README.md
+grep -Hc "^# Best Calculated Risk" 2004/burley/README.md
+grep -Hc "^# Best Use of Light and Spheres" 2004/gavare/README.md
+grep -Hc "^# Best of Show" 2004/gavin/README.md
+grep -Hc "^# Best Abuse of the Guidelines" 2004/hibachi/README.md
+grep -Hc "^# Most Functional Output" 2004/hoyle/README.md
+grep -Hc "^# Best Abuse of the Periodic Table" 2004/jdalbec/README.md
+grep -Hc "^# Best One-Liner" 2004/kopczynski/README.md
+grep -Hc "^# Best Font Engine" 2004/newbern/README.md
+grep -Hc "^# Best Utility" 2004/omoikane/README.md
+grep -Hc "^# Best Non-Use of Curses" 2004/schnitzi/README.md
+grep -Hc "^# Best Abuse of Indentation" 2004/sds/README.md
+grep -Hc "^# Best X11 Game" 2004/vik1/README.md
+grep -Hc "^# Best Abuse of CPP" 2004/vik2/README.md
+grep -Hc "^# Most ingenious puzzle solution" 2005/aidan/README.md
+grep -Hc "^# Best 3D puzzle" 2005/anon/README.md
+grep -Hc "^# Most superfluous output" 2005/boutines/README.md
+grep -Hc "^# Most ambiguous language" 2005/chia/README.md
+grep -Hc "^# Best 2D puzzle" 2005/giljade/README.md
+grep -Hc "^# Most sonorous output" 2005/jetro/README.md
+grep -Hc "^# Abuse of the rules" 2005/klausler/README.md
+grep -Hc "^# Best use of parenthesis" 2005/mikeash/README.md
+grep -Hc "^# Best use of the WWW" 2005/mynx/README.md
+grep -Hc "^# Best of Show" 2005/persano/README.md
+grep -Hc "^# Best Emulator" 2005/sykes/README.md
+grep -Hc "^# Most discourteous interpreter" 2005/timwi/README.md
+grep -Hc "^# Best Game" 2005/toledo/README.md
+grep -Hc "^# Most circuitous walk" 2005/vik/README.md
+grep -Hc "^# Most beauteous visuals" 2005/vince/README.md
+grep -Hc "^# EDAMAME Award" 2006/birken/README.md
+grep -Hc "^# Most Useful" 2006/borsanyi/README.md
+grep -Hc "^# Most Obfuscated Audio" 2006/grothe/README.md
+grep -Hc "^# Most Irrational" 2006/hamre/README.md
+grep -Hc "^# Best Game" 2006/meyer/README.md
+grep -Hc "^# Best Compiled Graphics" 2006/monge/README.md
+grep -Hc "^# Best Abuse of Computation" 2006/night/README.md
+grep -Hc "^# Homer's Favorite" 2006/sloane/README.md
+grep -Hc "^# Best Computed Graphics" 2006/stewart/README.md
+grep -Hc "^# Best Assembler" 2006/sykes1/README.md
+grep -Hc "^# Best One Liner" 2006/sykes2/README.md
+grep -Hc "^# Best Small Program" 2006/toledo1/README.md
+grep -Hc "^# Best of Show" 2006/toledo2/README.md
+grep -Hc "^# Most Portable Chess Set" 2006/toledo3/README.md
+grep -Hc "^# Best of Show - Most Shrinkable" 2011/akari/README.md
+grep -Hc "^# Most devolving" 2011/blakely/README.md
+grep -Hc "^# Best data utility" 2011/borsanyi/README.md
+grep -Hc "^# Most self deprecating" 2011/dlowe/README.md
+grep -Hc "^# Best ball" 2011/eastman/README.md
+grep -Hc "^# Most useful" 2011/fredriksson/README.md
+grep -Hc "^# Most artistic" 2011/goren/README.md
+grep -Hc "^# Best solved puzzle" 2011/hamaji/README.md
+grep -Hc "^# Best self documenting program" 2011/hou/README.md
+grep -Hc "^# Best one liner" 2011/konno/README.md
+grep -Hc "^# Most surprisingly portable" 2011/richards/README.md
+grep -Hc "^# Best non-chess game" 2011/toledo/README.md
+grep -Hc "^# Most sound" 2011/vik/README.md
+grep -Hc "^# Most shiny" 2011/zucker/README.md
+grep -Hc "^# Most GIFted expressions" 2012/blakely/README.md
+grep -Hc "^# Most notable and best tool" 2012/deckmyn/README.md
+grep -Hc "^# Best way to lose a life" 2012/dlowe/README.md
+grep -Hc "^# Most complex ASCII fluid - Honorable mention" 2012/endoh1/README.md
+grep -Hc "^# PiE in the sky award" 2012/endoh2/README.md
+grep -Hc "^# Most conspiratorial" 2012/grothe/README.md
+grep -Hc "^# Most elementary use of C - Silver award" 2012/hamano/README.md
+grep -Hc "^# Most useful obfuscation" 2012/hou/README.md
+grep -Hc "^# Best short program" 2012/kang/README.md
+grep -Hc "^# Best one liner" 2012/konno/README.md
+grep -Hc "^# Most surreptitious" 2012/omoikane/README.md
+grep -Hc "^# Most functional" 2012/tromp/README.md
+grep -Hc "^# Best use of cocoa - Bronze award" 2012/vik/README.md
+grep -Hc "^# Balanced use of obfuscation - Gold award" 2012/zeitak/README.md
+grep -Hc "^# Best painting tool" 2013/birken/README.md
+grep -Hc "^# Most partisan 1-liner" 2013/cable1/README.md
+grep -Hc "^# Best of show" 2013/cable2/README.md
+grep -Hc "^# Largest small system emulator" 2013/cable3/README.md
+grep -Hc "^# Best sparkling utility" 2013/dlowe/README.md
+grep -Hc "^# Most lazy SKIer" 2013/endoh1/README.md
+grep -Hc "^# Most recyclable" 2013/endoh2/README.md
+grep -Hc "^# Most tweetable 1-liner" 2013/endoh3/README.md
+grep -Hc "^# Most solid" 2013/endoh4/README.md
+grep -Hc "^# Best use of 1 Infinite Loop" 2013/hou/README.md
+grep -Hc "^# Most timely rendered" 2013/mills/README.md
+grep -Hc "^# Most catty" 2013/misaka/README.md
+grep -Hc "^# Smallest large system simulator" 2013/morgan1/README.md
+grep -Hc "^# Most playfully versatile" 2013/morgan2/README.md
+grep -Hc "^# Most poetic use of strings" 2013/robison/README.md
+grep -Hc "^# Best use of port 1701" 2014/birken/README.md
+grep -Hc "^# Most underscored argument" 2014/deak/README.md
+grep -Hc "^# Most square (YODA award)" 2014/endoh1/README.md
+grep -Hc "^# Best use of bioinformatics" 2014/endoh2/README.md
+grep -Hc "^# Homage to a classic game" 2014/maffiodo1/README.md
+grep -Hc "^# Most tweetable entry" 2014/maffiodo2/README.md
+grep -Hc "^# Most likely to succeed" 2014/morgan/README.md
+grep -Hc "^# Best choice of optimization" 2014/sinon/README.md
+grep -Hc "^# Most dynamic" 2014/skeggs/README.md
+grep -Hc "^# Best handling of beeps" 2014/vik/README.md
+grep -Hc "^# Most functional" 2014/wiedijk/README.md
+grep -Hc "^# Most Useful" 2015/burton/README.md
+grep -Hc "^# Most Crafty" 2015/dogon/README.md
+grep -Hc "^# Best Handwriting" 2015/duble/README.md
+grep -Hc "^# Most Diffused Reaction" 2015/endoh1/README.md
+grep -Hc "^# Most Overlooked Obfuscation" 2015/endoh2/README.md
+grep -Hc "^# Back to the Future Award" 2015/endoh3/README.md
+grep -Hc "^# Best One-liner" 2015/endoh4/README.md
+grep -Hc "^# Most Well-rounded Hash" 2015/hou/README.md
+grep -Hc "^# Most Different" 2015/howe/README.md
+grep -Hc "^# \"For the Birds!\" Award" 2015/mills1/README.md
+grep -Hc "^# Most Compact" 2015/mills2/README.md
+grep -Hc "^# Most Complete Use of CPP" 2015/muth/README.md
+grep -Hc "^# Best Documented" 2015/schweikhardt/README.md
+grep -Hc "^# Most Pointed Reaction" 2015/yang/README.md
+grep -Hc "^# Most cacophonic" 2018/algmyr/README.md
+grep -Hc "^# Most able to divine code gaps" 2018/anderson/README.md
+grep -Hc "^# Most inflationary" 2018/bellard/README.md
+grep -Hc "^# Best one-liner" 2018/burton1/README.md
+grep -Hc "^# Best abuse of the rules" 2018/burton2/README.md
+grep -Hc "^# Most likely to be awarded" 2018/ciura/README.md
+grep -Hc "^# Best tool to reveal holes" 2018/endoh1/README.md
+grep -Hc "^# Best use of python" 2018/endoh2/README.md
+grep -Hc "^# Best use of weasel words" 2018/ferguson/README.md
+grep -Hc "^# Most unstable" 2018/giles/README.md
+grep -Hc "^# Most likely to top the charts" 2018/hou/README.md
+grep -Hc "^# Best of show" 2018/mills/README.md
+grep -Hc "^# Most stellar" 2018/poikola/README.md
+grep -Hc "^# Most connected" 2018/vokes/README.md
+grep -Hc "^# Most shifty" 2018/yang/README.md
+grep -Hc "^# Most functional interpreter" 2019/adamovsky/README.md
+grep -Hc "^# Best one-liner" 2019/burton/README.md
+grep -Hc "^# Most alphabetic" 2019/ciura/README.md
+grep -Hc "^# Best small program" 2019/diels-grabsch1/README.md
+grep -Hc "^# Most self-aware" 2019/diels-grabsch2/README.md
+grep -Hc "^# Best use of space and time" 2019/dogon/README.md
+grep -Hc "^# Best collaborative graphics" 2019/duble/README.md
+grep -Hc "^# Most in need of debugging" 2019/endoh/README.md
+grep -Hc "^# Most in need of wide space" 2019/giles/README.md
+grep -Hc "^# Most in need of whitespace" 2019/karns/README.md
+grep -Hc "^# Most functional compiler" 2019/lynn/README.md
+grep -Hc "^# Most in need to be tweeted" 2019/mills/README.md
+grep -Hc "^# Most calendrical" 2019/poikola/README.md
+grep -Hc "^# Most in need of transparency" 2019/yang/README.md
+grep -Hc "^# Best one-liner" 2020/burton/README.md
+grep -Hc "^# Best of show - abuse of libc" 2020/carlini/README.md
+grep -Hc "^# Most explosive" 2020/endoh1/README.md
+grep -Hc "^# Best perspective" 2020/endoh2/README.md
+grep -Hc "^# Most head-turning" 2020/endoh3/README.md
+grep -Hc "^# Don't tread on me award" 2020/ferguson1/README.md
+grep -Hc "^# Most enigmatic" 2020/ferguson2/README.md
+grep -Hc "^# Most phony" 2020/giles/README.md
+grep -Hc "^# Best utility" 2020/kurdyukov1/README.md
+grep -Hc "^# Least detailed" 2020/kurdyukov2/README.md
+grep -Hc "^# Bset slaml prragom" 2020/kurdyukov3/README.md
+grep -Hc "^# Best abuse of lámatyávë" 2020/kurdyukov4/README.md
+grep -Hc "^# Most percussive" 2020/otterness/README.md
+grep -Hc "^# Most misleading indentation" 2020/tsoj/README.md
+grep -Hc "^# Best abuse of CPP" 2020/yang/README.md

--- a/tmp/year-auth-prize.csv
+++ b/tmp/year-auth-prize.csv
@@ -49,7 +49,7 @@
 1990_dg,Best Abuse of the C Preprocessor
 1990_jaw,Best Entropy-reducer
 1990_pjr,Most Unusual Data Structure
-1990_scjones,ANSI Committee''s Worst Abuse of C
+1990_scjones,ANSI Committee's Worst Abuse of C
 1990_stig,Strangest Abuse of the Rules
 1990_tbr,Best Utility
 1990_theorem,Best of Show
@@ -109,7 +109,7 @@
 1995_savastio,Most Obfuscated Syntax
 1995_schnitzi,Best One Liner
 1995_spinellis,Abusing The Rules
-1995_vanschnitz,Worst Abuse of the C Preprocessor/Most Likely to Amaze
+1995_vanschnitz,Worst Abuse of the C Preprocessor and Most Likely to Amaze
 1996_august,Best of Show
 1996_dalbec,Best Numerical Obfuscation
 1996_eldby,Best Output
@@ -141,7 +141,7 @@
 2000_briddlebane,Best Abuse of User
 2000_dhyang,Best Layout
 2000_dlowe,Worst Abuse of the Rules
-2000_jarijyrki,Best of show
+2000_jarijyrki,Best of Show
 2000_natori,Best Small Program
 2000_primenum,Best Abuse of CPP
 2000_rince,Astronomically Obfuscated
@@ -159,7 +159,7 @@
 2001_herrmann2,Most eye-crossing
 2001_jason,Best Of Show
 2001_kev,Best Curses Game
-2001_ollinger,Best Of Show
+2001_ollinger,Best of Show
 2001_rosten,Best abuse of the user
 2001_schweikh,Best one-liner
 2001_westley,Best position-independent code
@@ -167,7 +167,7 @@
 2004_anonymous,Best use of "Precious" Lines
 2004_arachnid,Best use of Vision
 2004_burley,Best Calculated Risk
-2004_gavare,Best use of Light and Spheres
+2004_gavare,Best Use of Light and Spheres
 2004_gavin,Best of Show
 2004_hibachi,Best Abuse of the Guidelines
 2004_hoyle,Most Functional Output
@@ -204,7 +204,7 @@
 2006_sloane,Homer''s Favorite
 2006_stewart,Best Computed Graphics
 2006_sykes1,Best Assembler
-2006_sykes2,Best One-liner
+2006_sykes2,Best One Liner
 2006_toledo1,Best Small Program
 2006_toledo2,Best of Show
 2006_toledo3,Most Portable Chess Set


### PR DESCRIPTION
This was done quite easily with a bit of thought. I generated a script
that could be modified in vim if necessary (as it turned out to be
though some of it could have been generated too but I did not think of
everything at once and it is a hack).

This is how I generated it:

    echo '#!/bin/bash' > bin/check_awards.sh ; ( while read -r g ; do echo grep "$g"; done < <(sed -e 's,_,/,g' -e 's/"/\\"/g' tmp/year-auth-prize.csv | awk -F, '{print grep "\x22" $2 "\x22" " " $1 "/" "README.md"}' ); ) >> bin/check_awards.sh

Then I modified the file (again this was a hack to make it easier and 
quicker and better for being tired too) in vim to make the grep use -Hc 
so I could pipe it to 'grep :0'. This found the files without the right
award. So the final command was: 

    sh bin/check_awards.sh |grep :0

though I did have to edit some files several times. 

For reference the script has been added to the repo too but with +x
permissions.

This change also required updating the CSV file in tmp/.
