### PR TITLE
Add -lm to 2000/briddlebane/Makefile

### DIFF
--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -74,7 +74,7 @@ CFLAGS= ${CSTD} ${CWARN} ${ARCH} ${CDEFINE} ${CINCLUDE} ${OPT}
 
 # Libraries needed to build
 #
-LIBS=
+LIBS= -lm
 
 # C compiler to use
 #

--- a/2000/briddlebane/README.md
+++ b/2000/briddlebane/README.md
@@ -1,18 +1,17 @@
 # Best Abuse of User
 
 Moxen N. Briddlebane  
-24 Oxtree Ave.  
-The Xoemn, MN 68214  
 
 Lord Zarbon  
-24 Oxtree Ave.  
-The Xoemn, MN 68214  
 
 ## To build:
 
 ```sh
 make
 ```
+
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile
+in systems that require one to explicitly link in `libm`. Thank you Cody!
 
 ## To run:
 
@@ -36,7 +35,7 @@ evening of Dec 22, 2000).
 Can you find out how it stores the insult strings?  Can you then take
 an insult and figure out when it will be uttered?
 
-[sc] The code also contains a buffer overflow bug which I have fixed!
+[sc] The code also contained a buffer overflow bug which I have fixed!
 The array size of `s` should be 1079 characters long.  (From 0 to 1078
 inclusive!).  Without this it results in an error in the encoding of
 "decrepit" -- For a 32bit little endian machine using GCC (because of
@@ -52,7 +51,7 @@ transmission, refers to himself simply as "Lord Zarbon", though
 offers no information in relation to the significance of that
 post. The sole purpose of this program appears to be to degrade
 and humiliate the people of this planet by calling them names.
-It takes no input, only produces a single line of slanderous output.
+It takes no input, it only produces a single line of slanderous output.
 
 The program appears to be rather confused, internally. It is
 unclear whether or not "Lord Zarbon" truly understands the


### PR DESCRIPTION
The entry would not compile in the systems that require the explicit use of -lm for libm. Two example systems are fedora and Rocky linux.

I also fixed a couple typos in README.md.