### PR TITLE
Improve some sgit error messages

### DIFF
--- a/src/sgit/Makefile
+++ b/src/sgit/Makefile
@@ -21,6 +21,7 @@ CP= cp
 INSTALL= install
 RM= rm
 SHELL= bash
+SHELLCHECK= shellcheck
 
 #CFLAGS= -O3 -g3 --pedantic -Wall -Werror
 CFLAGS= -O3 -g3 --pedantic -Wall
@@ -44,6 +45,10 @@ winner_name: winner_name.sh
 	${RM} -f -v $@
 	${CP} -f -v $? $@
 	${CHMOD} +x $@
+
+
+shellcheck: sgit.sh
+	@${SHELLCHECK} sgit.sh
 
 #################################################
 # .PHONY list of rules that do not create files #

--- a/src/sgit/Makefile
+++ b/src/sgit/Makefile
@@ -1,7 +1,6 @@
 #!/usr/bin/env make
 #
-# sgit - run sed (by default with -i) on all files (or one or more globs) under
-# git control.
+# sgit - run sed (by default with -i) on one or more globs under git control
 #
 # The most up to date version of this tool and everything related can be found
 # at https://github.com/xexyl/sgit.

--- a/src/sgit/README.md
+++ b/src/sgit/README.md
@@ -70,7 +70,7 @@ usage: sgit [-h] [-V] [-v level] [-x] [-I] [-i extension] [-o sed_option(s)] [-s
     -s sed		    set path to sed
     -e command		    append sed command to list of commands to execute on globs
 
-sgit version: 0.0.9-1 24-04-2023
+sgit version: 0.0.10-1 24-04-2023
 ```
 
 You **MUST** specify at least one `sed` command and one glob: the sed command by

--- a/src/sgit/sgit.sh
+++ b/src/sgit/sgit.sh
@@ -21,7 +21,7 @@
 # - Cody Boone Ferguson (@xexyl)
 #
 
-export SGIT_VERSION="0.0.9-1 24-04-2023" # format: major.minor.patch-release DD-MM-YYYY
+export SGIT_VERSION="0.0.10-1 24-04-2023" # format: major.minor.patch-release DD-MM-YYYY
 
 USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-x] [-I] [-i extension] [-o sed_option(s)] [-s sed] [-e command] <glob...>
 
@@ -93,7 +93,10 @@ while getopts :hVv:xIi:o:s:e: flag; do
 	echo "$USAGE" 1>&2
 	exit 3
 	;;
-   *)
+    *)  echo "$0: ERROR: unexpected value from getopts: $flag" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
 	;;
     esac
 done
@@ -104,7 +107,7 @@ shift $(( OPTIND - 1 ));
 
 # check that SED_COMMANDS is not empty!
 if [[ -z "${SED_COMMANDS[*]}" ]]; then
-    echo "$(basename "$0"): ERROR: you must specify at least one sed command" 1>&2
+    echo "$(basename "$0"): ERROR: you must specify at least one sed command and one glob" 1>&2
     echo 1>&2
     echo "$USAGE" 1>&2
     exit 2


### PR DESCRIPTION

If no sed command given (the first check on command line) say that at
least one sed command and one glob must be specified. This way they can
see that both are needed to help prevent the situation where one first
specifies no sed command and then after fixing that provides no glob. I
felt that it is not necessary to show this when there is no glob because
the check for sed commands comes first.

Add error message for unexpected value from getopts.
