### PR TITLE
Improve how 1989/westley alt versions are built

### DIFF
--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ver0.o ver1.o ver2.o ver3.o
+ALT_TARGET= ver0 ver1 ver2 ver3
 
 
 #################
@@ -129,13 +129,31 @@ all: data ${TARGET}
 	supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry uses non-standard args to main() that do not work with some modern compilers."
 	${CC} ${CFLAGS} $< -o $@ ${LIBS}
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+ver0: ${PROG}
+	./${PROG} < westley.c > ver0.c
+	-${CC} ${CFLAGS} ver0.c -o $@ ${LIBS}
+
+ver1: ${PROG}
+	./${PROG} 1 < westley.c > ver1.c
+	@echo "** NOTE: this version will not compile with clang **"
+	-${CC} ${CFLAGS} ver1.c -o $@ ${LIBS}
+
+ver2: ${PROG}
+	./${PROG} 1 2 < westley.c > ver2.c
+	@echo "** NOTE: this version will not compile with clang **"
+	-${CC} ${CFLAGS} ver2.c -o $@ ${LIBS}
+
+ver3: ${PROG}
+	./${PROG} 1 2 3 < westley.c > ver3.c
+	@echo "** NOTE: this version will not compile with clang **"
+	-${CC} ${CFLAGS} ver3.c -o $@ ${LIBS}
 
 # data files
 #


### PR DESCRIPTION
The Makefile now has the other versions as alt targets. Running make ver0 will generate ver0.c and then try compiling it. Running make ver1 will do the same for ver1.c and running make alt will do this on ver0, ver1, ver2 and ver3. Error in compilation in these rules are not fatal so that make alt can continue. This is important for clang.

I have some other enhancements on the presentation of this entry but they have to be reworked and decided upon (it might be that it's not necessary with the alt rule but then the README.md file really ought to be updated too which it will be in another commit).

It might be that making these alt targets is not even the right approach but for now it'll do as at least it's easier to generate and compile the individual files even if one does not use make alt. This is all TBD later.