### PR TITLE
Add note about sockets lying about in 2019/duble

### DIFF
--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -137,6 +137,8 @@ all: data ${TARGET}
 
 ${PROG}:
 	${MAKE} `${UNAME}`
+	@echo "WARNING: this entry will likely leave sockets lying about in the current"
+	@echo "working directory. See the bugs.md and README.md for details."
 
 check-os: check-os.sh
 	${SHELL} ./check-os.sh ${LINES} ${COLUMNS}

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -33,6 +33,17 @@ WARNING: if the file is deleted it might lock any session still in use. These
 will have to be killed from another shell session or by closing the terminal
 tab.
 
+NOTE: this entry might leave sockets lying about in the current working
+directory which you'll have to delete manually. Here's an example in macOS:
+
+```sh
+$ ls -al
+srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:19 .BDHFHALG
+srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:15 .CGGHAMGC
+srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:16 .CMDGAELH
+...
+```
+
 ### Alternate code:
 
 An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.  This alternate
@@ -48,8 +59,8 @@ Use `prog.alt` as you would `prog` above.
 
 ## Judges' remarks:
 
-After starting the program, use the cursor keys, then try some modes, like "p"
-or "l" (they toggle).
+After starting the program, use the cursor keys, then try some modes, like `p`
+or `l` (they toggle).
 
 ## Author's remarks:
 
@@ -69,13 +80,15 @@ To build, type `make` (assuming gcc) or `make CC=clang`.
 
 Then you can start the program. It expects a file path as its first argument:
 
-    $ ./prog /tmp/drawing
+```sh
+./prog /tmp/drawing
+```
 
 (If not started this way, `prog` will refuse to start.)
 
 If the file does not exist, you will start with a blank drawing.
 
-If someone else (or another *instance of yourself*, maybe??) is already
+If someone else (or another *instance of yourself*, maybe?) is already
 editing this file, you will join the session!
 
 ### Edition features:

--- a/bugs.md
+++ b/bugs.md
@@ -2066,6 +2066,26 @@ but this is expected and the file `ioccc.html` will be generated properly.
 
 # 2019
 
+## [2019/duble](2019/duble/prog.c) ([README.md](2019/duble/README.md)
+## STATUS: INABIAF - please **DO NOT** fix
+
+This program will very likely leave sockets lying about in the current working
+directory. For instance [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
+showed us this:
+
+```sh
+$ ls -al |grep '^s'
+srwxr-xr-x   1 cody  staff     0 Apr  6 08:19 .BDHFHALG=
+srwxr-xr-x   1 cody  staff     0 Apr  6 08:15 .CGGHAMGC=
+srwxr-xr-x   1 cody  staff     0 Apr  6 08:16 .CMDGAELH=
+srwxr-xr-x   1 cody  staff     0 Apr  3 08:47 .CMLBCCDA=
+[...]
+```
+
+This is NOT a bug and you'll have to (at least at this time?) delete the files
+manually. You shouldn't have to worry about these being added to git: it seems
+to ignore sockets (it did at least in macOS).
+
 ## [2019/ciura](2019/ciura/prog.c) ([README.md](2019/ciura/README.md))
 ## STATUS: known bug - please help us fix
 


### PR DESCRIPTION
The entry appears to leave sockets lying about in the current working directory. Although undesirable this is not a bug it's a feature. Updated bugs.md and the README.md file as well as the Makefile.

A useful thing I thought of that might be good to look at for other entries that show notes in the Makefile is that it might be good (and in this entry I did do it) to have the note _after_ compilation as it will be more likely seen. In the case of entries that might not compile with clang (due to some defects in it) it will have to be done with either || or else printed before the compilation (for instance in some of these we have to say that one should use make alt for clang).

This will be added to the todo.md in a future commit.