### PR TITLE
Partly fix and swap 2005/giljade alt and original

### DIFF
--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -134,6 +134,8 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	@echo "NOTE: this version requires non-standard args to main() and will fail with"
+	@echo "some compilers like clang. Try make alt for such compilers."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -16,26 +16,29 @@ make
 ./giljade
 ```
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for modern
-systems. The problem that was showing up is that with either optimising or
-anything but 32-bit was used it would not work. The optimising cannot be used
-still but it now works with both 32-bit and 64-bit. The problem was the size of
-`int` and `long` being different now. Instead of `long *E` it is now `int *E`.
-This solves the problem for both 32-bit and 64-bit as long as optimising is
-disabled. Tested under linux (32-bit, 64-bit) and macOS (arm64). Thank you Cody
-for your assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) partly (see below)
+fixed this for modern systems. The problem that was showing up is that with
+either optimising or anything but 32-bit was used it would not work. The
+optimising cannot be used still but it now works with both 32-bit and 64-bit.
+The problem was the size of `int` and `long` being different now. Instead of
+`long *E` it is now `int *E`.  This solves the problem for both 32-bit and
+64-bit as long as optimising is disabled. Tested under linux (32-bit, 64-bit)
+and macOS (arm64). Thank you Cody for your assistance!
 
 NOTE: the self-test feature no longer works due to the fix for clang (which
 requires the first arg of `main()` to be an `int` and the second arg to be `char
 **`). Believe it having more than two spaces in the code, except where the
-original code has them, appears to be part of the problem but it's not the full
-story. If you have a compiler that doesn't have this deficiency (e.g.  gcc) you
-can use the alternate code described below.
+original code has them, might be part of the problem but it's not the full
+story. If you have a compiler that doesn't have this defect (e.g.  gcc) you
+can use the alternate code described below. See also [bugs.md](/bugs.md).
+
 
 ### INABIAF - it's not a bug it's a feature! :-)
 
 If the program source file is not lying in the same directory this program will
 very likely crash or do something strange.
+
+This entry requires that both `sed` and `cc` are in the path.
 
 ## Try:
 

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -10,28 +10,36 @@ Israel
 make
 ```
 
+NOTE: if you do not have access to a compiler that lets you have alternative arg
+types to `main()` you must use the alternate code. This is hopefully just a
+temporary problem but it's a complicated problem as well. See 'To run' and
+'Alternate code' sections as well as [bugs.md](/bugs.md) for more information.
+
 ## To run:
 
 ```sh
 ./giljade
 ```
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) partly (see below)
-fixed this for modern systems. The problem that was showing up is that with
-either optimising or anything but 32-bit was used it would not work. The
-optimising cannot be used still but it now works with both 32-bit and 64-bit.
-The problem was the size of `int` and `long` being different now. Instead of
-`long *E` it is now `int *E`.  This solves the problem for both 32-bit and
-64-bit as long as optimising is disabled. Tested under linux (32-bit, 64-bit)
-and macOS (arm64). Thank you Cody for your assistance!
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for modern
+systems but there was a problem with both the clang fixed version (which Landon
+originally put in but Cody further fixed so that it would work somewhat) and the
+original version. There remains a problem with the clang version.
 
-NOTE: the self-test feature no longer works due to the fix for clang (which
-requires the first arg of `main()` to be an `int` and the second arg to be `char
-**`). Believe it having more than two spaces in the code, except where the
-original code has them, might be part of the problem but it's not the full
-story. If you have a compiler that doesn't have this defect (e.g.  gcc) you
-can use the alternate code described below. See also [bugs.md](/bugs.md).
+The problem that was showing up is that with either optimising or anything but
+32-bit was used it would not work. The optimising cannot be used still but it
+now works with both 32-bit and 64-bit. The solution has to do with the size
+difference between `int` and `long` so that the `long *E` is now `int *E`. This
+solves a specific problem for linux (32-bit, 64-bit) and macOS (arm64).
 
+But as noted there is another problem with clang: the self-test feature only
+completely works with the original version, not the one that will compile with
+clang. The alt version only passes some of its tests. If your compiler does not
+have the defect that clang has about arg types to `main()` you can use
+successfully run the self-test feature completely. Otherwise see the Alternate
+code section below.
+
+Thank you Cody for your assistance!
 
 ### INABIAF - it's not a bug it's a feature! :-)
 
@@ -53,19 +61,29 @@ vi out
 
 Press ^F (control F) repeatedly.
 
+### Also try:
+
+```sh
+./giljade > out
+./giljade out
+```
+
+NOTE: this will only completely work with the original version at least at this
+time.
+
 ### Alternate code:
 
-Thanks to the fix for `clang` the self-test feature (of the output, see the
-author's remarks) does not work. If however you have gcc which does not have the
-defect that clang has with requirements in `main()`s args you can still use it
-via the alternate code. To compile:
+This version is compilable with clang but as noted the self-test feature is
+incomplete. It did not work at all but Cody added a hack to make part of it work
+until this can be looked at further. See also the [bugs.md](/bugs.md) file.
 
+If you have clang you can use this version like:
 
 ```sh
 make alt
 ```
 
-Use `giljade.alt` as you would `giljade`.
+Use `giljade.alt` as you would `giljade` above.
 
 
 ## Judges' remarks:

--- a/2005/giljade/giljade.alt.c
+++ b/2005/giljade/giljade.alt.c
@@ -12,7 +12,7 @@
 ),l)u=u>>5-m &u;s=u&E[3-l];I(t(m),3-l) s=(u)a&*E;I\
 (t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s>*/
 /*c.c;cc/c.c /-c*/;;char*A=0,*_,*R,*Q, D[9999],*r,l
-[9999],T=42, M,V=32;long*E,k[9999],B[1 <<+21],*N=B+
+[9999],T=42, M,V=32;int*E,k[9999],B[1 <<+21],*N=B+
 1234567,q=0, h=3,j=2,O,b,f,u,s,c,a,t,e ,d;C(){F(h=N
 [3];(B[h]&&+ memcmp(N,B+B[h],16));h=B[ h]+4);B[h]||
 (B[h]=N-B,N= N+6);}main(char*U,int*w[] ){;;F(_=A=D+

--- a/2005/giljade/giljade.alt.c
+++ b/2005/giljade/giljade.alt.c
@@ -10,14 +10,14 @@
 \
 )u=(f&p)i(m) ;s=u&E[3];I(t(m),3)s=(u)a &E[l];I(t(m\
 ),l)u=u>>5-m &u;s=u&E[3-l];I(t(m),3-l) s=(u)a&*E;I\
-(t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s>*/
-/*c.c;cc/c.c /-c*/;;char*A=0,*_,*R,*Q, D[9999],*r,l
-[9999],T=42, M,V=32;int*E,k[9999],B[1 <<+21],*N=B+
+(t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s/|sed*/
+/*-e/ 's,intUa,int/ Ua,g'>c.c;cc/c.c/-Wno-implicit-function-declaration /-c*/
+;;char*A=0,*_,*R,*Q, D[9999],*r,l[9999],T=42, M,V=32;int*E,k[9999],B[1 <<+21],*N=B+
 1234567,q=0, h=3,j=2,O,b,f,u,s,c,a,t,e ,d;C(){F(h=N
 [3];(B[h]&&+ memcmp(N,B+B[h],16));h=B[ h]+4);B[h]||
-(B[h]=N-B,N= N+6);}main(char*U,int*w[] ){;;F(_=A=D+
-6666,A[fread (A,1,3333,fopen(__FILE__, "r"))]=0;*++
-_;h||(*_=V)) 
+(B[h]=N-B,N= N+6);}main(int Ua,char **wa){char*U
+=Ua;int**w= wa;;F(_=A=D+6666,A[fread(A,1,3333,fopen
+(__FILE__, "r"))]=0;*++ _;h||(*_=V))
 *_-59|_[1]-* _||(h&&(*_=+ 35),h---2||(_[9]=V));;F(_
 =A;*_;_++)10 -*_&&*_-V&&( *_-92)&&(k[q]=isalnum(l[q
 ]=*_),q++);M =47;*(E=N-6) =64;E[1]=289;E[2]=270336;

--- a/2005/giljade/giljade.c
+++ b/2005/giljade/giljade.c
@@ -11,14 +11,13 @@
 )u=(f&p)i(m) ;s=u&E[3];I(t(m),3)s=(u)a &E[l];I(t(m\
 ),l)u=u>>5-m &u;s=u&E[3-l];I(t(m),3-l) s=(u)a&*E;I\
 (t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s>*/
-/*c.c;cc/c.c/-Wno-implicit-function-declaration /-c*/
-;;char*A=0,*_,*R,*Q, D[9999],*r,l
+/*c.c;cc/c.c /-c*/;;char*A=0,*_,*R,*Q, D[9999],*r,l
 [9999],T=42, M,V=32;int*E,k[9999],B[1 <<+21],*N=B+
 1234567,q=0, h=3,j=2,O,b,f,u,s,c,a,t,e ,d;C(){F(h=N
 [3];(B[h]&&+ memcmp(N,B+B[h],16));h=B[ h]+4);B[h]||
-(B[h]=N-B,N= N+6);}int main(int Ua,char **wa){char*U
-=Ua;int**w= wa;;F(_=A=D+6666,A[fread(A,1,3333,fopen
-(__FILE__, "r"))]=0;*++ _;h||(*_=V))
+(B[h]=N-B,N= N+6);}main(char*U,int*w[] ){;;F(_=A=D+
+6666,A[fread (A,1,3333,fopen(__FILE__, "r"))]=0;*++
+_;h||(*_=V)) 
 *_-59|_[1]-* _||(h&&(*_=+ 35),h---2||(_[9]=V));;F(_
 =A;*_;_++)10 -*_&&*_-V&&( *_-92)&&(k[q]=isalnum(l[q
 ]=*_),q++);M =47;*(E=N-6) =64;E[1]=289;E[2]=270336;

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -194,7 +194,7 @@ arrays, so I did it.
 
 ### Other stuff
 
-[Cody](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
 previous entry. I hope that you will like this entry too.  Because I did not
 want to give too many clues to [the Judges](/judges.html), I tried to write this
 entry in a different way than [Most Stellar](/2018/poikola/prog.c), but in this

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -33,6 +33,11 @@ TZ=UTC48 make clobber prog
 ./prog 512 ./prog
 ```
 
+### INABIAF - it's not a bug it's a feature! :-)
+
+This program will not validate input so it might fail or get stuck if invoked
+erroneously.
+
 ## Judges' remarks:
 
 Do you have the time to see what this program does?  Think again, come back and
@@ -69,18 +74,20 @@ clang -O1 -o prog prog.c
 ### Poster:
 
 You can generate an A3 sized poster by `make docs`. This command creates a pdf
-file `poikola.pdf`.
+file `poikola.pdf`. This requires the
+[pdfTeX](https://en.wikipedia.org/wiki/PdfTeX) tool.
 
 ### What this entry does:
 
 An old wise man mumbled to me:
-> Implement a program, which can calculate SHA-3 checksum for a file
+> Implement a program, which can calculate SHA-3 checksum for a file --
 
-I think it is easy, but the wizard didn't stop yet:
+I thought it was easy, but the wizard didn't stop yet:
 
 > and primes and Fibonacci numbers.
 
-Still easy. But the Gandalf the Grey impersonator is not ready:
+Still easy. But the [Gandalf the
+Grey](https://www.glyphweb.com/arda/g/gandalf.html) impersonator was not ready:
 
 > But use only `main()`, and do not use `math.h` nor predefined stuff at all.
 But wait, there are more rules: This work should reflect the extraordinary mind
@@ -91,21 +98,34 @@ who passed away on fourth of February 2019.
 
 ### Oh boys:
 
-So, I followed the rules given by Gandalf the White and the Judges of IOCCC.
+So, I followed the rules given by [Gandalf the
+White](https://www.glyphweb.com/arda/g/gandalf.html) and the [Judges of
+IOCCC](/judges.html).
+
 Output of `iocccsize`, using the [2019 version of
 iocccsize](https://www.ioccc.org/2019/iocccsize.c), is carefully selected.  For
 the sake of clarity, I used single letter variables in the code. I also avoided
-unnecessary use of functions.  Like a tripundra, this program has three levels.
+unnecessary use of functions.  Like a
+[tripundra](https://en.wikipedia.org/wiki/Tripundra), this program has three levels.
 In order to reveal all of them, you have to compile this program on three
 consecutive days.
 
 As this is a contest for obfuscated code, the program does not perform
 unnecessary checks, but either fails or gets stuck if invoked erroneously. The
-program is invoked in this way: ./prog `<integer>` `<file>` in where `<integer>`
-is 224, 256, 384, 512 or even 1024. Yes, I know 1024 is not a supported length
-of output, but as I said, the program does not validate its input in any way.
-These same parameters should be given in calculating a Fibonacci sequence or
-prime numbers. *Please note that maximum file size is one gigabyte..
+program is invoked in this way:
+
+
+```sh
+./prog <integer> <file>
+
+```
+
+where `<integer>` is 224, 256, 384, 512 or even 1024. Yes, I know 1024 is not a
+supported length of output, but as I said, the program does not validate its
+input in any way.  These same parameters should be given in calculating a
+[Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_sequence) or [prime
+numbers](https://en.wikipedia.org/wiki/Prime_number). *Please note that maximum
+file size is one gigabyte*!
 
 ### Obfuscation:
 
@@ -116,67 +136,96 @@ the feeling that I've been here before.
 make your own decisions. Up there, it's all _up yours_.
 
 This code has some jumping too. I used some `goto`s instead of `longjmp()`. Some
-Finnish ski jumping sites are used as labels, however, there is `lahti` instead
-of <tt style="font-family: Monaco, Courier New, monospace;font-size:
-12px;">salpausselk&auml;</tt>.
+Finnish [ski jumping](https://en.wikipedia.org/wiki/Ski_jumping) sites are used
+as labels, however, there is `lahti` instead of <tt style="font-family: Monaco,
+Courier New, monospace;font-size: 12px;">salpausselk&auml;</tt>.
 
 ### SHA-3-512 Compatibility chart ###
 
 Tested against [test vectors](https://www.di-mgt.com.au/sha_testvectors.html).
-Clang-4.0: For optimization levels [0123s], the program compiles and produces correct output for every tested vector using
-c11, c89, c90, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1990, iso9899:199409, iso9899:1999 and
-iso9899:2011 as argument of `-std=`
 
-Gcc-6: For optimization level 0, correct output using
-c11, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1999 and iso9899:2011
+Clang-4.0: For optimization levels [0123s], the program compiles and produces
+correct output for every tested vector using the C standards c11, c89, c90, c99,
+gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1990, iso9899:199409, iso9899:1999
+and iso9899:2011 (argument of `-std=`).
+
+GCC-6: For optimization level 0, correct output using the C standards
+c11, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1999 and iso9899:2011.
 
 ### Missing a prime
 
-For obvious reason, the oddest prime is missing from output.
+For obvious reason, the [oddest
+prime](https://mathworld.wolfram.com/OddPrime.html) is missing from output.
 
 ### Observations
 
-Gcc and clang are very fragile compilers. I spent numerous hours trying to achieve exactly the same output from
-different optimization levels and compilers. Small change in code can produce really unexpected results, i.e. the compiler
-can skip a few expressions or statements without obvious reason.
+`gcc` and `clang` are very fragile compilers. I spent numerous hours trying to
+achieve exactly the same output from different optimization levels and
+compilers. Small change in code can produce really unexpected results, i.e. the
+compiler can skip a few expressions or statements without obvious reason.
 
 ### Major spoilers
 
-Please scroll down if you want to see spoilers.
-<div style="margin-bottom:61em;">&nbsp;</div>
-It is commonly believed that [Mike Keith's algorithm](http://www.cadaeic.net/calendar.htm) published in _Journal of
-Recreational Mathematics_, Vol. 22, No. 4, 1990, p. 280, is the shortest way to calculate weekday for given date.
-Keith's algorithm:<br>
-`(d+=m<3?y--:y-2,23*m/9+d+4+y/4-y/100+y/400)%7`<br>
-My algorithm: I noticed that<br>
-`(23*m/9+(m<3?y--:y-2)+d+4+y/4-y/100+y/400)%7`<br>
-is one character shorter. In my solution, `m<3?y--:y-2` is used directly, instead of assign value for `d`.
+It is commonly believed that [Mike Keith's
+algorithm](http://www.cadaeic.net/calendar.htm) published in _Journal of
+Recreational Mathematics_, Vol. 22, No. 4, 1990, p. 280, is the shortest way to
+calculate the day of the week for a given date.
 
-Q is pronounced in Finnish exactly like "kuu", a word for month or the Moon. So, `Q = k` is intended.
+#### Keith's versus my algorithm
 
-Last term of outputted Fibonacci sequence is the last one smaller than 2<sup>64</sup>. It is plain coincidence (but a funny)
-that value of '^' is 94 in ASCII table.
+Kieth's algorithm is `(d+=m<3?y--:y-2,23*m/9+d+4+y/4-y/100+y/400)%7`. I noticed
+that `(23*m/9+(m<3?y--:y-2)+d+4+y/4-y/100+y/400)%7` is one character shorter. In
+my solution, `m<3?y--:y-2` is used directly, instead of assigning a value to
+`d`.
 
-For prime calculations: I recycled code from my high school C-programming course. Originally, I wrote it over 20 years
-ago. My teacher said that it is (too) complicated to use bits stored in arrays, so I did it.
+Q is pronounced in Finnish exactly like "kuu", a word for
+[month](https://en.wikipedia.org/wiki/Month) or the
+[Moon](https://en.wikipedia.org/wiki/Moon). So, `Q = k` is intended.
+
+Last term of outputted [Fibonacci
+sequence](https://en.wikipedia.org/wiki/Fibonacci_sequence) is the last one
+smaller than 2<sup>64</sup>. It is a plain but funny coincidence
+that the value of `^` is 94 in [ASCII](https://en.wikipedia.org/wiki/ASCII).
+
+For [prime calculations](https://en.wikipedia.org/wiki/Prime_number): I recycled
+code from my high school C-programming course. Originally, I wrote it over 20
+years ago. My teacher said that it is (too) complicated to use bits stored in
+arrays, so I did it.
 
 ### Other stuff
 
-Cody: I really like that you enjoyed my previous entry. I hope that you will like this entry too.
-Because I did not want to give too many clues to Judges, I tried to write this entry in a different way
-than Most Stellar, but in this code there is at least one recycled thing from it. By the way,
-answers to questions: 1. 255. 2. Try to compare binary representations of those floats and binary representation
-of the string "25th IOCCC!". 3. I don't know. I used standard trigonometric functions from `math.h` for rotating the Big Dipper
-and later replaced those functions with my own implementations. But there was a bug in my code and the effect was more
-beautiful than intended. I did not even debug this bug and now it works as a feature. 4. It is not possible. If you
-change a single bit, the Fletcher 16 checksum does not match anymore and `goto` jumps to end of the code.
+[Cody](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
+previous entry. I hope that you will like this entry too.  Because I did not
+want to give too many clues to [the Judges](/judges.html), I tried to write this
+entry in a different way than [Most Stellar](/2018/poikola/prog.c), but in this
+code there is at least one recycled thing from it. By the way, the answers to
+the questions I posed: `(1)` 255. `(2)` Try to compare binary representations of
+those floats and binary representation of the string "`25th IOCCC!`". `(3)` I
+don't know. I used standard [trigonometric
+functions](https://en.wikipedia.org/wiki/Trigonometric_functions) from
+[math.h](https://en.wikipedia.org/wiki/C_mathematical_functions#Overview_of_functions)
+for rotating the [Big Dipper](https://en.wikipedia.org/wiki/Big_Dipper) and
+later replaced those functions with my own implementations.  But there was a bug
+in my code and the effect was more beautiful than intended.  I did not even
+debug this bug and now it works as a feature. `(4)` It is not possible. If you
+change a single bit, the [Fletcher's 16
+checksum](https://en.wikipedia.org/wiki/Fletcher%27s_checksum#Fletcher-16) does
+not match anymore and `goto` jumps to the end of the code.
 
-I see that _Volker Diels-Grabsch_'s winner is awarded in category __Most self-aware__. In last year, my entry incorporates
-the Fletcher 16 algorithm to ensure integrity of code. One of my first ideas for this year was to do the same thing,
-but with SHA-3. Using Fletcher 16, calculating a checksum which matches with `sleeping time factor` took about one minute.
-I realized that SHA-3 even with 224-bit output could take too much CPU time.
+I see that one of the [Volker
+Diels-Grabsch](/winners.html#Volker_Diels-Grabsch)'s winning entries is
+awarded the category [Most self-aware](/2019/diels-grabsch2/prog.c). In last
+year, my entry incorporates the [Fletcher's 16
+algorithm](https://en.wikipedia.org/wiki/Fletcher%27s_checksum#Fletcher-16) to
+ensure integrity of code. One of my first ideas for this year was to do the same
+thing, but with [SHA-3](https://en.wikipedia.org/wiki/SHA-3). Using Fletcher 16,
+calculating a [checksum](https://en.wikipedia.org/wiki/Checksum) which matches
+with `sleeping time factor` took about one minute.  I realized that SHA-3 even
+with 224-[bit](https://en.wikipedia.org/wiki/Bit) output could take too much
+[CPU](https://en.wikipedia.org/wiki/Central_processing_unit) time.
 
-I would like to say _thanks_ to PSP, because there were not too much interrupts during the coding phase.
+I would like to say _thanks_ to PSP, because there were not too many
+interruptions during the coding phase.
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2020/ferguson2/chocolate-cake.html
+++ b/2020/ferguson2/chocolate-cake.html
@@ -47,157 +47,157 @@ moaumqp yssl oldpk mew <k gbqg="nfqn://ejq.kxbg.wqz/amlzjrswm/200103068.hqi">XUS
 vvchf <gngrpy>'oq YMVBT'</evhpfa>: wl nxitrr xuom zil <xbyxzf>'Mvwkhwfyucdih Jzxrll rs Ofztr, Zsapqagyp
 ekl Bxahm Jmaxnjuadsfvq'</zulgbf>. Tbyhuyy.</h>
 
-<h>Jwi ndqw owa <e rqoi="vduzh://zycakph.ezz/gfptltdljsjre/wznrle/1290520266087571458?y=20">Resabtlkthvkv Ubjdlzry Fmrmpbovr Gyln Ewxoodl omhas</j> gxqb
-<x lwho="rfjxk://kuxvwgk.mbk/wphbaipivivcp">lkpwnx ORZDI zfwayb Fodp Opaulixym</y> (<v liht="mfvew://nbpsye.frp/tpjkcqajvaaxi">ErxZee</b>) wc kubq mc rmm
-<s kudy="ltkuq-qeyb.aaf">UTRRA swvw krabmq ktnrl</z> lx zmk hmwzmwu db hmh myvjs (zxkuk xi gguzshh qpvn
-ji xdrna qq wgs ufij pusy IWAZ).</i>
+<h>Jwi ndqw owa <e rqoi="vduzh://ixw.tvdrptb.aeh/frg/20200805053007/iemol://ulxzilo.fil/jerscjonjfaec/eptubc/1290520266087571458">Ukbtffidnzzyk Ggvayqgt Esgdremmv Qxnf Ifvflwe kunfw</p> ifbk
+<c xcrb="luona://tsc.hlvxa.kak/gfdjzub.pxco#Zyln_Bdgqcmoia">mvureq WFBXV dcqgbo Tahr Axgqinmng</w> (<j fafv="xqqwe://wxvnep.lnc/focngshqddrci">ZvzRel</x>) cc apnj mq ceq
+<r olxz="xlhoy-xvwu.oap">QEFPX vscv zlivas tgkpx</t> ln cdr vptbdwk wt szg wrsyw (xamfv yx jmbgchb fwtk
+yl ydeld gk jja lcly lhla MZDH).</x>
 
-<g2>Vmzbpkajdkuj</f2>
+<b2>Pqwfqlkefdui</w2>
 
-<r>Zyyy rco pshmzwqxwb qffs pm Zbmurfgp nncrgld lkxc ns ivg orwajarbrsyu jls oy blp
-FW vaoqvqcrk. L hleg wtuztwmk (zkzr qlv isla gkif rfqy enkz mzudrmz) me
-<z lmdg="kvfe://ygi.uymkyjhsmeivkgkd.tkb/tbzfxao.szd">npsw://eqg.wozhlmodaeqqnfks.lqt/wlgtpom.ozs</b>. Pfuh uyce loahexefdvig hzcmwa
-whf sfdf, zycmoblzw, nhzrikqxtmz uqb brdbrl.</h>
+<t>Maun vlg kyghpdsxbn mess ny Bdlyzauf tnttpfr dawb uy zgz crohhjvyqjuo gxv hm pqg
+SZ mrztkzlkr. F uevb wfengxss (xljh wnk ykgk zugq xptb ezbf xhwofsf) jo
+<t rhkj="qeza://pju.rytjmmrsladsxzuj.vqa/hqqsdio.mmz">tgzd://zsu.rkdyelqacxiwwrug.tzh/rhybkcu.dab</i>. Bxsf tneo rxxzkamtbpfk tuyeku
+hte acue, zduuqlwzf, vbusqevacen zdf frayxm.</t>
 
-<r2>Gjcym'w xbbtlzqpq</n2>
+<x2>Dwvpl'g aprppcrfo</s2>
 
-<v>Ruovw'b lqvtazxpd ev n dlosb brnm rul oud setwnmr kz omyhofyc yw kyzjuwoqckx
-xdpgrvizb mmmr ogfy utu cgedcr. Imubdurmb ni c <h atyz="vjgwm://hxo.jegsfxytjlpjt.lyy/fxcevnqmm-nmvz/">xgcorjiori SIW</c> vc qwpmh et
-xsuslw cqxxwxpke qnhror:</h>
+<y>Smtms'c muauqzvdx fe b jypyj izyr ucv ouu oprnshi hb jpnghmkp ot yhcahvjxupu
+gvrmidhxp zkop igqk twn hefnpo. Mzgbbibff jp h <x ukzd="prfdz://vjm.upfakpyneepbl.lno/btglwkzel-smiv/">rrcmbjcmrg XNJ</y> om dqznb vs
+luugow fstlcqylm oilkaf:</y>
 
-<ush><qpht>Tybhjw uckyhjdmd prooflkq zq boscn orl kw cunwh qyxehl 'whyzmipbolq' pn
-'ovnwyv' xfhwgfrvx. Fw htwr bnchcbgdt cv'v hpkjws 100% tozqw qxdfw xm'u
-fdrjzzvn fyiu dd zdhzkm eh xfrzy alnlt, feq dqdaszl xcbf.
-</zutt></vjg>
+<fpw><aiit>Nkrxyx anewkenhs wrkwbvle tt cbtvq lyi yg hdcio nfvjyx 'kawjwqciydh' xd
+'wfjnaz' jwazdaeyk. Na ulyo lsdsbjqib lb'r ntmqcf 100% kimuf uuzvl tq't
+vtxjqjpz efpp te sqjdge li qmrmh sbdzd, wcm tsqcgdt ctpz.
+</uaqh></lwm>
 
-<i>Ivf PHR hsdypdji vnry riq rfsnm ztif af mmai yvy t nhzqiy oalovw imqx yzl Q
-lqaorg szifn cfs hhzwvzpm qrxfbd jcvaa ruem aw'u laopuoiodfr qyesfauvx qoux wks
-edemkk. Xaz UBB yjuza dnvdv kmgp ozidw fkxj gykpyuylpdx zzc U nywk ce zpgh azhn
-eglj ewxmx bhcz dwd ta; D myapezi kawitme ya asmrvh'l wx dgkb.</o>
+<s>Ztf YMI agderadm dcvh kqm hnqkp enfb vn vfsc ibn c hqmlho triaoz nqho dqc V
+slkway jwmyh ddx ffkvgndh yegqfx wuooh lkzl yy'l sgrhdnoryje unxwlbpqy cxar tqy
+ppppbz. Ylk EMC wuowe japho hqqf cmvno wkti gqkgkrbhdux dia O sqhb hn prju swfw
+ejtb hhjeo lziv gfj yt; M cvgpnpi qmwurok hv geokxk'c sh cuip.</i>
 
-<h>Yoifpg tml oeahqo <jveeyu>qzvdq wqv nxjilqbsp zv qsj mnfuc rl pjb watumznon pr mmg dwidqk wzm
-kkhpba sryyo pawgbix meph'nm ctsvak ecbjlrdbk!</dkcmen></a>
+<h>Itqywj kps vizuzu <cytjxf>oigkn bnl pmkhwmwyv ez zyf xfobq wf pmw iakkisygx gc oyt zduxqu dyb
+mnwzgh wpkny qqqgxeb ozwr'df jwfkgw bwacwxftf!</jrjcky></j>
 
-<z2>Atbhglw jqhwh yvq dsc otct</b2>
+<t2>Uhrzfjy bqkwv vky nli udgo</w2>
 
-<v><jrjcky>JJE RFDCH JVVUQXCKL NK LQGUO:</oghdad></r>
+<u><cbfilx>SNR WZUAO NPFXCPHPB GK AGWQL:</wqedcz></e>
 
-<ku>
-<zp><g><prqear>LZV XKXRMAKDW</qstdzw>. Jejeuc uctt zdd lklw fbzb. Ku tkr xjaud mj rarx rbxs pcb
-vxqvxd hx conwr vcoxgc onn'ao isge wahqijiw; vb nlqd dxuv tjn cukpk!</y></gd>
-<wn><s>Uenw qzp kqpuk rpys kwvsapm mub mhqs sv ioy adfptrzcliv bzxakxkhc vnlkyrm;
-vohd ipun yj zn lzx qfion cyuo ziq fksi gju 1/4 saxma osel nwcpgd tf uu meiv qh
-iwuz ofz kzqjql pn gv mmjmd ghq kjpkanc jz vsickm. Yql hxi nmeevixaaoof zqlw
-je obsth'q zwg hjcpd.</e></wm>
-<hc><n>Wgk awddppj hekqxhqkb ij <vxciah>QFFL KYB QXPT WVG DUOWJOQZZ QTCF</uqdzbi>.</h></bs>
-<tl><a><cacmav>LTGCJS RBV KGYZ GNCS ZEJ UTEV 2 OWXEABI TCHFU CDBVNUEE HAHF CKJG</pplxjk>. Xepx nxziv
-fz ehiwc aucw vi ztiei. Gjw xjbhowylv qlydn zu kjeo ojhn tra'o jusjtkvt.</e></uk>
-<rh><u>Osfe zjb kympgb kow ospjv qacpzlp jwll qwzn ayfjkjtn idijo fg d ime; kuy
-aa'h hibcvwetychvl yncca dj y hhe. Zv jfg nboibwzltvsw eblx zko eehyqs imx
-wrqyw mokn 4 darz tsslu ucyhl fvclg.</g></wa>
-<aq><v>Qvf yntx <oshxup>XJVAA ZZJM</ukltzx> nzo jrky txryii; ers twnks'y vmgj cn hz zkwpef xxvmgkb
-vzk pstrl oprb ain fcz C omnk dntcst lnmu rgrf lzonei ueo sbim xhy bm
-ivfowdhdb pchq M dhfsc ddjsgvldw gtnrq fnxh hty zixc txpprp jaa. Lf svz osca
-ua kjxfr kjy uitcv <dxeekr>nq gtn ocjskz <jz>yztgvlpztu</mh> ol s L!</lgydik></d></og>
-<pk><y>Ihk efhi <brnzey>IKUG EQDFHOZ QTOOGKX</emwqdi>! Hu <vcwzwq>YRR QQU tuzjkzaqz suoubyg!</azdjca></z></vw>
-</wa>
-
-
-<e2>Vrda Fdzsyqrmfwe</v2>
-
-<zm>
-<fe>3 iv lpucryvwjwk (Wyjfk'f) ekaugohin</ce>
-<sd>2 zep 1/4 nnnv rtmle</cx>
-<yq>2 fcvl yeffyq qtfw</xn>
-<to>1/2 vhs owgz</xp>
-<yp>2 qdc 1/4 yybc bemfpg eqyfx qsnnm</bk>
-<iv>3 vcpz</cu>
-<pn>1 ssk 1/2 cme hlegnnp</tc>
-<ij>1/2 gwbw ijvfhxpil</dx>
-<op>1 srd (dkvdfgl) mrviu</ux>
-<ph>1 glt dzpz uwcmb</zs>
-</dm>
+<nd>
+<ia><g><asudfe>JML AMGEVNHAL</iewxef>. Decxsc jpsw fki ocqn ndqi. Ap gag spatw hk povc btxh mpq
+roxzpe tm oxeik mklnui tag'mm erkd placxxpz; uz pmzf autz nhz qcafa!</d></sa>
+<uz><l>Qcyq vtq krczt rlgd rneqsqh ayb chma hn reh xovjudihzxw tgcaakvmy dwnzfqj;
+irhx gfam xf cb lis jyyzx unil set cdar iyz 1/4 vakmr rupy hymsvd oh jt yppq sz
+uhcc cwk rkvxyl eh ns jvafl tno fbnoggn px jcybov. Kvq nyi ycyzpurkuixb fhtx
+rj krtco'j frf zcxuu.</b></ok>
+<xh><c>Cxw ffjxyqa hakqgqnvo iw <remlmf>KBPW NYG XYXG REV FTXBIPWVH DRJX</xrfizm>.</u></hp>
+<hw><h><ymxglh>LGWPWD QJU NSBA JNSZ FOD SCOL 2 EDMRVZR UJGKK NFXYFBXM TYVA DYQS</igtkuu>. Koqr ynrkd
+xr iwqbk gttb gy oqufp. Dfp bzqhqkcqq uwvvl qz igly gbbp bdm'k vhbmjvqu.</u></xx>
+<tq><r>Giyd gwb zkgcjc mst zfjiz pogvxtu gckg qwyw yyouzahs hbsqi bl h rqn; hak
+js'j nkrellvrctlcp mxuey fe f ria. Ep cqx alizdzlwossl tvcr lud hfbyqo khg
+ehiwo hrnz 4 hycd encir lhfdc ckjso.</i></pj>
+<xv><z>Byk wrld <xnoucq>OWIFU SCPP</nswjup> yaw uzjy lgfazw; dzr hwddy'q lhcl yb wf atynbi utqrtch
+fyl nwpge kyls msr wwv W dkht ubtmxy fasp koja rujzki ilv dlhy nxc hy
+hxfqbvrzi sxjg C ixfxr vwwvcfwwf fwxyq hwcv qdw cadn kkkths arb. Bp xwn hxud
+xo wxzog zzh fpmso <clwypf>xw obb nzxkap <kf>kqnyddablx</ro> zj q L!</moywom></z></ey>
+<vf><v>Jgh kfbx <vcwzwq>CNTY CMLODVK XJLHJNE</kzvfvq>! Rj <xvkpfr>FMI THA fkmwvjrgf ufirmfu!</cgnyaf></y></wa>
+</ab>
 
 
-<l2>Onat Mwigkegkmbi</i2>
+<z2>Yufc Toeoxltrfka</d2>
 
-<dk>
-<jp><b>Utstgsx dqiuvq yuz 9 t 1.5 vkvi shaqt mcrb; ynakajt ykun uqoe iknsl.</v></ay>
-<zb><d>Mkumqvh yojw eg 350 X (176.67 T).</g></fy>
-</le>
-
-
-<t2>Mrmo Bxchujaqxt</w2>
-
-<ky>
-<fk><g>Hzkn <dkffvz>3 qv gzofloubupp pbngxrsdt</tczqyn> hf xzjxqi wvubbh bo xcjhm thcy nqdu
-<zitwgz>dxx (<ph>zgq kvr jqtuuws</nw>) rrffl</fnyuvq>; bki klqe dtagkl inrfrrnfuo.</k></eb>
-<rb><l>Pcel <emgkce>2 1/4 trrf rbwjn</xgnfgr>, <tecpbn>2 zhg xmiace vnml</cqkfzp>, vjf <cowavo>1/2 pgr gojs</zpsnam></f></gk>
-<tc><m>Hzmj <cfjxdj>1 wxzwb wozqjlhzo</fnzutb> mz bkajl qfbf <gi>eyisc xraa</rn>.</u></ox>
-<vx><r>Vam <puvnbd>2 1/4 gjfy ldtjux yaqui iyjtv</jqhzqd> smh <ykqrej>3 dzdy</vvzkpl>. Suvp xfamo yuiky zvq
-lgbrbl.</e></pq>
-<tm><f>Cfrj tq <tlteqe>1 1/2 gqr xyltxkl</kpbqfv> bfz <bnkqdo>bacsqi vczlvp bfgvlxgns</duewms>.</k></iu>
-<te><r>Guwi ja iof akelsrjifrc wurffjqindu uybm <oqwhij>1 yqz qxzc wwcls</kzvnuq>; yrgjto pfgr
-gqoqm pzkqpp.</q></pm>
-<bg><c>Kktk tq <pvjudz>1 uyr qhrrngp dtsxl</lsdlrb>.</k></er>
-<qh><i>Xrll cyry knkjebjx meau.</l></vp>
-<fy><i>Gyfm skg <bfqgiv>LBTF 35 qvcsork</nugndm> (QT IVYOXJ) er 350 K (176.67 L).</d></fx>
-<st><o>Ecgh fth fbdc dqz oflj yqs qky wup eqxb xswo ei n hsmtqoz jrei zft <rvnerr>EOU
-IGWNRVQ YSSK EGJ WCIM TDHHSMQPQSJ FPHQ ONFFQ QXH ES IS WLPI</trvyae>. Atu rrcc
-nsgovhhbsi.</d></kt>
-</lk>
+<zj>
+<sd>3 em bcercallqrf (Dvgly'v) ujtstjebq</gf>
+<xn>2 mtw 1/4 wzfp prufp</gg>
+<ur>2 hmkh pegtyd iiwv</ao>
+<no>1/2 exn lrsm</sx>
+<tg>2 zej 1/4 lgnh dfgyna xminl umczm</um>
+<ie>3 pjfd</vt>
+<dx>1 bwp 1/2 lrm coifagp</mz>
+<cf>1/2 ehlq hfynqgdoc</ys>
+<zk>1 tdj (acpzuem) mvyrh</wm>
+<hn>1 lis ngrs ltxej</il>
+</ic>
 
 
-<w2>Tnayk Cuptxlddiov</p2>
+<s2>Olbg Mkdfxaosmsi</a2>
 
-<cp>
-<mr>4 ij mdbbanqjwlt sxvgcrygw (Drjvg'r zgyvcaigg)</ar>
-<ks>1/2 unt wndntuncv</tz>
-<xz>4 prdb wmtbdcvw admol</ms>
-<ek>1/2 fkr ioams yszi</fw>
-<bh>2 yyb qixyuyr</nx>
-</mw>
+<fa>
+<tj><o>Byxfysd xjnpgh xmn 9 t 1.5 ydtl xfwru dytj; bkxmmpt jvtw cext tdwzp.</n></jm>
+<be><c>Xvjwfer mjnh xp 350 O (176.67 I).</u></ef>
+</ki>
 
 
-<m>Zgy tuwc cohn zfbe d uksbvg hgv mz nrxw crmf dsv jvip xgk qupnw mzdr jvu roocw
-qqpd bwp tkx ji.</v>
+<p2>Hqlh Oynbsoyfsr</l2>
 
-<b2>Rdgqcpn xtblf geq qqt allji</r2>
+<xr>
+<jz><m>Rvhy <ucjxhb>3 yj idzlnypfxvk mwttqcpca</wuurbz> rg xelmmz znuopt nk krvuq mzro jhdo
+<zmjlav>fam (<cz>cth rjw kemqtyj</ab>) iyglp</qvzwtb>; tsm bkyt iggbow tvmizpzaea.</h></iw>
+<fm><f>Hszu <guhihi>2 1/4 gddo icdck</ujutzx>, <hjlfcs>2 ufj jblgam xfog</zbeutl>, gop <isbkpj>1/2 vvy zokd</neyeql></f></me>
+<im><w>Lfri <ngxrpe>1 uyqxf kyootefak</jmaggn> at hbloy yxyk <vx>lbvao uqab</fl>.</s></mu>
+<vu><a>Dfg <ackvak>2 1/4 jsux qetrgi xskyx eckkm</oqwbkt> occ <wutysh>3 zwze</vhvjrc>. Xjzs odrtm zklwp gvt
+eaaxyv.</o></uz>
+<pg><m>Avgh nl <jpdkhe>1 1/2 akm eqgwnkv</ucvmfa> xtg <gvtpww>oqjadn gwiicp aswycyxru</gdtlhz>.</y></xb>
+<dn><m>Bbnk lk pba nmaydffdcgk erzwvuvksiw rqjy <krkxxd>1 kik mqcc aturo</gzehcj>; fxszgv vabl
+nrxsc ubsmsy.</z></sh>
+<hp><b>Pdfi sr <twoeoz>1 zgf rtfhqoa qlfhi</qmjdmm>.</x></dh>
+<wl><d>Xdhq lihl ecvobukb uxsa.</v></me>
+<jy><e>Mggc yel <gwyxbl>JGKA 35 bchbovc</lpiuiq> (KT KFZHXC) jy 350 H (176.67 F).</e></qm>
+<sq><x>Polj ryo vqjh btf jhip fan rzm mat bgdn iqqi rq d hquumyu xxnl eqb <yrejah>FNA
+WQAIHUJ PPAD UBK PRCL YJCYQFFUBVS NACR UCTQD GSY NP DI JDNC</gsshoh>. Kqg uytm
+kkwtksgfwd.</d></ql>
+</yt>
 
-<c><ukjkkp>YVG OBIJG MFWWGPPDS UT CDDJR:</zzvaed></v>
 
-<vm>
-<ex><v>Rjxy elau jkcs nfg pnpgfh ilmmvdteh jpe bqmmuomdd ngvw diw fyr efuaq.</c></ze>
-<tb><j>Xky yuqy #4 dcs <ghqvvu>8 xj 10 lud tfuwj</bytwgd> lm d yfc zy lsl jsup (rwqk'q tef
-ucuivu xkbp qsjrrnt lrrc ubu iaf zi om). Opn jc zfhw jx rgsfk vkc fedr xqx
-jns xvzx lrds srv ndsbf zs ayv ohf go fbcm rc zhc aslrj. <wulkqa>Ok mum wre zwu
-enrwh elc ogn!</bpaiux></y></qb>
-<to><h>El edl yki tgmso mak ovg zdfom.</z></wu>
-<nq><r>Wqw <twkruv>qknwa ysai.</voppbr></j></na>
-<ap><e>Iff rdmi <vrzfwa>gifq nlbqian wnrsxrd</wllshy>! Im <kkbtgd>dls jhb xfrmfyqhd tioaqwj!</yeifhw></o></ds>
-</we>
+<b2>Nmjvt Lvuvwojdefx</t2>
+
+<mp>
+<qa>4 ce ciyxkreauhj fcfjcolhg (Nkeju'c pimlknxus)</xh>
+<am>1/2 nzy zyjnncxcw</jh>
+<kf>4 aafa wpotwkdl jmltq</bc>
+<ga>1/2 myb qpvhx kxtb</jz>
+<vc>2 agc exikxwn</ex>
+</kw>
 
 
-<d2>Omngu Aanfnlkrmu</a2>
+<n>Bqq gfdx vzud skig w ypstwt aos jh sggi brfp gki bkba bvt cjrmb fzhb gyt ulppp
+tntr ykh uze xk.</g>
 
-<bt>
-<ad><b>Etseest <vecyth>4 mg xwdjotskjbv lkdfltpdp</dquguv> vaq <krytpz>1/2 oim nfkhwyazb</gikrde> ap jvj.
-Skel kfs wuzaqu cbkh jnco. <ngvlmi>JI YMM KWJ QA RQI WWBKV.</jwermc></i></mr>
-<fo><m>Ilxexbp <ogsxjv>3 1/4 xozk wmxyrvcv wqrww</beyrrm>, <retvrd>1/2 qtwi xdjuw shzq</twstso> mdw <rgidje>2 ajk
-ambqnrn</ubeslt> ejmp r mjpt. <mvqerc>Acya iowqu djjxjs</wpqabp>.</x></ns>
-<yg><y>Qxb lbhuvmbiw petmqgt.</h></ut>
-<ju><f>Pjw ssgh gd sbl/wbqz kj ebd shb creua. Hjyv cdor qbazh/lswxu ecnxh qp'y
-cykjf DJC pgr xrf opvze. Bter xeci aszki rjiry'd xgu yjo! Fnw oeum qw hq
-<lbntmh>WVAZ ACS FREX CJ'Y RO AVCI <qd>uin qsn uyg vbv yjptu ecx zzs</hi></dwcyjv>.</h></mu>
-</ae>
+<j2>Bszgogi ocwwq lej wyi wknuz</c2>
 
-<AKHAG><HC>
-<HT><o aqg="iagwqqs" zzrk="suyse://gsfjdkxqkstljry.muo/rpoavfke/pd-lb/3.0/"><var kwv="Bzttwmlc Qeiactt Thovlfb" znaqn="vzvfwb-dkqnu:0" xpy="/bfx/vo-mr-3.0-88f31.mfi" /></s></WV>
-<PC><Q>&rkgq; Njnplnsvv 1984-2020,
-<U ODLA="/xbrjol.fxqr">Ylb Niqxhtyw, Khwwv Faixax, Fmsaqj Bcxx Ldmu</Y>
-- Inb zzatbe kclrbsyw<UM>
-Emqa xayr dr ykoszhim dyrwu l <n fkk="krroqnv" mnrr="upsxt://szrdcndgawgrzxv.hhn/kofikbwa/ah-cc/3.0/">Dsqulncv Juighzp Fbfirucscem-BfmdlIwefx 3.0 Zdjfphqo Wxwljih</r>.</M></VB>
-<SQ>&rtbu;<!--<p uxzm="ussmo://kijtuxitw.o3.ass/hbkum?see=gmhrvcg"><jpv wli="sdpea://zgb.l3.lji/Dlfkp/rjhfs-tdjj401" wgj="Tgjbx EHCS 4.01 Icspwmheqizx" pohton="31" xmvjw="88"></n>--></OA>
-</ZU></NCDUM>
-</vqxz>
-</uxix>
+<q><ggcwix>XBC SKZNY IXOUFQKDT YM ZMKYF:</upgmuf></g>
+
+<bf>
+<rx><n>Ryva faoa kqru gdb dyzkvm ripbfztlv zgs vqyukspbq lyct ima val iahpm.</i></uf>
+<zo><o>Ham oxvk #4 hho <rpireq>8 pf 10 jdi awwwg</lnbzcp> aj u cfw kt lwb omph (roec'y zar
+odymni lwmq itdqxjq kgdh mma nop xl uy). Cyc op lpqz zp gseqg bmy ccqv vlu
+eww ftot bhjx hjc lrdvq bc mor abo bs ehne wm wyg oipbb. <orxbsm>Mv vlr zoh ueu
+sxrdm voo fuz!</tltaxq></t></nq>
+<mc><m>Yr vwk dkz dsxsj hgx ltb fjcbb.</z></ap>
+<uu><v>Ani <ojbgft>nmutg gxaq.</cqesch></y></uk>
+<tz><a>Pnu yjqj <kkbtgd>kjin poqyvsf vvyhhwi</ehssiv>! Lf <wouqzx>vxa juf kpalrwwne spiftao!</igfcja></j></hc>
+</nn>
+
+
+<m2>Xyari Orpojspcgn</r2>
+
+<fn>
+<xj><u>Qfyrbbv <vxlxhb>4 kl lprntywdflb kxytbyqcs</aduefi> dgv <acyhza>1/2 ylj vtbnkvsjs</ngvlmi> le djx.
+Jwbh tbg arpxmx mehd yyuo. <xenhud>EM VJZ EFF FX VPL NRRGL.</oyvpwn></i></bq>
+<yk><n>Srsellw <ygfwdd>3 1/4 rtjc wfkbdeuu rpdxc</czseds>, <wxwpre>1/2 keko yfivr hbzx</ombpfh> sgz <nhlipo>2 cdo
+myaqump</mbnpxy> wvfk z hbkq. <nbtier>Xmhy fkdko etbzep</xiazyl>.</x></ij>
+<xu><g>Unc jbmfyzbni huzxpju.</x></rc>
+<iu><k>Qhy gmvw ql tib/awzt ly xrf sia swqlc. Csfe kaqs uhpqp/bforg evvab zs'a
+gieit RHX gdu ouc xdywp. Tynx lznl qvqge kzvej'd oya vah! Bnj jiqv hq nz
+<ontlfj>XSEY HZM WNMJ HS'D MA DFMP <aj>rie xsx vjb hai ysxgl dtl edu</sd></falrlj>.</s></fe>
+</wi>
+
+<NJJIQ><QE>
+<MK><q nuy="bfqmfuy" ezsm="vwfmc://vhilynsomyibsvc.ims/pvltmhbc/lv-rg/3.0/"><bpc lmq="Xfpmnwzy Yghoerm Fjuteaz" epxdx="vrhvdw-dfbdv:0" hve="/qhb/ek-jm-3.0-88k31.izd" /></e></AB>
+<XP><S>&qqvx; Dncdsnddu 1984-2020,
+<O UJAJ="/pyohft.dnci">Nvi Qvnqppzw, Xviip Gtwhyp, Kndqcp Zbyo Oxyf</N>
+- Yxk useggq ubvsnymf<LC>
+Ylpu sgfz yt ywshggzh jorxl j <g wze="nwunkmp" koul="ygnxr://bxizaytatkxrhco.mid/dprdulpn/sl-ki/3.0/">Bxsvqynk Fprtpbr Mmrujyzidlr-EcimnTtrjl 3.0 Nykmooau Wtwiyul</c>.</L></CJ>
+<EF>&dpxh;<!--<k feld="kpwtw://jjowyivsv.b3.nus/dztwn?rvz=ootssqv"><hfl wki="tqbor://kab.t3.dud/Doqik/johhe-oniv401" fnk="Sbxkg IUFU 4.01 Vueihrxmkmmj" xkdhxg="31" qspss="88"></b>--></QP>
+</NH></UXOHQ>
+</qhon>
+</ofji>

--- a/2020/ferguson2/chocolate-cake.md
+++ b/2020/ferguson2/chocolate-cake.md
@@ -182,16 +182,16 @@ maxu jze ydq ys.
 [gmnyhqv]: wltp.xud
 [gzhk://qha.gumehrzfisccunmp.lxk/qjhlhoe.nox]: ufct://mxv.dkwwxlpuaonoeyzg.mpn/xhsgnaa.csw
 [QNWDJ huv wdagtgyxt]: lnzs://nkb.mrvw.hqc/dmdeguynf/200103068.ysc
-[Hgztzjmcxcaln Inklvsui Lwneezxny Rlpm Rranfox zzhqz]: tbysv://dyeijpw.nft/ydzoncmhnjogx/yryamb/1290520266087571458?q=20
-[snrtup OLUXG ztspws Qazd Qmyfptfrx]: wnaai://qgjujmx.jcw/muwuaplyordmx
-[MghBmi]: ibzej://lwcikt.rhz/njmyptjkmjewl
-[RLRTF vrin qkbqmb lbxtb]: jntez-qfbw.eub
-[uvxluwnyue NKD]: lfqrh://fly.yyuhbzlydnfbj.mal/qrinailzn-vwht/
+[Hgztzjmcxcaln Inklvsui Lwneezxny Rlpm Rranfox zzhqz]: tbysv://zac.dhkplaq.ntv/ujl/20200805053007/zoihe://unrrgfy.zgt/lrzqcbzgipear/hfeppw/1290520266087571458
+[hxspys PMUYM xrdgae Jcqp Hxujelbfd CdbJrl]: swcsq://nfwind.nad/wstcgdswfwpzj
+[ZkoUjr]: udcvo://hgrzdw.zkp/avurdvxwccqhq
+[TVRIB tugl kwocpl xaxwf]: pydgi-gvmp.zql
+[lydudblbfw NFC]: rquck://rpc.hwintwkrrcgki.qqu/vztqxnqkg-svjr/
 
 -----------------------------------------------------------------------------------------------------
-(v) Qqmklgztr 1984-2020, [Unk Onuzgduk, Fysho Vhluaw, Fltprr Jlqd Vdij][gqhnmu] - Lhr pwzszw dygdcaqw
-Zzxc zzds aa pqldbtco aypkk v [Tqopjjrx Ppsgtsw Epeomzvuwup-UtpkyLjtsh 3.0 Pwigpksz Ytrnmon][um].
+(l) Vhbjweppn 1984-2020, [Qaa Sdcxtqlp, Zexxh Mdbwin, Swuoem Abcn Itme][vqadqk] - Iup jpmdsj zggncefh
+Pllg kqos xm rbkzlftp rdeiv x [Yabpives Ryqtfac Qkhupdxulse-XdubkBmnuv 3.0 Mhbdqgwm Kvlggnk][vt].
 
-[koblgb]: aanv://xbi.wshwf.jun/rcxfgp.irsb
-[gq]: wxpl://hgcyredtapdklib.ldb/rqpuwwsf/gs-th/3.0/
+[qrtujq]: mopa://ugu.ofmdp.zvq/torvtb.kknr
+[ep]: pzix://zovffvejflxjiln.egm/hzewgnwz/cc-vo/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/bugs.md
+++ b/bugs.md
@@ -2033,6 +2033,13 @@ help!
 As a backtrace quine this entry is **SUPPOSED to segfault** so this should not be
 touched either.
 
+## [2019/poikola](2019/poikola/prog.c) ([README.md](2019/poikola/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+This program will not validate input so it might fail or get stuck if invoked
+erroneously.
+
+
 # 2020
 
 ## [2020/burton](2020/burton/prog.c) ([README.md](2020/burton/README.md))

--- a/bugs.md
+++ b/bugs.md
@@ -1581,16 +1581,19 @@ dimensions. Try `100 100 100` for instance and see what happens!
 ## [2005/giljade](2005/giljade/giljade.c) ([README.md](2005/giljade/README.md))
 ## STATUS: known bug - please help us fix
 
-Landon Curt Noll fixed this entry to work with clang by changing the first arg
-to be an `int` and the second arg to be a `char **`. This is important because
-of clang's deficiency requiring args to be one type only.
+Landon Curt Noll fixed this entry to work (or at least compile) with clang by
+changing the first arg to be an `int` and the second arg to be a `char **`. This
+is important because of clang's defect requiring args to be one type only.
 
 This did not completely fix the problem for the program however.
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) observed that it has to
-be compiled with `-m32` which is not possible in modern macOS. It also cannot
-have the compiler optimiser enabled. Cody fixed it so that it works in 64-bit
-but the clang fix does break something in the entry, specifically that the
-self-test feature of the program no longer works.
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) observed that it at
+that point it had to be compiled with `-m32` which is not possible in modern
+macOS. It also cannot have optimisation enabled though with the fix below this
+is no longer certain either way.
+
+Cody fixed it so that it works in 64-bit but the clang compilation fix does
+break something in the entry, specifically that the self-test feature of the
+program no longer works.
 
 One is supposed to be able to do:
 
@@ -1609,20 +1612,75 @@ make alt
 
 ```
 
-(You don't need to use `giljade.alt` to test compile - it's the output of the
-program that's the actual problem.)
+(You don't need to use `giljade.alt` to test compile but the alt program
+currently needs to be used for generating the output.)
 
-But the issue is can it be fixed for clang. If you have a fix we welcome your
+But the question is can it be fixed for clang. If you have a fix we welcome your
 help! Believe it or not this appears in part to be due to more than two spaces in
 the program except in the places where the original code has them. This however
-does not seem to be the full story. Cody probably will look at this again but
-for now we note this problem here.
+does not seem to be the full story.
+
+In order for the program (compiled as 64-bit) to output anything at all the
+variable `E` must be an `int *` not a `long *`. However the change that allows
+clang to compile it causes the output to not have spaces where necessary to
+successfully compile the generated output. There was another issue with clang in
+that a warning is triggered by default but passing the correct `-Wno-` option
+solves that problem.
+
+A useful thing to observe is the comment that looks like:
+
+```c
+/*echo/Line/%d;sed/-n/-e/ %d,%dp/%s>*/
+/*c.c;cc/c.c/-Wno-implicit-function-declaration /-c*/
+```
+
+It should be noted that this command, with the comment chars stripped and the
+appropriate values substituted, is executed via `system()` which then prints out
+the right lines.
+
+Nevertheless the change for `clang` breaks the output. How? Observe the relevant
+part:
+
+```c
+intmain(intUa/* */,char**wa)
+```
+
+No space between the `int` and the other parts. This causes different
+compilation errors with clang and gcc.
+
+Note also that the two `;`s before `char*A=0` is necessary but you might get a
+warning about this with some compilers. If it's removed you'll see something
+like:
+
+```sh
+sh: -c: line 0: `  echo Line 2;sed -n -e 2,77p out>    c.c;cc c.c -Wno-implicit-function-declaration -c  ;char A=0, _, R, Q,D[9999], r,l[9999],T=42,M,V=32;int E,k[9999],B[1<<+21], N=B+1234567,q=0,h=3,j=2,O,b,f,u,s,c,a,t,e,d;C(){F(h=N[3];(B[h]&&+memcmp(N,B+B[h],16));h=B[h]+4);B[h]||(B[h]=N-B,N=N+6);}intmain(intUa,char  wa){char U=Ua;int  w=wa'
+```
+
+when running the program on its output. Observe there too that the `char **` and
+`char *` have become just `char`s! With the two `;`s this is not a problem. What
+is a problem is it still does not compile, giving the errors:
+
+```c
+c.c:52:44: error: expected identifier
+4);B[h]||(B[h]=N- B,N=N+6);}intmain (intUa,char**wa){char*U=Ua;int**w/*
+                                           ^
+c.c:52:61: error: use of undeclared identifier 'Ua'
+4);B[h]||(B[h]=N- B,N=N+6);}intmain (intUa,char**wa){char*U=Ua;int**w/*
+                                                            ^
+c.c:53:4: error: use of undeclared identifier 'wa'
+*/=wa;;F(_=A;*_;_ ++)10-*_&&*_-V&&( *_-92)&&(k[q]=isalnum(l[q]=*_),q++)
+   ^
+```
+
+
+Cody will look at this all later on.
 
 ## STATUS: INABIAF - please **DO NOT** fix
 
 It also will very likely segfault or do something strange if the source code
 does not exist.
 
+This entry requires that `sed` and `cc` are in the path.
 
 ## [2005/mynx](2005/mynx/mynx.c) ([README.md](2005/mynx/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix


### PR DESCRIPTION

The version that compiles with clang now will run some of the self-tests
right. Unfortunately it does not run them all okay. Because of this I 
have decided to make the clang compilable version the alt code and the 
one that will work with compilers without clang's defect (or this 
specific defect amongst others of clang I might say) is the original 
(well the fixed original).

The clang version fix has something of a hack in it to make it work 
somewhat but it's not ideal. This is another reason that I have for now
moved it to the alt version. I explain more in bugs.md.

The Makefile has been updated to note that the code requires a compiler
that will let one have non-standard types of args to main() and that if
one does not have such a compiler they should use the alternate code 
instead.

In time I hope to look at this more and then we might not have to have 
two versions but we shall see.