### PR TITLE
Add temporary workaround to 2001/anonymous

### DIFF
--- a/2001/anonymous/.gitignore
+++ b/2001/anonymous/.gitignore
@@ -4,3 +4,4 @@ ten.bak.od
 ten.bak.txt
 ten.od
 ten.txt
+anonymous_tmp

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -139,7 +139,8 @@ ${PROG}: ${PROG}.c
 	X='-DA(X)=#X'; \
 	warning='-Dprocessor'; \
 	$$magic $$warning -Dmagic= $$X "-DX=A($$magic \"$$X\")" \
-		$< -o $@ ${LIBS}
+		$< -o $@_tmp ${LIBS}
+	${CP} -af anonymous.sh $@
 
 
 ${PROG}.ten: ${PROG}.ten.c

--- a/2001/anonymous/anonymous.sh
+++ b/2001/anonymous/anonymous.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ "$#" -lt 1 ]]; then
+    exit 1
+fi
+
+make >/dev/null 2>&1
+
+if [[ -f "$1" ]]; then
+    ./anonymous_tmp "$1"
+    ./"$1"
+fi
+


### PR DESCRIPTION
Using a script running ./anonymous will run the program after modifying it. This is a temporary workaround and it's not certain when this will be changed back or fixed if it even can be. I am aware of some things that might make it work IF it actually IS supposed to run the program that it's run on (an additional reading of README.md suggests this might indeed be the case). In any event the entry DOES modify 32-bit binaries (bit twiddling) and then running the script (made a copy of anonymous.sh where anonymous.c is compiled to anonymous_tmp) it will run the program after doing this, assuming that the program to modify actually exists.

It should be noted that because things have changed so much it is hard to know if the modifications to 32-bit ELF binaries are correct but if nothing else the binary will not crash on 32-bit ELF binaries and it will modify it but still let it run (though from the author's comments this might not be possible; this cannot yet be confirmed). Leo it appears wrote the judges' comments so I will try and get more information from him later on.