### PR TITLE
Change bug status of 1994/ldb

### DIFF
--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -113,8 +113,8 @@ ENTRY= bellard
 PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
-DATA= bellard.otccex.c
-TARGET= ${PROG}
+DATA=
+TARGET= ${PROG} ${PROG}.otccex
 #
 ALT_OBJ=
 ALT_TARGET=
@@ -134,7 +134,7 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c
 	@echo "WARNING: ${PROG}.c must be compiled as 32-bit to use with the entry itself;"
 	@echo "if you cannot use -m32 this will NOT work!"
-	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS} || :
 
 ${PROG}.otccex: ${PROG}.otccex.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}

--- a/2001/bellard/bellard.otccex.c
+++ b/2001/bellard/bellard.otccex.c
@@ -107,7 +107,7 @@ main(int argc, char **argv)
     } else {
 	print_num(fib(n), base);
     }
-    printf("fact(%d) with base %d = ", base, n);
+    printf("\nfact(%d) with base %d = ", base, n);
     if (n > 12) {
         printf("Overflow");
     } else {

--- a/bugs.md
+++ b/bugs.md
@@ -751,7 +751,7 @@ If not enough args are specified this program will likely crash or do something
 else. This should NOT be fixed.
 
 ## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md))
-## STATUS: known bug - please help us fix
+## STATUS: INABIAF - please **DO NOT** fix
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to compile
 with modern systems (see the [thanks-for-fixes.md](thanks-for-fixes.md) file for
@@ -761,10 +761,10 @@ also overflow long lines.  Cody changed it to `fgets()` to prevent the display
 problem but this introduces another problem namely that newlines can be printed
 if the line length < 231.
 
-This seems like a worthy compromise but it would be ideal for it to never print
-a newline unless that's the line itself (a blank line).
-
-Cody will be looking at this later on.
+This seems like a worthy compromise to not have messed up output and although it
+would be ideal for it to never print a newline unless that's the line itself it
+might be tampering too much with the entry as it's not a real problem and as a
+one liner it's already quite long.
 
 
 ## [1994/schnitzi](1994/schnitzi/schnitzi.c) ([README.md])(1994/schnitzi/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -13,9 +13,10 @@ Ferguson](/winners.html#Cody_Boone_Ferguson) who is responsible for many of the
 improvements including many, many complicated bug fixes like
 [2001/anonymous](2001/anonymous/anonymous.c), making entries not require
 `-traditional-cpp`, fixing entries to compile with clang, providing alternate
-code where useful or necessary, typo and consistency fixes. Thank you **very
-much** for your extensive efforts in helping improve the IOCCC presentation of
-past IOCCC winners and making many work with modern systems!
+code where useful or necessary, fixing where possible dead links and otherwise
+removing them, typo and consistency fixes. Thank you **very much** for your
+extensive efforts in helping improve the IOCCC presentation of past IOCCC
+winners and making many work with modern systems!
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh) supplied a number of
 important bug fixes to a number of past IOCCC winners. Some of
@@ -625,9 +626,11 @@ Cody also changed the entry to use `fgets()` instead of `gets()` to make it safe
 for lines greater than 231 in length and to prevent a warning at linking or at
 runtime, the latter of which can be interspersed with output of the program.
 Note that this now prints a newline after the output but this seems like a
-worthy compromise for making the output incorrect in macOS and at the same time
-it's safer (fixing it to not have the extra newline is more problematic than
-it's worth and in macOS another line of output would be shown anyway).
+worthy compromise for preventing the interspersed output in macOS and at the
+same time it's safer (fixing it to not have the extra newline is more
+problematic than it's worth and in macOS another line of output would be shown
+without the change anyway and the difference is that now it's just a blank line
+rather than an annoying warning).
 
 A subtlety about this fix: if a line is greater than 231 in length if the
 program chooses that line it might print the first 231 characters or it might

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -904,20 +904,27 @@ sings [Ten in the Bed](https://allnurseryrhymes.com/ten-in-the-bed/).
 
 ## [2001/bellard](2001/bellard/bellard.c) ([README.md](2001/bellard/README.md]))
 
-Cody at least partially fixed this but he notes that this will not work without
-(according to the author) i386 linux or else some skill in resolving the
-portability issues. As it is it segfaults in 64-bit linux (and as expected
-macOS). He fixed an earlier segfault so that at least the file can be opened
-(but perhaps that will be wrong in i386 linux / older C?) and he also changed
-some of the macro used to what they evaluate to but mostly he kept it the same.
+Cody fixed this to compile with clang but according to the author this will not
+work without i386 linux. It generates i386 32-bit code (not bytecode) but
+unfortunately it will not work without i386 linux. Cody fixed an earlier
+segfault so that it can at least now open the file and he also changed some of
+the macros used to what they translate to but mostly it was kept the same.
+Yusuke added another change (see below) to make it even more portable across
+compilers besides what Cody did.
 
-Cody also fixed [bellard.otccex.c](bellard.otccex.c) so it does not segfault and
-seemingly works okay (it did not work at all). The main problem was that some
-ints were being used as pointers. Also the Fibonacci sequence (`fib()`) will
-overflow at `n > 48` so this is checked prior to running the function just like
-the author did for the factorial (overflowing at `>12`). Either way
-unfortunately this entry seems to not work in 64-bit linux or macOS. See below
-portability notes as well as another fix in this entry by Yusuke.
+
+Cody also fixed the [supplementary
+bellard.otccex.c](2001/bellard/bellard.otccex.c) so it does not segfault and
+works as well. The main problem was that some ints were being used as pointers.
+This includes, for example, an int used as a `char *`, an int used as a function
+pointer and an int to access `argv` as well as there being invalid access to
+`argv`. He updated the Makefile so that this program will compile by default.
+
+Also the Fibonacci sequence (`fib()`) will overflow at `n > 48` so this is
+checked prior to running the function just like the author did for the factorial
+(overflowing at `>12`). Either way unfortunately this entry seems to not work in
+64-bit linux or macOS. See below portability notes as well as another fix in
+this entry by Yusuke.
 
 ### Portability notes:
 


### PR DESCRIPTION

The issue is that when fixing the interspersed output of the annoying 
warning in macOS about using gets() an extra newline is printed out. 
This is because fgets() stores the newline and gets() does not. But 
since the warning kind of ruins the entry and a blank line is better 
than the warning it seems like a worthy compromise. That was already 
agreed upon but as it's a one liner and it's already quite long it might
be better to just not worry about it as although kind of annoying a 
blank line isn't a big deal. 