### PR TITLE
Change bug status of 1996/august

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -912,33 +912,12 @@ We would appreciate anyone who has it or even just knows the name! Thank you.
 # 1996
 
 ## [1996/august](1996/august/august.c) ([README.md](1996/august/README.md))
-## STATUS: doesn't work with some compilers - please provide alternative code
+## STATUS: INABIAF - please **DO NOT** fix
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed a segfault in
-this program that prevented it from working but he observes that this hangs
-in macOS with this invocation in particular:
-
-```sh
-cat august.c august.oc | ./august > august.oo
-```
-
-This happens to do with the fact that macOS is `clang` even the binary `gcc`.
-Trying clang in linux and the same problem occurs. As well if specifying (even
-with gcc) certain flags this also happens namely `-ggdb3`. The bug fix involved
-increasing the value of `Z` as it was accessing way out of range of the array,
-thus causing a segfault.
-
-The compilation should look like:
-
-```sh
-cc -std=gnu90 -Wall -Wextra -pedantic -Wno-error -Wno-implicit-function-declaration -Wno-invalid-source-encoding -Wno-invalid-utf8  -DZ=240000 -D'T=m[s]' -D'P=m[s++]' -D'L=m[p++]' -D'g=getchar()' -DE=else -DW=while -D'B=m[p++]' -DI=if -DR='s=s+l/2;T=r;I(l%2)s++' -D'X=m[s-' -D'D=Q(13,-)Q(14,*)Q(15,/)Q(16,%)Q(6,==)Q(7,!=)Q(8,<)C(1,r=P;m[T]=r;T=r)C(9,r=P;m[T]=r;s++)'  -O3 august.c -o august 
-```
-
-but again this will not work with clang. As the judges noted that some compilers
-compile it into an infinite loop I'm (Cody) inclined to believe that this is the
-source of the problem.
-
-Nevertheless if you have a fix for clang we welcome it!
+this program that prevented it from working in gcc. It is known, however, that
+some compilers (like clang) will compile the code so that it enters an infinite
+loop. See the README.md file for an example command that this can happen with.
 
 
 ## [1996/gandalf](1996/gandalf/gandalf.c) ([README.md](1996/gandalf/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -438,10 +438,8 @@ worked fine in macOS).
 
 Cody fixed this for modern systems. It had `1s` in places for a short int which
 was changed to just `1`.  Since it's instructional to see the differences he has
-provided an alternate version with the original code. See below.
-
-Cody provided the original source in [westley.alt.c](1990/westley/westley.alt.c).
-
+provided an alternate version, [westley.alt.c](1990/westley/westley.alt.c) which
+is the original code.
 
 
 ## [1991/brnstnd](1991/brnstnd/brnstnd.c) ([README.md](1991/brnstnd/README.md]))
@@ -667,13 +665,10 @@ calls which has the four args.
 ## [1996/august](1996/august/august.c) ([README.md](1996/august/README.md]))
 
 Cody fixed a segfault in this program that prevented it from working right but
-he notes it hangs in macOS. It works fine in linux. This is because macOS has
-clang, not gcc, even the gcc binary. He observed that with specific compiler
-flags it hangs in linux too and perhaps it's related to this in macOS; maybe
-other flags are needed but he doesn't know (at least not yet). He provided a bit
-more information in [bugs.md](/bugs.md) for anyone who wants to have a go at
-providing a fix for other compilers. As there are a lot of commands to try he
-also added [try.sh](1996/august/try.sh).
+he notes it hangs in macOS. This is because some compilers compile it into an
+infinite loop and this was documented by the judges. It works fine in linux if
+using gcc but macOS, having only clang by default (even the gcc binary) will not
+work.
 
 
 ## [1996/dalbec](1996/dalbec/dalbec.c) ([README.md](1996/dalbec/README.md]))


### PR DESCRIPTION
On another reading of one of the files it occurred to me that he hanging I observed with clang (after fixing it for gcc) was actually documented by the judges in the first place. They noted that some compilers compile the code into an infinite loop and that is indeed what clang does. Thus because it's documented it's a feature not a bug.