### PR TITLE
Improve fixes to 1990/dds

### DIFF
--- a/1990/dds/dds.c
+++ b/1990/dds/dds.c
@@ -6,13 +6,14 @@
 #define X ;break;case
 #define _ return
 #define R 999
+#define gets(x) fgets((x),R,stdin)
 typedef char*A;int*C,E[R],L[R],M[R],P[R],l,i,j;char B[R],F[2];A m[12*R],malloc
 (),p,q,x,y,z,s,d;FILE *f;A Q(s,o)A s,o;{for(x=s;*x;x++){for(y=x,z=o;*z&&*y==
-*z;y++)z++;if(z>o&&!*z)_ x;}_	0;}main(){m[11*R]="E";while(puts("Ok"),fgets(B,R,stdin),
+*z;y++)z++;if(z>o&&!*z)_ x;}_	0;}main(){m[11*R]="E";while(puts("Ok"),gets(B),
 B[strlen(B)-1]='\0',1)switch(*B){X'R':C=E;l=1;for(i=0;i<R;P[i++]=0);while(l){while(!(s=m[l]))l++;if
 (!Q(s,"\"")){U("<>",'#');U("<=",'$');U(">=",'!');}d=B;while(*F=*s){*s=='"'&&j
 ++;if(j&1||!Q(" \t",F))*d++=*s;s++;}*d--=j=0;if(B[1]!='=')switch(*B){X'E':l=-1
-X'R':B[2]!='M'&&(l=*--C)X'I':B[1]=='N'?fgets(p=B,R,stdin),P[*d]=S():(*(q=Q(B,"TH"))=0,p
+X'R':B[2]!='M'&&(l=*--C)X'I':B[1]=='N'?gets(p=B),P[*d]=S():(*(q=Q(B,"TH"))=0,p
 =B+2,S()&&(p=q+4,l=S()-1))X'P':B[5]=='"'?*d=0,puts(B+6):(p=B+5,printf("%d\n",S
 ()))X'G':p=B+4,B[2]=='S'&&(*C++=l,p++),l=S()-1 X'F':*(q=Q(B,"TO"))=0;p=B+5;P[i
 =B[3]]=S();p=q+2;M[i]=S();L[i]=l X'N':++P[*d]<=M[*d]&&(l=L[*d]);}else p=B+2,P[

--- a/1990/tbr/tbr.c
+++ b/1990/tbr/tbr.c
@@ -1,9 +1,12 @@
+int e(int x),r(int t,int o);
+#define gets(x)fgets((x),512,stdin)
+#define exit(x) exit((x)),0
 #define D ,close(
 
 char              *c,q              [512              ],m[              256
 ],*v[           99], **u,        *i[3];int         f[2],p;main       (){for
  (m[m        [60]=   m[62      ]=32   ]=m[*      m=124   [m]=       9]=6;
-  e(-8)     ,(c=fgets(q,512,stdin),(c==NULL &&(exit(0),1))||(c[strlen(c)-1]='\0'),1)||(exit(0),0);r(0,0)
+  e(-8)     ,(c=gets(q),       (c[strlen(c)-1]   ='\0'),1)||(exit(0));r(0,0)
    )for(    ;*++        c;);  }r(t,      o){    *i=i        [2]=    0;for
      (u=v  +98           ;m[*--c]         ^9;m [*c]          &32  ?i[*c
        &2]=                *u,u-             v^98              &&++u:

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -413,9 +413,19 @@ Endoh](/winners.html#Yusuke_Endoh).
 Cody fixed this to work with modern compilers; `exit(3)` returns void but the
 function was used in a binary expression so this wouldn't even compile. Cody
 also changed the code to use `fgets()` instead of `gets()` so one would not get
-a warning about the use of `gets()` at linking time or execution, the latter
-case causing confusing output due to the warning being interspersed with the
-program's (which is interactive) output.
+a warning about the use of `gets()` at linking time or execution, the latter of
+which was causing confusing output due to the warning being interspersed with
+the program's interactive output.
+
+Cody later improved the fix improved so that it looks more like the original. A
+problem that usually occurs with `gets()` to `fgets()` is for 'backwards
+compatibility' (so the man page once said) `fgets()` retains the newline and
+`gets()` does not.  In this program if one does not remove the newline it breaks
+the program. This usually requires that one check that `fgets()` does not return
+NULL but with some experimenting this proved to seem to not be a problem here so
+by adding a couple macros that redefine `exit()` and `gets()` a whole binary
+expression could be removed (thus removing an extra `exit()` call) and it now
+almost looks like the same as the original.
 
 
 ## [1990/theorem](1990/theorem/theorem.c) ([README.md](1990/theorem/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -388,13 +388,22 @@ judge and user the executioner? :-)
 Yusuke and Cody in conjunction fixed this for modern systems.
 
 Yusuke added the comma operator for a binary expression with `free(3)` which is
-an error because `free()` returns void.
+an error because `free()` returns void. Cody then made it slightly more like the
+original in this way by redefining `free` to have the comma operator itself.
 
 Cody removed the erroneous prototype to `fopen()` which caused a compiler error
 and he also made this use `fgets()` instead of `gets()` to make it safer and to
 prevent an annoying and potentially alarming warning at compiling and/or linking
-and/or runtime. He also changed a file to be a proper `FILE *` and fixed a typo
+and/or runtime.
+
+Cody also changed a file to be a proper `FILE *` and fixed a typo
 in [LANDER.BAS](1990/dds/LANDER.BAS).
+
+Later Cody improved the `gets()`/`fgets()` fix by redefining `gets()` to use
+`fgets()`. Notice that the original entry used `fgets()` in one case as it has
+to read from another file and in this place nothing was changed.
+
+With these improvements the entry looks much more like the original.
 
 
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))


### PR DESCRIPTION

Two things had to be done here to make the code look much more like the
original (though it is hardly discernible at first glance).

First thing was I redefined free() to be free() + the comma operator as
it was a binary expression error in modern systems (this fix was 
provided by Yusuke Endoh).

The second one was an improvement to one of my earlier several fixes and
in particular the prevention of warnings that cannot be disabled at 
compilation/linking/runtime (the latter of which can be interspersed 
with the output of the program): gets() to fgets(). The way this was 
done is redefining gets() to use fgets(). The second and third arg are 
the same so it was possible to just redefine gets() to use fgets() but 
gets() having one arg like the original function. It should be noticed 
that the original code used fgets() in one case because it has to read 
from a different FILE * than stdin so there still is a reference to 
fgets() that is not part of the macros.