### PR TITLE
Update bugs.md wrt 1995/cdua

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -890,7 +890,7 @@ Since it works there is no need to fix this except for a challenge to yourself.
 
 
 ## [1995/cdua](1995/cdua/cdua.c) ([README.md](1995/cdua/README.md))
-## STATUS: known bug - please help us fix
+## STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
 
 This did not originally compile under macOS and after it did compile under
 macOS, it crashed. [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
@@ -902,6 +902,9 @@ seem to be related to making it work under macOS as all that did was removing
 some invalid prototypes and use `printf()` instead of the invalid pointer to it
 (incompatible type). Besides that it happened under linux where there was no
 compilation error or crash.
+
+It's possible this is no longer an issue but if it's encountered again please
+let us know or offer a fix.
 
 
 ## [1995/vanschnitz](1995/vanschnitz/vanschnitz.c) ([README.md](1995/vanschnitz/README.md))


### PR DESCRIPTION
At one point prior to fixing (for clang) 1995/cdua I noticed that sometimes when running at runtime it would pause and ask you to press return/enter again to resume. I have not noticed the last several times (throughout many days) I have run it and that includes numerous runs each day and so I have changed the status to possible bug, not definitely a bug.

If I notice it again I will change it back or else look into the problem but without it happening it's obviously harder to verify that it's a problem (and since it's not every time it's also impossible to prove, especially with obfuscated code, that it's fixed).