### PR TITLE
Improve 2020/kurdyukov2 for MacPorts build

### DIFF
--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -61,7 +61,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE= -I ${HOMEBREW_PREFIX}/include -I /usr/local/include
+CINCLUDE= -I ${HOMEBREW_PREFIX}/include -I /usr/local/include -I /opt/local/include
 
 # Optimization
 #
@@ -73,7 +73,7 @@ CFLAGS= ${CSTD} ${CWARN} ${ARCH} ${CDEFINE} ${CINCLUDE} ${OPT}
 
 # Libraries needed to build
 #
-LIBS= -L ${HOMEBREW_PREFIX}/lib -L /usr/local/lib
+LIBS= -L ${HOMEBREW_PREFIX}/lib -L /usr/local/lib -L /opt/local/lib
 LIBJPEG= -ljpeg
 LIBPNG= -lpng
 

--- a/2020/kurdyukov2/README.md
+++ b/2020/kurdyukov2/README.md
@@ -76,7 +76,7 @@ make prog_ppm
 
 ### Building on macOS with MacPorts:
 
-- Thanks to Cody Boone Ferguson for this information!
+- Thanks to [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) for this information!
 
 First, make sure you have the compiler tools installed e.g. by:
 

--- a/bugs.md
+++ b/bugs.md
@@ -2073,11 +2073,21 @@ things that are misinterpreted as bugs. See his
 # 2021
 # 2022
 
-These years did not have an IOCCC entry.
+There was no IOCCC in these years.
+
+# 2023
+
+Probably there will be no IOCCC in 2023 but we do hope to at least run the
+IOCCCMOCK contest this year. This depends entirely on the work in this repo
+and the [mkiocccentry](https://github.com/ioccc-src/mkiocccentry) being
+completed.
 
 # Final words
 
 We hope this document was of use to you in determining which entries are known
 to have a problem, what entries are known to have features that are not bugs and
 so on. We also thank you for going through this document and, if you propose any
-fixes via a pull request or otherwise, we thank you as well for the help!
+[fixes](/thanks-for-fixes.md) via a [GitHub pull
+request](https://github.com/ioccc-src/temp-test-ioccc/pulls) or otherwise, we
+thank you as well for the help! We will happily add you to the
+[thanks-for-fixes.md](/thanks-for-fixes.md) file as well.

--- a/faq.md
+++ b/faq.md
@@ -64,8 +64,18 @@ Mill](/winners.html#Christopher_Mills)'s entry
 PDP-11/40 emulator. 
 
 Others are not so easy though we're working on this and over time have added
-alternative code. In some cases we replaced the original code with code that
-works for modern systems.
+alternative code. Most entries do now work and the others we are working on. In
+some cases we replaced the original code with code that works for modern systems
+but one can view the archive for the original code (sometimes the original code
+is in the directory usually as a `winner.alt.c` or `prog.alt.c` but note that
+sometimes authors have that already as well).
+
+## Q: After running a program my terminal is all messed up! How do I restore my terminal?
+
+The simplest way to do this is to type `reset`. If echo was disabled you can get
+usually away with `stty echo`. Sometimes you can also get away with `stty sane`.
+`reset` does the most but note that it will clear the screen (obviously `clear`
+will too but it won't reset the terminal).
 
 
 ## Q: How do I get X11 entries to work with macOS Mountain Lion and later?
@@ -164,14 +174,48 @@ brew install sdl2 sdl12-compat
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
+## Q: How do I compile and run entries that use sound in macOS?
+
+This might depend on the entry but in some cases like
+[2001/coupard](2001/coupard/coupard.c) one needs to do more work in order to get
+it to work. In this case you should be able to use the Swiss Army Knife of sound
+processing programs, [SoX](https://sox.sourceforge.net). To install this easily
+you can use either MacPorts or Homebrew. See below for instructions for each.
+
+Usually the README.md file will explain how to use it in linux so we do not
+include this here, at least for now.
+
+### MacPorts
+
+If you haven't already, install
+[MacPorts](https://www.macports.org/install.php). Then run:
+
+
+```sh
+sudo port install sox
+```
+
+### Homebrew
+
+If you have not already done so, install [Homebrew](https://brew.sh).
+
+Then to install SoX, execute the following command:
+
+```sh
+brew install sox
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
 ## Q: How did entry XYZZY win? It breaks rule 2!
 
 As entries have been fixed it is entirely possible that some of the entries no
 longer fit within the year's size restrictions. Invariably the length of columns
-and number of rows might also have changed.
+and/or number of rows have also changed.
 
 For the original version see the [/archive](/archive) directory where you can
-find all the original winning entries.
+find all the original winning entries. In some cases the `winner.alt.c` is the
+original source code.
+
 
 ## Q: I found a bug in a previous winner, what should I do?
 
@@ -188,12 +232,18 @@ fix. If it is accepted we'll be happy to credit you in the entry's _README.md_
 file. If you're a previous winner we will happily link to your entries; if
 you're not we can link to your website if you wish.
 
-## Q: After running a program my terminal is all messed up! How do I restore my terminal?
+More generally please see the file [how-to-bugfix.md](/how-to-bugfix.md). Note
+that this file is not a tutorial on how to fix X, Y and Z problems but rather
+what to do to get the fix in.
 
-The simplest way to do this is to type `reset`. If echo was disabled you can get
-away with `stty echo`. Sometimes you can also get away with `stty sane`. `reset`
-does the most but note that it will clear the screen (`clear` will too but it
-won't reset the terminal).
+## Q: Do you have a list of entries with known problems and/or features that might appear to be bugs but are not?
+
+Yes! Please see [bugs.md](/bugs.md) for a list of known bugs and/or issues of a
+variety of kinds.
+
+Note that just because an entry is not in the bugs file does not mean there is
+not an issue and note that some issues are simply missing files, dead URL(s) or
+something like that.
 
 ## Q: Are there types of entries that are submitted so frequently that the judges get tired of them?
 

--- a/how-to-bugfix.md
+++ b/how-to-bugfix.md
@@ -1,31 +1,39 @@
-# How to fix an IOCCC entry
+# How to submit a fix to an IOCCC entry
 
-If you see a problem with an IOCCC entry, first check the
-[known bugs](bugs.md) file.  In some cases what you might think
-of as a bug is instead a known feature.  On some cases the
-bug is known, but no fix has ever been submitted.  In other
-cases you may have found a new problem.
+If you see a problem with an IOCCC entry, first check the [known bugs](bugs.md)
+file.  In some cases what you might think of as a bug is instead a known
+feature.  In some cases the bug is known, but no fix has ever been submitted.
+In other cases you may have found a new problem.
 
-If you do have a fix, and the [known bugs](bugs.md) file **does
-not recommend against fixing it**, then please opening a [GitHub pull
+If you do have a fix, and the [known bugs](bugs.md) file **does not recommend
+against fixing it**, then please consider opening a [GitHub pull
 request](https://github.com/ioccc-src/winner/pulls) against the master
 [branch](https://github.com/ioccc-src/winner/branches) of the [ioccc-src/winner
 repo](https://github.com/ioccc-src/winner) repo.
 
-BTW: A **problem** is not limited to the code itself.  Fixing typos in files such
-as "_README.md_" files, fixing issues in a "_Makefile_", or otherwise correcting an
-IOCCC winner is **VERY MUCH WELCOME**!  Please use the same [GitHub pull
-request](https://github.com/ioccc-src/winner/pulls) process against the master
-[branch](https://github.com/ioccc-src/winner/branches) of the [ioccc-src/winner
-repo](https://github.com/ioccc-src/winner) repo.
+BTW: A **problem** is not limited to the code itself.  Fixing typos in files
+such as "_README.md_" files, fixing issues in a "_Makefile_", or otherwise
+correcting an IOCCC winner is **VERY MUCH WELCOME**!  Please use the same
+[GitHub pull request](https://github.com/ioccc-src/winner/pulls) process against
+the master [branch](https://github.com/ioccc-src/winner/branches) of the
+[ioccc-src/winner repo](https://github.com/ioccc-src/winner) repo.
 
-**Please help us fix typos and / or otherwise improve the write-up** of
-how IOCCC winning entries are presented!
+NOTE: some of the issues in the [bugs.md](/bugs.md) file includes just missing
+files and we welcome these too!
 
-And of course, an IOCCC winner's may update their own entries
+**Please also help us fix typos and / or otherwise improve the write-up** of how
+IOCCC winning entries are presented!
+
+In any event we will happily add you to the
+[thanks-for-fixes.md](/thanks-for-fixes.md) file for your help!
+
+And of course, an IOCCC winner may update their own entries
 (metadata as well as source code and any extra files) by opening a
 [GitHub pull request](https://github.com/ioccc-src/winner/pulls)
 against the master [branch](https://github.com/ioccc-src/winner/branches)
 of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner)
 repo.
-e
+
+Note that we're much more inclined to accept an author's fixes but the judges
+have the final say in the matter.
+

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -790,7 +790,7 @@ Cody fixed both the supplementary program and the program itself (both of which
 segfaulted and once that was fixed only the binary was modified; it was not run
 but according to the author's remarks it should be executed). He managed to do
 this with linux but it will not work with macOS (see [bugs.md](/bugs.md) for why
-this is); _this is not a bug, it's a feature_ inherent in what it does!
+this is); _this is **not** a bug, it's a feature_ inherent in what it does!
 
 The following had to be done in order to get this to work:
 
@@ -845,26 +845,27 @@ sings [Ten in the Bed](https://allnurseryrhymes.com/ten-in-the-bed/).
 
 ## [2001/bellard](2001/bellard/bellard.c) ([README.md](2001/bellard/README.md]))
 
-Cody partially fixed this but he notes that this will not work without
+Cody at least partially fixed this but he notes that this will not work without
 (according to the author) i386 linux or else some skill in resolving the
 portability issues. As it is it segfaults in 64-bit linux (and as expected
 macOS). He fixed an earlier segfault so that at least the file can be opened
-(but perhaps that will be wrong in i386 linux?) and he also changed some of the
-macro used to what they evaluate to but mostly he kept it the same.
+(but perhaps that will be wrong in i386 linux / older C?) and he also changed
+some of the macro used to what they evaluate to but mostly he kept it the same.
 
 Cody also fixed [bellard.otccex.c](bellard.otccex.c) so it does not segfault and
 seemingly works okay (it did not work at all). The main problem was that some
 ints were being used as pointers. Also the Fibonacci sequence (`fib()`) will
-overflow at `n > 48` so this is checked prior to running the function. Either
-way unfortunately this entry seems to not work in 64-bit linux or macOS. See
-below portability notes.
+overflow at `n > 48` so this is checked prior to running the function just like
+the author did for the factorial (overflowing at `>12`). Either way
+unfortunately this entry seems to not work in 64-bit linux or macOS. See below
+portability notes as well as another fix in this entry by Yusuke.
 
 ### Portability notes:
 
-With a tip from Yusuke we rediscovered the
-author's [web page for this program](https://bellard.org/otcc/) where it is
-stated that this will only work in i386 linux.  The author also stated in the
-remarks in this document that they used [gcc
+With a tip from Yusuke we rediscovered the author's [web page for this
+program](https://bellard.org/otcc/) where it is stated that this will only work
+in i386 linux.  The author also stated in the remarks in this document that they
+used [gcc
 2.95.2](https://ftp.gnu.org/gnu/gcc/gcc-2.95.2/gcc-everything-2.95.2.tar.gz) but
 we don't know if that's relevant or not.
 
@@ -877,17 +878,18 @@ by Yusuke.
 
 ## [2001/cheong](2001/cheong/cheong.c) ([README.md](2001/cheong/README.md]))
 
-Cody fixed this to work with
-clang by adding another function that is allowed to have a third arg as an int,
-not a `char **`. He chose pain() because it's a four letter word that would
-match the format and because it's pain that clang forces this. :-) This fix
-makes a point of the author's notes on portability no longer valid, btw.
+Cody fixed this to work with clang by adding another function that is allowed to
+have a third arg as an int, not a `char **`. He chose pain() because it's a four
+letter word that would match the format and because it's pain that clang forces
+this. :-) This fix makes a point of the author's notes on portability no longer
+valid, btw.
 
 
 ## [2001/coupard](2001/coupard/coupard.c) ([README.md](2001/coupard/README.md]))
 
-Thanks go to Yusuke for providing a proper command line (see
-[/2013/endoh3/README.md](2013/endoh3/README.md).
+Thanks go to Yusuke for providing a proper command line for macOS (to do with
+sound; see his [/2013/endoh3/README.md](2013/endoh3/README.md) entry where he
+also refers to sound devices in macOS).
 
 
 ## [2001/ctk](2001/ctk/ctk.c) ([README.md](2001/ctk/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1212,3 +1212,10 @@ not sure why as it worked fine before on the same systems tested but `-O0`
 appears to fix the problem in both macOS and linux. Perhaps this is the problem
 that the author reported where it sometimes segfaults but Cody did not try
 debugging it yet.
+
+## [2020/kurdyukov2](2020/kurdyukov2/prog.c) ([README.md](2020/kurdyukov2/README.md))
+
+Cody added `-L`/`-I` paths to the Makefile to let this compile more easily if
+the user has installed the appropriate library with
+[MacPorts](https://www.macports.org) (with the default MacPorts prefix
+`/opt/local`).

--- a/www-history.md
+++ b/www-history.md
@@ -2,56 +2,70 @@
 
 ## In the beginning of www.ioccc.org
 
-The long history of the [official IOCCC web site](https://www.ioccc.org)
-may be viewed at the [Internet Archive Wayback Machine](https://web.archive.org).
-One may view several thousand
-snapshots showing how the [IOCCC web site has
-evolved](https://web.archive.org/web/20230000000000*/www.ioccc.org) going
-back as far as [1998 Dec 12
+The long history of the [official IOCCC web site](https://www.ioccc.org) can be
+viewed at the [Internet Wayback Machine Wayback Machine](https://web.archive.org).
+
+One can view several thousand snapshots showing how the [IOCCC web site has
+evolved](https://web.archive.org/web/20230000000000*/www.ioccc.org) going back
+as far as [1998 Dec 12
 www.ioccc.org](https://web.archive.org/web/19981212030016/http://www.ioccc.org/).
 
 On 2020 Dec 31, the IOCCC source tree was moved to the [IOCCC winner
-repo](https://web.archive.org/web/20210101211346/http://www.ioccc.org/)
-on [GitHub](https://github.com).  From this point on, the [official
-IOCCC web site](https://www.ioccc.org) became a [GitHub
-Pages](https://pages.github.com) web site.
+repo](https://web.archive.org/web/20210101211346/http://www.ioccc.org/) on
+[GitHub](https://github.com).  From this point on, the [official IOCCC web
+site](https://www.ioccc.org) became a [GitHub Pages](https://pages.github.com)
+web site.
 
 ## 2020 Dec 28 bzip2 compressed tarball archive
 
-Furthermore, an bzip2 compressed tarballs containing the released
-IOCCC winner source code may be found under the `archive/` directory.
-These files were obtained from the Internet Archive as
-of  [2020 Dec 28](https://web.archive.org/web/20201228005211/http://www.ioccc.org/).
-See `archive/README.md` for details about these bzip2 compressed tarballs;
+Furthermore, a bzip2 compressed tarball containing the released
+IOCCC winner source code may be found under the [archive/](/archive) directory.
+The file [archive-all.tar.bz2](/archive/archive-all.tar.bz2) contains all years
+and the individual years are in the form `archive/archive-YYYY.tar.bz2`.
+
+These files were obtained from the [Internet Wayback
+Machine](https://web.archive.org) from the [snapshot of the website on 2020 Dec
+28](https://web.archive.org/web/20201228005211/http://www.ioccc.org/).  See
+`archive/README.md` for details about these bzip2 compressed tarballs.
 
 **XXX**: Change the references to _temp-test-ioccc_ to _winners_
 when these fixes are merged.
 
 ## 2022 Dec 29 repo fork
 
-On 2022 Dec 29, the [IOCCC winner
-repo](https://github.com/ioccc-src/winner), from which the [official
-IOCCC web site of 2022 Dec
+On 2022 Dec 29, the [IOCCC winner repo](https://github.com/ioccc-src/winner),
+from which the [official IOCCC web site of 2022 Dec
 29](https://web.archive.org/web/20221231001721/https://www.ioccc.org/) was
-generated, was forked into a temporary repo where it underwent
-several thousand changes and important improvements such as:
+generated, was forked into a temporary repo where it is currently undergoing
+changes with several thousand changes and important improvements already such
+as:
+
+-- 
+
+***XXX**: change the above text to read:
+
+... where it underwent several thousand changes and important improvements such
+as:
+
+--
 
 * Moving IOCCC winners into their own separate directories
 * Fixing lots and lots of typos
-* Fixing Makefiles and code to allow for nearly all winners to be compiled on modern systems
+* Fixing Makefiles and code to allow for nearly all winners to be compiled and
+work on modern systems
 * Reworking the Makefiles to use a consistent set of rules
-* Reworking the Makefiles to specific to the gcc and clang C compilers
+* Reworking the Makefiles specific to the gcc and clang C compilers
 * Replacing the various hint files with a README.md markdown that is more consistent across IOCCC years
 * Setting up a system whereby authors of IOCCC entries may update their own contact information via a GitHub pull request
 * Setting up to generate the top level years.html file via a tool
 * Setting up to generate the top level winners.html file via a tool
 * etc.
 
-## 20yy mmm dd pull request
+## 20yy mm dd pull request
 
-On 20yy mmm ddd, the temporary repo was merged back into the [IOCCC winner
+On 20yy mm dd, the temporary repo was merged back into the [IOCCC winner
 repo](https://github.com/ioccc-src/winner) resulting in substantial improvements
 to the [official IOCCC web site](https://www.ioccc.org).
 
-**XXX**: Fill in the date when the pull request happens including perhaps,
+**XXX**: Fill in the date when the pull request happens including the
 size of the pull request and/or number of changes that went into the pull request.


### PR DESCRIPTION

The -I/-L options to the compiler/linker have been updated for those who
use MacPorts with the default MacPorts prefix.