### PR TITLE
Fix details about 2019/duble sockets

### DIFF
--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -137,6 +137,8 @@ all: data ${TARGET}
 
 ${PROG}:
 	${MAKE} `${UNAME}`
+	@echo "WARNING: this entry will likely leave sockets lying about in the current"
+	@echo "working directory. See the bugs.md and README.md for details."
 
 check-os: check-os.sh
 	${SHELL} ./check-os.sh ${LINES} ${COLUMNS}

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -33,6 +33,17 @@ WARNING: if the file is deleted it might lock any session still in use. These
 will have to be killed from another shell session or by closing the terminal
 tab.
 
+NOTE: this entry might leave sockets lying about in the current working
+directory which you'll have to delete manually. Here's an example in macOS:
+
+```sh
+$ ls -al
+srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:19 .BDHFHALG
+srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:15 .CGGHAMGC
+srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:16 .CMDGAELH
+...
+```
+
 ### Alternate code:
 
 An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.  This alternate
@@ -48,8 +59,8 @@ Use `prog.alt` as you would `prog` above.
 
 ## Judges' remarks:
 
-After starting the program, use the cursor keys, then try some modes, like "p"
-or "l" (they toggle).
+After starting the program, use the cursor keys, then try some modes, like `p`
+or `l` (they toggle).
 
 ## Author's remarks:
 
@@ -69,13 +80,15 @@ To build, type `make` (assuming gcc) or `make CC=clang`.
 
 Then you can start the program. It expects a file path as its first argument:
 
-    $ ./prog /tmp/drawing
+```sh
+./prog /tmp/drawing
+```
 
 (If not started this way, `prog` will refuse to start.)
 
 If the file does not exist, you will start with a blank drawing.
 
-If someone else (or another *instance of yourself*, maybe??) is already
+If someone else (or another *instance of yourself*, maybe?) is already
 editing this file, you will join the session!
 
 ### Edition features:

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -29,6 +29,9 @@ Open another window / terminal.
 
 Open more terminals and repeat...
 
+### INABIAF - it's not a bug it's a feature! :-)
+
+
 WARNING: if the file is deleted it might lock any session still in use. These
 will have to be killed from another shell session or by closing the terminal
 tab.
@@ -43,6 +46,20 @@ srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:15 .CGGHAMGC
 srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:16 .CMDGAELH
 ...
 ```
+
+To get a list of files with this glob try:
+
+```sh
+ls -al |awk '{print $NF}' | grep -E '^\.[A-Z]+'
+```
+
+To delete them you can do:
+
+```sh
+find . -name '.[A-Z]*' -delete
+```
+
+though one might want to check that the program is not currently running. :-)
 
 ### Alternate code:
 

--- a/bugs.md
+++ b/bugs.md
@@ -2086,6 +2086,20 @@ This is NOT a bug and you'll have to (at least at this time?) delete the files
 manually. You shouldn't have to worry about these being added to git: it seems
 to ignore sockets (it did at least in macOS).
 
+NOTE: To get a list of files with this glob try:
+
+```sh
+ls -al |awk '{print $NF}' | grep -E '^\.[A-Z]+'
+```
+
+To delete them you can do:
+
+```sh
+find . -name '.[A-Z]*' -delete
+```
+
+though one might want to check that the program is not currently running. :-)
+
 ## [2019/ciura](2019/ciura/prog.c) ([README.md](2019/ciura/README.md))
 ## STATUS: known bug - please help us fix
 

--- a/bugs.md
+++ b/bugs.md
@@ -2066,6 +2066,26 @@ but this is expected and the file `ioccc.html` will be generated properly.
 
 # 2019
 
+## [2019/duble](2019/duble/prog.c) ([README.md](2019/duble/README.md)
+## STATUS: INABIAF - please **DO NOT** fix
+
+This program will very likely leave sockets lying about in the current working
+directory. For instance [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
+showed us this:
+
+```sh
+$ ls -al |grep '^s'
+srwxr-xr-x   1 cody  staff     0 Apr  6 08:19 .BDHFHALG=
+srwxr-xr-x   1 cody  staff     0 Apr  6 08:15 .CGGHAMGC=
+srwxr-xr-x   1 cody  staff     0 Apr  6 08:16 .CMDGAELH=
+srwxr-xr-x   1 cody  staff     0 Apr  3 08:47 .CMLBCCDA=
+[...]
+```
+
+This is NOT a bug and you'll have to (at least at this time?) delete the files
+manually. You shouldn't have to worry about these being added to git: it seems
+to ignore sockets (it did at least in macOS).
+
 ## [2019/ciura](2019/ciura/prog.c) ([README.md](2019/ciura/README.md))
 ## STATUS: known bug - please help us fix
 

--- a/todo.md
+++ b/todo.md
@@ -1,12 +1,12 @@
 # A todo list of known things to check and/or do
-*Last updated: Wed 24 May 2023 12:35:37 UTC*
+*Last updated: Wed 31 May 2023 09:52:55 UTC*
 
 More things will likely be added over time and as items are done they _should
-be_ removed from the list IF AND ONLY IF (!!) we are certain it is done (many
-times it's thought that this was done only to find out that they are not). It is
-hoped that this will be referenced and updated as this is an easy way to keep
-track of things that have been done already and what have not been done (mostly
-not been done).
+be_ removed from the list IF AND ONLY IF (!!) we are _absolutely certain_ it is
+done (many times it's thought that a task was done only to find out it wasn't).
+It is hoped that this will be referenced and updated as this is an easy way to
+keep track of things that have been done already and what hasn't been done (in
+this file the case is mostly _NOT_ been done).
 
 - Find entries with bugs as well INABIAF and add to [bugs.md](/bugs.md).
     For instance a INABIAF section should be added to [bugs.md](bugs.md) for
@@ -47,14 +47,20 @@ fix any issues.
     except that a few years I am pretty sure I did not check typos (I'd say about
     1987 or 1988 through 1995 should be rechecked for typos).  It's very likely
     I won't keep this updated until it's finished but I wanted to note it now.
+    * NOTE: a while back (as of 31 May 2023) Cody noticed that some of the files
+    he already checked could be improved wrt formatting so he'll have to have a
+    quick look at the previously edited files; some he has done already but the
+    vast majority have not been checked. These should be relatively easy to fix
+    but will only be done _after_ the rest of the files are processed
+    (presumably with complete changes made :-) ).
 
 - Remove addresses from older winning entries but (if known) keep country code +
 add country code to winners.csv. As of half past 4 Pacific time on 22 April 2023
-only the years through 1986 are done. This should not take much time but I
-(Cody) am bored with it for now and would rather do other more important things.
-This will likely not be updated until after it's done (and when I remember to
-remove it - I expect that when I go for it I'll do it in one sitting or maybe a
-few sittings with a few brief breaks).
+only the years through 1986 have been done entirely. This should not take much
+time but I (Cody) am bored with it for now and would rather do other more
+important things.  This will likely not be updated until after it's done (and
+when I remember to remove it - I expect that when I go for it I'll do it in one
+sitting or maybe a few sittings with a few brief breaks).
 
 - Verify that [2004/gavin](2004/gavin/)'s [img/fs.tar](2004/gavin/img/fs.tar)
 contains the same version of files as under [2004/gavin](2004/gavin/) itself.
@@ -66,4 +72,17 @@ subdirectory and then typing the below from the entry's main directory
 
 - Try and see if I (Cody) can make [1985/sicherman](1985/sicherman/sicherman.c)
 even more like its original form. I have some ideas here but it might involve
-some discussion too.
+some discussion too. See 22 May 2023 commits for the improvements already made.
+
+- Check all Makefiles for notes / warnings on compilation and see if they can be
+moved to _after_ the compilation as they're more likely to be seen this way. In
+some cases this will have to be done in the Makefile via `|| :` (that might be
+good to have in the Makefiles anyway so that additional rules / targets are
+run) or else they'll have to be put above the compilation.
+    * Make compilation of targets use `|| :` in the Makefiles to allow
+    additional targets to compile and/or let warnings/notes be printed. An
+    important use of this is that some entries won't compile with clang due to
+    defects but the alternate version will. Whether this is a good idea is TBD
+    but it's noted here as a reminder to be discussed.
+
+


### PR DESCRIPTION

Of course the globs do not have a = at the end of the line; that's from
an aliased ls that shows different characters at EOL depending on the 
file type.

I also explained how to delete these files assuming that glob pattern.

In the README.md this was done in the new INABIAF section which is where
it belonged in the first place.