### PR TITLE
Resolve bug/not a bug status in 1995/cdua

### DIFF
--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -1,10 +1,6 @@
 # Best Output
 
 Carlos Duarte  
-Instituto Superior Tecnico  
-Largo da Igreja, 5 R/C DTo  
-Damaia  
-2720 Amadora   
 Portugal  
 
 
@@ -30,8 +26,11 @@ For this alternate, slower version, please see below.
 ```
 
 
+## INABIAF - it's not a bug it's a feature! :-)
+
 NOTE: sometimes the program needs you to press enter a second time to continue
-solving the maze. See [bugs.md](/bugs.md) for more details.
+solving the maze. This is a feature, not a bug. See [bugs.md](/bugs.md) for more
+details.
 
 
 ### Alternate code:

--- a/bugs.md
+++ b/bugs.md
@@ -890,21 +890,17 @@ Since it works there is no need to fix this except for a challenge to yourself.
 
 
 ## [1995/cdua](1995/cdua/cdua.c) ([README.md](1995/cdua/README.md))
-## STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
+## STATUS: INABIAF - please **DO NOT** fix
 
 This did not originally compile under macOS and after it did compile under
 macOS, it crashed. [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
 fixed these problems.
 
-However he observed that sometimes the program asks the user to hit return a
-second time to resume solving the maze. It does not always happen. It doesn't
-seem to be related to making it work under macOS as all that did was removing
-some invalid prototypes and use `printf()` instead of the invalid pointer to it
-(incompatible type). Besides that it happened under linux where there was no
-compilation error or crash.
-
-It's possible this is no longer an issue but if it's encountered again please
-let us know or offer a fix.
+It should be noted however that there is a condition where the program will
+prompt you to press return again. This was thought to be a bug but looking at
+the code it can clearly be seen that if `g - a` is 0 then the message is
+supposed to be printed again and one is supposed to press a key as at that point
+it calls `getchar()` via the pointer `m`. So this is a feature not a bug.
 
 
 ## [1995/vanschnitz](1995/vanschnitz/vanschnitz.c) ([README.md](1995/vanschnitz/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -45,7 +45,7 @@ We are pleased to note the many contributions, **made since 2021 Jan 01**,
 on a winner by winner basis.
 
 
-## [1984/anonymous](1984/anonymous/anonymous.c) ([README.md](1984/anonymous/README.md)
+## [1984/anonymous](1984/anonymous/anonymous.c) ([README.md](1984/anonymous/README.md))
 
 Cody fixed this to work for macOS.
 
@@ -611,8 +611,8 @@ Cody fixed this to work for clang by changing the third and fourth arg of
 He also added the alternate version that the author gave in the remarks that is
 specifically for the USA rather than the world.
 
-NOTE: as noted in the README.md file and the bugs.md, this program and the
-alternate version will very likely crash or
+NOTE: as noted in the README.md file and the [bugs.md](/bugs.md), this program and the
+[alternate version](1992/westley/westley.alt.c) will very likely crash or
 [nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough


### PR DESCRIPTION
 
What was once thought to be a bug or possible bug is actually a feature.
With a more lucid head I see that in a certain condition (which I noted
in bugs.md) it very clearly is intentional that one should have to hit a
key (it says return as '<RET>' but it uses getchar() via the pointer
'm'). The condition is !(g-a). I do not know the purpose of it but 
INABIAF and so should not be changed.

Thus it's not a possible bug or bug but a feature. This is noted also in
the README.md file.