### PR TITLE
Make 2001/anonymous.c more like it was before

### DIFF
--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -117,7 +117,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} cpp ${PROG}.ten
+TARGET= ${PROG} ${PROG}.ten
 #
 ALT_OBJ= 
 ALT_TARGET=

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -80,16 +80,6 @@ notice that although the binaries do differ it's not many differences and the
 output of the supplementary program both before and after is the same. See the
 author's warning about this in their remarks.
 
-### INABIAF - it's not a bug it's a feature! :-)
-
-This entry will not work on 64-bit binaries! The program itself can be compiled
-as 64-bit but the files it processes must be 32-bit ELF binaries. Not doing this
-will likely cause a crash or cause your computer to [halt and catch
-fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)! :-)
-
-This entry will also very likely crash if no arg is specified. It might do
-something funny if you run it on itself as well but see below :-)
-
 ## Try:
 
 ```sh

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -60,13 +60,12 @@ Thank you Cody for your assistance!
 
 ### INABIAF - it's not a bug it's a feature! :-)
 
-If you do not specify a 32-bit binary as the arg of this program it will very
-likely crash or do something terribly wrong like slaughtering all the elves of
-Imladris! :-) so please don't do that :-(
+If you do not specify a 32-bit ELF binary as the arg of this program it will
+very likely crash or do something terribly wrong like slaughtering all the elves
+of Imladris! :-) so please don't do that :-(
 
-If the program cannot be run (for instance under macOS as it's an ELF file) then
-the program will touch the file but it won't run it; it'll silently fail to
-execute it.
+If the program cannot be run (for instance under macOS as an ELF file) then
+the program will fail to execute it and might not even touch it.
 
 ### WARNING on note from the author
 

--- a/2001/anonymous/anonymous.c
+++ b/2001/anonymous/anonymous.c
@@ -45,5 +45,5 @@ return (z?(stat(M,&t)?P+=a+'{'?0:3:execv(M,k),a=(signed char)E(*L(P++,0)),i=P,y=
 }
 int
 main (int cka, char **k) { char *ck = (char *)cka;
-  (E((ck?pain((char*)cka,k):system((sprintf(M,"rm -f .%s*",k[1]),M)),z,*(B+13))));munmap(B,N);close(f);execv(k[1],k);
+  (E((ck?(pain((char*)cka,k),munmap(B,N),close(f),execv(k[1],k)):system((sprintf(M,"rm -f .%s*",k[1]),M)),z,*(B+13))));
 }


### PR DESCRIPTION

In other words try and make it so that the munmap(),close(),execv() is
like how it was before (via comma operator) though of course the
munmap() and close() were not there until yesterday's fix as text file
busy error was not a problem in the past with this entry.