### PR TITLE
Improve fix of 1990/tbr

### DIFF
--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -9,11 +9,11 @@ make all
 ```
 
 There is an alternate version. See the Alternate code section for the commentary
-on why this is: there was a funny problem depending on the compiler and flags
-where it would work with one compiler with the optimiser but it would not work
-with the other; and if the optimiser state is changed the previous problematic
-compiler might work but the other one would not! We describe this in more detail
-below and we encourage you to read it.
+on why this is: there was a funny problem in modern systems where depending on
+the compiler and flags it would work with one compiler with the optimiser but it
+would not work with the other; and if the optimiser state is changed the
+previous problematic compiler might work but the other one would not! We
+describe this in more detail below and we encourage you to read it.
 
 
 ## Try:
@@ -30,10 +30,10 @@ you can see if your compiler has the problem as described below.
 
 In some versions of gcc and clang (this was first discovered in fedora linux 38)
 depending on whether or not the optimiser was enabled would cause one compiler
-to segfault but not another but when changing the state of the optimiser the
-opposite would happen: the compiler that did not segfault suddenly did and the
-one that did now worked! Another problem was an infinite loop also depending on
-the optimiser.
+to generate code that segfaults but not another - but when changing the state
+of the optimiser the opposite would happen: the compiler that did not cause a
+segfault suddenly did and the one that did now worked! Another problem was an
+infinite loop also depending on the optimiser.
 
 The alternate code has the original fix for clang which works with some
 compilers depending on the optimiser. When we refer to the code below we refer

--- a/1990/dds/README.md
+++ b/1990/dds/README.md
@@ -27,7 +27,9 @@ OLD LANDER.BAS
 RUN
 ```
 
-NOTE: this is case sensitive.
+NOTE: this entry is probably one of the only times CAPS LOCK might be worth
+having (though still not useful enough to enable :-) ) as all input has to be
+UPPER CASE.
 
 ## Judges' remarks:
 

--- a/1990/tbr/.gitignore
+++ b/1990/tbr/.gitignore
@@ -1,3 +1,4 @@
 tbr
 tbr.orig
+tbr.alt
 prog.orig

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
-	-Wno-unused-value -Wno-deprecated-non-prototype -Wno-return-type
+	-Wno-unused-value -Wno-deprecated-non-prototype -Wno-return-type -Wno-implicit-int \
+	-Wno-empty-body
 
 # Common C compiler warning flags
 #
@@ -114,8 +115,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1990/tbr/tbr.alt.c
+++ b/1990/tbr/tbr.alt.c
@@ -1,0 +1,11 @@
+#define D ,close(
+char*c,q[512],m[256],*v[99],**u,*i[3];int f[2],p;main(){for(m[m[60]=m[62]=
+32]=m[*m=124[m]=9]=6;e(-8),gets(1+(c=q))||(exit(0),0);r(0,0))for(;*++c;);}
+r(t,o){*i=i[2]=0;for(u=v+98;m[*--c]^9;m[*c]&32?i[*c&2]=
+*u,u-v^98&&++u:3)if(!m[*c]){for(*++c=0;!m[*--c];);*--u=
+++c;}u-v^98?strcmp(*u,"cd")?*c?pipe(f),o=f[1]:1,(p=fork())?e(p),o?
+r(o,0)D o)D*f):4,wait(0):(o?dup2(*f,0)D*f)D o):*i?1 D
+0),e(open(*i,0)):5,t?dup2(t,1)D t):i[2]?9 D
+1),e(creat(i[2],438)):2,e(execvp(*u,u))):e(chdir(u[1])*2):6;}
+e(x){x<0?write(2,"?\n$ "-x/4,2),x+1||(exit(1),0):5;}
+

--- a/1990/tbr/tbr.c
+++ b/1990/tbr/tbr.c
@@ -1,4 +1,3 @@
-int e(int x),r(int t,int o);
 #define gets(x)fgets((x),512,stdin)
 #define exit(x) exit((x)),0
 #define D ,close(

--- a/2005/mikeash/.gitignore
+++ b/2005/mikeash/.gitignore
@@ -1,3 +1,5 @@
 mikeash
 mikeash.orig
+mikeash2
+mikeash2.c
 prog.orig

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1389,7 +1389,7 @@ for strlen() with malloc(). This prevented it from working.
 
 ## [2006/borsanyi](2006/borsanyi/borsanyi.c) ([README.md](2006/borsanyi/README.md]))
 
-Cody fixed (the Makefile) under some systems where the `lpthread` was not
+Cody fixed the Makefile under some systems where the `lpthread` was not
 implicitly linked in.
 
 
@@ -1406,7 +1406,7 @@ well segfault (for instance it segfaulted on his MacBook Pro with the M1 chip).
 ## [2006/night](2006/night/night.c) ([README.md](2006/night/README.md]))
 
 As Cody is a lost :-) `vim` user he took the author's remarks to add support
-back for arrow keys.
+back for arrow keys in the [alternate version](2006/night/night.alt.c).
 
 
 ## [2006/sloane](2006/sloane/sloane.c) ([README.md](2006/sloane/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -396,26 +396,27 @@ judge and user the executioner? :-)
 
 ## [1990/dds](1990/dds/dds.c) ([README.md](1990/dds/README.md]))
 
-Yusuke and Cody in conjunction fixed this for modern systems.
+Yusuke and Cody in conjunction fixed this for modern systems (both fixed a
+different compiler error but more fixes were also made).
 
 Yusuke added the comma operator for a binary expression with `free(3)` which is
-an error because `free()` returns void. Cody then made it slightly more like the
+is a compiler error because `free()` returns void. Cody then made it slightly more like the
 original in this way by redefining `free` to have the comma operator itself.
 
-Cody removed the erroneous prototype to `fopen()` which caused a compiler error
-and he also made this use `fgets()` instead of `gets()` to make it safer and to
-prevent an annoying and potentially alarming warning at compiling and/or linking
-and/or runtime.
+Cody fixed another compiler error by removing the erroneous prototype to
+`fopen()`.  Cody also changed a file to be a proper `FILE *` and fixed a typo in
+[LANDER.BAS](1990/dds/LANDER.BAS).
 
-Cody also changed a file to be a proper `FILE *` and fixed a typo
-in [LANDER.BAS](1990/dds/LANDER.BAS).
+Cody also made this use `fgets()` instead of `gets()` to make it safer and to
+prevent an annoying and potentially alarming warning at compiling and/or linking
+and/or runtime, the latter of which is unfortunately interspersed with the
+output of the program.
 
 Later Cody improved the `gets()`/`fgets()` fix by redefining `gets()` to use
 `fgets()`. Notice that the original entry used `fgets()` in one case as it has
 to read from another file and in this place nothing was changed.
 
 With these improvements the entry looks much more like the original!
-
 
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))
 


### PR DESCRIPTION

In particular the fix to make it more like the original. There was no 
need to have the function prototypes at the top of the file.

I also added a couple -Wno- options to the CSILENCE variable in the 
Makefile.

I also added to the Makefile so that make alt will build the alt version
(only functional difference is that there is gets() instead of fgets()).