### PR TITLE
Credits go in the thanks file, not README.md files

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -20,8 +20,8 @@ request](https://github.com/ioccc-src/temp-test-ioccc/pulls) (with ONE PULL
 REQUEST *PER* FIX, please)!
 
 We will be **happy to credit anyone who submits successful [GitHub pull
-requests](https://github.com/ioccc-src/temp-test-ioccc/pulls)** in the entry's
-_README.md_ file. If you're a previous winner we will add a link to your winning
+requests](https://github.com/ioccc-src/temp-test-ioccc/pulls)** in the [thanks
+file](thanks-for-fixes.md). If you're a previous winner we will add a link to your winning
 entries in the file (if you're not a previous winner we can add a link to your
 GitHub page or personal website if you have one, should you wish).
 
@@ -411,7 +411,7 @@ are clang).
 If you do wish to provide an alternate version of the program that does not need
 compiler supporting you are welcome to summit such code via a
 [GitHub pull request](https://github.com/ioccc-src/temp-test-ioccc/pulls) and we
-will be happy to credit you in the entry's _README.md_ file.
+will be happy to credit you in the [thanks file](thanks-for-fixes.md).
 
 NOTE: as of commit fa8a9b8b28a6b69a6b4efd74a45402f745e280b3 we believe that all
 the entries with this problem have been fixed due [Cody Boone
@@ -819,7 +819,7 @@ value of `getc()`; this is important because `EOF` is **NOT** guaranteed to be
 would enter an infinite loop until the program crashed, by chance reads a `-1`
 or was killed. See the README.md for more details. If you don't feel comfortable
 changing it to `EOF` Cody will happily do it for you but otherwise go right
-ahead. We'll credit you in the README.md file regardless.
+ahead. We'll credit you in the [thanks file](thanks-for-fixes.md) regardless.
 
 # 1995
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -14,7 +14,7 @@ many of the improvements.  Thank you **very much** for the
 extensive efforts in helping improve the IOCCC presentation of past
 IOCCC winners!
 
-Yusuke Endoh](/winners.html#Yusuke_Endoh) supplied a number of
+[Yusuke Endoh](/winners.html#Yusuke_Endoh) supplied a number of
 important bug fixes to a number of past IOCCC winners.  Some of
 those fixes were very technically challenging.  Thank you **very
 much** for your help!

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -332,12 +332,6 @@ Endoh](/winners.html#Yusuke_Endoh). Thank you Yusuke for your implementation of
 `btoa`!
 
 
-## [1990/scjones](1990/scjones/scjones.c) ([README.md](1990/scjones/README.md]))
-
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) pointed out that the
-compiler option `-trigraphs` would also have worked.
-
-
 ## [1990/tbr](1990/tbr/tbr.c) ([README.md](1990/tbr/README.md]))
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to work with


### PR DESCRIPTION

As of moving the many thanks from the individual README.md files to one
file alone (a move I agree with and had thought of before) the bugs.md 
had to be updated to not refer to credits in the README.md files but 
rather the thanks file.