### PR TITLE
Further fix 1984/decot for clang (for linux)

### DIFF
--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -20,7 +20,7 @@ _O: while (!(k['a'] <<= - dup)) {	/*/*\*/
 while(b = 3, i); {
 k['a'] = b,i;
   _0:if(b&&(int)k+
-sin(signal)              / *    ((main) (((struct tag *)b)-> xO)));/*}
+sin(signal)              / *    ((main) (*((struct tag *)b)-> xO)));/*}
   ;
 }
 

--- a/2005/mikeash/README.md
+++ b/2005/mikeash/README.md
@@ -33,7 +33,7 @@ Having problems speaking code?  Do you [LISP][]?  Parenthetically
 speaking, this entry takes advantage of C99 features, while
 speaking parenthetically.  Best of all, it self-reproduces!
 
-John McCarthy might not of imagined it quite like this!  :-)
+John McCarthy might not have imagined it quite like this!  :-)
 
 [LISP]: https://en.wikipedia.org/wiki/Lisp_(programming_language)
 

--- a/2005/mikeash/mikeash.c
+++ b/2005/mikeash/mikeash.c
@@ -1,22 +1,22 @@
-;typedef char n;typedef n*m;int C;n c[11];n y[]={37,100,0};n b[2048];int i
+;typedef char n;typedef n*m;int C;n c[12];n y[]={37,100,0};n b[2048];int i
 ;int A(void){return C=getchar();}int B(m s){return strlen(s)
 ;}n w[2048];typedef m defvar;m R(void){do A();while(isblank(C) || C == '\n')
 ;if(C<0) return 0;i=0;if(C==';'){for
 (defvar q=
-";typedef char n;typedef n*m;int C;n c[11];n y[]={37,100,0};n b[2048];int iY;int A(void){return C=getchar();}int B(m s){return strlen(s)Y;}n w[2048];typedef m defvar;m R(void){do A();while(isblank(C) || C == '\n')Y;if(C<0) return 0;i=0;if(C==';'){forY(defvar q=Y~sY;C!='\n';A()Y);R();}else if(C=='('||C==')')b[i++]=C;else if(C==34)do b[i++]=CY;while(A()!=34);else do b[i++]=C;while(!isblank(A())&&C!='\n')Y;b[i] = 0;return b;}typedef defvar*format;m E(void){Y;m a=R();if(!a) return 0;if(*a==34)return aY;if(*a=='#'){c[0]=a[2]=='N'?'\n':a[2];return c;}if(*a=='q')return wY;if(*a=='('){a=R();if(*a=='d'){R();strcpy(w,E());R();return wY;}else if(*a=='f'){R();m f = strdup(E());*strchr(f,126)=37Y;m s=E();s[B(s)+1]=0;s[B(s)]=34;printf(f+1,s);R()Y;}else if(*a=='s'){n p=*E();n o=*E();m r=strdup(E());a=r;forY(format t ;*a;a++)*a=*a==o?p:*aY;R();return r;}else if(*a=='c'){c[0]=*E()-32/*Y(substitute #\Newline (char-upcase #\y ) q= )q= );*/Y;R();return c;}else{n z=*a;int d=atoi(E()),e=atoi(E())Y;sprintf(c,y,z-'+'?z-'-'?z-'*'?d/e:d*e:d-e:d+e);R();return cY;}}return a;}int main(void){while(C+1)E();return 0;}Y"
+";typedef char n;typedef n*m;int C;n c[12];n y[]={37,100,0};n b[2048];int iY;int A(void){return C=getchar();}int B(m s){return strlen(s)Y;}n w[2048];typedef m defvar;m R(void){do A();while(isblank(C) || C == '\n')Y;if(C<0) return 0;i=0;if(C==';'){forY(defvar q=Y~sY;C!='\n';A()Y);R();}else if(C=='('||C==')')b[i++]=C;else if(C==34)do b[i++]=CY;while(A()!=34);else do b[i++]=C;while(!isblank(A())&&C!='\n')Y;b[i] = 0;return b;}typedef defvar*format;m E(void){Y;m a=R();if(!a) return 0;if(*a==34)return aY;if(*a=='#'){c[0]=a[2]=='n'?'\n':a[2];return c;}if(*a=='q')return wY;if(*a=='('){a=R();if(*a=='d'){R();strcpy(w,E());R();return wY;}else if(*a=='f'){R();m f = strdup(E());*strchr(f,126)=37Y;m s=E();s[B(s)+1]=0;s[B(s)]=34;printf(f+1,s);R()Y;}else if(*a=='s'){n p=*E();n o=*E();m r=strdup(E());a=r;forY(format t ;*a;a++)*a=*a==o?p:*aY;R();return r;}else if(*a=='c'){c[0]=*E()-32/*Y(substitute #\nnewline (char-upcase #\y ) q= )q= );*/Y;R();return c;}else{n z=*a;int d=atoi(E()),e=atoi(E())Y;sprintf(c,y,z-'+'?z-'-'?z-'*'?d/e:d*e:d-e:d+e);R();return cY;}}return a;}int main(void){while(C+1)E();return 0;}Y"
 ;C!='\n';A()
 );R();}else if(C=='('||C==')')b[i++]=C;else if(C==34)do b[i++]=C
 ;while(A()!=34);else do b[i++]=C;while(!isblank(A())&&C!='\n')
 ;b[i] = 0;return b;}typedef defvar*format;m E(void){
 ;m a=R();if(!a) return 0;if(*a==34)return a
-;if(*a=='#'){c[0]=a[2]=='N'?'\n':a[2];return c;}if(*a=='q')return w
+;if(*a=='#'){c[0]=a[2]=='n'?'\n':a[2];return c;}if(*a=='q')return w
 ;if(*a=='('){a=R();if(*a=='d'){R();strcpy(w,E());R();return w
 ;}else if(*a=='f'){R();m f = strdup(E());*strchr(f,126)=37
 ;m s=E();s[B(s)+1]=0;s[B(s)]=34;printf(f+1,s);R()
 ;}else if(*a=='s'){n p=*E();n o=*E();m r=strdup(E());a=r;for
 (format t ;*a;a++)*a=*a==o?p:*a
 ;R();return r;}else if(*a=='c'){c[0]=*E()-32/*
-(substitute #\Newline (char-upcase #\y ) q= )q= );*/
+(substitute #\nnewline (char-upcase #\y ) q= )q= );*/
 ;R();return c;}else{n z=*a;int d=atoi(E()),e=atoi(E())
 ;sprintf(c,y,z-'+'?z-'-'?z-'*'?d/e:d*e:d-e:d+e);R();return c
 ;}}return a;}int main(void){while(C+1)E();return 0;}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1139,9 +1139,8 @@ the README.md for details.
 ## [2005/giljade](2005/giljade/giljade.c) ([README.md](2005/giljade/README.md]))
 
 After Landon fixed the entry to compile with clang (but see above and below)
-Cody noticed this does not
-work at all in modern systems. He fixed this to work but he notes that the fix
-to let clang compile it breaks the self-test feature.
+Cody noticed this does not work at all in modern systems. He fixed this to work
+but he notes that the fix to let clang compile it breaks the self-test feature.
 
 The problem that was showing up is that with either optimising or if anything
 but 32-bit (as in `-m32`) was used it would not work (at least in 64-bit
@@ -1151,7 +1150,7 @@ and 64-bit. The solution has to do with the size difference between `int` and
 linux (32-bit, 64-bit) and macOS (arm64).
 
 But as noted there is another problem with clang: the self-test feature only
-completely works with the original version ([giljade.alt.c](giljade.alt.c)), not
+completely works with the original version ([giljade.alt.c](giljade.alt.c), not
 the one that will compile with clang ([giljade.c](giljade.c)). The alternate
 version, which will not compile with clang, is the only one that passes the
 self-tests. If your compiler does not have the defect that clang has about arg
@@ -1164,6 +1163,29 @@ For much more details on the problem see [bugs.md](/bugs.md).
 
 Cody added explicit linking of libm (`-lm`) for systems like linux that seem to
 not do it implicitly (like macOS does).
+
+## [2005/mikeash](2005/mikeash/mikeash.c) ([README.md](2005/mikeash/README.md))
+
+Cody fixed this to work in linux. The problem was an unknown escape sequence,
+`\N` which caused a funny compiler error:
+
+```c
+};n b[2048];int i
+mikeash.c: In function 'R':
+mikeash.c:7:1: error: '\N' not followed by '{'
+    7 | ;C!='\n';A()
+      | ^
+mikeash.c:7:1: error: incomplete universal character name \Ne
+```
+
+The problem was that in the string above there was a `\Newline` but this is
+invalid C. This was changed to be `\nNewline` and then, because the code is
+supposed to output itself when fed itself, the reference to `'N'` had to be
+updated in both the string and the code to be `'n'`.
+
+The array size of `c` was updated by 1 out of caution just in case as the array
+is used to store at least part of the string.
+
 
 
 ## [2005/mynx](2005/mynx/mynx.c) ([README.md](2005/mynx/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -64,8 +64,10 @@ Scovell](https://web.archive.org/web/20070120220721/https://thomasscovell.com/ta
 Cody fixed this to not require `-traditional-cpp` which not all compilers
 support (clang does not support it for example). Clang is also more strict about
 the args' types in `main()` and this was also a problem that Cody fixed, making
-it work with both clang and gcc. For the original code with the gcc fix
-described below, see the alternate code section in the README.md file.
+it work with both clang and gcc - in macOS. It was then noticed that with clang
+in linux it did not work so this had to be further fixed which Cody also did.
+For the original code with the gcc fix (noted below), see the alternate code
+section in the README.md file.
 
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.


### PR DESCRIPTION

Although my change of not requiring -traditional-cpp worked in macOS it
turns out one change had to be made for clang in linux which has now 
been done.
