### PR TITLE
Update FAQ about incongruent code & author remarks

### DIFF
--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -1,9 +1,6 @@
 # Most Educational
 
 Adrian Mariano  
-University of Washington  
-2729 72nd Ave SE  
-Mercer Island, WA 98040  
 US  
 
 

--- a/1992/adrian/adrian.c
+++ b/1992/adrian/adrian.c
@@ -5,6 +5,7 @@
 #define G 17
 #define z 8
 #define v(jr) jr
+#define gets(Y) fgets((Y),998,stdin)
 int W ,head;
 #define S(W,b,f) strncpy(W,b,f),W[f]=0\
 
@@ -104,7 +105,7 @@ while( s = strtok(0,wcs)) {
                   < 10 && printf((W,Y)); }
    if(j+28) { {
                 ; } printf("%7u%7u%7u\n", wcl , wcw , wcc); }
-   while( fgets(Y,998,stdin) ){ Y[strlen(Y)-1]='\0'; if(A(Y)) puts(Y); }
+   while( gets(Y) ){ Y[strlen(Y)-1]='\0'; if(A(Y)) puts(Y); }
    W, jr; }
 
 O(int wc,char**V) {

--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -17,8 +17,6 @@ make all
 ./runme.sh
 ```
 
-For the original entry see the [archive tarball](/archive/archive-1992.tar.bz2).
-
 
 ## Judges' remarks:
 

--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -1,9 +1,6 @@
 # Worst Abuse of the C Preprocessor
 
 Ed Luke  
-Mississippi State University  
-P.O. Box 6176  
-Mississippi State, MS 39762  
 US    
 
 

--- a/1992/lush/lush.c
+++ b/1992/lush/lush.c
@@ -1,3 +1,5 @@
+#define gets(_) fgets((_),999,stdin)
+#line 1
 #define f 000:
           char
 	  *s,*
@@ -63,8 +65,8 @@
           ;;;}
 	  ;for
 	  (  ;
-	  fgets
-	  (_,999,stdin);
+	  gets
+	  (_);
 	  )  {
 	  for(
 #define f 301:

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -1,9 +1,6 @@
 # Best Small Program
 
 Brian Westley (aka Merlyn LeRoy)  
-Digi International  
-1026 Blair Ave.  
-St. Paul, MN  55104  
 US  
 <http://www.westley.org>  
 
@@ -60,7 +57,8 @@ This program and the alternate version will very likely crash or
 [nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
-args. This should not be fixed.
+args. And not that we need any help with this or anything :-) but we do
+encourage you to test it. This should not be fixed.
 
 ## Judges' remarks:
 

--- a/2004/burley/README.md
+++ b/2004/burley/README.md
@@ -70,6 +70,9 @@ the program so this "strategy" no longer works?
 Notice the clever use of `setjmp()` and `longjmp()` calls.  Can you keep track
 of what state is being saved and restored?
 
+NOTE: the author talks about how it is a single statement. This might not be
+strictly true in 2023 for the fixes for it to work so you can look at the
+original file [burley.orig.c](burley.orig.c) to see what is meant.
 
 ## Author's remarks:
 

--- a/bugs.md
+++ b/bugs.md
@@ -712,9 +712,11 @@ welcome but it's not currently considered enough of a problem to fix.
 ## STATUS: doesn't work with some compilers - please provide alternative code
 
 We used a patch from [Yusuke Endoh](/winners.html#Yusuke_Endoh) to get this to
-work but it only works with gcc. Unfortunately due to the way the entry works
-and the fact that other compilers like clang have different warnings and errors
-this simply does not work with them. Can you help us?
+work but it only works with gcc. Cody removed the warnings of `gets()`.
+
+Unfortunately due to the way the entry works and the fact that other compilers
+like clang have different warnings and errors this simply does not work with
+them. Can you help us?
 
 ## [1992/westley](1992/westley/westley.c) ([README.md](1992/westley/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
@@ -723,7 +725,8 @@ This program and the alternate version will very likely crash or
 [nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
-args. This should not be fixed! :-)
+args. And not that we need any help with this or anything :-) but we do
+encourage you to test it. This should not be fixed.
 
 # 1993
 

--- a/faq.md
+++ b/faq.md
@@ -33,6 +33,14 @@ By tradition, we do not say.
 ## Q: How many judging rounds do you have?
 Are you trying to trick us? We will not say that either.
 
+## Q: How come some entries have code that is incongruent with what the author(s) wrote about the entry?
+
+It is very likely in this case that the code was fixed to work for modern
+systems as part of the reworking of the website. If you have this problem in
+some entries you should look at the original code as in `winner.orig.c` or
+`prog.orig.c`. Sometimes the original is in an alt version like `winner.alt.c`
+or `prog.alt.c`.
+
 ## Q: I cannot get entry XYZZY from year 19xx to compile!
 
 Some winners, particularly winners from long ago, no longer compile on more
@@ -64,9 +72,12 @@ Mill](/winners.html#Christopher_Mills)'s entry
 PDP-11/40 emulator. 
 
 Others are not so easy though we're working on this and over time have added
-alternative code. Most entries do now work and the others we are working on. In
-some cases we replaced the original code with code that works for modern systems
-but one can view the original code in the `.orig.c` files (sometimes the
+alternative code and/or fixed them. Most entries do now work and the others we
+are working on (slowly as other things are also being done and this is on free
+time).
+
+In some cases we replaced the original code with code that works for modern
+systems but one can view the original code in the `.orig.c` files (sometimes the
 original code is also in the directory as a `winner.alt.c` or `prog.alt.c`).
 
 ## Q: After running a program my terminal is all messed up! How do I restore my terminal?

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -594,9 +594,19 @@ different compiler messages. See [bugs.md](/bugs.md) for details.
 ## [1992/westley](1992/westley/westley.c) ([README.md](1992/westley/README.md]))
 
 Cody fixed this to work for clang by changing the third and fourth arg of
-`main()` to be `char **` inside `main()`; clang requires args 2 - 4 to be `char **`.
+`main()` to be `char **` inside `main()`; clang requires args 2 - 4 to be `char
+**` and some versions do not even allow a fourth arg.
+
 He also added the alternate version that the author gave in the remarks that is
 specifically for the USA rather than the world.
+
+NOTE: as noted in the README.md file and the bugs.md, this program and the
+alternate version will very likely crash or
+[nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
+world](https://en.wikipedia.org/wiki/Earth) or just the
+[USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
+args (2). And not that we need the help or anything for this :-) but we do
+encourage you to test this :-) This should not be fixed.
 
 
 ## [1993/jonth](1993/jonth/jonth.c) ([README.md](1993/jonth/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -585,6 +585,11 @@ which can be confusing) and also added the `runme.sh` script to demonstrate it
 (using make was problematic). Cody notes that unfortunately this does not work
 with clang due to different compiler messages.
 
+Cody later improved the `fgets()` change to look more like the original i.e. it
+now uses a redefined `gets()`. This did require modifying the line number with
+`#line 1` under the macro `gets()`. Still this cannot work with clang due to
+different compiler messages. See [bugs.md](/bugs.md) for details.
+
 
 ## [1992/westley](1992/westley/westley.c) ([README.md](1992/westley/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -403,7 +403,7 @@ Later Cody improved the `gets()`/`fgets()` fix by redefining `gets()` to use
 `fgets()`. Notice that the original entry used `fgets()` in one case as it has
 to read from another file and in this place nothing was changed.
 
-With these improvements the entry looks much more like the original.
+With these improvements the entry looks much more like the original!
 
 
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))
@@ -426,16 +426,15 @@ a warning about the use of `gets()` at linking time or execution, the latter of
 which was causing confusing output due to the warning being interspersed with
 the program's interactive output.
 
-Cody later improved the fix improved so that it looks more like the original. A
-problem that usually occurs with `gets()` to `fgets()` is for 'backwards
-compatibility' (so the man page once said) `fgets()` retains the newline and
-`gets()` does not.  In this program if one does not remove the newline it breaks
-the program. This usually requires that one check that `fgets()` does not return
-NULL but with some experimenting this proved to seem to not be a problem here so
-by adding a couple macros that redefine `exit()` and `gets()` a whole binary
-expression could be removed (thus removing an extra `exit()` call) and it now
-almost looks like the same as the original.
-
+Cody later improved his fix so that it looks more like the original. A problem
+that usually occurs with `gets()` to `fgets()` is for 'backwards compatibility'
+(so the man page once said) `fgets()` retains the newline and `gets()` does not.
+In this program if one does not remove the newline it breaks the program. This
+usually requires that one check that `fgets()` does not return NULL but with
+some experimenting this proved to seem to not be a problem here so by adding a
+couple macros that redefine `exit()` and `gets()` a whole binary expression
+could be removed (thus removing an extra `exit()` call) and it now almost looks
+like the same as the original.
 
 ## [1990/theorem](1990/theorem/theorem.c) ([README.md](1990/theorem/README.md]))
 
@@ -488,10 +487,10 @@ invalid operands to binary expressions were resolved with the comma operator.
 
 ## [1991/dds](1991/dds/dds.c) ([README.md](1991/dds/README.md]))
 
-Cody fixed a segfault that prevented this entry from working at all and made an
-[alternate version](1991/dds/dds.alt.c) that works with `clang`. The alternate
-code, described in the README.md file, is what is needed for clang. Reading it
-might be instructive even if you have gcc.
+Cody fixed a segfault that prevented this entry from working in any condition
+and he also made an [alternate version](1991/dds/dds.alt.c) that works with
+`clang`. The alternate code, described in the README.md file, is what is needed
+for clang.  Reading it might be instructive even if you have gcc.
 
 
 ## [1991/westley](1991/westley/westley.c) ([README.md](1991/westley/README.md]))
@@ -508,15 +507,34 @@ value that works without having to find the correct value.
 
 Cody changed the location that it used `gets()` to be `fgets()` instead to make
 it safer and to prevent annoying warnings during compiling, linking or runtime
-(interspersed with the program's output). One might think that simply changing
-the gets() to fgets() (with stdin) would work but it did not because `fgets()`
-stores the newline and `gets()` does not. The code was relying on not having
-this newline. With `fgets()` the code `if(A(Y)) puts(Y);` ended up printing an
-extra line which made the generation of some files (like `adhead.c`) fail to
-compile. Why? There was a blank line after a `\` at the end of the first line of
-a macro definition!  Thus the code now first trims off the last character of the
-buffer read to get the same correct functionality but in a safe way and
-non obnoxious way.
+(interspersed with the program's output).
+
+Later Cody improved the change to `fgets()` to make it slightly more like the
+original. This still requires the additional stripping of the newline inside the
+loop but now it uses what looks like before, just a call to `gets()`.
+
+One might think that simply changing the gets() to fgets() (with stdin) would
+work but it did not because `fgets()` stores the newline and `gets()` does not.
+The code was relying on not having this newline. With `fgets()` the code
+`if(A(Y)) puts(Y);` ended up printing an extra line which made the generation of
+some files (like `adhead.c`) fail to compile. Why? There was a blank line after
+a `\` at the end of the first line of a macro definition!  Thus the code now
+first trims off the last character of the buffer read to get the same correct
+functionality but in a safe way and non obnoxious way.
+
+But the improvement so that it uses `gets()` could not be changed to have the
+macro do the removal of the extra line (as in with a comma operator or a `&&`)
+as this caused compilation errors with another generated file (`adwc.c`). Thus
+after the `gets()` call in the line that looks like:
+
+```c
+while( gets(Y) ){ Y[strlen(Y)-1]='\0'; if(A(Y)) puts(Y); }
+```
+
+one must keep the `Y[strlen(Y)-1]='\0';` part and keep it there.
+
+This is a complex change due to the way the program and Makefile generate
+additional tools.
 
 
 ## [1992/gson](1992/gson/gson.c) ([README.md](1992/gson/README.md]))


### PR DESCRIPTION

As I was looking at 2004/burley/README.md it occurred to me that 
numerous entries have been modified in ways that are incongruent with 
what the author(s) originally wrote about the entry. In some cases this
has been noted in the README.md file (like has been added to 
2004/burley/README.md itself) but not in all. That should probably be 
checked for and I will do that in time most likely but in the meantime 
it felt even better to update the FAQ about this which this commit does
as well.
