### PR TITLE
Minor improvements to 1985/applin

### DIFF
--- a/1985/applin/README.md
+++ b/1985/applin/README.md
@@ -16,20 +16,30 @@ make all
 ./applin
 ```
 
-NOTE: [Yusuke Endoh](/winners.html#Yusuke_Endoh) provided a patch to get this to
+[Yusuke Endoh](/winners.html#Yusuke_Endoh) provided a patch to get this to
 not issue crash and [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
-fixed this to work with macOS.  The problem with the crash is that it
-destructively rewrites string literals but with `strdup()` it's safe. For macOS
-it's because there was no prototype for `execlp()` and macOS has problems with
-missing prototypes for some functions (this was also seen when Cody fixed
-[1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well though that fix
-was more complicated). Ironically this fix was discovered through linux! Thank
-you Yusuke and Cody for your help!
+fixed this to work with macOS (it printed the string `H????` in a seemingly
+infinite loop of printing more and more `?`s).
 
+The problem with the crash is that it destructively rewrites string literals but
+with `strdup()` it's safe.
+
+For macOS it's because there was no prototype for `execlp()` and macOS has
+problems with missing prototypes for some functions (this was also seen when
+Cody fixed [1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well
+though that fix was more complicated). Ironically this fix was discovered
+through linux!
+
+NOTE: originally this entry did not print a newline prior to returning to the
+shell, after the output (despite having `\n` in the string - why?) but to make
+it more friendly to users Cody made it print a `\n` prior to returning to the
+shell.
+
+Thank you Yusuke and Cody for your help!
 
 ## Judges' remarks:
 
-One liner programs are short but twisted.  This "Hello, World" version
+One liner programs are short but twisted.  This `Hello, world!` version
 certainly takes its time saying hello.
 
 ## Author's remarks:

--- a/1985/applin/applin.c
+++ b/1985/applin/applin.c
@@ -1,1 +1,1 @@
-main(v,c)char**c;{for(v[c++]=strdup("Hello, world!\n");(!!c)[*c]&&(v--||--c&&execlp(*c,*c,c[!!c]+!!c,!c));**c=!c)write(!!*c,*c,!!**c);}
+main(v,c)char**c;{for(v[c++]=strdup("Hello, world!\n\n");(!!c)[*c]&&(v--||--c&&execlp(*c,*c,c[!!c]+!!c,!c));**c=!c)write(!!*c,*c,!!**c);}


### PR DESCRIPTION
Now prints a newline after the output. This is to make the output more friendly to the user as seeing text like:

    $ ./applin
    Hello, world!$

can be confusing or at least annoying.

Further format fixed README.md.