### PR TITLE
Updates to 2001/herrmann2

### DIFF
--- a/2001/herrmann2/.gitignore
+++ b/2001/herrmann2/.gitignore
@@ -1,1 +1,2 @@
 herrmann2
+herrmann2.orig.c

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -114,8 +114,8 @@ OBJ= ${PROG}.o
 DATA= herrmann2.cup herrmann2.ioccc
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -137,7 +137,7 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-${ALT_TARGET}: herrmann2.c
+${ALT_TARGET}: herrmann2.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # data files

--- a/2001/herrmann2/README.md
+++ b/2001/herrmann2/README.md
@@ -15,7 +15,10 @@ both 64-bit and 32-bit compiles by changing most of the `int`s (all but that in
 `main`) to `long`s. He also fixed it to compile with clang by changing the args
 of main to be `int` and `char **` respectively and changing specific references
 to the `argv` arg, casting to `long` (was `int` but the 64-bit fix requires
-`long`) which was its old type. Thank you Cody for your assistance!
+`long`) which was its old type. The original file, used for demonstration
+purposes, as well as if you want to see if your system works with the original
+code (in which case see below Alternate code section), is in
+[herrmann2.alt.c](herrmann2.alt.c). Thank you Cody for your assistance!
 
 
 ## To run:
@@ -63,7 +66,33 @@ and in [herrmann2.ioccc](herrmann2.ioccc) try:
 /n
 ```
 
-	
+### Also try:
+
+```sh
+./herrmann2 \
+'char*d,A[9876];e;b;*ad,a,c;  tw,ndr,T; wri; ;*h; _,ar  ;on;'\
+' ;l ;i(V)man,n    {-!har  ;   =Aadre(0,&e,o||n -- +,o4,=9,l=b=8,'\
+'!( te-*Aim)|(0~l),srand  (l),,!A,d=,b))&&+((A + te-A(&(*)=+ +95>'\
+'e?(*& c_*r=5,r+e-r +_:2-19<-+?|(d==d),!n ?*d| *( (char**)+V+), ('\
+'  +0,*d-7 ) -r+8)c:7:+++7+! r: and%9- 85! ()-(r+o):(+w,_+ A*(=er'\
+'i+(o)+b)),!write,(=_((-b+*h)(1,A+b,!!((((-+, a >T^l,( o-95=+))w?'\
+'++  &&r:b<<2+a +w) ((!main(n*n,V) , +-) ),l)),w= +T-->o +o+;{ &!'\
+'a;}return _+= ' < herrmann2.ioccc > herrmann2.orig.c && \
+diff herrmann2.alt.c herrmann2.orig.c && echo "output matches with original code"
+```
+
+
+### Alternate code:
+
+If you wish to use the original version that does not work for all platforms,
+you can make use of the [herrmann2.alt.c](herrmann2.alt.c) by running:
+
+```sh
+make alt
+```
+
+Use `herrmann2.alt` as you would `herrmann2` above.
+
 ## Judges' remarks:
 
 Be careful when staring at the source code - your eyes might cross, but
@@ -130,7 +159,7 @@ effect.
 ### Extra-Features
 
 - The program is able to handle all common kinds of line breaks:
-Unix, Dos and Mac. To get an output with a certain kind of line
+Unix, DOS and Mac. To get an output with a certain kind of line
 breaks, simply use the same kind of line breaks in the input
 file.
 
@@ -165,7 +194,7 @@ on normal-sized terminals.
 - The layout is of a completely new kind. And it describes what
 the program does more precisely than any comment could.
 
-- I don't think there has ever been an ioccc program with so
+- I don't think there has ever been an IOCCC program with so
 severe layout constraints. Once the 3D picture has been fixed,
 only a sixth of the characters can be chosen freely! (457 of
 1840, to be exact.) In contrast, in palindrome programs, for
@@ -185,7 +214,7 @@ stuff doing mostly nothing.)
 
 - Just in case this is not enough: Yes, the code itself is
 obfuscated: It's (almost) only one big expression, with deep
-nesting of () and ?:, and full of unnecessary operations which
+nesting of `()` and `?:`, and full of unnecessary operations which
 do not really help making it readable. And it contains a lot of
 "magic numbers". (My favourite is the "7" in line 15 (each
 one). Which is the other digit I could have put there instead,
@@ -232,7 +261,7 @@ functions appear as function pointers, and as such they are not
 generated implicitly. So the build script has to pass `-include
 ...` to gcc. A problem with this is that the complete path of
 the include files has to be provided. In the build script, I
-assume that the path is /usr/include, but this can easily be
+assume that the path is `/usr/include`, but this can easily be
 adapted.
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2001/herrmann2/herrmann2.alt.c
+++ b/2001/herrmann2/herrmann2.alt.c
@@ -1,0 +1,23 @@
+char*d,A[9876];char*d,A[9876];char*d,A[9876];char*d,A[9876];char*d,A[9876];char
+e;b;*ad,a,c;  te;b;*ad,a,c;  te;*ad,a,c;  w,te;*ad,a,  w,te;*ad,and,  w,te;*ad,
+r,T; wri; ;*h; r,T; wri; ;*h; r; wri; ;*h;_, r; wri;*h;_, r; wri;*har;_, r; wri
+  ;on; ;l ;i(V)  ;on; ;l ;i(V)  ;o ;l ;mai(V)  ;o  ;mai(n,V)    ;main (n,V)    
+   {-!har  ;      {-!har  ;      {har  =A;      {h  =A;ad        =A;read       
+(0,&e,o||n -- +(0,&e,o||n -- +(0,&o||n ,o-- +(0,&on ,o-4,- +(0,n ,o-=94,- +(0,n
+,l=b=8,!( te-*A,l=b=8,!( te-*A,l=b,!( time-*A,l=b, time)|-*A,l= time(0)|-*A,l= 
+~l),srand  (l),~l),srand  (l),~l),and  ,!(l),~l),a  ,!(A,l),~l)  ,!(d=A,l),~l) 
+,b))&&+((A + te,b))&&+((A + te,b))+((A -A+ te,b))+A -A+ (&te,b+A -A+(* (&te,b+A
+)=+ +95>e?(*& c)=+ +95>e?(*& c) +95>e?(*& _*c) +95>(*& _*c) +95>(*&r= _*c) +95>
+5,r+e-r +_:2-195,r+e-r +_:2-195+e-r +_:2-1<-95+e-r +_-1<-95+e-r ++?_-1<-95+e-r 
+|(d==d),!n ?*d||(d==d),!n ?*d||(d==d),!n ?*d||(d==d),!n ?*d||(d==d),!n ?*d||(d=
+ *( (char**)+V+ *( (char)+V+ *( (c),har)+V+  (c),har)+ (V+  (c),r)+ (V+  (  c),
++0,*d-7 ) -r+8)+0,*d-7 -r+8)+0,*d-c:7 -r+80,*d-c:7 -r+7:80,*d-7 -r+7:80,*d++-7 
++7+! r: and%9- +7+! rand%9-85 +7+! rand%95 +7+!!  rand%95 +7+  rand()%95 +7+  r
+-(r+o):(+w,_+ A-(r+o)+w,_+*( A-(r+o)+w,_+ A-(r=e+o)+w,_+ A-(r+o)+wri,_+ A-(r+o)
++(o)+b)),!write+(o)+b,!wri,(te+(o)+b,!write+(o=_)+b,!write+(o)+b,!((write+(o)+b
+-b+*h)(1,A+b,!!-b+*h),A+b,((!!-b+*h),A+b,!!-b+((*h),A+b,!!-b+*h),A-++b,!!-b+*h)
+, a >T^l,( o-95, a >T,( o-=+95, a >T,( o-95, a)) >T,( o-95, a >T,(w? o-95, a >T
+++  &&r:b<<2+a ++  &&b<<2+a+w ++  &&b<<2+w ++  ) &&b<<2+w ++  &&b<<((2+w ++  &&
+!main(n*n,V) , !main(n,V) , !main(+-n,V) ,main(+-n,V) ) ,main(n,V) ) ,main),(n,
+l)),w= +T-->o +l)),w= +T>o +l)),w=o+ +T>o +l,w=o+ +T>o;{ +l,w=o+T>o;{ +l,w &=o+
+!a;}return _+= !a;}return _+= !a;}return _+= !a;}return _+= !a;}return _+= !a;}


### PR DESCRIPTION
Added herrmann2.alt.c. This is for a new try command to show a feature of the entry. It can generate the original code so the try command does this, redirecting stdout to a file (herrmann2.orig.c) and then does a diff on the two files, to show how they're the same.

The make alt rule was fixed so it doesn't compile with herrmann2.c but rather herrmann2.alt.c though I'm not even sure why that was defined at all except to say that it must have been something I forgot to change after fixing it properly.

Updated .gitignore to add herrmann2.orig.c.

Further format fixes in README.md.