### PR TITLE
1988/reddy - fgets() to remove annoying warnings

### DIFF
--- a/1988/reddy/reddy.c
+++ b/1988/reddy/reddy.c
@@ -3,4 +3,5 @@
 #define w printf
 #define p while
 #define t(s) (W=T(s))
+#define gets(I) fgets((I), 99, stdin)
 char*X,*B,*L,I[99];M,W,V;D(){W==9?(w("`%.*s' is ",V,X),t(0)):W==40?(t(0),D(),t(41)):W==42?(t(0),D(),w("ptr to ")):0;p(W==40?(t(0),w("func returning "),t(41)):W==91?(t(0)==32?(w("array[0..%d] of ",atoi(X)-1),t(0)):w("array of "),t(93)):0);}main(){p(w("input: "),B=gets(I))if(t(0)==9)L=X,M=V,t(0),D(),w("%.*s.\n\n",M,L);}T(s){if(!s||s==W){p(*B==9||*B==32)B++;X=B;V=0;if(W=isalpha(*B)?9:isdigit(*B)?32:*B++)if(W<33)p(isalnum(*B))B++,V++;}return W;}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -272,6 +272,11 @@ changing `main()` to call the new function `pain()` (chosen because it's a pain
 that clang requires these args to be `char **` :-) ) with the correct args it
 now works.
 
+## [1988/reddy](1988/reddy/reddy.c) ([README.md](1988/reddy/README.md))
+
+Cody made this use `fgets()` to prevent annoying warnings during compiling,
+linking and runtime, the latter of which being the most annoying.
+
 
 ## [1988/spinellis](1988/spinellis/spinellis.c) ([README.md](1988/spinellis/README.md]))
 


### PR DESCRIPTION
It redefines gets() to use fgets() so that the only change is an additional #define macro.

Now the entry won't have an obnoxious warning at compiling, linking or runtime (the most annoying kind).