### PR TITLE
Improve documentation of installing SDL and SDL2

### DIFF
--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -128,6 +128,8 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+	@echo "NOTE: in linux after running this program it might drop core dumps"
+	@echo "even though it doesn't show any error."
 
 # alternative executable
 #

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -11,24 +11,29 @@ make all
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this for modern
 compilers. There were two problems to address. One was that the entry required
-`-traditional-cpp` which it no longer does. It needed this because of two things
+`-traditional-cpp` (which <strike>not all compilers support</strike> `clang`
+does not support) which Cody fixed. It needed that option because of two things
 it did:
 
 ```c
 #define a(x)get/***/x/***/id())
 
+/* ... */
+
 p Z=chroot("/");L(!a(u)execv((q(v="/ipu6ljov"),v),C);Z-=kill(l);
 
-...
+/* ... */
 
 case_2:L(!--V){O/*/*/c*c+c);wait(A+c*c-c);L(!Z)f(A,"\n",c);return(A*getgid());};C++;
 ```
 
-does not work to create `getuid()` and `getgid()`. The second is that
+no longer works to create `getuid()` and `getgid()`. The second is that
 
-    for/*/(;;);/*/k()){O/*/*/c);
+```c
+for/*/(;;);/*/k()){O/*/*/c);
+```
 
-cannot form 'fork())' in modern C compilers. What is quite fun is that the cpp
+cannot form `fork())` in modern C compilers. What is quite fun is that the cpp
 can!
 
 The other problem was that modern compilers do not allow directives like:
@@ -49,8 +54,6 @@ so Cody changed the lines to be in the form of:
 
 Thank you Cody for your assistance!
 
-
-
 ## Try:
 
 ```sh
@@ -58,8 +61,20 @@ Thank you Cody for your assistance!
 ./dale these files are in this directory: *
 ```
 
-NOTE: in linux it might happen that core dumps are created when running this
-entry even though it works fine.
+What do the following commands do and why do they do it? Why do they differ in
+format from the above command? Finally how can you get the more likely desired
+behaviour?
+
+
+```sh
+./dale $(printf "the following files exist in this directory:\n%s\n" *)
+./dale "$(printf "the following files exist in this directory:\n%s\n" *)"
+```
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+In linux it might happen that core dumps are created when running this entry
+even though it works fine and you don't see any message about dumping core.
 
 ### Alternate code
 
@@ -67,7 +82,7 @@ If you have an old enough compiler you can try the original version in
 [dale.alt.c](dale.alt.c). To use:
 
 ```sh
-make alt
+make clobber alt
 ```
 
 Use `dale.alt` as you would `dale` above.

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -1,10 +1,8 @@
 # Best One-liner
 
 Laurion Burchall  
-Brown University  
-Unit 4641  
-Providence RI 02912-4641  
 US  
+<https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/>
 
 ## To build:
 

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -62,14 +62,14 @@ vi README.md
 
 Press and hold any key.
 
-### Alternate method
+### Alternate method:
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh)  provided the `kernel` and `fs.tar`
 files which can be used if you cannot normally use this entry. Instead of
 generating the files just use the files provided, found under the [img/](img/)
 directory. Note that the `img/fs.tar` extracts into `fs/` so you will have to
-fix the tarball; this is done to prevent extraction from the entry directory
-overwriting the files and preventing `make clobber` from wiping some of them
+fix the tarball; this is done this way to prevent extraction from the entry
+directory overwriting the files and causing `make clobber` to wipe some of them
 out.
 
 Thank you Yusuke!
@@ -95,7 +95,7 @@ but your experience will be limited (replace `-DK=0` with `-DK=1` in the
 [Makefile](Makefile), and you will have to move the mouse to trigger the initial
 screen update).
 
-The judges were able to write a few more programs to run on this OS
+The judges were able to write a few more programs to run in this OS.
 What are the limitations for such programs?
 
 What you can do and what you cannot do in such programs?

--- a/2004/gavin/gavin.md
+++ b/2004/gavin/gavin.md
@@ -6,7 +6,7 @@ other than Linux you may need modify the [Makefile](Makefile) to compile `sh`
 using a cross-compiler that produces ELF binaries - i.e. a cross-compiler
 targeting x86 Linux.  In short, you need to build this on an x86 Linux machine.
 
-2) Next, find a suitable machine to run the OS on.  It should be perfectly safe,
+2. Next, find a suitable machine to run the OS on.  It should be perfectly safe,
 and since it does not directly attempt to access any hard disk drives (only a
 ramdisk loaded by the bootloader) it should do no damage to your existing setup,
 BUT I ACCEPT NO LIABILITY FOR ANY DAMAGE DONE BY THIS PROGRAM.  Run it at your

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -50,7 +50,7 @@ srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:16 .CMDGAELH
 To get a list of files with this glob try:
 
 ```sh
-ls -al |awk '{print $NF}' | grep -E '^\.[A-Z]+'
+ls -al|awk '{print $NF}'|grep -E '^\.[A-Z]{2,}'
 ```
 
 To delete them you can do:

--- a/bugs.md
+++ b/bugs.md
@@ -519,6 +519,11 @@ so maybe he's doing something wrong.
 
 # 1988
 
+## [1988/dale](1988/dale/dale.c) ([README.md](1988/dale/README.md))
+## STATUS: INABIAF - please **DO NOT** fix
+
+In linux it might happen that despite no error message or message about doing
+so, the program drops a core file into the directory.
 
 # 1989
 

--- a/faq.md
+++ b/faq.md
@@ -68,8 +68,9 @@ applications.
 
 ## Q: How do I compile and run entries that use SDL1/SDL2 ?
 
-This depends on your operating system but below are some instructions for some
-OSes.
+This depends on your operating system but below are instructions for linux and
+macOS with alternative methods for macOS and different package managers with
+linux.
 
 ### Red Hat based linux
 
@@ -121,10 +122,17 @@ but this might not be necessary in more modern days especially as we use
 `sdl-config` and `sdl2-config` which should find the proper paths.
 
 
+### Other linux distributions
+
+Use your package manager to install the appropriate packages. Try the search
+feature of the package manager to determine which packages you need to install.
+Note that you might have to install both the library and the developmental
+packages: one for compiling and one for linking / running.
+
 ### macOS
 
 If you're using macOS there are at least three ways to obtain it. You can
-download it from the SDL website and install the package. This will possibly not
+download it from the SDL website and install the package. The latter will not
 work well for the IOCCC but these will:
 
 #### MacPorts
@@ -152,7 +160,7 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 
 As entries have been fixed it is entirely possible that some of the entries no
 longer fit within the year's size restrictions. Invariably the length of columns
-and number of rows might also be changed.
+and number of rows might also have changed.
 
 For the original version see the [/archive](/archive) directory where you can
 find all the original winning entries.

--- a/tmp/author.csv
+++ b/tmp/author.csv
@@ -41,7 +41,7 @@ briddlebane,Moxen N. Briddlebane,Moxen_N_Briddlebane,null,moxen@gateway.net,null
 bright,Walter Bright,Walter_Bright,http://www.walterbright.com/,emperor@classicempire.com,null,null,null,null,
 broukhis,Leonid A. Broukhis,Leonid_A_Broukhis,http://www.mailcom.com/leob,leob@mailcom.com,US,null,null,null,
 bsoup,bsoup,bsoup,null,mail@bsoup.skr.jp,JP,null,null,null,
-burchall,Laurion Burchall,Laurion_Burchall,http://www.netspace.org/users/ldb,ldb@netspace.org,null,null,null,null,
+burchall,Laurion Burchall,Laurion_Burchall,https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/,ldb@netspace.org,null,null,null,null,
 burley,Brent Burley,Brent_Burley,null,brent.burley@disney.com,US,null,null,null,
 burton,Dave Burton,Dave_Burton,http://snox.net/ioccc,daveb@snox.net,US,@lv2jmp,null,null,
 buttimore,Gavin Buttimore,Gavin_Buttimore,null,gavin.buttimore@creaturelabs.com,null,null,null,null,

--- a/var.mk
+++ b/var.mk
@@ -282,40 +282,19 @@ X11_LIBDIR= /opt/X11/lib
 X11_INCDIR= /opt/X11/include
 
 
-############################
-# SD1 and SDL2 include files
-############################
-
-# macOS users:
+##########################
+# SD1 and SDL2 libraries #
+##########################
 #
-# If you have not aleady do so, install Homebrew.  See the following for information:
+# For details on how to install SDL/SDL2 see faq.md.
 #
-#	https://brew.sh
-#
-# Then to install SDL and SDL2, execute the following command:
-#
-#	brew install sdl2 sdl12-compat
-#	eval "$(/opt/homebrew/bin/brew shellenv)"
-
-# Linux users:
-#
-# To install SDL and SDL2, execute the following command as root:
-#
-#	dnf install SDL2 SDL2-devel sdl12-compat sdl12-compat-devel
-
-# Debian users:
-#
-# To install SDL and SDL2, execute the following command as root:
-#
-#	apt install libsdl1.2debian libsdl1.2-dev libsdl2-dev
-
 # SDL2_INCLUDE_ROOT is the directory under which include/SDL/ and/or
 # include/SDL2/ may be found.
 #
-# Even if you do not use HomeBrew, you might set the environment
-# variable $HOMEBREW_PREFIX to the SDL2_INCLUDE_ROOT directory path
-# as the default SDL2_INCLUDE_ROOT value is $HOMEBREW_PREFIX.
-# Of you may run make and set SDL2_INCLUDE_ROOT directly:
+# Even if you do not use Homebrew (one of the methods for macOS), you might set
+# the environment variable $HOMEBREW_PREFIX to the SDL2_INCLUDE_ROOT directory
+# path as the default SDL2_INCLUDE_ROOT value is $HOMEBREW_PREFIX.  Of you may
+# run make and set SDL2_INCLUDE_ROOT directly:
 #
 #	make all SDL2_INCLUDE_ROOT=/some/path
 #

--- a/winners.html
+++ b/winners.html
@@ -240,7 +240,7 @@ Contest </I></FONT></CENTER><BR>
 <LI TYPE=square>Best solved puzzle (<A HREF="years.html#2011_hamaji">2011 hamaji</A>)
 </UL><BR>
 
-<LI TYPE=none><A NAME="Laurion_Burchall"></A><B><a href="&#x6D;&#x61;&#105;&#108;&#116;o&#x3A;&#108;&#x64;&#x62;&#64;&#x6E;&#x65;&#116;&#115;p&#x61;&#x63;&#101;&#x2E;&#x6F;&#x72;&#x67;">Laurion Burchall</a></B> -- <A HREF="http://www.netspace.org/users/ldb">http://www.netspace.org/users/ldb</a>
+<LI TYPE=none><A NAME="Laurion_Burchall"></A><B><a href="&#x6D;&#x61;&#105;&#108;&#116;o&#x3A;&#108;&#x64;&#x62;&#64;&#x6E;&#x65;&#116;&#115;p&#x61;&#x63;&#101;&#x2E;&#x6F;&#x72;&#x67;">Laurion Burchall</a></B> -- <A HREF="https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/">https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/</a>
 <UL>
 <LI TYPE=square>Best One-liner (<A HREF="years.html#1994_ldb">1994 ldb</A>)
 </UL><BR>


### PR DESCRIPTION

Remove how to install SDL1 / SDL2 from var.mk as it's already in faq.md.
Instead refer to faq.md. How to compile (variables etc.) is still in the
var.mk file.

Reworded that section a bit and added 'Other linux distributions'
subsection to 'Linux' (in faq.md).

Minor typo fix in faq.md at the same time as the above change. Normally
I would not do this but it's one word changed and I am too tired at this
time (or can't be bothered?) to do another pull request for one word.