### PR TITLE
Fixes in 1998/schweikh1/README.md

### DIFF
--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -1,10 +1,6 @@
 # Best Output
 
 Carlos Duarte  
-Instituto Superior Tecnico  
-Largo da Igreja, 5 R/C DTo  
-Damaia  
-2720 Amadora   
 Portugal  
 
 
@@ -30,8 +26,11 @@ For this alternate, slower version, please see below.
 ```
 
 
+## INABIAF - it's not a bug it's a feature! :-)
+
 NOTE: sometimes the program needs you to press enter a second time to continue
-solving the maze. See [bugs.md](/bugs.md) for more details.
+solving the maze. This is a feature, not a bug. See [bugs.md](/bugs.md) for more
+details.
 
 
 ### Alternate code:

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -52,11 +52,10 @@ respectively, 44 and 46.  But how does this work? Well the string is:
 
 The first number means: the length starting from 0 up through the `>`. The
 second number is the same starting point but up through the `\0` which is why
-it's +2. Somehow it was basic intuition that made me figure out these two
-numbers and a quick test confirmed it. But what happens if only the first number
-is updated? Most of the output will be just `#define` by itself; in the cases
-where there was text after that it was macros that certainly were not defined.
-There might have been other errors as well.
+it's +2. But what happens if only the first number is updated? Most of the
+output will be just `#define` by itself; in the cases where there was text after
+that it was macros that certainly were not defined.  There might have been other
+errors as well.
 
 This allows for opening the right files. The problem with the macOS is
 `/usr/include` does not exist: instead it's

--- a/bugs.md
+++ b/bugs.md
@@ -890,21 +890,17 @@ Since it works there is no need to fix this except for a challenge to yourself.
 
 
 ## [1995/cdua](1995/cdua/cdua.c) ([README.md](1995/cdua/README.md))
-## STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
+## STATUS: INABIAF - please **DO NOT** fix
 
 This did not originally compile under macOS and after it did compile under
 macOS, it crashed. [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
 fixed these problems.
 
-However he observed that sometimes the program asks the user to hit return a
-second time to resume solving the maze. It does not always happen. It doesn't
-seem to be related to making it work under macOS as all that did was removing
-some invalid prototypes and use `printf()` instead of the invalid pointer to it
-(incompatible type). Besides that it happened under linux where there was no
-compilation error or crash.
-
-It's possible this is no longer an issue but if it's encountered again please
-let us know or offer a fix.
+It should be noted however that there is a condition where the program will
+prompt you to press return again. This was thought to be a bug but looking at
+the code it can clearly be seen that if `g - a` is 0 then the message is
+supposed to be printed again and one is supposed to press a key as at that point
+it calls `getchar()` via the pointer `m`. So this is a feature not a bug.
 
 
 ## [1995/vanschnitz](1995/vanschnitz/vanschnitz.c) ([README.md](1995/vanschnitz/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -13,13 +13,15 @@ Ferguson](/winners.html#Cody_Boone_Ferguson) who is responsible for many of the
 improvements including many, many **very complicated bug fixes** such as
 [2001/anonymous](2001/anonymous/anonymous.c) and
 [2004/burley](2004/burley/burley.c), making entries not require
-`-traditional-cpp` (which are **very complicated fixes**), fixing entries to compile
-with clang, providing alternate code where useful or necessary, fixing where
-possible dead links and otherwise removing them, typo and consistency fixes and
-writing the [sgit tool](https://github.com/xexyl/sgit) that we've published on the
-website. Thank you **very much** for your extensive efforts in helping improve
-the IOCCC presentation of past IOCCC winners and making many many past entries
-work with modern systems!
+`-traditional-cpp` (which are **very complicated fixes**), fixing entries to
+compile with clang, fixing entries to work with macOS (some of which are **very
+complicated** such as [1998/schweikh1](1998/schweikh1/schweikh1.c)), providing
+alternate code where useful or necessary, fixing where possible dead links and
+otherwise removing them, typo and consistency fixes and writing the [sgit
+tool](https://github.com/xexyl/sgit) that we've published on the website. Thank
+you **very much** for your extensive efforts in helping improve the IOCCC
+presentation of past IOCCC winners and making many many past entries work with
+modern systems!
 
 [Yusuke Endoh](/winners.html#Yusuke_Endoh) supplied a number of
 important bug fixes to a number of past IOCCC winners. Some of
@@ -838,8 +840,9 @@ enough though this did not seem to be an issue though I cannot explain why. He
 notes that it works fine with `clang` as well as `gcc` (which is what is used
 but in macOS - see below for alternate code - `gcc` is clang).
 
-Additionally Cody provided an alternate version for macOS. See the README.md
-file for details on the alternate version.
+Additionally Cody provided an alternate version for macOS. The fix is
+rather complicated but very interesting. See the README.md file for details on
+how it works and how to use it.
 
 
 ## [1998/schweikh2](1998/schweikh2/schweikh2.c) ([README.md](1998/schweikh2/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -45,7 +45,7 @@ We are pleased to note the many contributions, **made since 2021 Jan 01**,
 on a winner by winner basis.
 
 
-## [1984/anonymous](1984/anonymous/anonymous.c) ([README.md](1984/anonymous/README.md)
+## [1984/anonymous](1984/anonymous/anonymous.c) ([README.md](1984/anonymous/README.md))
 
 Cody fixed this to work for macOS.
 
@@ -611,8 +611,8 @@ Cody fixed this to work for clang by changing the third and fourth arg of
 He also added the alternate version that the author gave in the remarks that is
 specifically for the USA rather than the world.
 
-NOTE: as noted in the README.md file and the bugs.md, this program and the
-alternate version will very likely crash or
+NOTE: as noted in the README.md file and the [bugs.md](/bugs.md), this program and the
+[alternate version](1992/westley/westley.alt.c) will very likely crash or
 [nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough


### PR DESCRIPTION

There was 'I' in the README.md that was an artefact left over from
before the thanks file was introduced so that sentence was removed.

The thanks file was slightly updated too wrt this entry both as a new
category of fixes (the alternate code I made so that it works with macOS
but also referring to the README.md file).
