### PR TITLE
Fix 1990/theorem/Makefile for clang in linux

### DIFF
--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -86,7 +86,7 @@ CC= cc
 ifeq ($(CC),clang)
 #
 CSILENCE+= -Wno-comma -Wno-implicit-int-conversion -Wno-missing-prototypes \
-	-Wno-missing-variable-declarations -Wno-poison-system-directories
+	-Wno-missing-variable-declarations -Wno-poison-system-directories \
 	-Wno-sign-conversion -Wno-strict-prototypes
 #
 CWARN+= -Weverything

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-deprecated-declarations -Wno-empty-body -Wno-error -Wno-unused-value \
 	-Wno-implicit-function-declaration -Wno-incompatible-pointer-types \
 	-Wno-macro-redefined -Wno-parentheses -Wno-return-type -Wno-unused-parameter \
-	-Wno-empty-translation-unit
+	-Wno-empty-translation-unit -Wno-int-conversion
 
 # Common C compiler warning flags
 #

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -38,7 +38,7 @@ include ../../var.mk
 
 # Common C compiler warnings to silence
 #
-CSILENCE= -Wno-trigraphs
+CSILENCE= -Wno-trigraphs -Wno-int-conversion
 
 # Common C compiler warning flags
 #

--- a/1994/ldb/ldb.c
+++ b/1994/ldb/ldb.c
@@ -1,1 +1,1 @@
-int _,O,__??('}'??);main(){while(O?(fgets((rand()%O++?':':_)+__,232,stdin))||puts(&__??(_??))&_:(srand(time((O+++_))),0)||O);}
+int _,O,__??('}'??);main(){while(O?(fgets((rand()%O++?':':_)+__,232,stdin))||puts(&__??(_??))&_:(srand(time((time_t *)(O+++_))),0)||O);}

--- a/1995/makarios/makarios.c
+++ b/1995/makarios/makarios.c
@@ -1,2 +1,3 @@
-main(int n, char **ia, char **aa, char **ma){int i=ia, a=aa, m=ma; while(i=++n)
+pain(int n, char **ia, char **aa, char **ma){int i=ia, a=aa, m=ma; while(i=++n)
 for(a=0;a<i?a=a*8+i%8,i/=8,m=a==i|a/8==i,1:(n-++m||printf("%o\n",n))&&n%m;);}
+main(int n, char **ia, char **aa) { return pain(n, ia, aa, 0); }

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	-Wno-deprecated-declarations -Wno-format -Wno-parentheses \
 	-Wno-shift-op-parentheses -Wno-sign-compare -Wno-unused-variable \
-	-Wno-main-return-type -Wno-return-type -Wno-unused-parameter
+	-Wno-main-return-type -Wno-return-type -Wno-unused-parameter -Wno-implicit-function-declaration
 
 # Common C compiler warning flags
 #
@@ -64,7 +64,7 @@ CDEFINE= -DX=1280l -DY=1024l -DZ=0x20000000
 
 # Include files that are needed to compile
 #
-CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11
+CINCLUDE= -include stdio.h -I ${X11_INCDIR} -I ${X11_INCDIR}/X11
 
 # Optimization
 #

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -424,6 +424,10 @@ and to prevent a warning about `gets()` at linking or runtime. Since this
 program is so incredible the extra fixes were deemed worth having and this is why
 it was done.
 
+Cody disabled a warning in the Makefile that proved to be a problem only with
+clang in linux but which was defaulting to an error. This way was the simplest
+way to deal with the problem in question due to the way the entry works.
+
 Yusuke pointed out that `atof` nowadays needs `#include <stdlib.h>` which was
 used in order to get this to work initially (prior to this output was there but
 incomplete).

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1443,6 +1443,7 @@ might as well.
 Cody added explicit linking of libm (`-lm`) for systems that do not do this
 (linux does not seem to but macOS does).
 
+He also fixed the Makefile so that it compiles with clang in linux.
 
 ## [2019/karns](2019/karns/prog.c) ([README.md](2019/karns/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -652,6 +652,12 @@ missing `int` for the `f` variable. He felt it was important that it works
 because the layout does indeed look to him like a rat is dropping core,
 something that the judges suggested.
 
+## [1995/makarios](1995/makarios/makarios.c) ([README.md](1995/makarios/README.md))
+
+Cody fixed this so that it will compile with versions of clang that has a defect
+which only allows `main()` to have 0, 2 or 3 args. This is done by a new
+function (`pain()` as it's annoying that clang is this way :-) ) that main()
+calls which has the four args.
 
 ## [1996/august](1996/august/august.c) ([README.md](1996/august/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -604,14 +604,19 @@ which main() calls with the right parameters.
 
 Cody fixed this so it would compile and work with modern compilers. The problem
 was that `srand()` returns void but it was used in a `||` expression. Thus the
-comma operator was needed.  Cody also changed the entry to use `fgets()` instead
-of `gets()` to make it safe for lines greater than 231 in length and to prevent
-a warning at linking or at runtime, the latter of which can be interspersed with
-output of the program.  Note that this now prints a newline after the output but
-this seems like a worthy compromise for making the output incorrect in macOS and
-at the same time it's safer (fixing it to not have the extra newline is more
-problematic than it's worth and in macOS another line of output would be shown
-anyway).
+comma operator was needed.
+
+Cody also fixed it for clang under linux which objected to incompatible pointer
+type (because `time(2)` takes a `time_t *` which in some systems is a `long *`
+but what was being passed to it is an `int`).
+
+Cody also changed the entry to use `fgets()` instead of `gets()` to make it safe
+for lines greater than 231 in length and to prevent a warning at linking or at
+runtime, the latter of which can be interspersed with output of the program.
+Note that this now prints a newline after the output but this seems like a
+worthy compromise for making the output incorrect in macOS and at the same time
+it's safer (fixing it to not have the extra newline is more problematic than
+it's worth and in macOS another line of output would be shown anyway).
 
 A subtlety about this fix: if a line is greater than 231 in length if the
 program chooses that line it might print the first 231 characters or it might


### PR DESCRIPTION

Disabled a warning that defaulted to an error. In this case it was 
easier to do it this way due to the way the entry works.