### PR TITLE
Remove cpp from 2001/anonymous/Makefile TARGET

### DIFF
--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -117,7 +117,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} cpp ${PROG}.ten
+TARGET= ${PROG} ${PROG}.ten
 #
 ALT_OBJ= 
 ALT_TARGET=


### PR DESCRIPTION
This is important so that make does not fail. Apparently I had a copy of cpp.c still in my directory so this was not detected.