### PR TITLE
Fix thank you note / bug note in 2015/yang

### DIFF
--- a/2015/yang/README.md
+++ b/2015/yang/README.md
@@ -10,8 +10,8 @@ make
 ```
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed an unfortunate
-typo in the Makefile that was causing some of the files to compile properly,
-trying instead to compile already compiled code. Thank you Cody!
+typo in the Makefile that was preventing some of the files from compiling
+properly, trying instead to compile already compiled code. Thank you Cody!
 
 ## To run:
 


### PR DESCRIPTION
I had put in the README.md by accident that the typo in the Makefile was making make compile the code properly rather than improperly. Obviously it was the opposite problem!