### PR TITLE
Clean up 1987/wall warnings, fix README.md to run

### DIFF
--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -41,7 +41,8 @@ include ../../var.mk
 CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	-Wno-incompatible-library-redeclaration -Wno-return-type -Wno-string-plus-int \
 	-Wno-unknown-escape-sequence -Wno-deprecated-declarations \
-	-Wno-deprecated-non-prototype
+	-Wno-deprecated-non-prototype -Wno-implicit-int -Wno-incompatible-pointer-types \
+	-Wno-unused-value
 
 # Common C compiler warning flags
 #
@@ -98,7 +99,17 @@ endif
 #
 ifeq ($(CC),gcc)
 #
-#CSILENCE+=
+CSILENCE+= -Wno-missing-parameter-type -Wno-builtin-declaration-mismatch -Wno-unknown-warning-option
+#
+#CWARN+=
+#
+endif
+
+# Specific add-ons or replacements for cc only
+#
+ifeq ($(CC),cc)
+#
+CSILENCE+= -Wno-missing-parameter-type -Wno-builtin-declaration-mismatch -Wno-unknown-warning-option
 #
 #CWARN+=
 #

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -14,10 +14,10 @@ make all
 
 ```sh
 ./wall
-# enter some strings
+# enter some numbers
 
 ./wall | some_command
-# enter some strings
+# enter some strings or numbers, depending on command
 ```
 
 
@@ -46,7 +46,6 @@ m*m
 
 ./wall | cat
 ```
-
 
 and enter some input like:
 


### PR DESCRIPTION
(Well .. some warnings. See below.)

Depending on system (compiler and possibly platform) different warnings were being triggered. It was easy to fix the code for some of them (like wrong prototypes and then #including stdlib.h) but this caused problems in another way (in macOS clang - clang is more strict and has -Werror or else an equivalent by default which might or might not be possible to disable .. haven't tried it) but since the code works as is I simply silenced the warnings in the Makefile.

A note that might be useful to know for other Makefiles that has to do with the fact that macOS gcc equates to clang (which I have noted many times as it's an unfortunate problem): since it is seen as gcc the Makefile check for gcc only will be triggered in macOS even though the compiler is clang.

A similar problem is that if one does in linux just 'make' they might end up with the compiler being 'cc' so I added an ifeq in the Makefile for just cc. It might or might not be useful to add this to the rest of the entry Makefiles. The same warnings disabled for cc and gcc were added.

Another thing to keep in mind is with gcc/cc in linux it will still show the warnings that were silenced as in it will show that some warnings might have been disabled (it won't warn about the problems but will note that some warnings were disabled - no I can't figure out the real purpose of it either other than to be extra careful .. or annoying :-) ).

In linux clang also triggers even more warnings including the ridiculous misleading indentation that they unfortunately adopted from gcc. These warnings were not disabled at this time.

As far as the README.md goes one of the to run commands was incorrect in that when running './wall' by itself one should put in numbers only, not just any text.