### PR TITLE
Format fix 2019/poikola/README.md

### DIFF
--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -194,7 +194,7 @@ arrays, so I did it.
 
 ### Other stuff
 
-[Cody](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
 previous entry. I hope that you will like this entry too.  Because I did not
 want to give too many clues to [the Judges](/judges.html), I tried to write this
 entry in a different way than [Most Stellar](/2018/poikola/prog.c), but in this

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -33,6 +33,11 @@ TZ=UTC48 make clobber prog
 ./prog 512 ./prog
 ```
 
+### INABIAF - it's not a bug it's a feature! :-)
+
+This program will not validate input so it might fail or get stuck if invoked
+erroneously.
+
 ## Judges' remarks:
 
 Do you have the time to see what this program does?  Think again, come back and
@@ -69,18 +74,20 @@ clang -O1 -o prog prog.c
 ### Poster:
 
 You can generate an A3 sized poster by `make docs`. This command creates a pdf
-file `poikola.pdf`.
+file `poikola.pdf`. This requires the
+[pdfTeX](https://en.wikipedia.org/wiki/PdfTeX) tool.
 
 ### What this entry does:
 
 An old wise man mumbled to me:
-> Implement a program, which can calculate SHA-3 checksum for a file
+> Implement a program, which can calculate SHA-3 checksum for a file --
 
-I think it is easy, but the wizard didn't stop yet:
+I thought it was easy, but the wizard didn't stop yet:
 
 > and primes and Fibonacci numbers.
 
-Still easy. But the Gandalf the Grey impersonator is not ready:
+Still easy. But the [Gandalf the
+Grey](https://www.glyphweb.com/arda/g/gandalf.html) impersonator was not ready:
 
 > But use only `main()`, and do not use `math.h` nor predefined stuff at all.
 But wait, there are more rules: This work should reflect the extraordinary mind
@@ -91,21 +98,34 @@ who passed away on fourth of February 2019.
 
 ### Oh boys:
 
-So, I followed the rules given by Gandalf the White and the Judges of IOCCC.
+So, I followed the rules given by [Gandalf the
+White](https://www.glyphweb.com/arda/g/gandalf.html) and the [Judges of
+IOCCC](/judges.html).
+
 Output of `iocccsize`, using the [2019 version of
 iocccsize](https://www.ioccc.org/2019/iocccsize.c), is carefully selected.  For
 the sake of clarity, I used single letter variables in the code. I also avoided
-unnecessary use of functions.  Like a tripundra, this program has three levels.
+unnecessary use of functions.  Like a
+[tripundra](https://en.wikipedia.org/wiki/Tripundra), this program has three levels.
 In order to reveal all of them, you have to compile this program on three
 consecutive days.
 
 As this is a contest for obfuscated code, the program does not perform
 unnecessary checks, but either fails or gets stuck if invoked erroneously. The
-program is invoked in this way: ./prog `<integer>` `<file>` in where `<integer>`
-is 224, 256, 384, 512 or even 1024. Yes, I know 1024 is not a supported length
-of output, but as I said, the program does not validate its input in any way.
-These same parameters should be given in calculating a Fibonacci sequence or
-prime numbers. *Please note that maximum file size is one gigabyte..
+program is invoked in this way:
+
+
+```sh
+./prog <integer> <file>
+
+```
+
+where `<integer>` is 224, 256, 384, 512 or even 1024. Yes, I know 1024 is not a
+supported length of output, but as I said, the program does not validate its
+input in any way.  These same parameters should be given in calculating a
+[Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_sequence) or [prime
+numbers](https://en.wikipedia.org/wiki/Prime_number). *Please note that maximum
+file size is one gigabyte*!
 
 ### Obfuscation:
 
@@ -116,67 +136,96 @@ the feeling that I've been here before.
 make your own decisions. Up there, it's all _up yours_.
 
 This code has some jumping too. I used some `goto`s instead of `longjmp()`. Some
-Finnish ski jumping sites are used as labels, however, there is `lahti` instead
-of <tt style="font-family: Monaco, Courier New, monospace;font-size:
-12px;">salpausselk&auml;</tt>.
+Finnish [ski jumping](https://en.wikipedia.org/wiki/Ski_jumping) sites are used
+as labels, however, there is `lahti` instead of <tt style="font-family: Monaco,
+Courier New, monospace;font-size: 12px;">salpausselk&auml;</tt>.
 
 ### SHA-3-512 Compatibility chart ###
 
 Tested against [test vectors](https://www.di-mgt.com.au/sha_testvectors.html).
-Clang-4.0: For optimization levels [0123s], the program compiles and produces correct output for every tested vector using
-c11, c89, c90, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1990, iso9899:199409, iso9899:1999 and
-iso9899:2011 as argument of `-std=`
 
-Gcc-6: For optimization level 0, correct output using
-c11, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1999 and iso9899:2011
+Clang-4.0: For optimization levels [0123s], the program compiles and produces
+correct output for every tested vector using the C standards c11, c89, c90, c99,
+gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1990, iso9899:199409, iso9899:1999
+and iso9899:2011 (argument of `-std=`).
+
+GCC-6: For optimization level 0, correct output using the C standards
+c11, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1999 and iso9899:2011.
 
 ### Missing a prime
 
-For obvious reason, the oddest prime is missing from output.
+For obvious reason, the [oddest
+prime](https://mathworld.wolfram.com/OddPrime.html) is missing from output.
 
 ### Observations
 
-Gcc and clang are very fragile compilers. I spent numerous hours trying to achieve exactly the same output from
-different optimization levels and compilers. Small change in code can produce really unexpected results, i.e. the compiler
-can skip a few expressions or statements without obvious reason.
+`gcc` and `clang` are very fragile compilers. I spent numerous hours trying to
+achieve exactly the same output from different optimization levels and
+compilers. Small change in code can produce really unexpected results, i.e. the
+compiler can skip a few expressions or statements without obvious reason.
 
 ### Major spoilers
 
-Please scroll down if you want to see spoilers.
-<div style="margin-bottom:61em;">&nbsp;</div>
-It is commonly believed that [Mike Keith's algorithm](http://www.cadaeic.net/calendar.htm) published in _Journal of
-Recreational Mathematics_, Vol. 22, No. 4, 1990, p. 280, is the shortest way to calculate weekday for given date.
-Keith's algorithm:<br>
-`(d+=m<3?y--:y-2,23*m/9+d+4+y/4-y/100+y/400)%7`<br>
-My algorithm: I noticed that<br>
-`(23*m/9+(m<3?y--:y-2)+d+4+y/4-y/100+y/400)%7`<br>
-is one character shorter. In my solution, `m<3?y--:y-2` is used directly, instead of assign value for `d`.
+It is commonly believed that [Mike Keith's
+algorithm](http://www.cadaeic.net/calendar.htm) published in _Journal of
+Recreational Mathematics_, Vol. 22, No. 4, 1990, p. 280, is the shortest way to
+calculate the day of the week for a given date.
 
-Q is pronounced in Finnish exactly like "kuu", a word for month or the Moon. So, `Q = k` is intended.
+#### Keith's versus my algorithm
 
-Last term of outputted Fibonacci sequence is the last one smaller than 2<sup>64</sup>. It is plain coincidence (but a funny)
-that value of '^' is 94 in ASCII table.
+Kieth's algorithm is `(d+=m<3?y--:y-2,23*m/9+d+4+y/4-y/100+y/400)%7`. I noticed
+that `(23*m/9+(m<3?y--:y-2)+d+4+y/4-y/100+y/400)%7` is one character shorter. In
+my solution, `m<3?y--:y-2` is used directly, instead of assigning a value to
+`d`.
 
-For prime calculations: I recycled code from my high school C-programming course. Originally, I wrote it over 20 years
-ago. My teacher said that it is (too) complicated to use bits stored in arrays, so I did it.
+Q is pronounced in Finnish exactly like "kuu", a word for
+[month](https://en.wikipedia.org/wiki/Month) or the
+[Moon](https://en.wikipedia.org/wiki/Moon). So, `Q = k` is intended.
+
+Last term of outputted [Fibonacci
+sequence](https://en.wikipedia.org/wiki/Fibonacci_sequence) is the last one
+smaller than 2<sup>64</sup>. It is a plain but funny coincidence
+that the value of `^` is 94 in [ASCII](https://en.wikipedia.org/wiki/ASCII).
+
+For [prime calculations](https://en.wikipedia.org/wiki/Prime_number): I recycled
+code from my high school C-programming course. Originally, I wrote it over 20
+years ago. My teacher said that it is (too) complicated to use bits stored in
+arrays, so I did it.
 
 ### Other stuff
 
-Cody: I really like that you enjoyed my previous entry. I hope that you will like this entry too.
-Because I did not want to give too many clues to Judges, I tried to write this entry in a different way
-than Most Stellar, but in this code there is at least one recycled thing from it. By the way,
-answers to questions: 1. 255. 2. Try to compare binary representations of those floats and binary representation
-of the string "25th IOCCC!". 3. I don't know. I used standard trigonometric functions from `math.h` for rotating the Big Dipper
-and later replaced those functions with my own implementations. But there was a bug in my code and the effect was more
-beautiful than intended. I did not even debug this bug and now it works as a feature. 4. It is not possible. If you
-change a single bit, the Fletcher 16 checksum does not match anymore and `goto` jumps to end of the code.
+[Cody](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
+previous entry. I hope that you will like this entry too.  Because I did not
+want to give too many clues to [the Judges](/judges.html), I tried to write this
+entry in a different way than [Most Stellar](/2018/poikola/prog.c), but in this
+code there is at least one recycled thing from it. By the way, the answers to
+the questions I posed: `(1)` 255. `(2)` Try to compare binary representations of
+those floats and binary representation of the string "`25th IOCCC!`". `(3)` I
+don't know. I used standard [trigonometric
+functions](https://en.wikipedia.org/wiki/Trigonometric_functions) from
+[math.h](https://en.wikipedia.org/wiki/C_mathematical_functions#Overview_of_functions)
+for rotating the [Big Dipper](https://en.wikipedia.org/wiki/Big_Dipper) and
+later replaced those functions with my own implementations.  But there was a bug
+in my code and the effect was more beautiful than intended.  I did not even
+debug this bug and now it works as a feature. `(4)` It is not possible. If you
+change a single bit, the [Fletcher's 16
+checksum](https://en.wikipedia.org/wiki/Fletcher%27s_checksum#Fletcher-16) does
+not match anymore and `goto` jumps to the end of the code.
 
-I see that _Volker Diels-Grabsch_'s winner is awarded in category __Most self-aware__. In last year, my entry incorporates
-the Fletcher 16 algorithm to ensure integrity of code. One of my first ideas for this year was to do the same thing,
-but with SHA-3. Using Fletcher 16, calculating a checksum which matches with `sleeping time factor` took about one minute.
-I realized that SHA-3 even with 224-bit output could take too much CPU time.
+I see that one of the [Volker
+Diels-Grabsch](/winners.html#Volker_Diels-Grabsch)'s winning entries is
+awarded the category [Most self-aware](/2019/diels-grabsch2/prog.c). In last
+year, my entry incorporates the [Fletcher's 16
+algorithm](https://en.wikipedia.org/wiki/Fletcher%27s_checksum#Fletcher-16) to
+ensure integrity of code. One of my first ideas for this year was to do the same
+thing, but with [SHA-3](https://en.wikipedia.org/wiki/SHA-3). Using Fletcher 16,
+calculating a [checksum](https://en.wikipedia.org/wiki/Checksum) which matches
+with `sleeping time factor` took about one minute.  I realized that SHA-3 even
+with 224-[bit](https://en.wikipedia.org/wiki/Bit) output could take too much
+[CPU](https://en.wikipedia.org/wiki/Central_processing_unit) time.
 
-I would like to say _thanks_ to PSP, because there were not too much interrupts during the coding phase.
+I would like to say _thanks_ to PSP, because there were not too many
+interruptions during the coding phase.
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/bugs.md
+++ b/bugs.md
@@ -2033,6 +2033,13 @@ help!
 As a backtrace quine this entry is **SUPPOSED to segfault** so this should not be
 touched either.
 
+## [2019/poikola](2019/poikola/prog.c) ([README.md](2019/poikola/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+This program will not validate input so it might fail or get stuck if invoked
+erroneously.
+
+
 # 2020
 
 ## [2020/burton](2020/burton/prog.c) ([README.md](2020/burton/README.md))


### PR DESCRIPTION
Yesterday I noticed that Timo wrote directly to me in his remarks and I wanted to address this by adding a link to myself (which is what is being done with all winners being referred to) but this naturally meant I should format fix the file too. I am very touched by this especially as 2019 was a very hard year for me and I didn't even think I was going to participate in that year (did in the end and didn't win but funnily enough some of my entry ideas actually won though with some differences of course) so I wanted to address it now. I might end up changing my name to my full name but I want to keep it as close to as possible (format fixed and links added notwithstanding) first to see how it looks. Thank you Timo! It means a great deal to me.

In the paragraph to me Timo wrote about his 2018 entry and I linked to that too.

I changed another winner Timo mentioned to be a link (the winner in winners.html as well as the winning entry referred to are now both links).

Add some links and other format fixes.

Added INABIAF section to both the README.md file and bugs.md.

Typo fixes or at least adding a word here and there to make certain things a bit clearer.