### PR TITLE
Remove 1985/shapiro alt code

### DIFF
--- a/1985/applin/README.md
+++ b/1985/applin/README.md
@@ -16,20 +16,30 @@ make all
 ./applin
 ```
 
-NOTE: [Yusuke Endoh](/winners.html#Yusuke_Endoh) provided a patch to get this to
+[Yusuke Endoh](/winners.html#Yusuke_Endoh) provided a patch to get this to
 not issue crash and [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
-fixed this to work with macOS.  The problem with the crash is that it
-destructively rewrites string literals but with `strdup()` it's safe. For macOS
-it's because there was no prototype for `execlp()` and macOS has problems with
-missing prototypes for some functions (this was also seen when Cody fixed
-[1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well though that fix
-was more complicated). Ironically this fix was discovered through linux! Thank
-you Yusuke and Cody for your help!
+fixed this to work with macOS (it printed the string `H????` in a seemingly
+infinite loop of printing more and more `?`s).
 
+The problem with the crash is that it destructively rewrites string literals but
+with `strdup()` it's safe.
+
+For macOS it's because there was no prototype for `execlp()` and macOS has
+problems with missing prototypes for some functions (this was also seen when
+Cody fixed [1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well
+though that fix was more complicated). Ironically this fix was discovered
+through linux!
+
+NOTE: originally this entry did not print a newline prior to returning to the
+shell, after the output (despite having `\n` in the string - why?) but to make
+it more friendly to users Cody made it print a `\n` prior to returning to the
+shell.
+
+Thank you Yusuke and Cody for your help!
 
 ## Judges' remarks:
 
-One liner programs are short but twisted.  This "Hello, World" version
+One liner programs are short but twisted.  This `Hello, world!` version
 certainly takes its time saying hello.
 
 ## Author's remarks:

--- a/1985/applin/applin.c
+++ b/1985/applin/applin.c
@@ -1,1 +1,1 @@
-main(v,c)char**c;{for(v[c++]=strdup("Hello, world!\n");(!!c)[*c]&&(v--||--c&&execlp(*c,*c,c[!!c]+!!c,!c));**c=!c)write(!!*c,*c,!!**c);}
+main(v,c)char**c;{for(v[c++]=strdup("Hello, world!\n\n");(!!c)[*c]&&(v--||--c&&execlp(*c,*c,c[!!c]+!!c,!c));**c=!c)write(!!*c,*c,!!**c);}

--- a/1985/august/README.md
+++ b/1985/august/README.md
@@ -22,7 +22,7 @@ make all
 ```
 
 If you have the `primes(6)` tool (sometimes part of BSD Games) you can see
-what of the output in the first N (say 15) lines are primes:
+what of the output in the first `N` (say `15`) lines are primes:
 
 ```sh
 while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n 15 ))
@@ -30,13 +30,13 @@ while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n 15 ))
 
 ## Judges' remarks:
 
-An interesting use of a recursive call to main.  Compile and execute
-without args.  What is the initial value of b, and does it alter the
+An interesting use of a recursive call to `main()`.  Compile and execute
+without args.  What is the initial value of `b`? Does it alter the
 action of the program?
 
-If you let it, the program will continue to print a numerical sequence
-(can you guess in what base it is printed?) until you run out of
-memory or until they sell your computer, which ever comes first.
+If you let it, the program will continue to print a numerical sequence (can you
+guess in what base it is printed by looking at the code?) until you run out of
+memory or until they sell your computer, whichever comes first.
 
 ## Author's remarks:
 

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -9,17 +9,19 @@ make all
 ```
 
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile with
-modern compilers. In the past 'define' in `#define` could even be defined but to
-get this to work on modern systems Cody changed the `#o` lines to `#define`. The
-`lycklama.alt.c` is the original source code as it provides some fun input for
-the entry. Thank you Cody! With a tip from [Yusuke
-Endoh](/winners.html#Yusuke_Endoh)  it was indirectly noticed that if one slows
-down the call to `write()` one can see some fun output that's not visible with
-modern systems so Cody added a call to `usleep()`. The default time is `0`
-which disables it (in order to make it as close to original as possible; an alt
-version already exists mostly for fun output). In order to change the speed (try
-500 or 700) do:
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile
+with modern compilers. In the past one could get away with defining some macro
+to `#define` and then use `#foo` to have the same effect as using `#define` but
+this does not work in modern systems so Cody changed the `#o` lines to
+`#define`. The `lycklama.alt.c` is the original source code as it provides some
+fun input for the entry. Thank you Cody!
+
+With a tip from [Yusuke Endoh](/winners.html#Yusuke_Endoh)  it was indirectly
+noticed that if one slows down the call to `write()` one can see some fun output
+that's not visible with modern systems so Cody added a call to `usleep()`. The
+default time is `0` which disables it (in order to make it as close to original
+as possible; an alt version already exists mostly for fun output). In order to
+change the speed (try 500 or 700) do:
 
 ```sh
 make CDEFINE+="-DZ=700" clobber all
@@ -27,9 +29,13 @@ make CDEFINE+="-DZ=700" clobber all
 
 Thank you Yusuke!
 
+## To run:
+
+```sh
+./lycklama < some_file
+```
 
 ## Try:
-
 
 ```sh
 ./lycklama < lycklama.c
@@ -40,11 +46,13 @@ Thank you Yusuke!
 ./lycklama < README.md
 
 ./lycklama < Makefile
+
+make CDEFINE+="-DZ=700" clobber all && ./lycklama < lycklama.c
 ```
 
 ### Alternative code:
 
-If you have an older compiler that lets you define some object to define and
+If you have an older compiler that lets you define some object to `#define` and
 then use it in place of `#define` you can run:
 
 ```sh
@@ -52,12 +60,6 @@ make alt
 ```
 
 Use `./lylycklama.alt` as you would `./lycklama` above.
-
-## To run:
-
-```sh
-./lycklama < some_file
-```
 
 
 ## Judges' remarks:

--- a/1985/shapiro/.gitignore
+++ b/1985/shapiro/.gitignore
@@ -1,2 +1,1 @@
 shapiro
-shapiro.alt

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ=
+ALT_TARGET=
 
 
 #################

--- a/1985/shapiro/README.md
+++ b/1985/shapiro/README.md
@@ -18,8 +18,7 @@ make all
 ## Judges' remarks:
 
 As submitted, this program was 3 lines (2 of defines and 1 of code).
-To make news & mail happy we split the last line into 7. The file
-[shapiro.alt.c](shapiro.alt.c) is the original version.
+To make news & mail happy we split the last line into seven lines.
 
 This program was selected for the 1987 t-shirt collection.
 

--- a/1985/shapiro/shapiro.alt.c
+++ b/1985/shapiro/shapiro.alt.c
@@ -1,3 +1,0 @@
-#define P(X)j=write(1,X,1)
-#define C 39
-int M[5000]={2},*u=M,N[5000],R=22,a[4],l[]={0,-1,C-1,-1},m[]={1,-C,-1,C},*b=N, *d=N,c,e,f,g,i,j,k,s;main(){for(M[i=C*R-1]=24;f|d>=b;){c=M[g=i];i=e;for(s=f=0; s<4;s++)if((k=m[s]+g)>=0&&k<C*R&&l[s]!=k%C&&(!M[k]||!j&&c>=16!=M[k]>=16))a[f++ ]=s;if(f){f=M[e=m[s=a[rand()/(1+2147483647/f)]]+g];j=j<f?f:j;f+=c&-16*!j;M[g]= c|1<<s;M[*d++=e]=f|1<<(s+2)%4;}else e=d>b++?b[-1]:e;}P(" ");for(s=C;--s;P("_"))P(" ");for(;P("\n"),R--;P("|"))for(e=C;e--;P("_ "+(*u++/8)%2))P("| "+(*u/4)%2);}


### PR DESCRIPTION

There was no functional difference; it was a matter of formatting: the
judges had split the last line into seven lines.
