### PR TITLE
More fixes in 2001/bellard

### DIFF
--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -113,8 +113,8 @@ ENTRY= bellard
 PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
-DATA= bellard.otccex.c
-TARGET= ${PROG}
+DATA=
+TARGET= ${PROG} ${PROG}.otccex
 #
 ALT_OBJ=
 ALT_TARGET=
@@ -134,7 +134,7 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c
 	@echo "WARNING: ${PROG}.c must be compiled as 32-bit to use with the entry itself;"
 	@echo "if you cannot use -m32 this will NOT work!"
-	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS} || :
 
 ${PROG}.otccex: ${PROG}.otccex.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}

--- a/2001/bellard/bellard.otccex.c
+++ b/2001/bellard/bellard.otccex.c
@@ -107,7 +107,7 @@ main(int argc, char **argv)
     } else {
 	print_num(fib(n), base);
     }
-    printf("fact(%d) with base %d = ", base, n);
+    printf("\nfact(%d) with base %d = ", base, n);
     if (n > 12) {
         printf("Overflow");
     } else {

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -904,20 +904,27 @@ sings [Ten in the Bed](https://allnurseryrhymes.com/ten-in-the-bed/).
 
 ## [2001/bellard](2001/bellard/bellard.c) ([README.md](2001/bellard/README.md]))
 
-Cody at least partially fixed this but he notes that this will not work without
-(according to the author) i386 linux or else some skill in resolving the
-portability issues. As it is it segfaults in 64-bit linux (and as expected
-macOS). He fixed an earlier segfault so that at least the file can be opened
-(but perhaps that will be wrong in i386 linux / older C?) and he also changed
-some of the macro used to what they evaluate to but mostly he kept it the same.
+Cody fixed this to compile with clang but according to the author this will not
+work without i386 linux. It generates i386 32-bit code (not bytecode) but
+unfortunately it will not work without i386 linux. Cody fixed an earlier
+segfault so that it can at least now open the file and he also changed some of
+the macros used to what they translate to but mostly it was kept the same.
+Yusuke added another change (see below) to make it even more portable across
+compilers besides what Cody did.
 
-Cody also fixed [bellard.otccex.c](bellard.otccex.c) so it does not segfault and
-seemingly works okay (it did not work at all). The main problem was that some
-ints were being used as pointers. Also the Fibonacci sequence (`fib()`) will
-overflow at `n > 48` so this is checked prior to running the function just like
-the author did for the factorial (overflowing at `>12`). Either way
-unfortunately this entry seems to not work in 64-bit linux or macOS. See below
-portability notes as well as another fix in this entry by Yusuke.
+
+Cody also fixed the [supplementary
+bellard.otccex.c](2001/bellard/bellard.otccex.c) so it does not segfault and
+works as well. The main problem was that some ints were being used as pointers.
+This includes, for example, an int used as a `char *`, an int used as a function
+pointer and an int to access `argv` as well as there being invalid access to
+`argv`. He updated the Makefile so that this program will compile by default.
+
+Also the Fibonacci sequence (`fib()`) will overflow at `n > 48` so this is
+checked prior to running the function just like the author did for the factorial
+(overflowing at `>12`). Either way unfortunately this entry seems to not work in
+64-bit linux or macOS. See below portability notes as well as another fix in
+this entry by Yusuke.
 
 ### Portability notes:
 


### PR DESCRIPTION
Fixed supplementary program to add a newline after printing the first line: else the output of both lines were merged and hard to read.

Updated Makefile to always compile the supplementary program.

Modified thanks-for-fixes.md wrt this entry including fixing the link to the supplementary program (it did not specify the directory: it just had the file name itself).