### PR TITLE
Add alt supplementary program to 2001/anonymous

### DIFF
--- a/1988/dale/.gitignore
+++ b/1988/dale/.gitignore
@@ -1,1 +1,2 @@
 dale
+dale.alt

--- a/1993/lmfjyh/.gitignore
+++ b/1993/lmfjyh/.gitignore
@@ -1,2 +1,3 @@
 "*
 lmfjyh
+lmfjyh.alt

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -111,8 +111,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -129,7 +129,8 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c
 	@echo "NOTE: This will not compile when using modern compilers because"
 	@echo "it relies on a compiler bug which was fixed in gcc 2.3.3 (a very"
-	@echo "long time ago now)."
+	@echo "long time ago now). Try make alt for a version that works with gcc"
+	@echo ">=2.3.3."
 	${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${CP} lmfjyh.c \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${CC} ${CFLAGS} \

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -1,49 +1,56 @@
 # Most Versatile Source
 
 Jyrki Holopainen  
-Oy LM Ericsson Ab  
-SF-02420 Jorvas  
 Finland  
 
 ## To build:
 
 This entry will not compile with gcc < 2.3.3 as it relied on a bug which was
-fixed in gcc 2.3.3 which was fixed a very long time ago now. If you have such a
-compiler you can run `make all`.
+fixed in gcc 2.3.3 which was fixed a very long time ago now. There is an
+alternate version for [those of
+us](https://www.collinsdictionary.com/dictionary/english/everyone) with gcc >=
+2.3.3. See Alternate code section below for more details.
 
-**WARNING**: Trying to compile this entry without the affected gcc will also
-make a bogus file on your file system.  To delete it you can use the inode
-option `-inum` with `find` with the delete option after finding the inode with
-`ls -li` or else use a GUI to do it.  Should you wish to try compiling it you
-might see something like:
+If you have gcc < 2.3.3 you can build this entry like:
 
 ```sh
-$ make all
-NOTE: This will not compile when using modern compilers because
-it relies on a compiler bug which was fixed in gcc 2.3.3 (a very
-long time ago now).
-rm -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
-cp lmfjyh.c \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
-cc -std=gnu90 -Wall -Wextra -pedantic    -include stdio.h -O3 \
-	    \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c -o lmfjyh
-Undefined symbols for architecture arm64:
-  "_main", referenced from:
-     implicit entry/start for main executable
-ld: symbol(s) not found for architecture arm64
-clang: error: linker command failed with exit code 1 (use -v to see invocation)
-make: *** [lmfjyh] Error 1
+make all
 ```
-and the bogus file will be `";main(){puts("Hello World!");}char*C=".c`.
 
-For an explanation of why this is see the author's remarks.
+This will create a file called `";main(){puts("Hello World!");}char*C=".c` which
+would print `Hello World!` when compiled.
+
+For an explanation of why and how this works see the author's remarks. The gist
+of the entry itself, however, is the file name _itself **is** the code_.
+
+NOTE: we delete the bogus file whether or not the compilation succeeds.
+
+There is an alternate version which simply does what the program did with gcc <
+2.3.3.
+
 
 ## To run:
 
-If you have gcc < 2.3.3:
+If you have gcc < 2.3.3 (i.e. the entry can compile):
 
 ```sh
 ./lmfjyh
 ```
+
+### Alternate code
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) added an alternate
+version which does what the program did with gcc < 2.3.3. To use:
+
+```sh
+make alt
+```
+
+Use `lmfjyh.alt` as you would `lmfjyh` above. Note that other code could also be
+done with this bug; see the author's remarks for more details.
+
+Thank you Cody!
+
 
 ## Judges' remarks:
     
@@ -106,7 +113,7 @@ megabyte of source code file can be compressed to 64 kilobytes.
 One might easily think that the program could be compressed to a
 single byte by writing a one character long preprocessor directive
 in the source file and defining the actual source code in the
-command line, eg. `cc hello.c -DX='main(){puts ...'`.  With this
+command line, e.g. `cc hello.c -DX='main(){puts ...'`.  With this
 method nothing is gained, since the compiling commands must be
 stored in a file, and that takes even more space than writing the
 code in a source file as presented in listing 1.

--- a/1993/lmfjyh/lmfjyh.alt.c
+++ b/1993/lmfjyh/lmfjyh.alt.c
@@ -1,0 +1,1 @@
+main(void){puts("Hello World!");}

--- a/2001/anonymous/.gitignore
+++ b/2001/anonymous/.gitignore
@@ -5,3 +5,4 @@ ten.bak.od
 ten.bak.txt
 ten.od
 ten.txt
+anonymous.ten.64

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -117,10 +117,10 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} ${PROG}.ten
+TARGET= ${PROG} ${PROG}.ten ${PROG}.ten.64
 #
-ALT_OBJ= 
-ALT_TARGET=
+ALT_OBJ= ${PROG}.ten.64.o
+ALT_TARGET= ${PROG}.ten.64
 
 
 #################
@@ -156,6 +156,11 @@ ${PROG}.ten: ${PROG}.ten.c
 	@echo
 	${CC} ${CFLAGS} -m32 $< -o $@ ${LIBS}
 
+${PROG}.ten.64: ${PROG}.ten.c
+	@echo "WARNING: the file created by this rule will NOT work with the entry itself;"
+	@echo "this is because it works ONLY on 32-bit ELF binaries! This however at least"
+	@echo "lets you see the supplementary program in action."
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable
 #

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -82,6 +82,8 @@ What happens if you try it on another file like [anonymous.c](anonymous.c)? Can
 you recompile it okay? What if you run it on `anonymous` itself? Can you run the
 program successfully after it without recompiling?
 
+NOTE: if the 32-bit version cannot be compiled the script will at least run the
+alternate version of the [anonymous.ten](anonymous.ten.c) program.
 
 ## Judges' remarks:
 

--- a/2001/anonymous/try.me.sh
+++ b/2001/anonymous/try.me.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-make clobber all >/dev/null 2>&1
+make clobber alt all >/dev/null 2>&1
 
 
 TARGET="anonymous.ten"
@@ -27,5 +27,8 @@ if [[ -f "$TARGET" ]]; then
     diff -s ten.txt ten.bak.txt
 else
     echo "cannot compile anonymous.ten.c as 32-bit, sorry."
-    exit 1
+    echo "will run 64-bit version directly."
+    sleep 3
+    echo "$ ./$TARGET.64"
+    ./"$TARGET".64
 fi

--- a/bugs.md
+++ b/bugs.md
@@ -715,6 +715,14 @@ this simply does not work with them. Can you help us?
 If not enough args are specified this program will likely crash or do something
 else. This should NOT be fixed.
 
+## [1993/lmfjyh](1993/lmfjyh/lmfjyh.c) ([README.md](1993/lmfjyh/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+This entry relied on a bug in gcc that was fixed with gcc version 2.3.3. This
+cannot be fixed for modern systems as the bug is long gone.
+
+An alternate version, however, does exist. See the README.md file for details.
+
 
 # 1994
 


### PR DESCRIPTION

Running make alt will compile the anonymous.ten.c without specifying 
-m32: whether it'll end up being 64-bit or not would depend on the 
system but it'll be saved as anonymous.ten.64 anyway. 

The try.me.sh script will run this program directly, skipping the entry 
itself, if the anonymous.ten.c cannot be compiled as a 32-bit binary.

Updated .gitignore.