### PR TITLE
Mass .gitignore update for .orig.c files

### DIFF
--- a/1984/anonymous/.gitignore
+++ b/1984/anonymous/.gitignore
@@ -1,2 +1,4 @@
 anonymous
 anonymous.alt
+anonymous.orig
+prog.orig

--- a/1984/decot/.gitignore
+++ b/1984/decot/.gitignore
@@ -1,1 +1,3 @@
 decot
+decot.orig
+prog.orig

--- a/1984/laman/.gitignore
+++ b/1984/laman/.gitignore
@@ -1,1 +1,3 @@
 laman
+laman.orig
+prog.orig

--- a/1984/mullender/.gitignore
+++ b/1984/mullender/.gitignore
@@ -1,3 +1,5 @@
 mullender
 mullender.alt
 gentab
+mullender.orig
+prog.orig

--- a/1985/applin/.gitignore
+++ b/1985/applin/.gitignore
@@ -1,1 +1,3 @@
 applin
+applin.orig
+prog.orig

--- a/1985/august/.gitignore
+++ b/1985/august/.gitignore
@@ -1,1 +1,3 @@
 august
+august.orig
+prog.orig

--- a/1985/lycklama/.gitignore
+++ b/1985/lycklama/.gitignore
@@ -1,2 +1,4 @@
 lycklama
 lycklama.alt
+lycklama.orig
+prog.orig

--- a/1985/lycklama/.gitignore
+++ b/1985/lycklama/.gitignore
@@ -1,1 +1,2 @@
 lycklama
+lycklama.alt

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -58,7 +58,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -DZ=0
+CDEFINE= -DZ=500
 
 # Include files that are needed to compile
 #

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -8,25 +8,24 @@ Ed Lycklama
 make all
 ```
 
-
-With a tip from [Yusuke Endoh](/winners.html#Yusuke_Endoh)  it was indirectly
-noticed that if one slows down the call to `write()` one can see some fun output
-that's not visible with modern systems so Cody added a call to `usleep()`. The
-default time is `0` which disables it (in order to make it as close to original
-as possible; an alt version already exists mostly for fun output). In order to
-change the speed (try 500 or 700) do:
+If you have an old enough compiler you can try:
 
 ```sh
-make CDEFINE+="-DZ=700" clobber all
+make lycklama.orig
 ```
 
-Thank you Yusuke!
+
+
 
 ## To run:
 
 ```sh
 ./lycklama < some_file
 ```
+
+There is an alternate version which slows down the output for a more fun display
+with modern systems. For this reason we encourage you to try that version
+as well. See Alternate code section below. 
 
 ## Try:
 
@@ -40,20 +39,29 @@ Thank you Yusuke!
 
 ./lycklama < Makefile
 
-make CDEFINE+="-DZ=700" clobber all && ./lycklama < lycklama.c
 ```
+
 
 ### Alternative code:
 
-If you have an older compiler that lets you define some object to `#define` and
-then use it in place of `#define` you can run:
+This alternate version slows down the output which will provide more fun
+output. The default time passed to `usleep(3)` is `500` but you can reconfigure
+it like:
+
 
 ```sh
-make alt
+make CDEFINE+="-DZ=700" clobber alt
 ```
 
-Use `./lylycklama.alt` as you would `./lycklama` above.
+Use `./lycklama.alt` as you would `./lycklama` above.
 
+#### Try:
+
+```sh
+./lycklama.alt < lycklama.alt.c
+./lycklama.alt < lycklama.orig.c
+./lycklama.alt < Makefile
+```
 
 ## Judges' remarks:
 

--- a/1985/lycklama/lycklama.alt.c
+++ b/1985/lycklama/lycklama.alt.c
@@ -1,16 +1,16 @@
 #define o define
-#o ___o write
-#o ooo (unsigned)
-#o o_o_ 1
-#o _o_ char
-#o _oo goto
-#o _oo_ read
-#o o_o for
-#o o_ main
-#o o__ if
-#o oo_ 0
-#o _o(_,__,___)(void)___o(_,__,ooo(___))
-#o __o (o_o_<<((o_o_<<(o_o_<<o_o_))+(o_o_<<o_o_)))+(o_o_<<(o_o_<<(o_o_<<o_o_)))
+#define ___o write
+#define ooo (unsigned)
+#define o_o_ 1
+#define _o_ char
+#define _oo goto
+#define _oo_ read
+#define o_o for
+#define o_ main
+#define o__ if
+#define oo_ 0
+#define _o(_,__,___)(void)___o(_,__,ooo(___),Z&&usleep(Z))
+#define __o (o_o_<<((o_o_<<(o_o_<<o_o_))+(o_o_<<o_o_)))+(o_o_<<(o_o_<<(o_o_<<o_o_)))
 o_(){_o_ _=oo_,__,___,____[__o];_oo ______;_____:___=__o-o_o_; _______:
 _o(o_o_,____,__=(_-o_o_<___?_-o_o_:___));o_o(;__;_o(o_o_,"\b",o_o_),__--);
 _o(o_o_," ",o_o_);o__(--___)_oo _______;_o(o_o_,"\n",o_o_);______:o__(_=_oo_(

--- a/1985/lycklama/lycklama.c
+++ b/1985/lycklama/lycklama.c
@@ -9,7 +9,7 @@
 #define o_ main
 #define o__ if
 #define oo_ 0
-#define _o(_,__,___)(void)___o(_,__,ooo(___),Z&&usleep(Z))
+#define _o(_,__,___)(void)___o(_,__,ooo(___))
 #define __o (o_o_<<((o_o_<<(o_o_<<o_o_))+(o_o_<<o_o_)))+(o_o_<<(o_o_<<(o_o_<<o_o_)))
 o_(){_o_ _=oo_,__,___,____[__o];_oo ______;_____:___=__o-o_o_; _______:
 _o(o_o_,____,__=(_-o_o_<___?_-o_o_:___));o_o(;__;_o(o_o_,"\b",o_o_),__--);

--- a/1985/shapiro/.gitignore
+++ b/1985/shapiro/.gitignore
@@ -1,1 +1,3 @@
 shapiro
+shapiro.orig
+prog.orig

--- a/1985/sicherman/.gitignore
+++ b/1985/sicherman/.gitignore
@@ -1,2 +1,4 @@
 sicherman
 sicherman.alt
+sicherman.orig
+prog.orig

--- a/1986/applin/.gitignore
+++ b/1986/applin/.gitignore
@@ -1,1 +1,3 @@
 applin
+applin.orig
+prog.orig

--- a/1986/august/.gitignore
+++ b/1986/august/.gitignore
@@ -1,1 +1,3 @@
 august
+august.orig
+prog.orig

--- a/1986/bright/.gitignore
+++ b/1986/bright/.gitignore
@@ -1,1 +1,3 @@
 bright
+bright.orig
+prog.orig

--- a/1986/hague/.gitignore
+++ b/1986/hague/.gitignore
@@ -1,1 +1,3 @@
 hague
+hague.orig
+prog.orig

--- a/1986/holloway/.gitignore
+++ b/1986/holloway/.gitignore
@@ -1,1 +1,3 @@
 holloway
+holloway.orig
+prog.orig

--- a/1986/marshall/.gitignore
+++ b/1986/marshall/.gitignore
@@ -1,1 +1,3 @@
 marshall
+marshall.orig
+prog.orig

--- a/1986/pawka/.gitignore
+++ b/1986/pawka/.gitignore
@@ -1,1 +1,3 @@
 pawka
+pawka.orig
+prog.orig

--- a/1986/stein/.gitignore
+++ b/1986/stein/.gitignore
@@ -1,2 +1,4 @@
 a.out
 stein
+stein.orig
+prog.orig

--- a/1986/wall/.gitignore
+++ b/1986/wall/.gitignore
@@ -1,2 +1,4 @@
 wall
 wall.alt
+wall.orig
+prog.orig

--- a/1987/biggar/.gitignore
+++ b/1987/biggar/.gitignore
@@ -1,1 +1,3 @@
 biggar
+biggar.orig
+prog.orig

--- a/1987/heckbert/.gitignore
+++ b/1987/heckbert/.gitignore
@@ -5,3 +5,5 @@ foo.c
 heckbert
 ph
 ph.c
+heckbert.orig
+prog.orig

--- a/1987/hines/.gitignore
+++ b/1987/hines/.gitignore
@@ -1,2 +1,4 @@
 hines
 hines.alt
+hines.orig
+prog.orig

--- a/1987/korn/.gitignore
+++ b/1987/korn/.gitignore
@@ -1,1 +1,3 @@
 korn
+korn.orig
+prog.orig

--- a/1987/lievaart/.gitignore
+++ b/1987/lievaart/.gitignore
@@ -2,3 +2,5 @@ lievaart
 lievaart.alt
 lievaart2
 lievaart2.alt
+lievaart.orig
+prog.orig

--- a/1987/wall/.gitignore
+++ b/1987/wall/.gitignore
@@ -1,2 +1,4 @@
 wall
 wall.alt
+wall.orig
+prog.orig

--- a/1987/westley/.gitignore
+++ b/1987/westley/.gitignore
@@ -1,1 +1,3 @@
 westley
+westley.orig
+prog.orig

--- a/1988/applin/.gitignore
+++ b/1988/applin/.gitignore
@@ -3,3 +3,5 @@ large.c
 zsmall
 zsmall.c
 applin.alt
+applin.orig
+prog.orig

--- a/1988/dale/.gitignore
+++ b/1988/dale/.gitignore
@@ -1,2 +1,4 @@
 dale
 dale.alt
+dale.orig
+prog.orig

--- a/1988/isaak/.gitignore
+++ b/1988/isaak/.gitignore
@@ -1,3 +1,5 @@
 isaak
 isaak.alt
 isaak.output
+isaak.orig
+prog.orig

--- a/1988/litmaath/.gitignore
+++ b/1988/litmaath/.gitignore
@@ -1,2 +1,4 @@
 litmaath
 litmaath.alt
+litmaath.orig
+prog.orig

--- a/1988/phillipps/.gitignore
+++ b/1988/phillipps/.gitignore
@@ -1,1 +1,3 @@
 phillipps
+phillipps.orig
+prog.orig

--- a/1988/reddy/.gitignore
+++ b/1988/reddy/.gitignore
@@ -1,1 +1,3 @@
 reddy
+reddy.orig
+prog.orig

--- a/1988/robison/.gitignore
+++ b/1988/robison/.gitignore
@@ -1,1 +1,3 @@
 robison
+robison.orig
+prog.orig

--- a/1988/spinellis/.gitignore
+++ b/1988/spinellis/.gitignore
@@ -1,3 +1,5 @@
 prog.c
 spinellis
 spinellis.alt
+spinellis.orig
+prog.orig

--- a/1988/westley/.gitignore
+++ b/1988/westley/.gitignore
@@ -1,2 +1,4 @@
 westley
 westley.alt
+westley.orig
+prog.orig

--- a/1989/fubar/.gitignore
+++ b/1989/fubar/.gitignore
@@ -3,3 +3,5 @@ ouroboros
 ouroboros.c
 x
 x1
+fubar.orig
+prog.orig

--- a/1989/jar.1/.gitignore
+++ b/1989/jar.1/.gitignore
@@ -1,1 +1,3 @@
 jar.1
+jar.1.orig
+prog.orig

--- a/1989/jar.2/.gitignore
+++ b/1989/jar.2/.gitignore
@@ -1,1 +1,3 @@
 jar.2
+jar.2.orig
+prog.orig

--- a/1989/ovdluhe/.gitignore
+++ b/1989/ovdluhe/.gitignore
@@ -1,2 +1,4 @@
 ovdluhe
 ovdluhe.alt
+ovdluhe.orig
+prog.orig

--- a/1989/paul/.gitignore
+++ b/1989/paul/.gitignore
@@ -1,1 +1,3 @@
 paul
+paul.orig
+prog.orig

--- a/1989/robison/.gitignore
+++ b/1989/robison/.gitignore
@@ -1,1 +1,3 @@
 robison
+robison.orig
+prog.orig

--- a/1989/roemer/.gitignore
+++ b/1989/roemer/.gitignore
@@ -1,1 +1,3 @@
 roemer
+roemer.orig
+prog.orig

--- a/1989/tromp/.gitignore
+++ b/1989/tromp/.gitignore
@@ -1,3 +1,5 @@
 tromp
 tromp.alt
 HI
+tromp.orig
+prog.orig

--- a/1989/vanb/.gitignore
+++ b/1989/vanb/.gitignore
@@ -1,1 +1,3 @@
 vanb
+vanb.orig
+prog.orig

--- a/1989/westley/.gitignore
+++ b/1989/westley/.gitignore
@@ -7,3 +7,5 @@ ver2.c
 ver3
 ver3.c
 westley
+westley.orig
+prog.orig

--- a/1990/baruch/.gitignore
+++ b/1990/baruch/.gitignore
@@ -1,2 +1,4 @@
 baruch
 baruch.alt
+baruch.orig
+prog.orig

--- a/1990/cmills/.gitignore
+++ b/1990/cmills/.gitignore
@@ -1,1 +1,3 @@
 cmills
+cmills.orig
+prog.orig

--- a/1990/dds/.gitignore
+++ b/1990/dds/.gitignore
@@ -1,1 +1,3 @@
 dds
+dds.orig
+prog.orig

--- a/1990/dg/.gitignore
+++ b/1990/dg/.gitignore
@@ -1,1 +1,3 @@
 dg
+dg.orig
+prog.orig

--- a/1990/jaw/.gitignore
+++ b/1990/jaw/.gitignore
@@ -4,3 +4,5 @@ zcat
 receive
 unshark
 unshark.c
+jaw.orig
+prog.orig

--- a/1990/pjr/.gitignore
+++ b/1990/pjr/.gitignore
@@ -1,1 +1,3 @@
 pjr
+pjr.orig
+prog.orig

--- a/1990/scjones/.gitignore
+++ b/1990/scjones/.gitignore
@@ -1,1 +1,3 @@
 scjones
+scjones.orig
+prog.orig

--- a/1990/stig/.gitignore
+++ b/1990/stig/.gitignore
@@ -1,3 +1,5 @@
 o
 o.c
 stig
+stig.orig
+prog.orig

--- a/1990/tbr/.gitignore
+++ b/1990/tbr/.gitignore
@@ -1,1 +1,3 @@
 tbr
+tbr.orig
+prog.orig

--- a/1990/theorem/.gitignore
+++ b/1990/theorem/.gitignore
@@ -6,3 +6,5 @@ sorter
 sorter.c
 theorem_bkp
 theorem_bkp.c
+theorem.orig
+prog.orig

--- a/1990/westley/.gitignore
+++ b/1990/westley/.gitignore
@@ -1,1 +1,3 @@
 westley
+westley.orig
+prog.orig

--- a/1991/ant/.gitignore
+++ b/1991/ant/.gitignore
@@ -1,2 +1,4 @@
 ant
 hill
+ant.orig
+prog.orig

--- a/1991/brnstnd/.gitignore
+++ b/1991/brnstnd/.gitignore
@@ -1,1 +1,3 @@
 brnstnd
+brnstnd.orig
+prog.orig

--- a/1991/buzzard/.gitignore
+++ b/1991/buzzard/.gitignore
@@ -1,1 +1,3 @@
 buzzard
+buzzard.orig
+prog.orig

--- a/1991/cdupont/.gitignore
+++ b/1991/cdupont/.gitignore
@@ -1,1 +1,3 @@
 cdupont
+cdupont.orig
+prog.orig

--- a/1991/davidguy/.gitignore
+++ b/1991/davidguy/.gitignore
@@ -1,1 +1,3 @@
 davidguy
+davidguy.orig
+prog.orig

--- a/1991/dds/.gitignore
+++ b/1991/dds/.gitignore
@@ -3,3 +3,5 @@ dds.alt
 a
 a.c
 a.out
+dds.orig
+prog.orig

--- a/1991/fine/.gitignore
+++ b/1991/fine/.gitignore
@@ -1,1 +1,3 @@
 fine
+fine.orig
+prog.orig

--- a/1991/rince/.gitignore
+++ b/1991/rince/.gitignore
@@ -1,1 +1,3 @@
 rince
+rince.orig
+prog.orig

--- a/1991/westley/.gitignore
+++ b/1991/westley/.gitignore
@@ -7,3 +7,5 @@ ttt_game
 ttt_game.c
 westley
 ttt_old.c
+westley.orig
+prog.orig

--- a/1992/adrian/.gitignore
+++ b/1992/adrian/.gitignore
@@ -22,3 +22,5 @@ adwc
 adwc.alt
 adwc.alt.c
 adwc.c
+adrian.orig
+prog.orig

--- a/1992/albert/.gitignore
+++ b/1992/albert/.gitignore
@@ -1,1 +1,3 @@
 albert
+albert.orig
+prog.orig

--- a/1992/ant/.gitignore
+++ b/1992/ant/.gitignore
@@ -3,3 +3,5 @@ am.safe
 ant
 node.*
 leaf.*
+ant.orig
+prog.orig

--- a/1992/buzzard.1/.gitignore
+++ b/1992/buzzard.1/.gitignore
@@ -2,3 +2,5 @@ babble
 babble.cppcb
 buzzard.1
 tmp
+buzzard.1.orig
+prog.orig

--- a/1992/buzzard.2/.gitignore
+++ b/1992/buzzard.2/.gitignore
@@ -1,2 +1,4 @@
 buzzard.2
 first
+buzzard.2.orig
+prog.orig

--- a/1992/gson/.gitignore
+++ b/1992/gson/.gitignore
@@ -1,3 +1,5 @@
 gson
 ag
 words
+gson.orig
+prog.orig

--- a/1992/imc/.gitignore
+++ b/1992/imc/.gitignore
@@ -1,3 +1,5 @@
 imc
 screen1.ras
 screen2.ras
+imc.orig
+prog.orig

--- a/1992/kivinen/.gitignore
+++ b/1992/kivinen/.gitignore
@@ -1,1 +1,3 @@
 kivinen
+kivinen.orig
+prog.orig

--- a/1992/lush/.gitignore
+++ b/1992/lush/.gitignore
@@ -1,2 +1,4 @@
 lush
 lush.alt
+lush.orig
+prog.orig

--- a/1992/marangon/.gitignore
+++ b/1992/marangon/.gitignore
@@ -1,1 +1,3 @@
 marangon
+marangon.orig
+prog.orig

--- a/1992/nathan/.gitignore
+++ b/1992/nathan/.gitignore
@@ -1,1 +1,3 @@
 nathan
+nathan.orig
+prog.orig

--- a/1992/vern/.gitignore
+++ b/1992/vern/.gitignore
@@ -1,2 +1,4 @@
 vern
 vern.tmp.c
+vern.orig
+prog.orig

--- a/1992/westley/.gitignore
+++ b/1992/westley/.gitignore
@@ -1,3 +1,5 @@
 westley
 whereami
 westley.alt
+westley.orig
+prog.orig

--- a/1993/ant/.gitignore
+++ b/1993/ant/.gitignore
@@ -2,3 +2,5 @@ ag
 ag.txt
 ant
 ant
+ant.orig
+prog.orig

--- a/1993/cmills/.gitignore
+++ b/1993/cmills/.gitignore
@@ -1,1 +1,3 @@
 cmills
+cmills.orig
+prog.orig

--- a/1993/dgibson/.gitignore
+++ b/1993/dgibson/.gitignore
@@ -1,3 +1,5 @@
 data.name
 dgibson
 life.d 
+dgibson.orig
+prog.orig

--- a/1993/ejb/.gitignore
+++ b/1993/ejb/.gitignore
@@ -1,1 +1,3 @@
 ejb
+ejb.orig
+prog.orig

--- a/1993/jonth/.gitignore
+++ b/1993/jonth/.gitignore
@@ -1,2 +1,4 @@
 jonth
 jonth.tmp.c
+jonth.orig
+prog.orig

--- a/1993/leo/.gitignore
+++ b/1993/leo/.gitignore
@@ -1,2 +1,4 @@
 leo
 mind
+leo.orig
+prog.orig

--- a/1993/lmfjyh/.gitignore
+++ b/1993/lmfjyh/.gitignore
@@ -1,3 +1,5 @@
 "*
 lmfjyh
 lmfjyh.alt
+lmfjyh.orig
+prog.orig

--- a/1993/plummer/.gitignore
+++ b/1993/plummer/.gitignore
@@ -1,2 +1,4 @@
 plummer
 plummer.alt
+plummer.orig
+prog.orig

--- a/1993/rince/.gitignore
+++ b/1993/rince/.gitignore
@@ -1,2 +1,4 @@
 jkb
 rince
+rince.orig
+prog.orig

--- a/1993/schnitzi/.gitignore
+++ b/1993/schnitzi/.gitignore
@@ -1,1 +1,3 @@
 schnitzi
+schnitzi.orig
+prog.orig

--- a/1993/vanb/.gitignore
+++ b/1993/vanb/.gitignore
@@ -1,1 +1,3 @@
 vanb
+vanb.orig
+prog.orig

--- a/1994/dodsond1/.gitignore
+++ b/1994/dodsond1/.gitignore
@@ -1,1 +1,3 @@
 dodsond1
+dodsond1.orig
+prog.orig

--- a/1994/dodsond2/.gitignore
+++ b/1994/dodsond2/.gitignore
@@ -1,1 +1,3 @@
 dodsond2
+dodsond2.orig
+prog.orig

--- a/1994/horton/.gitignore
+++ b/1994/horton/.gitignore
@@ -1,3 +1,5 @@
 gtface
 horton
 horton.alt
+horton.orig
+prog.orig

--- a/1994/imc/.gitignore
+++ b/1994/imc/.gitignore
@@ -1,1 +1,3 @@
 imc
+imc.orig
+prog.orig

--- a/1994/ldb/.gitignore
+++ b/1994/ldb/.gitignore
@@ -1,2 +1,4 @@
 ldb
 ldb.alt
+ldb.orig
+prog.orig

--- a/1994/schnitzi/.gitignore
+++ b/1994/schnitzi/.gitignore
@@ -1,2 +1,4 @@
 schnitzi
 schnitzi.alt
+schnitzi.orig
+prog.orig

--- a/1994/shapiro/.gitignore
+++ b/1994/shapiro/.gitignore
@@ -1,3 +1,5 @@
 shapiro
 shapiro_t1
 shapiro_t2.c
+shapiro.orig
+prog.orig

--- a/1994/smr/.gitignore
+++ b/1994/smr/.gitignore
@@ -1,2 +1,4 @@
 smr
 smr.out
+smr.orig
+prog.orig

--- a/1994/tvr/.gitignore
+++ b/1994/tvr/.gitignore
@@ -1,2 +1,4 @@
 tvr
 tvr.alt
+tvr.orig
+prog.orig

--- a/1994/weisberg/.gitignore
+++ b/1994/weisberg/.gitignore
@@ -1,2 +1,4 @@
 weisberg
 weisberg.alt
+weisberg.orig
+prog.orig

--- a/1994/westley/.gitignore
+++ b/1994/westley/.gitignore
@@ -1,1 +1,3 @@
 westley
+westley.orig
+prog.orig

--- a/1995/cdua/.gitignore
+++ b/1995/cdua/.gitignore
@@ -1,2 +1,4 @@
 cdua
 cdua.alt
+cdua.orig
+prog.orig

--- a/1995/dodsond1/.gitignore
+++ b/1995/dodsond1/.gitignore
@@ -1,1 +1,3 @@
 dodsond1
+dodsond1.orig
+prog.orig

--- a/1995/dodsond2/.gitignore
+++ b/1995/dodsond2/.gitignore
@@ -1,1 +1,3 @@
 dodsond2
+dodsond2.orig
+prog.orig

--- a/1995/esde/.gitignore
+++ b/1995/esde/.gitignore
@@ -1,1 +1,3 @@
 esde
+esde.orig
+prog.orig

--- a/1995/garry/.gitignore
+++ b/1995/garry/.gitignore
@@ -1,2 +1,4 @@
 garry
 garry.alt
+garry.orig
+prog.orig

--- a/1995/heathbar/.gitignore
+++ b/1995/heathbar/.gitignore
@@ -1,1 +1,3 @@
 heathbar
+heathbar.orig
+prog.orig

--- a/1995/leo/.gitignore
+++ b/1995/leo/.gitignore
@@ -1,1 +1,3 @@
 leo
+leo.orig
+prog.orig

--- a/1995/makarios/.gitignore
+++ b/1995/makarios/.gitignore
@@ -1,1 +1,3 @@
 makarios
+makarios.orig
+prog.orig

--- a/1995/savastio/.gitignore
+++ b/1995/savastio/.gitignore
@@ -1,1 +1,3 @@
 savastio
+savastio.orig
+prog.orig

--- a/1995/schnitzi/.gitignore
+++ b/1995/schnitzi/.gitignore
@@ -1,1 +1,3 @@
 schnitzi
+schnitzi.orig
+prog.orig

--- a/1995/spinellis/.gitignore
+++ b/1995/spinellis/.gitignore
@@ -1,1 +1,3 @@
 spinellis
+spinellis.orig
+prog.orig

--- a/1995/vanschnitz/.gitignore
+++ b/1995/vanschnitz/.gitignore
@@ -1,1 +1,3 @@
 vanschnitz
+vanschnitz.orig
+prog.orig

--- a/1996/august/.gitignore
+++ b/1996/august/.gitignore
@@ -6,3 +6,5 @@ parse.oo
 prog.oc
 august.oo
 prog.oo
+august.orig
+prog.orig

--- a/1996/dalbec/.gitignore
+++ b/1996/dalbec/.gitignore
@@ -1,1 +1,3 @@
 dalbec
+dalbec.orig
+prog.orig

--- a/1996/eldby/.gitignore
+++ b/1996/eldby/.gitignore
@@ -1,2 +1,4 @@
 eldby
 eldby.alt
+eldby.orig
+prog.orig

--- a/1996/gandalf/.gitignore
+++ b/1996/gandalf/.gitignore
@@ -1,3 +1,5 @@
 cathat
 gandalf
 hatcat
+gandalf.orig
+prog.orig

--- a/1996/huffman/.gitignore
+++ b/1996/huffman/.gitignore
@@ -1,1 +1,3 @@
 huffman
+huffman.orig
+prog.orig

--- a/1996/jonth/.gitignore
+++ b/1996/jonth/.gitignore
@@ -1,1 +1,3 @@
 jonth
+jonth.orig
+prog.orig

--- a/1996/rcm/.gitignore
+++ b/1996/rcm/.gitignore
@@ -1,1 +1,3 @@
 rcm
+rcm.orig
+prog.orig

--- a/1996/schweikh1/.gitignore
+++ b/1996/schweikh1/.gitignore
@@ -1,1 +1,3 @@
 schweikh1
+schweikh1.orig
+prog.orig

--- a/1996/schweikh2/.gitignore
+++ b/1996/schweikh2/.gitignore
@@ -1,1 +1,3 @@
 schweikh2
+schweikh2.orig
+prog.orig

--- a/1996/schweikh3/.gitignore
+++ b/1996/schweikh3/.gitignore
@@ -1,1 +1,3 @@
 schweikh3
+schweikh3.orig
+prog.orig

--- a/1996/westley/.gitignore
+++ b/1996/westley/.gitignore
@@ -1,2 +1,4 @@
 westley
 westley.alt
+westley.orig
+prog.orig

--- a/1998/banks/.gitignore
+++ b/1998/banks/.gitignore
@@ -1,2 +1,4 @@
 banks
 banks.alt
+banks.orig
+prog.orig

--- a/1998/bas1/.gitignore
+++ b/1998/bas1/.gitignore
@@ -1,1 +1,3 @@
 bas1
+bas1.orig
+prog.orig

--- a/1998/bas2/.gitignore
+++ b/1998/bas2/.gitignore
@@ -1,1 +1,3 @@
 bas2
+bas2.orig
+prog.orig

--- a/1998/chaos/.gitignore
+++ b/1998/chaos/.gitignore
@@ -1,3 +1,5 @@
 chaos
 chaos_nohalf
 chaos_nohalf.c
+chaos.orig
+prog.orig

--- a/1998/df/.gitignore
+++ b/1998/df/.gitignore
@@ -1,1 +1,3 @@
 df
+df.orig
+prog.orig

--- a/1998/dlowe/.gitignore
+++ b/1998/dlowe/.gitignore
@@ -1,3 +1,5 @@
 dlowe
 dlowe.alt
 README.poot.md
+dlowe.orig
+prog.orig

--- a/1998/dloweneil/.gitignore
+++ b/1998/dloweneil/.gitignore
@@ -1,2 +1,4 @@
 dloweneil
 pootris
+dloweneil.orig
+prog.orig

--- a/1998/dorssel/.gitignore
+++ b/1998/dorssel/.gitignore
@@ -1,1 +1,3 @@
 dorssel
+dorssel.orig
+prog.orig

--- a/1998/fanf/.gitignore
+++ b/1998/fanf/.gitignore
@@ -1,3 +1,5 @@
 fanf
 fanftmp1.c
 fanftmp2.c
+fanf.orig
+prog.orig

--- a/1998/schnitzi/.gitignore
+++ b/1998/schnitzi/.gitignore
@@ -2,3 +2,5 @@ data
 schnitzi
 sort
 sort.c
+schnitzi.orig
+prog.orig

--- a/1998/schweikh1/.gitignore
+++ b/1998/schweikh1/.gitignore
@@ -1,2 +1,4 @@
 schweikh1
 schweikh1.alt
+schweikh1.orig
+prog.orig

--- a/1998/schweikh2/.gitignore
+++ b/1998/schweikh2/.gitignore
@@ -1,1 +1,3 @@
 schweikh2
+schweikh2.orig
+prog.orig

--- a/1998/schweikh3/.gitignore
+++ b/1998/schweikh3/.gitignore
@@ -3,3 +3,5 @@ file1
 file2
 file3
 file4
+schweikh3.orig
+prog.orig

--- a/1998/tomtorfs/.gitignore
+++ b/1998/tomtorfs/.gitignore
@@ -1,1 +1,3 @@
 tomtorfs
+tomtorfs.orig
+prog.orig

--- a/2000/anderson/.gitignore
+++ b/2000/anderson/.gitignore
@@ -1,2 +1,4 @@
 anderson
 anderson.alt
+anderson.orig
+prog.orig

--- a/2000/bellard/.gitignore
+++ b/2000/bellard/.gitignore
@@ -1,1 +1,3 @@
 bellard
+bellard.orig
+prog.orig

--- a/2000/bmeyer/.gitignore
+++ b/2000/bmeyer/.gitignore
@@ -1,2 +1,4 @@
 bmeyer
 lavabus.glic
+bmeyer.orig
+prog.orig

--- a/2000/briddlebane/.gitignore
+++ b/2000/briddlebane/.gitignore
@@ -1,1 +1,3 @@
 briddlebane
+briddlebane.orig
+prog.orig

--- a/2000/dhyang/.gitignore
+++ b/2000/dhyang/.gitignore
@@ -6,3 +6,5 @@ soku
 soku.c
 zan
 zan.c
+dhyang.orig
+prog.orig

--- a/2000/dlowe/.gitignore
+++ b/2000/dlowe/.gitignore
@@ -1,1 +1,3 @@
 dlowe
+dlowe.orig
+prog.orig

--- a/2000/jarijyrki/.gitignore
+++ b/2000/jarijyrki/.gitignore
@@ -1,3 +1,5 @@
 jarijyrki
 myedits.info
 outfile.info
+jarijyrki.orig
+prog.orig

--- a/2000/natori/.gitignore
+++ b/2000/natori/.gitignore
@@ -1,2 +1,4 @@
 natori
 natori.alt
+natori.orig
+prog.orig

--- a/2000/primenum/.gitignore
+++ b/2000/primenum/.gitignore
@@ -1,1 +1,3 @@
 primenum
+primenum.orig
+prog.orig

--- a/2000/rince/.gitignore
+++ b/2000/rince/.gitignore
@@ -1,2 +1,4 @@
 dmy2jd
 rince
+rince.orig
+prog.orig

--- a/2000/robison/.gitignore
+++ b/2000/robison/.gitignore
@@ -1,1 +1,3 @@
 robison
+robison.orig
+prog.orig

--- a/2000/schneiderwent/.gitignore
+++ b/2000/schneiderwent/.gitignore
@@ -1,1 +1,3 @@
 schneiderwent
+schneiderwent.orig
+prog.orig

--- a/2000/thadgavin/.gitignore
+++ b/2000/thadgavin/.gitignore
@@ -2,3 +2,5 @@ thadgavin
 thadgavin_sdl
 thadgavin.alt
 thadgavin.alt_sdl
+thadgavin.orig
+prog.orig

--- a/2000/tomx/.gitignore
+++ b/2000/tomx/.gitignore
@@ -1,2 +1,4 @@
 tomx
 mkentry
+tomx.orig
+prog.orig

--- a/2001/anonymous/.gitignore
+++ b/2001/anonymous/.gitignore
@@ -8,3 +8,5 @@ ten.txt
 anonymous.ten.64
 anonymous.bed
 anonymous.bed.64
+anonymous.orig
+prog.orig

--- a/2001/bellard/.gitignore
+++ b/2001/bellard/.gitignore
@@ -1,3 +1,5 @@
 bellard
 bellard.otccex
 otccelf
+bellard.orig
+prog.orig

--- a/2001/cheong/.gitignore
+++ b/2001/cheong/.gitignore
@@ -1,1 +1,3 @@
 cheong
+cheong.orig
+prog.orig

--- a/2001/coupard/.gitignore
+++ b/2001/coupard/.gitignore
@@ -1,2 +1,4 @@
 coupard
 test.wav
+coupard.orig
+prog.orig

--- a/2001/ctk/.gitignore
+++ b/2001/ctk/.gitignore
@@ -1,1 +1,3 @@
 ctk
+ctk.orig
+prog.orig

--- a/2001/dgbeards/.gitignore
+++ b/2001/dgbeards/.gitignore
@@ -1,2 +1,4 @@
 dgbeards
 dgbeards.alt
+dgbeards.orig
+prog.orig

--- a/2001/herrmann1/.gitignore
+++ b/2001/herrmann1/.gitignore
@@ -2,3 +2,5 @@ herrmann1
 error
 herrmann1-1.c
 herrmann1-3.c
+herrmann1.orig
+prog.orig

--- a/2001/herrmann2/.gitignore
+++ b/2001/herrmann2/.gitignore
@@ -1,2 +1,4 @@
 herrmann2
 herrmann2.orig.c
+herrmann2.orig
+prog.orig

--- a/2001/jason/.gitignore
+++ b/2001/jason/.gitignore
@@ -1,1 +1,3 @@
 jason
+jason.orig
+prog.orig

--- a/2001/kev/.gitignore
+++ b/2001/kev/.gitignore
@@ -1,2 +1,4 @@
 kev
 kev.alt
+kev.orig
+prog.orig

--- a/2001/ollinger/.gitignore
+++ b/2001/ollinger/.gitignore
@@ -1,1 +1,3 @@
 ollinger
+ollinger.orig
+prog.orig

--- a/2001/rosten/.gitignore
+++ b/2001/rosten/.gitignore
@@ -1,1 +1,3 @@
 rosten
+rosten.orig
+prog.orig

--- a/2001/schweikh/.gitignore
+++ b/2001/schweikh/.gitignore
@@ -1,1 +1,3 @@
 schweikh
+schweikh.orig
+prog.orig

--- a/2001/westley/.gitignore
+++ b/2001/westley/.gitignore
@@ -4,3 +4,5 @@ westley2
 westley2.c
 westley.punch
 westley.sort
+westley.orig
+prog.orig

--- a/2001/williams/.gitignore
+++ b/2001/williams/.gitignore
@@ -1,1 +1,3 @@
 williams
+williams.orig
+prog.orig

--- a/2004/anonymous/.gitignore
+++ b/2004/anonymous/.gitignore
@@ -1,2 +1,4 @@
 anonymous
 anonymous.pgm
+anonymous.orig
+prog.orig

--- a/2004/arachnid/.gitignore
+++ b/2004/arachnid/.gitignore
@@ -1,2 +1,4 @@
 arachnid
 arachnid.alt
+arachnid.orig
+prog.orig

--- a/2004/burley/.gitignore
+++ b/2004/burley/.gitignore
@@ -1,1 +1,3 @@
 burley
+burley.orig
+prog.orig

--- a/2004/gavare/.gitignore
+++ b/2004/gavare/.gitignore
@@ -1,3 +1,5 @@
 gavare
 ioccc_ray.ppm
 gavare.r3
+gavare.orig
+prog.orig

--- a/2004/gavin/.gitignore
+++ b/2004/gavin/.gitignore
@@ -8,3 +8,5 @@ img/README.md
 kernel
 sh
 vi
+gavin.orig
+prog.orig

--- a/2004/hibachi/.gitignore
+++ b/2004/hibachi/.gitignore
@@ -3,3 +3,5 @@ src/config.log
 src/config.status
 src/hibachi
 src/makefile
+hibachi.orig
+prog.orig

--- a/2004/hoyle/.gitignore
+++ b/2004/hoyle/.gitignore
@@ -1,2 +1,4 @@
 hoyle
 hoyle.alt
+hoyle.orig
+prog.orig

--- a/2004/jdalbec/.gitignore
+++ b/2004/jdalbec/.gitignore
@@ -1,3 +1,5 @@
 jdalbec
 jdalbec2.c
 jdalbec3.c
+jdalbec.orig
+prog.orig

--- a/2004/kopczynski/.gitignore
+++ b/2004/kopczynski/.gitignore
@@ -1,2 +1,4 @@
 kopczynski
 kopczynski.alt
+kopczynski.orig
+prog.orig

--- a/2004/newbern/.gitignore
+++ b/2004/newbern/.gitignore
@@ -1,1 +1,3 @@
 newbern
+newbern.orig
+prog.orig

--- a/2004/omoikane/.gitignore
+++ b/2004/omoikane/.gitignore
@@ -1,1 +1,3 @@
 omoikane
+omoikane.orig
+prog.orig

--- a/2004/schnitzi/.gitignore
+++ b/2004/schnitzi/.gitignore
@@ -1,1 +1,3 @@
 schnitzi
+schnitzi.orig
+prog.orig

--- a/2004/sds/.gitignore
+++ b/2004/sds/.gitignore
@@ -6,3 +6,5 @@ sds2_msg
 sds2_msg.c
 sds_msg
 sds_msg.c
+sds.orig
+prog.orig

--- a/2004/vik1/.gitignore
+++ b/2004/vik1/.gitignore
@@ -1,1 +1,3 @@
 vik1
+vik1.orig
+prog.orig

--- a/2004/vik2/.gitignore
+++ b/2004/vik2/.gitignore
@@ -2,3 +2,5 @@ cat-killing-curiosity
 vik2
 vik2.possible.cat.death_1.c
 vik2.possible.cat.death_2.c
+vik2.orig
+prog.orig

--- a/2005/aidan/.gitignore
+++ b/2005/aidan/.gitignore
@@ -1,2 +1,4 @@
 aidan
 aidan.alt
+aidan.orig
+prog.orig

--- a/2005/anon/.gitignore
+++ b/2005/anon/.gitignore
@@ -1,2 +1,4 @@
 anon
 anon.alt
+anon.orig
+prog.orig

--- a/2005/boutines/.gitignore
+++ b/2005/boutines/.gitignore
@@ -1,3 +1,5 @@
 boutines
 test.svg
 test.png
+boutines.orig
+prog.orig

--- a/2005/chia/.gitignore
+++ b/2005/chia/.gitignore
@@ -1,1 +1,3 @@
 chia
+chia.orig
+prog.orig

--- a/2005/giljade/.gitignore
+++ b/2005/giljade/.gitignore
@@ -2,3 +2,5 @@ giljade
 giljade.alt
 out
 c.c
+giljade.orig
+prog.orig

--- a/2005/jetro/.gitignore
+++ b/2005/jetro/.gitignore
@@ -1,1 +1,3 @@
 jetro
+jetro.orig
+prog.orig

--- a/2005/klausler/.gitignore
+++ b/2005/klausler/.gitignore
@@ -1,2 +1,4 @@
 dict.h
 klausler
+klausler.orig
+prog.orig

--- a/2005/mikeash/.gitignore
+++ b/2005/mikeash/.gitignore
@@ -1,1 +1,3 @@
 mikeash
+mikeash.orig
+prog.orig

--- a/2005/mynx/.gitignore
+++ b/2005/mynx/.gitignore
@@ -2,3 +2,5 @@ mynx
 mynx.alt
 source/config.*
 source/makefile
+mynx.orig
+prog.orig

--- a/2005/persano/.gitignore
+++ b/2005/persano/.gitignore
@@ -1,2 +1,4 @@
 persano
 foo.gif
+persano.orig
+prog.orig

--- a/2005/sykes/.gitignore
+++ b/2005/sykes/.gitignore
@@ -1,3 +1,5 @@
 pet.rom
 sykes
 dungeon.prg
+sykes.orig
+prog.orig

--- a/2005/timwi/.gitignore
+++ b/2005/timwi/.gitignore
@@ -1,1 +1,3 @@
 timwi
+timwi.orig
+prog.orig

--- a/2005/toledo/.gitignore
+++ b/2005/toledo/.gitignore
@@ -1,3 +1,5 @@
 toledo
 toledo2
 toledo3
+toledo.orig
+prog.orig

--- a/2005/vik/.gitignore
+++ b/2005/vik/.gitignore
@@ -1,1 +1,3 @@
 vik
+vik.orig
+prog.orig

--- a/2005/vince/.gitignore
+++ b/2005/vince/.gitignore
@@ -1,2 +1,4 @@
 vince
 vince.alt
+vince.orig
+prog.orig

--- a/2006/birken/.gitignore
+++ b/2006/birken/.gitignore
@@ -1,1 +1,3 @@
 birken
+birken.orig
+prog.orig

--- a/2006/borsanyi/.gitignore
+++ b/2006/borsanyi/.gitignore
@@ -1,2 +1,4 @@
 borsanyi
 example.gif
+borsanyi.orig
+prog.orig

--- a/2006/grothe/.gitignore
+++ b/2006/grothe/.gitignore
@@ -1,1 +1,3 @@
 grothe
+grothe.orig
+prog.orig

--- a/2006/hamre/.gitignore
+++ b/2006/hamre/.gitignore
@@ -1,1 +1,3 @@
 hamre
+hamre.orig
+prog.orig

--- a/2006/meyer/.gitignore
+++ b/2006/meyer/.gitignore
@@ -1,1 +1,3 @@
 meyer
+meyer.orig
+prog.orig

--- a/2006/monge/.gitignore
+++ b/2006/monge/.gitignore
@@ -1,1 +1,3 @@
 monge
+monge.orig
+prog.orig

--- a/2006/night/.gitignore
+++ b/2006/night/.gitignore
@@ -1,2 +1,4 @@
 night
 night.alt
+night.orig
+prog.orig

--- a/2006/sloane/.gitignore
+++ b/2006/sloane/.gitignore
@@ -1,2 +1,4 @@
 sloane
 sloane.alt
+sloane.orig
+prog.orig

--- a/2006/stewart/.gitignore
+++ b/2006/stewart/.gitignore
@@ -2,3 +2,5 @@ stewart
 stewart.html
 maze.xbm
 maze.png
+stewart.orig
+prog.orig

--- a/2006/sykes1/.gitignore
+++ b/2006/sykes1/.gitignore
@@ -1,2 +1,4 @@
 sykes1
 sykes1.html
+sykes1.orig
+prog.orig

--- a/2006/sykes2/.gitignore
+++ b/2006/sykes2/.gitignore
@@ -1,1 +1,3 @@
 sykes2
+sykes2.orig
+prog.orig

--- a/2006/toledo1/.gitignore
+++ b/2006/toledo1/.gitignore
@@ -1,1 +1,3 @@
 toledo1
+toledo1.orig
+prog.orig

--- a/2006/toledo2/.gitignore
+++ b/2006/toledo2/.gitignore
@@ -24,3 +24,5 @@ toledo2.alt
 DDT.COM
 *.COM
 *.ASM
+toledo2.orig
+prog.orig

--- a/2006/toledo3/.gitignore
+++ b/2006/toledo3/.gitignore
@@ -1,3 +1,5 @@
 toledo3
 toledo3-sbar
 toledo3-txt
+toledo3.orig
+prog.orig

--- a/2011/akari/.gitignore
+++ b/2011/akari/.gitignore
@@ -7,3 +7,5 @@ akari4
 akari4.c
 even_output.ppm
 odd_output.ppm
+akari.orig
+prog.orig

--- a/2011/blakely/.gitignore
+++ b/2011/blakely/.gitignore
@@ -1,2 +1,4 @@
 blakely
 garden.txt
+blakely.orig
+prog.orig

--- a/2011/borsanyi/.gitignore
+++ b/2011/borsanyi/.gitignore
@@ -1,1 +1,3 @@
 borsanyi
+borsanyi.orig
+prog.orig

--- a/2011/dlowe/.gitignore
+++ b/2011/dlowe/.gitignore
@@ -1,2 +1,4 @@
 dlowe
 trailed.net
+dlowe.orig
+prog.orig

--- a/2011/eastman/.gitignore
+++ b/2011/eastman/.gitignore
@@ -1,1 +1,3 @@
 eastman
+eastman.orig
+prog.orig

--- a/2011/fredriksson/.gitignore
+++ b/2011/fredriksson/.gitignore
@@ -1,3 +1,5 @@
 fredriksson
 ag
 ag.c
+fredriksson.orig
+prog.orig

--- a/2011/goren/.gitignore
+++ b/2011/goren/.gitignore
@@ -1,1 +1,3 @@
 goren
+goren.orig
+prog.orig

--- a/2011/hamaji/.gitignore
+++ b/2011/hamaji/.gitignore
@@ -1,1 +1,3 @@
 hamaji
+hamaji.orig
+prog.orig

--- a/2011/hou/.gitignore
+++ b/2011/hou/.gitignore
@@ -1,1 +1,3 @@
 hou
+hou.orig
+prog.orig

--- a/2011/konno/.gitignore
+++ b/2011/konno/.gitignore
@@ -1,1 +1,3 @@
 konno
+konno.orig
+prog.orig

--- a/2011/richards/.gitignore
+++ b/2011/richards/.gitignore
@@ -1,1 +1,3 @@
 richards
+richards.orig
+prog.orig

--- a/2011/toledo/.gitignore
+++ b/2011/toledo/.gitignore
@@ -1,1 +1,3 @@
 toledo
+toledo.orig
+prog.orig

--- a/2011/vik/.gitignore
+++ b/2011/vik/.gitignore
@@ -1,3 +1,5 @@
 vik
 audio_file.raw
 vik.alt
+vik.orig
+prog.orig

--- a/2011/zucker/.gitignore
+++ b/2011/zucker/.gitignore
@@ -2,3 +2,5 @@ image.ppm
 hello.ppm
 image2.ppm
 zucker
+zucker.orig
+prog.orig

--- a/2012/blakely/.gitignore
+++ b/2012/blakely/.gitignore
@@ -6,3 +6,5 @@ flat.gif
 pic.gif
 ripple.gif
 saddle.gif
+blakely.orig
+prog.orig

--- a/2012/deckmyn/.gitignore
+++ b/2012/deckmyn/.gitignore
@@ -5,3 +5,5 @@ sheetmusic.pbm
 sheetmusic.pbm
 sheetmusic.pbm
 output.pbm
+deckmyn.orig
+prog.orig

--- a/2012/dlowe/.gitignore
+++ b/2012/dlowe/.gitignore
@@ -1,1 +1,3 @@
 dlowe
+dlowe.orig
+prog.orig

--- a/2012/endoh1/.gitignore
+++ b/2012/endoh1/.gitignore
@@ -2,3 +2,5 @@ endoh1
 endoh1.alt
 endoh1_color
 configuration.txt
+endoh1.orig
+prog.orig

--- a/2012/endoh2/.gitignore
+++ b/2012/endoh2/.gitignore
@@ -39,3 +39,5 @@ e.c
 endoh2
 pi
 pi.c
+endoh2.orig
+prog.orig

--- a/2012/grothe/.gitignore
+++ b/2012/grothe/.gitignore
@@ -1,3 +1,5 @@
 grothe
 grothe.c.1
 grothe.c.2
+grothe.orig
+prog.orig

--- a/2012/hamano/.gitignore
+++ b/2012/hamano/.gitignore
@@ -5,3 +5,5 @@ hello.pdf
 hello2
 hello3
 output.pdf
+hamano.orig
+prog.orig

--- a/2012/hou/.gitignore
+++ b/2012/hou/.gitignore
@@ -2,3 +2,5 @@ hou
 hou.html
 remarks.htm
 remarks.htm
+hou.orig
+prog.orig

--- a/2012/kang/.gitignore
+++ b/2012/kang/.gitignore
@@ -1,1 +1,3 @@
 kang
+kang.orig
+prog.orig

--- a/2012/konno/.gitignore
+++ b/2012/konno/.gitignore
@@ -1,2 +1,4 @@
 konno
 konno.alt
+konno.orig
+prog.orig

--- a/2012/omoikane/.gitignore
+++ b/2012/omoikane/.gitignore
@@ -6,3 +6,5 @@ nyaruko
 output
 output.c
 regenerated.bin
+omoikane.orig
+prog.orig

--- a/2012/tromp/.gitignore
+++ b/2012/tromp/.gitignore
@@ -1,3 +1,5 @@
 tromp
 tromp32
 tromp64
+tromp.orig
+prog.orig

--- a/2012/vik/.gitignore
+++ b/2012/vik/.gitignore
@@ -6,3 +6,5 @@ restored-ioccc.png
 restored.png
 vik
 vik.alt
+vik.orig
+prog.orig

--- a/2012/zeitak/.gitignore
+++ b/2012/zeitak/.gitignore
@@ -1,2 +1,4 @@
 zeitak
 zeitak.alt
+zeitak.orig
+prog.orig

--- a/2013/birken/.gitignore
+++ b/2013/birken/.gitignore
@@ -1,2 +1,4 @@
 birken
 birken.alt
+birken.orig
+prog.orig

--- a/2013/cable1/.gitignore
+++ b/2013/cable1/.gitignore
@@ -1,1 +1,3 @@
 cable1
+cable1.orig
+prog.orig

--- a/2013/cable2/.gitignore
+++ b/2013/cable2/.gitignore
@@ -1,1 +1,3 @@
 cable2
+cable2.orig
+prog.orig

--- a/2013/cable3/.gitignore
+++ b/2013/cable3/.gitignore
@@ -1,1 +1,3 @@
 cable3
+cable3.orig
+prog.orig

--- a/2013/dlowe/.gitignore
+++ b/2013/dlowe/.gitignore
@@ -1,1 +1,3 @@
 dlowe
+dlowe.orig
+prog.orig

--- a/2013/endoh1/.gitignore
+++ b/2013/endoh1/.gitignore
@@ -2,3 +2,5 @@ echo
 endoh1
 hello
 tac
+endoh1.orig
+prog.orig

--- a/2013/endoh2/.gitignore
+++ b/2013/endoh2/.gitignore
@@ -2,3 +2,5 @@ endoh2
 jpeg
 jpeg.c
 jpeg.jpg
+endoh2.orig
+prog.orig

--- a/2013/endoh3/.gitignore
+++ b/2013/endoh3/.gitignore
@@ -1,1 +1,3 @@
 endoh3
+endoh3.orig
+prog.orig

--- a/2013/endoh4/.gitignore
+++ b/2013/endoh4/.gitignore
@@ -1,1 +1,3 @@
 endoh4
+endoh4.orig
+prog.orig

--- a/2013/hou/.gitignore
+++ b/2013/hou/.gitignore
@@ -1,3 +1,5 @@
 a
 a.c
 hou
+hou.orig
+prog.orig

--- a/2013/mills/.gitignore
+++ b/2013/mills/.gitignore
@@ -1,1 +1,3 @@
 mills
+mills.orig
+prog.orig

--- a/2013/misaka/.gitignore
+++ b/2013/misaka/.gitignore
@@ -16,3 +16,5 @@ misaka8.c
 misaka9.c
 same_as_long_cat
 vertical_cat
+misaka.orig
+prog.orig

--- a/2013/morgan1/.gitignore
+++ b/2013/morgan1/.gitignore
@@ -1,1 +1,3 @@
 morgan1
+morgan1.orig
+prog.orig

--- a/2013/morgan2/.gitignore
+++ b/2013/morgan2/.gitignore
@@ -1,1 +1,3 @@
 morgan2
+morgan2.orig
+prog.orig

--- a/2013/robison/.gitignore
+++ b/2013/robison/.gitignore
@@ -1,1 +1,3 @@
 robison
+robison.orig
+prog.orig

--- a/2014/birken/.gitignore
+++ b/2014/birken/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2014/deak/.gitignore
+++ b/2014/deak/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2014/endoh1/.gitignore
+++ b/2014/endoh1/.gitignore
@@ -3,3 +3,4 @@ main.c
 prog
 treacle
 treacle.c
+prog.orig

--- a/2014/endoh2/.gitignore
+++ b/2014/endoh2/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2014/maffiodo1/.gitignore
+++ b/2014/maffiodo1/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2014/maffiodo2/.gitignore
+++ b/2014/maffiodo2/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2014/morgan/.gitignore
+++ b/2014/morgan/.gitignore
@@ -1,2 +1,3 @@
 prog
 morgan
+prog.orig

--- a/2014/sinon/.gitignore
+++ b/2014/sinon/.gitignore
@@ -1,2 +1,3 @@
 prog
 sinon.c
+prog.orig

--- a/2014/skeggs/.gitignore
+++ b/2014/skeggs/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2014/vik/.gitignore
+++ b/2014/vik/.gitignore
@@ -1,3 +1,4 @@
 audio_file.raw
 prog
 prog.raw
+prog.orig

--- a/2014/wiedijk/.gitignore
+++ b/2014/wiedijk/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2015/burton/.gitignore
+++ b/2015/burton/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2015/dogon/.gitignore
+++ b/2015/dogon/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2015/duble/.gitignore
+++ b/2015/duble/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2015/endoh1/.gitignore
+++ b/2015/endoh1/.gitignore
@@ -7,3 +7,4 @@ gray-scott-3
 gray-scott-4
 oregonator
 prog
+prog.orig

--- a/2015/endoh2/.gitignore
+++ b/2015/endoh2/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2015/endoh3/.gitignore
+++ b/2015/endoh3/.gitignore
@@ -3,3 +3,4 @@ ioccc
 koch
 pi
 quine
+prog.orig

--- a/2015/endoh4/.gitignore
+++ b/2015/endoh4/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2015/hou/.gitignore
+++ b/2015/hou/.gitignore
@@ -1,2 +1,3 @@
 prebuild
 prog
+prog.orig

--- a/2015/howe/.gitignore
+++ b/2015/howe/.gitignore
@@ -22,3 +22,4 @@ CBABAC.tmp
 EMPTY.tmp
 patch.tmp
 ABD.tmp
+prog.orig

--- a/2015/mills1/.gitignore
+++ b/2015/mills1/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2015/mills2/.gitignore
+++ b/2015/mills2/.gitignore
@@ -4,3 +4,4 @@ test1
 test1.Z 
 test2 
 test2.Z
+prog.orig

--- a/2015/muth/.gitignore
+++ b/2015/muth/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2015/schweikhardt/.gitignore
+++ b/2015/schweikhardt/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2015/yang/.gitignore
+++ b/2015/yang/.gitignore
@@ -5,3 +5,4 @@ prog_c90
 prog_c99
 prog_cpp11
 prog_cpp98
+prog.orig

--- a/2018/algmyr/.gitignore
+++ b/2018/algmyr/.gitignore
@@ -2,3 +2,4 @@ out.raw
 prog
 prog.alt
 spectrogram.png
+prog.orig

--- a/2018/anderson/.gitignore
+++ b/2018/anderson/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2018/bellard/.gitignore
+++ b/2018/bellard/.gitignore
@@ -4,3 +4,4 @@ small.jpg
 fruits.ppm
 lena512.ppm
 vintage_cars.ppm
+prog.orig

--- a/2018/burton1/.gitignore
+++ b/2018/burton1/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2018/burton2/.gitignore
+++ b/2018/burton2/.gitignore
@@ -1,3 +1,4 @@
 keywords
 manpage
 prog
+prog.orig

--- a/2018/ciura/.gitignore
+++ b/2018/ciura/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2018/endoh1/.gitignore
+++ b/2018/endoh1/.gitignore
@@ -4,3 +4,4 @@ output.gif
 prog
 prog.gif
 smily.gif
+prog.orig

--- a/2018/endoh2/.gitignore
+++ b/2018/endoh2/.gitignore
@@ -1,3 +1,4 @@
 prog
 prog_next
 prog_next.c
+prog.orig

--- a/2018/ferguson/.gitignore
+++ b/2018/ferguson/.gitignore
@@ -3,3 +3,4 @@ prog.alt
 prog.orig
 weasel
 weasel.alt
+prog.orig

--- a/2018/giles/.gitignore
+++ b/2018/giles/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2018/hou/.gitignore
+++ b/2018/hou/.gitignore
@@ -2,3 +2,4 @@ ioccc.html
 ioccc.json
 output.html
 prog
+prog.orig

--- a/2018/mills/.gitignore
+++ b/2018/mills/.gitignore
@@ -7,3 +7,4 @@ rk05.v6.fs
 v0
 v6
 v6.img.bz2
+prog.orig

--- a/2018/poikola/.gitignore
+++ b/2018/poikola/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2018/vokes/.gitignore
+++ b/2018/vokes/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2018/yang/.gitignore
+++ b/2018/yang/.gitignore
@@ -11,3 +11,4 @@ shift
 rotated_counterclockwise.txt
 rotated_clockwise.txt
 no_leading_space.txt
+prog.orig

--- a/2019/adamovsky/.gitignore
+++ b/2019/adamovsky/.gitignore
@@ -2,3 +2,4 @@ identify.unl
 iocccsize_2018
 prog
 prog2
+prog.orig

--- a/2019/burton/.gitignore
+++ b/2019/burton/.gitignore
@@ -2,3 +2,4 @@ prog
 prog.clean
 correct
 remarks
+prog.orig

--- a/2019/ciura/.gitignore
+++ b/2019/ciura/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2019/diels-grabsch1/.gitignore
+++ b/2019/diels-grabsch1/.gitignore
@@ -3,3 +3,4 @@ dg1.Z
 ref.Z
 guidelines.txt.Z
 guidelines2.txt
+prog.orig

--- a/2019/diels-grabsch2/.gitignore
+++ b/2019/diels-grabsch2/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2019/dogon/.gitignore
+++ b/2019/dogon/.gitignore
@@ -1,2 +1,3 @@
 apholife
 prog
+prog.orig

--- a/2019/duble/.gitignore
+++ b/2019/duble/.gitignore
@@ -7,3 +7,4 @@ Linux.alt
 prog
 prog.alt
 .[A-Z][A-Z]*
+prog.orig

--- a/2019/endoh/.gitignore
+++ b/2019/endoh/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog2.c
+prog.orig

--- a/2019/giles/.gitignore
+++ b/2019/giles/.gitignore
@@ -1,2 +1,3 @@
 prog
 out.wav
+prog.orig

--- a/2019/karns/.gitignore
+++ b/2019/karns/.gitignore
@@ -1,2 +1,3 @@
 prog
 tbfs
+prog.orig

--- a/2019/lynn/.gitignore
+++ b/2019/lynn/.gitignore
@@ -7,3 +7,4 @@ lol
 lol.c
 scc
 scc.c
+prog.orig

--- a/2019/mills/.gitignore
+++ b/2019/mills/.gitignore
@@ -21,3 +21,4 @@ rnn1
 rnn2
 rnn3
 IOCCC-hints.output.txt
+prog.orig

--- a/2019/poikola/.gitignore
+++ b/2019/poikola/.gitignore
@@ -1,2 +1,3 @@
 prog
 poikola.pdf
+prog.orig

--- a/2019/yang/.gitignore
+++ b/2019/yang/.gitignore
@@ -5,3 +5,4 @@ d
 prog
 e
 output.txt
+prog.orig

--- a/2020/burton/.gitignore
+++ b/2020/burton/.gitignore
@@ -1,3 +1,4 @@
 prog
 prog_be
 prog_le
+prog.orig

--- a/2020/carlini/.gitignore
+++ b/2020/carlini/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2020/endoh1/.gitignore
+++ b/2020/endoh1/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2020/endoh2/.gitignore
+++ b/2020/endoh2/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2020/endoh3/.gitignore
+++ b/2020/endoh3/.gitignore
@@ -2,3 +2,4 @@ clock
 clock.c
 prog
 prog.alt
+prog.orig

--- a/2020/ferguson1/.gitignore
+++ b/2020/ferguson1/.gitignore
@@ -5,3 +5,4 @@ snake
 snake-colours
 snake.alt
 termcaps
+prog.orig

--- a/2020/ferguson2/.gitignore
+++ b/2020/ferguson2/.gitignore
@@ -3,3 +3,4 @@ recode
 chocolate-cake.dat
 chocolate-cake.key
 cake.sh
+prog.orig

--- a/2020/giles/.gitignore
+++ b/2020/giles/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2020/kurdyukov1/.gitignore
+++ b/2020/kurdyukov1/.gitignore
@@ -1,2 +1,3 @@
 prog
 prog.alt
+prog.orig

--- a/2020/kurdyukov2/.gitignore
+++ b/2020/kurdyukov2/.gitignore
@@ -1,3 +1,4 @@
 prog
 prog_png
 prog_ppm
+prog.orig

--- a/2020/kurdyukov3/.gitignore
+++ b/2020/kurdyukov3/.gitignore
@@ -1,3 +1,4 @@
 prog
 prog.alt
 prog.extra
+prog.orig

--- a/2020/kurdyukov4/.gitignore
+++ b/2020/kurdyukov4/.gitignore
@@ -1,3 +1,4 @@
 prog
 rand
 test.txt
+prog.orig

--- a/2020/otterness/.gitignore
+++ b/2020/otterness/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2020/tsoj/.gitignore
+++ b/2020/tsoj/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/2020/yang/.gitignore
+++ b/2020/yang/.gitignore
@@ -1,1 +1,2 @@
 prog
+prog.orig

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -109,12 +109,8 @@ changed the `#o` lines to `#define`. The
 [lycklama.alt.c](1985/lycklama/lycklama.alt.c) is the original source
 code as it provides some fun input for the entry.
 
-Yusuke provided some useful information that amounts to an alternate version but
-which does not actually modify the code except by a provided macro for a
-`usleep()` call which Cody added. This was not put in an alt file because the
-original code is in the alt file but the default to the `usleep()` call is 0,
-making it functionally equivalent not calling it.  See the README.md file
-details.
+Yusuke provided some useful information that amounts to an alternate version
+that Cody added. See the README.md for details.
 
 
 ## [1985/sicherman](1985/sicherman/sicherman.c) ([README.md](1985/sicherman/README.md]))


### PR DESCRIPTION

Due to the fact we now have .orig.c files and thus the possibility of
winner.orig or prog.orig being built I have updated all the .gitignore
files so that these files ignored. This was done with the following
shell commands, for reference:

    for i in $(find 19* 200* 201[0123] -mindepth 2 -maxdepth 2 -name .gitignore) ; do echo $(dirname "$i"|sed -e 's,[0-9]\{4\}/,,g').orig >> "$i"; done
    for i in $(find 201[4-9] 2020 -mindepth 2 -maxdepth 2 -name .gitignore) ; do echo prog.orig >> "$i"; done

and the two commands is because it was only in 2014 that the winning
entries were renamed to prog so prog.orig is the correct glob.