### PR TITLE
Remove last references to .hint files

### DIFF
--- a/1998/dorssel/README.md
+++ b/1998/dorssel/README.md
@@ -54,7 +54,7 @@ altering the behavior ?
 
 Extra credit: Change the program so that it does not SHOUT IN ALL CAPS.
 
-You might also want to read the [dorssel.hint](dorssel.hint) file.
+You might also want to read the [dorssel.md](dorssel.md) file.
 
 ## Author's remarks:
 
@@ -108,11 +108,11 @@ is the same as
 ./dorssel < dorssel.c | ./dorssel
 ```
 
-- The file "dorssel.hint" contains all the information needed to understand this
-program.  For an obfuscated spoiler, try
+- The file [dorssel.md](dorssel.md) contains all the information needed to
+understand this program.  For an obfuscated spoiler, try
 
 ```sh
-./dorssel < dorssel.hint 
+./dorssel < dorssel.md 
 ```
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/bugs.md
+++ b/bugs.md
@@ -1429,7 +1429,7 @@ gavin: gavin.c
         ${RM} -f vi
         ${CP} sh vi
         ${RM} -f fs.tar
-        ${TAR} -cvf fs.tar sh vi gavin.c gavin.hint prim
+        ${TAR} -cvf fs.tar sh vi gavin.c README.md prim
 
 gavin_clean:
         ${RM} -f sh vi kernel gavin.o

--- a/faq.md
+++ b/faq.md
@@ -433,6 +433,12 @@ which you should update and submit, using the instructions above if necessary.
 
 There are none. There was no IOCCC in those years.
 
+## Q: What are the .orig.c files in the directories in winning entries ?
+
+Due to the fact that the original code has sometimes had to change these files
+are the original winning entry or as close to as possible to the original that
+we can find.
+
 ## Q: Why don't you publish non-winners?
 
 Because the publication on the IOCCC site **_IS_**
@@ -545,7 +551,9 @@ Thank you Cody for your help!
 BTW: in this case it's a slight fix and improvement to our original suggested
 code:
 
-	main(){int i=512;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);}
+```c
+main(){int i=512;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);}
+```
 
 BTW: is there such a thing as too fast a CPU ? :-) actually yes for certain code
 which is probably not as uncommon as you think :-) ).
@@ -598,7 +606,7 @@ Thus began the tradition of putting typos in the contest rules and guidelines
 BTW: This posting was made back in the days when AT&amp;T was the evil giant.
 Now, Microsoft makes AT&amp;T look mild and kind in comparison. :-( (IMHO) ).
 
-BTW: See the story about the '[Bill Gates](/1993/mills/mills.hint)' award. :-)
+BTW: See the story about the '[Bill Gates](/1993/mills/README.md)' award. :-)
 
 OK, back to the story.
 

--- a/years.html
+++ b/years.html
@@ -8,7 +8,9 @@
 
 <BODY TEXT="#000000">
 
-<CENTER><a HREF="2011/zucker/hint.html"><IMG ALT="IOCCC" SRC="png/ioccc.png"></a><br><FONT SIZE="1">Logo by winner <a href="2011/zucker/hint.html">Matt Zucker</a></font></CENTER><BR>
+<CENTER><a HREF="2011/zucker/README.md"><IMG ALT="IOCCC"
+	SRC="png/ioccc.png"></a><br><FONT SIZE="1">Logo by winner <a
+	    href="2011/zucker/README.md">Matt Zucker</a></font></CENTER><BR>
 <CENTER><FONT SIZE="6"><I>The International Obfuscated C Code
 Contest </I></FONT></CENTER><BR>
 
@@ -2267,7 +2269,7 @@ Contest </I></FONT></CENTER><BR>
 <UL TYPE=square>
 <LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/Makefile">Makefile</A>
 <LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c">dorssel.c</A>
-<LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.hint">dorssel.hint</A>
+<LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.md">dorssel.md</A>
 <LI><A HREF="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/README.md">README.md</A>
 </UL>
 <A NAME="1998_fanf"></A>


### PR DESCRIPTION

This changes in years.html the 2011/zucker/hint.html to
2011/zucker/README.md (at the top of the file - to do with the IOCCC
logo) and also 1998/dorssel/dorssel.hint to 1998/dorssel/dorssel.md in
years.html (which should have been done in
ccbbacb31b7bb145b529380cada5af54ae33110e but was left out by accident).
As well it fixes 2004/gavin in bugs.md to refer to (in the Makefile rule
that is included) README.md.

There are still files with 'hint' in the name however. I believe these
to be correct.
