### PR TITLE
Add initial tmp/author-wins.csv

### DIFF
--- a/1984/mullender/.gitignore
+++ b/1984/mullender/.gitignore
@@ -1,2 +1,3 @@
 mullender
 mullender.alt
+gentab

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -131,6 +131,10 @@ ${PROG}: ${PROG}.c
 	@echo "than a Vax-11 or pdp-11."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
+gentab: gentab.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+
 # alternative executable
 #
 alt: data ${ALT_TARGET}
@@ -164,6 +168,7 @@ clean:
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
 	${RM} -f core
+	${RM} -f gentab
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -17,11 +17,11 @@ make all
 ./mullender
 ```
 
-> NOTE: If your machine is not a Vax-11 or pdp-11, this program will
+> NOTE: If your machine is not a VAX-11 or PDP-11, this program will
 > not execute correctly.  In later years, machine dependent
 > code was discouraged.
 
-### Alternative code:
+### Alternate code:
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) added the alternative
 code which lets you run this on other systems. He notes though that this was
@@ -94,6 +94,30 @@ message on the screen.  Can you guess what is printed?  We knew you
 couldn't!  :-)
 
 BTW: this remains my (Landon Curt Noll's) all time favorite entries!
+
+Cody found the remarks from [Sjoerd Mullender](/winners.html#Sjoerd_Mullender)
+and added the program that was used by the authors to generate the array that he
+referred to. Because [a.out.h](a.out.h) is not available in all systems (like macOS) and
+more importantly because he wanted it to be as close to as the original as
+possible he used a copy of
+<https://raw.githubusercontent.com/dspinellis/unix-history-repo/Research-Release/usr/include/a.out.h>
+in the *fabulous* [Unix History
+Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
+
+This tool can be built by running:
+
+
+```sh
+make gentab
+```
+
+Cody notes that it does not appear to work in modern systems (unbalanced braces)
+or something else is wrong but given that this was done a long time ago on a now
+archaic system maybe that is why. He also noted that if the `short`s are not
+changed to just `int` it prints out a lot of negative numbers but since
+[mullender.c](mullender.c) has a negative number he kept it as is.
+
+Thank you Cody!
 
 ## Author's remarks:
 

--- a/1984/mullender/a.out.h
+++ b/1984/mullender/a.out.h
@@ -1,0 +1,33 @@
+struct	exec {	/* a.out header */
+	int     	a_magic;	/* magic number */
+	unsigned	a_text; 	/* size of text segment */
+	unsigned	a_data; 	/* size of initialized data */
+	unsigned	a_bss;  	/* size of unitialized data */
+	unsigned	a_syms; 	/* size of symbol table */
+	unsigned	a_entry; 	/* entry point */
+	unsigned	a_unused;	/* not used */
+	unsigned	a_flag; 	/* relocation info stripped */
+};
+
+#define	A_MAGIC1	0407       	/* normal */
+#define	A_MAGIC2	0410       	/* read-only text */
+#define	A_MAGIC3	0411       	/* separated I&D */
+#define	A_MAGIC4	0405       	/* overlay */
+
+struct	nlist {	/* symbol table entry */
+	char    	n_name[8];	/* symbol name */
+	int     	n_type;    	/* type flag */
+	unsigned	n_value;	/* value */
+};
+
+		/* values for type flag */
+#define	N_UNDF	0	/* undefined */
+#define	N_ABS	01	/* absolute */
+#define	N_TEXT	02	/* text symbol */
+#define	N_DATA	03	/* data symbol */
+#define	N_BSS	04	/* bss symbol */
+#define	N_TYPE	037
+#define	N_REG	024	/* register name */
+#define	N_FN	037	/* file name symbol */
+#define	N_EXT	040	/* external bit, or'ed in */
+#define	FORMAT	"%06o"	/* to print a value */

--- a/1984/mullender/gentab.c
+++ b/1984/mullender/gentab.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "a.out.h"
+
+main(argc, argv) char **argv;
+{
+    register FILE *fp;
+    register short pos = 0, c, n;
+    register char *fmt = "";
+    if (argc != 2) {
+	fprintf (stderr, "Usage: %s file\n", argv[0]);
+	exit (1);
+    }
+
+    if ((fp = fopen(argv[1], "r")) == NULL) {
+	fprintf(stderr, "%s: can't open %s\n", argv[0], argv[1]);
+	exit(2);
+    }
+
+    fseek (fp, (long) sizeof (struct exec), 0); 
+    printf("/* portable between VAX and PDP11 */\n\n");
+    printf ("short main[] = {\n");
+    for (;;) {
+	if (pos == 0)
+	    printf("\t");
+
+	c=getc(fp) & 0377;
+	if (feof(fp)) break;
+	n = getc(fp) << 8|c;
+
+	switch (rand() % 5) {
+	    case 0:
+	    case 1:
+		fmt = "%d"; break;
+	    case 2:
+		fmt = "%u"; break;
+	    case 3:
+		fmt = "0%o"; break;
+	    case 4:
+		fmt = "0x%x"; break;
+	}
+
+	if (32 <= n && n < 127 && (rand() % 4)) fmt = "'%c'";
+	printf(n < 8 ? "%d" : fmt, n);
+	printf(",");
+	if (pos++ == 8) {
+	    printf("\n");
+	    pos = 0;
+	}
+	else printf(" ");
+
+	printf("};\n");
+    }
+}

--- a/tmp/author-wins.csv
+++ b/tmp/author-wins.csv
@@ -1,0 +1,6 @@
+Ondrej_Adamovsky,2019_adamovsky,
+Jack_Applin,1985_applin,1986_applin,1988_applin,
+Cody_Boone_Ferguson,2018_ferguson,2020_ferguson1,2020_ferguson2,
+David_Korn,1987_korn,
+Brian_Westley,1987_westley,1988_westley,1989_westley,1990_westley,1991 westley,1992_westley,1994_westley,1996_westley,2001_westley,
+Matt_Zucker,2011_zucker,


### PR DESCRIPTION

As Landon noted on GitHub:

    One of the key elements that we are missing from the SQL command set 
    is a way to tie a winning author handle to the entry handles..

    We think what is needed is an CVS file, perhaps, tmp/author-wins.csv 
    that connects the author handle with the winning entries that they 
    won.
    
    The proposed tmp/author-wins.csv will be used to generate the list 
    of winning entries that a given author has submitted. This will be 
    used to generate the per-author JSON files.

As I just wanted to start it and I've not given any thought whatever at
how to generate it (except very briefly yesterday morning) I've only for
now included what Landon did. Once I've generated it all it'll be sorted
maybe by year or maybe by surname: that's to be determined later but 
this is a nice start at least.