### PR TITLE
Fix command to find sockets in 2019/duble

### DIFF
--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -128,6 +128,8 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+	@echo "NOTE: in linux after running this program it might drop core dumps"
+	@echo "even though it doesn't show any error."
 
 # alternative executable
 #

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -11,24 +11,29 @@ make all
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for modern
 compilers. There were two problems to address. One was that the entry required
-`-traditional-cpp` which it no longer does. It needed this because of two things
+`-traditional-cpp` (which <strike>not all compilers support</strike> `clang`
+does not support) which Cody fixed. It needed that option because of two things
 it did:
 
 ```c
 #define a(x)get/***/x/***/id())
 
+/* ... */
+
 p Z=chroot("/");L(!a(u)execv((q(v="/ipu6ljov"),v),C);Z-=kill(l);
 
-...
+/* ... */
 
 case_2:L(!--V){O/*/*/c*c+c);wait(A+c*c-c);L(!Z)f(A,"\n",c);return(A*getgid());};C++;
 ```
 
-does not work to create `getuid()` and `getgid()`. The second is that
+no longer works to create `getuid()` and `getgid()`. The second is that
 
-    for/*/(;;);/*/k()){O/*/*/c);
+```c
+for/*/(;;);/*/k()){O/*/*/c);
+```
 
-cannot form 'fork())' in modern C compilers. What is quite fun is that the cpp
+cannot form `fork())` in modern C compilers. What is quite fun is that the cpp
 can!
 
 The other problem was that modern compilers do not allow directives like:
@@ -49,8 +54,6 @@ so Cody changed the lines to be in the form of:
 
 Thank you Cody for your assistance!
 
-
-
 ## Try:
 
 ```sh
@@ -58,8 +61,20 @@ Thank you Cody for your assistance!
 ./dale these files are in this directory: *
 ```
 
-NOTE: in linux it might happen that core dumps are created when running this
-entry even though it works fine.
+What do the following commands do and why do they do it? Why do they differ in
+format from the above command? Finally how can you get the more likely desired
+behaviour?
+
+
+```sh
+./dale $(printf "the following files exist in this directory:\n%s\n" *)
+./dale "$(printf "the following files exist in this directory:\n%s\n" *)"
+```
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+In linux it might happen that core dumps are created when running this entry
+even though it works fine and you don't see any message about dumping core.
 
 ### Alternate code
 
@@ -67,7 +82,7 @@ If you have an old enough compiler you can try the original version in
 [dale.alt.c](dale.alt.c). To use:
 
 ```sh
-make alt
+make clobber alt
 ```
 
 Use `dale.alt` as you would `dale` above.

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -1,10 +1,8 @@
 # Best One-liner
 
 Laurion Burchall  
-Brown University  
-Unit 4641  
-Providence RI 02912-4641  
 US  
+<https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/>
 
 ## To build:
 

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -62,14 +62,14 @@ vi README.md
 
 Press and hold any key.
 
-### Alternate method
+### Alternate method:
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh)  provided the `kernel` and `fs.tar`
 files which can be used if you cannot normally use this entry. Instead of
 generating the files just use the files provided, found under the [img/](img/)
 directory. Note that the `img/fs.tar` extracts into `fs/` so you will have to
-fix the tarball; this is done to prevent extraction from the entry directory
-overwriting the files and preventing `make clobber` from wiping some of them
+fix the tarball; this is done this way to prevent extraction from the entry
+directory overwriting the files and causing `make clobber` to wipe some of them
 out.
 
 Thank you Yusuke!
@@ -95,7 +95,7 @@ but your experience will be limited (replace `-DK=0` with `-DK=1` in the
 [Makefile](Makefile), and you will have to move the mouse to trigger the initial
 screen update).
 
-The judges were able to write a few more programs to run on this OS
+The judges were able to write a few more programs to run in this OS.
 What are the limitations for such programs?
 
 What you can do and what you cannot do in such programs?

--- a/2004/gavin/gavin.md
+++ b/2004/gavin/gavin.md
@@ -6,7 +6,7 @@ other than Linux you may need modify the [Makefile](Makefile) to compile `sh`
 using a cross-compiler that produces ELF binaries - i.e. a cross-compiler
 targeting x86 Linux.  In short, you need to build this on an x86 Linux machine.
 
-2) Next, find a suitable machine to run the OS on.  It should be perfectly safe,
+2. Next, find a suitable machine to run the OS on.  It should be perfectly safe,
 and since it does not directly attempt to access any hard disk drives (only a
 ramdisk loaded by the bootloader) it should do no damage to your existing setup,
 BUT I ACCEPT NO LIABILITY FOR ANY DAMAGE DONE BY THIS PROGRAM.  Run it at your

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -50,7 +50,7 @@ srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:16 .CMDGAELH
 To get a list of files with this glob try:
 
 ```sh
-ls -al |awk '{print $NF}' | grep -E '^\.[A-Z]+'
+ls -al|awk '{print $NF}'|grep -E '^\.[A-Z]{2,}'
 ```
 
 To delete them you can do:

--- a/bugs.md
+++ b/bugs.md
@@ -519,6 +519,11 @@ so maybe he's doing something wrong.
 
 # 1988
 
+## [1988/dale](1988/dale/dale.c) ([README.md](1988/dale/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+In linux it might happen that despite no error message or message about doing
+so, the program drops a core file into the directory.
 
 # 1989
 

--- a/tmp/author.csv
+++ b/tmp/author.csv
@@ -41,7 +41,7 @@ briddlebane,Moxen N. Briddlebane,Moxen_N_Briddlebane,null,moxen@gateway.net,null
 bright,Walter Bright,Walter_Bright,http://www.walterbright.com/,emperor@classicempire.com,null,null,null,null,
 broukhis,Leonid A. Broukhis,Leonid_A_Broukhis,http://www.mailcom.com/leob,leob@mailcom.com,US,null,null,null,
 bsoup,bsoup,bsoup,null,mail@bsoup.skr.jp,JP,null,null,null,
-burchall,Laurion Burchall,Laurion_Burchall,http://www.netspace.org/users/ldb,ldb@netspace.org,null,null,null,null,
+burchall,Laurion Burchall,Laurion_Burchall,https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/,ldb@netspace.org,null,null,null,null,
 burley,Brent Burley,Brent_Burley,null,brent.burley@disney.com,US,null,null,null,
 burton,Dave Burton,Dave_Burton,http://snox.net/ioccc,daveb@snox.net,US,@lv2jmp,null,null,
 buttimore,Gavin Buttimore,Gavin_Buttimore,null,gavin.buttimore@creaturelabs.com,null,null,null,null,

--- a/winners.html
+++ b/winners.html
@@ -240,7 +240,7 @@ Contest </I></FONT></CENTER><BR>
 <LI TYPE=square>Best solved puzzle (<A HREF="years.html#2011_hamaji">2011 hamaji</A>)
 </UL><BR>
 
-<LI TYPE=none><A NAME="Laurion_Burchall"></A><B><a href="&#x6D;&#x61;&#105;&#108;&#116;o&#x3A;&#108;&#x64;&#x62;&#64;&#x6E;&#x65;&#116;&#115;p&#x61;&#x63;&#101;&#x2E;&#x6F;&#x72;&#x67;">Laurion Burchall</a></B> -- <A HREF="http://www.netspace.org/users/ldb">http://www.netspace.org/users/ldb</a>
+<LI TYPE=none><A NAME="Laurion_Burchall"></A><B><a href="&#x6D;&#x61;&#105;&#108;&#116;o&#x3A;&#108;&#x64;&#x62;&#64;&#x6E;&#x65;&#116;&#115;p&#x61;&#x63;&#101;&#x2E;&#x6F;&#x72;&#x67;">Laurion Burchall</a></B> -- <A HREF="https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/">https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/</a>
 <UL>
 <LI TYPE=square>Best One-liner (<A HREF="years.html#1994_ldb">1994 ldb</A>)
 </UL><BR>


### PR DESCRIPTION

The grep expression in particular was incorrect. This commit fixes the 
problem. Note that it doesn't look for lower case letters as there are 
legitimate dot files in the repo with lower case letters. Hopefully no 
system will leave lower case file sockets lying about (though for all I
know it's the entry deciding it - didn't look into it).