### PR TITLE
Change how 1985/lycklama is built + fix typo

### DIFF
--- a/1985/lycklama/.gitignore
+++ b/1985/lycklama/.gitignore
@@ -1,1 +1,2 @@
 lycklama
+lycklama.alt

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -58,7 +58,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -DZ=0
+CDEFINE= -DZ=500
 
 # Include files that are needed to compile
 #

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -8,25 +8,24 @@ Ed Lycklama
 make all
 ```
 
-
-With a tip from [Yusuke Endoh](/winners.html#Yusuke_Endoh)  it was indirectly
-noticed that if one slows down the call to `write()` one can see some fun output
-that's not visible with modern systems so Cody added a call to `usleep()`. The
-default time is `0` which disables it (in order to make it as close to original
-as possible; an alt version already exists mostly for fun output). In order to
-change the speed (try 500 or 700) do:
+If you have an old enough compiler you can try:
 
 ```sh
-make CDEFINE+="-DZ=700" clobber all
+make lycklama.orig
 ```
 
-Thank you Yusuke!
+
+
 
 ## To run:
 
 ```sh
 ./lycklama < some_file
 ```
+
+There is an alternate version which slows down the output for a more fun display
+with modern systems. For this reason we encourage you to try that version
+as well. See Alternate code section below. 
 
 ## Try:
 
@@ -40,20 +39,29 @@ Thank you Yusuke!
 
 ./lycklama < Makefile
 
-make CDEFINE+="-DZ=700" clobber all && ./lycklama < lycklama.c
 ```
+
 
 ### Alternative code:
 
-If you have an older compiler that lets you define some object to `#define` and
-then use it in place of `#define` you can run:
+This alternate version slows down the output which will provide more fun
+output. The default time passed to `usleep(3)` is `500` but you can reconfigure
+it like:
+
 
 ```sh
-make alt
+make CDEFINE+="-DZ=700" clobber alt
 ```
 
-Use `./lylycklama.alt` as you would `./lycklama` above.
+Use `./lycklama.alt` as you would `./lycklama` above.
 
+#### Try:
+
+```sh
+./lycklama.alt < lycklama.alt.c
+./lycklama.alt < lycklama.orig.c
+./lycklama.alt < Makefile
+```
 
 ## Judges' remarks:
 

--- a/1985/lycklama/lycklama.alt.c
+++ b/1985/lycklama/lycklama.alt.c
@@ -1,16 +1,16 @@
 #define o define
-#o ___o write
-#o ooo (unsigned)
-#o o_o_ 1
-#o _o_ char
-#o _oo goto
-#o _oo_ read
-#o o_o for
-#o o_ main
-#o o__ if
-#o oo_ 0
-#o _o(_,__,___)(void)___o(_,__,ooo(___))
-#o __o (o_o_<<((o_o_<<(o_o_<<o_o_))+(o_o_<<o_o_)))+(o_o_<<(o_o_<<(o_o_<<o_o_)))
+#define ___o write
+#define ooo (unsigned)
+#define o_o_ 1
+#define _o_ char
+#define _oo goto
+#define _oo_ read
+#define o_o for
+#define o_ main
+#define o__ if
+#define oo_ 0
+#define _o(_,__,___)(void)___o(_,__,ooo(___),Z&&usleep(Z))
+#define __o (o_o_<<((o_o_<<(o_o_<<o_o_))+(o_o_<<o_o_)))+(o_o_<<(o_o_<<(o_o_<<o_o_)))
 o_(){_o_ _=oo_,__,___,____[__o];_oo ______;_____:___=__o-o_o_; _______:
 _o(o_o_,____,__=(_-o_o_<___?_-o_o_:___));o_o(;__;_o(o_o_,"\b",o_o_),__--);
 _o(o_o_," ",o_o_);o__(--___)_oo _______;_o(o_o_,"\n",o_o_);______:o__(_=_oo_(

--- a/1985/lycklama/lycklama.c
+++ b/1985/lycklama/lycklama.c
@@ -9,7 +9,7 @@
 #define o_ main
 #define o__ if
 #define oo_ 0
-#define _o(_,__,___)(void)___o(_,__,ooo(___),Z&&usleep(Z))
+#define _o(_,__,___)(void)___o(_,__,ooo(___))
 #define __o (o_o_<<((o_o_<<(o_o_<<o_o_))+(o_o_<<o_o_)))+(o_o_<<(o_o_<<(o_o_<<o_o_)))
 o_(){_o_ _=oo_,__,___,____[__o];_oo ______;_____:___=__o-o_o_; _______:
 _o(o_o_,____,__=(_-o_o_<___?_-o_o_:___));o_o(;__;_o(o_o_,"\b",o_o_),__--);

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -109,12 +109,8 @@ changed the `#o` lines to `#define`. The
 [lycklama.alt.c](1985/lycklama/lycklama.alt.c) is the original source
 code as it provides some fun input for the entry.
 
-Yusuke provided some useful information that amounts to an alternate version but
-which does not actually modify the code except by a provided macro for a
-`usleep()` call which Cody added. This was not put in an alt file because the
-original code is in the alt file but the default to the `usleep()` call is 0,
-making it functionally equivalent not calling it.  See the README.md file
-details.
+Yusuke provided some useful information that amounts to an alternate version
+that Cody added. See the README.md for details.
 
 
 ## [1985/sicherman](1985/sicherman/sicherman.c) ([README.md](1985/sicherman/README.md]))


### PR DESCRIPTION
Now that we have the original code in lycklama.orig.c we can have what would more appropriately be an alternate version in lycklama.alt.c which is now done.

Typo fix was really unfortunate: it was in an example command to try which would have failed to work as the name was wrong.