### PR TITLE
Improve my earlier fixes to 1990/tbr

### DIFF
--- a/1990/tbr/tbr.c
+++ b/1990/tbr/tbr.c
@@ -1,9 +1,12 @@
+int e(int x),r(int t,int o);
+#define gets(x)fgets((x),512,stdin)
+#define exit(x) exit((x)),0
 #define D ,close(
 
 char              *c,q              [512              ],m[              256
 ],*v[           99], **u,        *i[3];int         f[2],p;main       (){for
  (m[m        [60]=   m[62      ]=32   ]=m[*      m=124   [m]=       9]=6;
-  e(-8)     ,(c=fgets(q,512,stdin),(c==NULL &&(exit(0),1))||(c[strlen(c)-1]='\0'),1)||(exit(0),0);r(0,0)
+  e(-8)     ,(c=gets(q),       (c[strlen(c)-1]   ='\0'),1)||(exit(0));r(0,0)
    )for(    ;*++        c;);  }r(t,      o){    *i=i        [2]=    0;for
      (u=v  +98           ;m[*--c]         ^9;m [*c]          &32  ?i[*c
        &2]=                *u,u-             v^98              &&++u:

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -413,9 +413,19 @@ Endoh](/winners.html#Yusuke_Endoh).
 Cody fixed this to work with modern compilers; `exit(3)` returns void but the
 function was used in a binary expression so this wouldn't even compile. Cody
 also changed the code to use `fgets()` instead of `gets()` so one would not get
-a warning about the use of `gets()` at linking time or execution, the latter
-case causing confusing output due to the warning being interspersed with the
-program's (which is interactive) output.
+a warning about the use of `gets()` at linking time or execution, the latter of
+which was causing confusing output due to the warning being interspersed with
+the program's interactive output.
+
+Cody later improved the fix improved so that it looks more like the original. A
+problem that usually occurs with `gets()` to `fgets()` is for 'backwards
+compatibility' (so the man page once said) `fgets()` retains the newline and
+`gets()` does not.  In this program if one does not remove the newline it breaks
+the program. This usually requires that one check that `fgets()` does not return
+NULL but with some experimenting this proved to seem to not be a problem here so
+by adding a couple macros that redefine `exit()` and `gets()` a whole binary
+expression could be removed (thus removing an extra `exit()` call) and it now
+almost looks like the same as the original.
 
 
 ## [1990/theorem](1990/theorem/theorem.c) ([README.md](1990/theorem/README.md]))


### PR DESCRIPTION
The code now looks much more like the original. This was done through the use of macros to redefine exit() and gets() so that the exit() call uses the comma operator (,0) (because it is used in a binary expression) and gets() now uses fgets() (details below).

The usual problem with fgets() versus gets() (and it was changed primarily because with macOS the warning about gets() also occurs at runtime and it is interspersed with the interactive output of this program and this caused confusing output though a nice side effect is it's safer too) is that fgets() retains the newline whereas gets() does not (supposedly for backwards compatibility).

In some cases one can get away with not removing it (at the expense of a newline possibly being printed) but that was not possible here. This normally means one has to check for fgets() returning NULL which required another binary expression (... != NULL || exit(0),0 ...) which made the line much longer and not snakey. It appears that in this case (possibly because it's used in a for loop but I did not examine this in more detail) one can get away with not checking for NULL first and just remove the newline so that the line looks much more like the original.