### PR TITLE
Add ioccc_status.sh to quickly update status.json

### DIFF
--- a/tmp/check_awards.sh
+++ b/tmp/check_awards.sh
@@ -36,324 +36,324 @@
 # modify this script.
 #
 
-grep -Hc "^# Dishonorable mention" 1984/anonymous/README.md
-grep -Hc "^# Second place" 1984/decot/README.md
-grep -Hc "^# Third place" 1984/laman/README.md
-grep -Hc "^# Grand Prize" 1984/mullender/README.md
-grep -Hc "^# Best one liner" 1985/applin/README.md
-grep -Hc "^# Most obscure program" 1985/august/README.md
-grep -Hc "^# Strangest appearing program" 1985/lycklama/README.md
-grep -Hc "^# Grand prize for most well-rounded in confusion" 1985/shapiro/README.md
-grep -Hc "^# Worst abuse of the C preprocessor" 1985/sicherman/README.md
-grep -Hc "^# Most adaptable program" 1986/applin/README.md
-grep -Hc "^# Best complex task done in a complex way" 1986/august/README.md
-grep -Hc "^# Most useful obfuscation" 1986/bright/README.md
-grep -Hc "^# Worst abuse of the C preprocessor" 1986/hague/README.md
-grep -Hc "^# Best simple task performed in a complex way" 1986/holloway/README.md
-grep -Hc "^# Best layout" 1986/marshall/README.md
-grep -Hc "^# Most illegible code" 1986/pawka/README.md
-grep -Hc "^# Best one liner" 1986/stein/README.md
-grep -Hc "^# Grand prize in most well-rounded in confusion" 1986/wall/README.md
-grep -Hc "^# Best Abuse of the Rules" 1987/biggar/README.md
-grep -Hc "^# Best Obfuscator of Programs" 1987/heckbert/README.md
-grep -Hc "^# Worst Style" 1987/hines/README.md
-grep -Hc "^# Best One Liner" 1987/korn/README.md
-grep -Hc "^# Grand Prize" 1987/lievaart/README.md
-grep -Hc "^# Most Useful Obfuscation" 1987/wall/README.md
-grep -Hc "^# Best Layout" 1987/westley/README.md
-grep -Hc "^# Best of show" 1988/applin/README.md
-grep -Hc "^# Best abuse of system calls" 1988/dale/README.md
-grep -Hc "^# Best visuals" 1988/isaak/README.md
-grep -Hc "^# Best small program" 1988/litmaath/README.md
-grep -Hc "^# Least likely to compile successfully" 1988/phillipps/README.md
-grep -Hc "^# Most useful Obfuscated C program" 1988/reddy/README.md
-grep -Hc "^# Best abuse of C constructs" 1988/robison/README.md
-grep -Hc "^# Best abuse of the rules" 1988/spinellis/README.md
-grep -Hc "^# Best layout" 1988/westley/README.md
-grep -Hc "^# Best self-modifying program" 1989/fubar/README.md
-grep -Hc "^# Strangest abuse of the rules" 1989/jar.1/README.md
-grep -Hc "^# Best of show" 1989/jar.2/README.md
-grep -Hc "^# Most humorous output" 1989/ovdluhe/README.md
-grep -Hc "^# Most complex algorithm" 1989/paul/README.md
-grep -Hc "^# Best minimal use of C" 1989/robison/README.md
-grep -Hc "^# Best layout" 1989/roemer/README.md
-grep -Hc "^# Best game" 1989/tromp/README.md
-grep -Hc "^# Best one liner" 1989/vanb/README.md
-grep -Hc "^# Most algorithms in one program" 1989/westley/README.md
-grep -Hc "^# Best Small Program" 1990/baruch/README.md
-grep -Hc "^# Best Game" 1990/cmills/README.md
-grep -Hc "^# Best Language Tool" 1990/dds/README.md
-grep -Hc "^# Best Abuse of the C Preprocessor" 1990/dg/README.md
-grep -Hc "^# Best Entropy-reducer" 1990/jaw/README.md
-grep -Hc "^# Most Unusual Data Structure" 1990/pjr/README.md
-grep -Hc "^# ANSI Committee's Worst Abuse of C" 1990/scjones/README.md
-grep -Hc "^# Strangest Abuse of the Rules" 1990/stig/README.md
-grep -Hc "^# Best Utility" 1990/tbr/README.md
-grep -Hc "^# Best of Show" 1990/theorem/README.md
-grep -Hc "^# Best Layout" 1990/westley/README.md
-grep -Hc "^# Best Utility" 1991/ant/README.md
-grep -Hc "^# Best Of Show" 1991/brnstnd/README.md
-grep -Hc "^# Best Output" 1991/buzzard/README.md
-grep -Hc "^# Most Useful Label" 1991/cdupont/README.md
-grep -Hc "^# Best X11 Graphics" 1991/davidguy/README.md
-grep -Hc "^# Most Well Rounded" 1991/dds/README.md
-grep -Hc "^# Best One Liner" 1991/fine/README.md
-grep -Hc "^# Best Game" 1991/rince/README.md
-grep -Hc "^# Grand Prize" 1991/westley/README.md
-grep -Hc "^# Most Educational" 1992/adrian/README.md
-grep -Hc "^# Most Useful Program" 1992/albert/README.md
-grep -Hc "^# Best Utility" 1992/ant/README.md
-grep -Hc "^# Most Obfuscated Algorithm" 1992/buzzard.1/README.md
-grep -Hc "^# Best Language Tool" 1992/buzzard.2/README.md
-grep -Hc "^# Most Humorous Output" 1992/gson/README.md
-grep -Hc "^# Best Output" 1992/imc/README.md
-grep -Hc "^# Best X Program" 1992/kivinen/README.md
-grep -Hc "^# Worst Abuse of the C Preprocessor" 1992/lush/README.md
-grep -Hc "^# Best Game" 1992/marangon/README.md
-grep -Hc "^# Worst Abuse of the Rules" 1992/nathan/README.md
-grep -Hc "^# Best of Show" 1992/vern/README.md
-grep -Hc "^# Best Small Program" 1992/westley/README.md
-grep -Hc "^# Best Utility" 1993/ant/README.md
-grep -Hc "^# \"Bill Gates\" Award" 1993/cmills/README.md
-grep -Hc "^# Best Abuse of the C Preprocessor" 1993/dgibson/README.md
-grep -Hc "^# Best Obfuscated Algorithm" 1993/ejb/README.md
-grep -Hc "^# Most Obfuscated X Program" 1993/jonth/README.md
-grep -Hc "^# Best Game" 1993/leo/README.md
-grep -Hc "^# Most Versatile Source" 1993/lmfjyh/README.md
-grep -Hc "^# Best One Liner" 1993/plummer/README.md
-grep -Hc "^# Most Well Rounded" 1993/rince/README.md
-grep -Hc "^# Obfuscated Intelligence Award" 1993/schnitzi/README.md
-grep -Hc "^# Most Irregular Expression" 1993/vanb/README.md
-grep -Hc "^# Best Game" 1994/dodsond1/README.md
-grep -Hc "^# Most Obfuscated Packaging" 1994/dodsond2/README.md
-grep -Hc "^# Best Utility" 1994/horton/README.md
-grep -Hc "^# Most Obfuscated Algorithm" 1994/imc/README.md
-grep -Hc "^# Best One-liner" 1994/ldb/README.md
-grep -Hc "^# Best Layout" 1994/schnitzi/README.md
-grep -Hc "^# Most Well Rounded Obfuscation" 1994/shapiro/README.md
-grep -Hc "^# Worst Abuse of the Rules" 1994/smr/README.md
-grep -Hc "^# Best X11 Program" 1994/tvr/README.md
-grep -Hc "^# Best Short Program" 1994/weisberg/README.md
-grep -Hc "^# Worst Abuse of the C Preprocessor" 1994/westley/README.md
-grep -Hc "^# Best Output" 1995/cdua/README.md
-grep -Hc "^# Most Humorous" 1995/dodsond1/README.md
-grep -Hc "^# Best Game" 1995/dodsond2/README.md
-grep -Hc "^# Interesting Algorithm" 1995/esde/README.md
-grep -Hc "^# Best Utility" 1995/garry/README.md
-grep -Hc "^# Best Layout" 1995/heathbar/README.md
-grep -Hc "^# Best Use of Obfuscation" 1995/leo/README.md
-grep -Hc "^# Best Short Program" 1995/makarios/README.md
-grep -Hc "^# Most Obfuscated Syntax" 1995/savastio/README.md
-grep -Hc "^# Best One Liner" 1995/schnitzi/README.md
-grep -Hc "^# Abusing The Rules" 1995/spinellis/README.md
-grep -Hc "^# Worst Abuse of the C Preprocessor and Most Likely To Amaze" 1995/vanschnitz/README.md
-grep -Hc "^# Best of Show" 1996/august/README.md
-grep -Hc "^# Best Numerical Obfuscation" 1996/dalbec/README.md
-grep -Hc "^# Best Output" 1996/eldby/README.md
-grep -Hc "^# Best Layout" 1996/gandalf/README.md
-grep -Hc "^# Best Obfuscated Character Set Utility" 1996/huffman/README.md
-grep -Hc "^# Best X11 Entry" 1996/jonth/README.md
-grep -Hc "^# Best RFC Obfuscation" 1996/rcm/README.md
-grep -Hc "^# Worst Abuse of the C Preprocessor" 1996/schweikh1/README.md
-grep -Hc "^# Best Algorithm" 1996/schweikh2/README.md
-grep -Hc "^# Best Utility" 1996/schweikh3/README.md
-grep -Hc "^# Best One Liner" 1996/westley/README.md
-grep -Hc "^# Best of Show" 1998/banks/README.md
-grep -Hc "^# Best Encapsulation" 1998/bas1/README.md
-grep -Hc "^# Best Small Program" 1998/bas2/README.md
-grep -Hc "^# Best Object Orientation" 1998/chaos/README.md
-grep -Hc "^# Best Data Hiding" 1998/df/README.md
-grep -Hc "^# Best Utility" 1998/dlowe/README.md
-grep -Hc "^# Most Fun" 1998/dloweneil/README.md
-grep -Hc "^# Obsolescent Feature" 1998/dorssel/README.md
-grep -Hc "^# Most Obfuscated Translator" 1998/fanf/README.md
-grep -Hc "^# Best Flow Control" 1998/schnitzi/README.md
-grep -Hc "^# CPP Abuse" 1998/schweikh1/README.md
-grep -Hc "^# Most Erratic Behavior" 1998/schweikh2/README.md
-grep -Hc "^# Most Space Efficient" 1998/schweikh3/README.md
-grep -Hc "^# Best Self-Documenting" 1998/tomtorfs/README.md
-grep -Hc "^# Best Use of Flags" 2000/anderson/README.md
-grep -Hc "^# Most Specific Output" 2000/bellard/README.md
-grep -Hc "^# Best Utility" 2000/bmeyer/README.md
-grep -Hc "^# Best Abuse of User" 2000/briddlebane/README.md
-grep -Hc "^# Best Layout" 2000/dhyang/README.md
-grep -Hc "^# Worst Abuse of the Rules" 2000/dlowe/README.md
-grep -Hc "^# Best of Show" 2000/jarijyrki/README.md
-grep -Hc "^# Best Small Program" 2000/natori/README.md
-grep -Hc "^# Best Abuse of CPP" 2000/primenum/README.md
-grep -Hc "^# Astronomically Obfuscated" 2000/rince/README.md
-grep -Hc "^# Best game" 2000/robison/README.md
-grep -Hc "^# Most Timely Output" 2000/schneiderwent/README.md
-grep -Hc "^# Most Portable Output" 2000/thadgavin/README.md
-grep -Hc "^# Most Complete Program" 2000/tomx/README.md
-grep -Hc "^# Dishonorable mention" 2001/anonymous/README.md
-grep -Hc "^# Best abuse of the rules" 2001/bellard/README.md
-grep -Hc "^# Best short program" 2001/cheong/README.md
-grep -Hc "^# Most obfuscated sound" 2001/coupard/README.md
-grep -Hc "^# Worst Driver" 2001/ctk/README.md
-grep -Hc "^# Best AI" 2001/dgbeards/README.md
-grep -Hc "^# Best abuse of the C preprocessor" 2001/herrmann1/README.md
-grep -Hc "^# Most eye-crossing" 2001/herrmann2/README.md
-grep -Hc "^# Best Of Show" 2001/jason/README.md
-grep -Hc "^# Best Curses Game" 2001/kev/README.md
-grep -Hc "^# Best of Show" 2001/ollinger/README.md
-grep -Hc "^# Best abuse of the user" 2001/rosten/README.md
-grep -Hc "^# Best one-liner" 2001/schweikh/README.md
-grep -Hc "^# Best position-independent code" 2001/westley/README.md
-grep -Hc "^# Best Graphic Game" 2001/williams/README.md
-grep -Hc "^# Best use of \"Precious\" Lines" 2004/anonymous/README.md
-grep -Hc "^# Best use of Vision" 2004/arachnid/README.md
-grep -Hc "^# Best Calculated Risk" 2004/burley/README.md
-grep -Hc "^# Best Use of Light and Spheres" 2004/gavare/README.md
-grep -Hc "^# Best of Show" 2004/gavin/README.md
-grep -Hc "^# Best Abuse of the Guidelines" 2004/hibachi/README.md
-grep -Hc "^# Most Functional Output" 2004/hoyle/README.md
-grep -Hc "^# Best Abuse of the Periodic Table" 2004/jdalbec/README.md
-grep -Hc "^# Best One-Liner" 2004/kopczynski/README.md
-grep -Hc "^# Best Font Engine" 2004/newbern/README.md
-grep -Hc "^# Best Utility" 2004/omoikane/README.md
-grep -Hc "^# Best Non-Use of Curses" 2004/schnitzi/README.md
-grep -Hc "^# Best Abuse of Indentation" 2004/sds/README.md
-grep -Hc "^# Best X11 Game" 2004/vik1/README.md
-grep -Hc "^# Best Abuse of CPP" 2004/vik2/README.md
-grep -Hc "^# Most ingenious puzzle solution" 2005/aidan/README.md
-grep -Hc "^# Best 3D puzzle" 2005/anon/README.md
-grep -Hc "^# Most superfluous output" 2005/boutines/README.md
-grep -Hc "^# Most ambiguous language" 2005/chia/README.md
-grep -Hc "^# Best 2D puzzle" 2005/giljade/README.md
-grep -Hc "^# Most sonorous output" 2005/jetro/README.md
-grep -Hc "^# Abuse of the rules" 2005/klausler/README.md
-grep -Hc "^# Best use of parenthesis" 2005/mikeash/README.md
-grep -Hc "^# Best use of the WWW" 2005/mynx/README.md
-grep -Hc "^# Best of Show" 2005/persano/README.md
-grep -Hc "^# Best Emulator" 2005/sykes/README.md
-grep -Hc "^# Most discourteous interpreter" 2005/timwi/README.md
-grep -Hc "^# Best Game" 2005/toledo/README.md
-grep -Hc "^# Most circuitous walk" 2005/vik/README.md
-grep -Hc "^# Most beauteous visuals" 2005/vince/README.md
-grep -Hc "^# EDAMAME Award" 2006/birken/README.md
-grep -Hc "^# Most Useful" 2006/borsanyi/README.md
-grep -Hc "^# Most Obfuscated Audio" 2006/grothe/README.md
-grep -Hc "^# Most Irrational" 2006/hamre/README.md
-grep -Hc "^# Best Game" 2006/meyer/README.md
-grep -Hc "^# Best Compiled Graphics" 2006/monge/README.md
-grep -Hc "^# Best Abuse of Computation" 2006/night/README.md
-grep -Hc "^# Homer's Favorite" 2006/sloane/README.md
-grep -Hc "^# Best Computed Graphics" 2006/stewart/README.md
-grep -Hc "^# Best Assembler" 2006/sykes1/README.md
-grep -Hc "^# Best One Liner" 2006/sykes2/README.md
-grep -Hc "^# Best Small Program" 2006/toledo1/README.md
-grep -Hc "^# Best of Show" 2006/toledo2/README.md
-grep -Hc "^# Most Portable Chess Set" 2006/toledo3/README.md
-grep -Hc "^# Best of Show - Most Shrinkable" 2011/akari/README.md
-grep -Hc "^# Most devolving" 2011/blakely/README.md
-grep -Hc "^# Best data utility" 2011/borsanyi/README.md
-grep -Hc "^# Most self deprecating" 2011/dlowe/README.md
-grep -Hc "^# Best ball" 2011/eastman/README.md
-grep -Hc "^# Most useful" 2011/fredriksson/README.md
-grep -Hc "^# Most artistic" 2011/goren/README.md
-grep -Hc "^# Best solved puzzle" 2011/hamaji/README.md
-grep -Hc "^# Best self documenting program" 2011/hou/README.md
-grep -Hc "^# Best one liner" 2011/konno/README.md
-grep -Hc "^# Most surprisingly portable" 2011/richards/README.md
-grep -Hc "^# Best non-chess game" 2011/toledo/README.md
-grep -Hc "^# Most sound" 2011/vik/README.md
-grep -Hc "^# Most shiny" 2011/zucker/README.md
-grep -Hc "^# Most GIFted expressions" 2012/blakely/README.md
-grep -Hc "^# Most notable and best tool" 2012/deckmyn/README.md
-grep -Hc "^# Best way to lose a life" 2012/dlowe/README.md
-grep -Hc "^# Most complex ASCII fluid - Honorable mention" 2012/endoh1/README.md
-grep -Hc "^# PiE in the sky award" 2012/endoh2/README.md
-grep -Hc "^# Most conspiratorial" 2012/grothe/README.md
-grep -Hc "^# Most elementary use of C - Silver award" 2012/hamano/README.md
-grep -Hc "^# Most useful obfuscation" 2012/hou/README.md
-grep -Hc "^# Best short program" 2012/kang/README.md
-grep -Hc "^# Best one liner" 2012/konno/README.md
-grep -Hc "^# Most surreptitious" 2012/omoikane/README.md
-grep -Hc "^# Most functional" 2012/tromp/README.md
-grep -Hc "^# Best use of cocoa - Bronze award" 2012/vik/README.md
-grep -Hc "^# Balanced use of obfuscation - Gold award" 2012/zeitak/README.md
-grep -Hc "^# Best painting tool" 2013/birken/README.md
-grep -Hc "^# Most partisan 1-liner" 2013/cable1/README.md
-grep -Hc "^# Best of show" 2013/cable2/README.md
-grep -Hc "^# Largest small system emulator" 2013/cable3/README.md
-grep -Hc "^# Best sparkling utility" 2013/dlowe/README.md
-grep -Hc "^# Most lazy SKIer" 2013/endoh1/README.md
-grep -Hc "^# Most recyclable" 2013/endoh2/README.md
-grep -Hc "^# Most tweetable 1-liner" 2013/endoh3/README.md
-grep -Hc "^# Most solid" 2013/endoh4/README.md
-grep -Hc "^# Best use of 1 Infinite Loop" 2013/hou/README.md
-grep -Hc "^# Most timely rendered" 2013/mills/README.md
-grep -Hc "^# Most catty" 2013/misaka/README.md
-grep -Hc "^# Smallest large system simulator" 2013/morgan1/README.md
-grep -Hc "^# Most playfully versatile" 2013/morgan2/README.md
-grep -Hc "^# Most poetic use of strings" 2013/robison/README.md
-grep -Hc "^# Best use of port 1701" 2014/birken/README.md
-grep -Hc "^# Most underscored argument" 2014/deak/README.md
-grep -Hc "^# Most square (YODA award)" 2014/endoh1/README.md
-grep -Hc "^# Best use of bioinformatics" 2014/endoh2/README.md
-grep -Hc "^# Homage to a classic game" 2014/maffiodo1/README.md
-grep -Hc "^# Most tweetable entry" 2014/maffiodo2/README.md
-grep -Hc "^# Most likely to succeed" 2014/morgan/README.md
-grep -Hc "^# Best choice of optimization" 2014/sinon/README.md
-grep -Hc "^# Most dynamic" 2014/skeggs/README.md
-grep -Hc "^# Best handling of beeps" 2014/vik/README.md
-grep -Hc "^# Most functional" 2014/wiedijk/README.md
-grep -Hc "^# Most Useful" 2015/burton/README.md
-grep -Hc "^# Most Crafty" 2015/dogon/README.md
-grep -Hc "^# Best Handwriting" 2015/duble/README.md
-grep -Hc "^# Most Diffused Reaction" 2015/endoh1/README.md
-grep -Hc "^# Most Overlooked Obfuscation" 2015/endoh2/README.md
-grep -Hc "^# Back to the Future Award" 2015/endoh3/README.md
-grep -Hc "^# Best One-liner" 2015/endoh4/README.md
-grep -Hc "^# Most Well-rounded Hash" 2015/hou/README.md
-grep -Hc "^# Most Different" 2015/howe/README.md
-grep -Hc "^# \"For the Birds!\" Award" 2015/mills1/README.md
-grep -Hc "^# Most Compact" 2015/mills2/README.md
-grep -Hc "^# Most Complete Use of CPP" 2015/muth/README.md
-grep -Hc "^# Best Documented" 2015/schweikhardt/README.md
-grep -Hc "^# Most Pointed Reaction" 2015/yang/README.md
-grep -Hc "^# Most cacophonic" 2018/algmyr/README.md
-grep -Hc "^# Most able to divine code gaps" 2018/anderson/README.md
-grep -Hc "^# Most inflationary" 2018/bellard/README.md
-grep -Hc "^# Best one-liner" 2018/burton1/README.md
-grep -Hc "^# Best abuse of the rules" 2018/burton2/README.md
-grep -Hc "^# Most likely to be awarded" 2018/ciura/README.md
-grep -Hc "^# Best tool to reveal holes" 2018/endoh1/README.md
-grep -Hc "^# Best use of python" 2018/endoh2/README.md
-grep -Hc "^# Best use of weasel words" 2018/ferguson/README.md
-grep -Hc "^# Most unstable" 2018/giles/README.md
-grep -Hc "^# Most likely to top the charts" 2018/hou/README.md
-grep -Hc "^# Best of show" 2018/mills/README.md
-grep -Hc "^# Most stellar" 2018/poikola/README.md
-grep -Hc "^# Most connected" 2018/vokes/README.md
-grep -Hc "^# Most shifty" 2018/yang/README.md
-grep -Hc "^# Most functional interpreter" 2019/adamovsky/README.md
-grep -Hc "^# Best one-liner" 2019/burton/README.md
-grep -Hc "^# Most alphabetic" 2019/ciura/README.md
-grep -Hc "^# Best small program" 2019/diels-grabsch1/README.md
-grep -Hc "^# Most self-aware" 2019/diels-grabsch2/README.md
-grep -Hc "^# Best use of space and time" 2019/dogon/README.md
-grep -Hc "^# Best collaborative graphics" 2019/duble/README.md
-grep -Hc "^# Most in need of debugging" 2019/endoh/README.md
-grep -Hc "^# Most in need of wide space" 2019/giles/README.md
-grep -Hc "^# Most in need of whitespace" 2019/karns/README.md
-grep -Hc "^# Most functional compiler" 2019/lynn/README.md
-grep -Hc "^# Most in need to be tweeted" 2019/mills/README.md
-grep -Hc "^# Most calendrical" 2019/poikola/README.md
-grep -Hc "^# Most in need of transparency" 2019/yang/README.md
-grep -Hc "^# Best one-liner" 2020/burton/README.md
-grep -Hc "^# Best of show - abuse of libc" 2020/carlini/README.md
-grep -Hc "^# Most explosive" 2020/endoh1/README.md
-grep -Hc "^# Best perspective" 2020/endoh2/README.md
-grep -Hc "^# Most head-turning" 2020/endoh3/README.md
-grep -Hc "^# Don't tread on me award" 2020/ferguson1/README.md
-grep -Hc "^# Most enigmatic" 2020/ferguson2/README.md
-grep -Hc "^# Most phony" 2020/giles/README.md
-grep -Hc "^# Best utility" 2020/kurdyukov1/README.md
-grep -Hc "^# Least detailed" 2020/kurdyukov2/README.md
-grep -Hc "^# Bset slaml prragom" 2020/kurdyukov3/README.md
-grep -Hc "^# Best abuse of lámatyávë" 2020/kurdyukov4/README.md
-grep -Hc "^# Most percussive" 2020/otterness/README.md
-grep -Hc "^# Most misleading indentation" 2020/tsoj/README.md
-grep -Hc "^# Best abuse of CPP" 2020/yang/README.md
+grep -Hc "^# Dishonorable mention" ../1984/anonymous/README.md
+grep -Hc "^# Second place" ../1984/decot/README.md
+grep -Hc "^# Third place" ../1984/laman/README.md
+grep -Hc "^# Grand Prize" ../1984/mullender/README.md
+grep -Hc "^# Best one liner" ../1985/applin/README.md
+grep -Hc "^# Most obscure program" ../1985/august/README.md
+grep -Hc "^# Strangest appearing program" ../1985/lycklama/README.md
+grep -Hc "^# Grand prize for most well-rounded in confusion" ../1985/shapiro/README.md
+grep -Hc "^# Worst abuse of the C preprocessor" ../1985/sicherman/README.md
+grep -Hc "^# Most adaptable program" ../1986/applin/README.md
+grep -Hc "^# Best complex task done in a complex way" ../1986/august/README.md
+grep -Hc "^# Most useful obfuscation" ../1986/bright/README.md
+grep -Hc "^# Worst abuse of the C preprocessor" ../1986/hague/README.md
+grep -Hc "^# Best simple task performed in a complex way" ../1986/holloway/README.md
+grep -Hc "^# Best layout" ../1986/marshall/README.md
+grep -Hc "^# Most illegible code" ../1986/pawka/README.md
+grep -Hc "^# Best one liner" ../1986/stein/README.md
+grep -Hc "^# Grand prize in most well-rounded in confusion" ../1986/wall/README.md
+grep -Hc "^# Best Abuse of the Rules" ../1987/biggar/README.md
+grep -Hc "^# Best Obfuscator of Programs" ../1987/heckbert/README.md
+grep -Hc "^# Worst Style" ../1987/hines/README.md
+grep -Hc "^# Best One Liner" ../1987/korn/README.md
+grep -Hc "^# Grand Prize" ../1987/lievaart/README.md
+grep -Hc "^# Most Useful Obfuscation" ../1987/wall/README.md
+grep -Hc "^# Best Layout" ../1987/westley/README.md
+grep -Hc "^# Best of show" ../1988/applin/README.md
+grep -Hc "^# Best abuse of system calls" ../1988/dale/README.md
+grep -Hc "^# Best visuals" ../1988/isaak/README.md
+grep -Hc "^# Best small program" ../1988/litmaath/README.md
+grep -Hc "^# Least likely to compile successfully" ../1988/phillipps/README.md
+grep -Hc "^# Most useful Obfuscated C program" ../1988/reddy/README.md
+grep -Hc "^# Best abuse of C constructs" ../1988/robison/README.md
+grep -Hc "^# Best abuse of the rules" ../1988/spinellis/README.md
+grep -Hc "^# Best layout" ../1988/westley/README.md
+grep -Hc "^# Best self-modifying program" ../1989/fubar/README.md
+grep -Hc "^# Strangest abuse of the rules" ../1989/jar.1/README.md
+grep -Hc "^# Best of show" ../1989/jar.2/README.md
+grep -Hc "^# Most humorous output" ../1989/ovdluhe/README.md
+grep -Hc "^# Most complex algorithm" ../1989/paul/README.md
+grep -Hc "^# Best minimal use of C" ../1989/robison/README.md
+grep -Hc "^# Best layout" ../1989/roemer/README.md
+grep -Hc "^# Best game" ../1989/tromp/README.md
+grep -Hc "^# Best one liner" ../1989/vanb/README.md
+grep -Hc "^# Most algorithms in one program" ../1989/westley/README.md
+grep -Hc "^# Best Small Program" ../1990/baruch/README.md
+grep -Hc "^# Best Game" ../1990/cmills/README.md
+grep -Hc "^# Best Language Tool" ../1990/dds/README.md
+grep -Hc "^# Best Abuse of the C Preprocessor" ../1990/dg/README.md
+grep -Hc "^# Best Entropy-reducer" ../1990/jaw/README.md
+grep -Hc "^# Most Unusual Data Structure" ../1990/pjr/README.md
+grep -Hc "^# ANSI Committee's Worst Abuse of C" ../1990/scjones/README.md
+grep -Hc "^# Strangest Abuse of the Rules" ../1990/stig/README.md
+grep -Hc "^# Best Utility" ../1990/tbr/README.md
+grep -Hc "^# Best of Show" ../1990/theorem/README.md
+grep -Hc "^# Best Layout" ../1990/westley/README.md
+grep -Hc "^# Best Utility" ../1991/ant/README.md
+grep -Hc "^# Best Of Show" ../1991/brnstnd/README.md
+grep -Hc "^# Best Output" ../1991/buzzard/README.md
+grep -Hc "^# Most Useful Label" ../1991/cdupont/README.md
+grep -Hc "^# Best X11 Graphics" ../1991/davidguy/README.md
+grep -Hc "^# Most Well Rounded" ../1991/dds/README.md
+grep -Hc "^# Best One Liner" ../1991/fine/README.md
+grep -Hc "^# Best Game" ../1991/rince/README.md
+grep -Hc "^# Grand Prize" ../1991/westley/README.md
+grep -Hc "^# Most Educational" ../1992/adrian/README.md
+grep -Hc "^# Most Useful Program" ../1992/albert/README.md
+grep -Hc "^# Best Utility" ../1992/ant/README.md
+grep -Hc "^# Most Obfuscated Algorithm" ../1992/buzzard.1/README.md
+grep -Hc "^# Best Language Tool" ../1992/buzzard.2/README.md
+grep -Hc "^# Most Humorous Output" ../1992/gson/README.md
+grep -Hc "^# Best Output" ../1992/imc/README.md
+grep -Hc "^# Best X Program" ../1992/kivinen/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor" ../1992/lush/README.md
+grep -Hc "^# Best Game" ../1992/marangon/README.md
+grep -Hc "^# Worst Abuse of the Rules" ../1992/nathan/README.md
+grep -Hc "^# Best of Show" ../1992/vern/README.md
+grep -Hc "^# Best Small Program" ../1992/westley/README.md
+grep -Hc "^# Best Utility" ../1993/ant/README.md
+grep -Hc "^# \"Bill Gates\" Award" ../1993/cmills/README.md
+grep -Hc "^# Best Abuse of the C Preprocessor" ../1993/dgibson/README.md
+grep -Hc "^# Best Obfuscated Algorithm" ../1993/ejb/README.md
+grep -Hc "^# Most Obfuscated X Program" ../1993/jonth/README.md
+grep -Hc "^# Best Game" ../1993/leo/README.md
+grep -Hc "^# Most Versatile Source" ../1993/lmfjyh/README.md
+grep -Hc "^# Best One Liner" ../1993/plummer/README.md
+grep -Hc "^# Most Well Rounded" ../1993/rince/README.md
+grep -Hc "^# Obfuscated Intelligence Award" ../1993/schnitzi/README.md
+grep -Hc "^# Most Irregular Expression" ../1993/vanb/README.md
+grep -Hc "^# Best Game" ../1994/dodsond1/README.md
+grep -Hc "^# Most Obfuscated Packaging" ../1994/dodsond2/README.md
+grep -Hc "^# Best Utility" ../1994/horton/README.md
+grep -Hc "^# Most Obfuscated Algorithm" ../1994/imc/README.md
+grep -Hc "^# Best One-liner" ../1994/ldb/README.md
+grep -Hc "^# Best Layout" ../1994/schnitzi/README.md
+grep -Hc "^# Most Well Rounded Obfuscation" ../1994/shapiro/README.md
+grep -Hc "^# Worst Abuse of the Rules" ../1994/smr/README.md
+grep -Hc "^# Best X11 Program" ../1994/tvr/README.md
+grep -Hc "^# Best Short Program" ../1994/weisberg/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor" ../1994/westley/README.md
+grep -Hc "^# Best Output" ../1995/cdua/README.md
+grep -Hc "^# Most Humorous" ../1995/dodsond1/README.md
+grep -Hc "^# Best Game" ../1995/dodsond2/README.md
+grep -Hc "^# Interesting Algorithm" ../1995/esde/README.md
+grep -Hc "^# Best Utility" ../1995/garry/README.md
+grep -Hc "^# Best Layout" ../1995/heathbar/README.md
+grep -Hc "^# Best Use of Obfuscation" ../1995/leo/README.md
+grep -Hc "^# Best Short Program" ../1995/makarios/README.md
+grep -Hc "^# Most Obfuscated Syntax" ../1995/savastio/README.md
+grep -Hc "^# Best One Liner" ../1995/schnitzi/README.md
+grep -Hc "^# Abusing The Rules" ../1995/spinellis/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor and Most Likely To Amaze" ../1995/vanschnitz/README.md
+grep -Hc "^# Best of Show" ../1996/august/README.md
+grep -Hc "^# Best Numerical Obfuscation" ../1996/dalbec/README.md
+grep -Hc "^# Best Output" ../1996/eldby/README.md
+grep -Hc "^# Best Layout" ../1996/gandalf/README.md
+grep -Hc "^# Best Obfuscated Character Set Utility" ../1996/huffman/README.md
+grep -Hc "^# Best X11 Entry" ../1996/jonth/README.md
+grep -Hc "^# Best RFC Obfuscation" ../1996/rcm/README.md
+grep -Hc "^# Worst Abuse of the C Preprocessor" ../1996/schweikh1/README.md
+grep -Hc "^# Best Algorithm" ../1996/schweikh2/README.md
+grep -Hc "^# Best Utility" ../1996/schweikh3/README.md
+grep -Hc "^# Best One Liner" ../1996/westley/README.md
+grep -Hc "^# Best of Show" ../1998/banks/README.md
+grep -Hc "^# Best Encapsulation" ../1998/bas1/README.md
+grep -Hc "^# Best Small Program" ../1998/bas2/README.md
+grep -Hc "^# Best Object Orientation" ../1998/chaos/README.md
+grep -Hc "^# Best Data Hiding" ../1998/df/README.md
+grep -Hc "^# Best Utility" ../1998/dlowe/README.md
+grep -Hc "^# Most Fun" ../1998/dloweneil/README.md
+grep -Hc "^# Obsolescent Feature" ../1998/dorssel/README.md
+grep -Hc "^# Most Obfuscated Translator" ../1998/fanf/README.md
+grep -Hc "^# Best Flow Control" ../1998/schnitzi/README.md
+grep -Hc "^# CPP Abuse" ../1998/schweikh1/README.md
+grep -Hc "^# Most Erratic Behavior" ../1998/schweikh2/README.md
+grep -Hc "^# Most Space Efficient" ../1998/schweikh3/README.md
+grep -Hc "^# Best Self-Documenting" ../1998/tomtorfs/README.md
+grep -Hc "^# Best Use of Flags" ../2000/anderson/README.md
+grep -Hc "^# Most Specific Output" ../2000/bellard/README.md
+grep -Hc "^# Best Utility" ../2000/bmeyer/README.md
+grep -Hc "^# Best Abuse of User" ../2000/briddlebane/README.md
+grep -Hc "^# Best Layout" ../2000/dhyang/README.md
+grep -Hc "^# Worst Abuse of the Rules" ../2000/dlowe/README.md
+grep -Hc "^# Best of Show" ../2000/jarijyrki/README.md
+grep -Hc "^# Best Small Program" ../2000/natori/README.md
+grep -Hc "^# Best Abuse of CPP" ../2000/primenum/README.md
+grep -Hc "^# Astronomically Obfuscated" ../2000/rince/README.md
+grep -Hc "^# Best game" ../2000/robison/README.md
+grep -Hc "^# Most Timely Output" ../2000/schneiderwent/README.md
+grep -Hc "^# Most Portable Output" ../2000/thadgavin/README.md
+grep -Hc "^# Most Complete Program" ../2000/tomx/README.md
+grep -Hc "^# Dishonorable mention" ../2001/anonymous/README.md
+grep -Hc "^# Best abuse of the rules" ../2001/bellard/README.md
+grep -Hc "^# Best short program" ../2001/cheong/README.md
+grep -Hc "^# Most obfuscated sound" ../2001/coupard/README.md
+grep -Hc "^# Worst Driver" ../2001/ctk/README.md
+grep -Hc "^# Best AI" ../2001/dgbeards/README.md
+grep -Hc "^# Best abuse of the C preprocessor" ../2001/herrmann1/README.md
+grep -Hc "^# Most eye-crossing" ../2001/herrmann2/README.md
+grep -Hc "^# Best Of Show" ../2001/jason/README.md
+grep -Hc "^# Best Curses Game" ../2001/kev/README.md
+grep -Hc "^# Best of Show" ../2001/ollinger/README.md
+grep -Hc "^# Best abuse of the user" ../2001/rosten/README.md
+grep -Hc "^# Best one-liner" ../2001/schweikh/README.md
+grep -Hc "^# Best position-independent code" ../2001/westley/README.md
+grep -Hc "^# Best Graphic Game" ../2001/williams/README.md
+grep -Hc "^# Best use of \"Precious\" Lines" ../2004/anonymous/README.md
+grep -Hc "^# Best use of Vision" ../2004/arachnid/README.md
+grep -Hc "^# Best Calculated Risk" ../2004/burley/README.md
+grep -Hc "^# Best Use of Light and Spheres" ../2004/gavare/README.md
+grep -Hc "^# Best of Show" ../2004/gavin/README.md
+grep -Hc "^# Best Abuse of the Guidelines" ../2004/hibachi/README.md
+grep -Hc "^# Most Functional Output" ../2004/hoyle/README.md
+grep -Hc "^# Best Abuse of the Periodic Table" ../2004/jdalbec/README.md
+grep -Hc "^# Best One-Liner" ../2004/kopczynski/README.md
+grep -Hc "^# Best Font Engine" ../2004/newbern/README.md
+grep -Hc "^# Best Utility" ../2004/omoikane/README.md
+grep -Hc "^# Best Non-Use of Curses" ../2004/schnitzi/README.md
+grep -Hc "^# Best Abuse of Indentation" ../2004/sds/README.md
+grep -Hc "^# Best X11 Game" ../2004/vik1/README.md
+grep -Hc "^# Best Abuse of CPP" ../2004/vik2/README.md
+grep -Hc "^# Most ingenious puzzle solution" ../2005/aidan/README.md
+grep -Hc "^# Best 3D puzzle" ../2005/anon/README.md
+grep -Hc "^# Most superfluous output" ../2005/boutines/README.md
+grep -Hc "^# Most ambiguous language" ../2005/chia/README.md
+grep -Hc "^# Best 2D puzzle" ../2005/giljade/README.md
+grep -Hc "^# Most sonorous output" ../2005/jetro/README.md
+grep -Hc "^# Abuse of the rules" ../2005/klausler/README.md
+grep -Hc "^# Best use of parenthesis" ../2005/mikeash/README.md
+grep -Hc "^# Best use of the WWW" ../2005/mynx/README.md
+grep -Hc "^# Best of Show" ../2005/persano/README.md
+grep -Hc "^# Best Emulator" ../2005/sykes/README.md
+grep -Hc "^# Most discourteous interpreter" ../2005/timwi/README.md
+grep -Hc "^# Best Game" ../2005/toledo/README.md
+grep -Hc "^# Most circuitous walk" ../2005/vik/README.md
+grep -Hc "^# Most beauteous visuals" ../2005/vince/README.md
+grep -Hc "^# EDAMAME Award" ../2006/birken/README.md
+grep -Hc "^# Most Useful" ../2006/borsanyi/README.md
+grep -Hc "^# Most Obfuscated Audio" ../2006/grothe/README.md
+grep -Hc "^# Most Irrational" ../2006/hamre/README.md
+grep -Hc "^# Best Game" ../2006/meyer/README.md
+grep -Hc "^# Best Compiled Graphics" ../2006/monge/README.md
+grep -Hc "^# Best Abuse of Computation" ../2006/night/README.md
+grep -Hc "^# Homer's Favorite" ../2006/sloane/README.md
+grep -Hc "^# Best Computed Graphics" ../2006/stewart/README.md
+grep -Hc "^# Best Assembler" ../2006/sykes1/README.md
+grep -Hc "^# Best One Liner" ../2006/sykes2/README.md
+grep -Hc "^# Best Small Program" ../2006/toledo1/README.md
+grep -Hc "^# Best of Show" ../2006/toledo2/README.md
+grep -Hc "^# Most Portable Chess Set" ../2006/toledo3/README.md
+grep -Hc "^# Best of Show - Most Shrinkable" ../2011/akari/README.md
+grep -Hc "^# Most devolving" ../2011/blakely/README.md
+grep -Hc "^# Best data utility" ../2011/borsanyi/README.md
+grep -Hc "^# Most self deprecating" ../2011/dlowe/README.md
+grep -Hc "^# Best ball" ../2011/eastman/README.md
+grep -Hc "^# Most useful" ../2011/fredriksson/README.md
+grep -Hc "^# Most artistic" ../2011/goren/README.md
+grep -Hc "^# Best solved puzzle" ../2011/hamaji/README.md
+grep -Hc "^# Best self documenting program" ../2011/hou/README.md
+grep -Hc "^# Best one liner" ../2011/konno/README.md
+grep -Hc "^# Most surprisingly portable" ../2011/richards/README.md
+grep -Hc "^# Best non-chess game" ../2011/toledo/README.md
+grep -Hc "^# Most sound" ../2011/vik/README.md
+grep -Hc "^# Most shiny" ../2011/zucker/README.md
+grep -Hc "^# Most GIFted expressions" ../2012/blakely/README.md
+grep -Hc "^# Most notable and best tool" ../2012/deckmyn/README.md
+grep -Hc "^# Best way to lose a life" ../2012/dlowe/README.md
+grep -Hc "^# Most complex ASCII fluid - Honorable mention" ../2012/endoh1/README.md
+grep -Hc "^# PiE in the sky award" ../2012/endoh2/README.md
+grep -Hc "^# Most conspiratorial" ../2012/grothe/README.md
+grep -Hc "^# Most elementary use of C - Silver award" ../2012/hamano/README.md
+grep -Hc "^# Most useful obfuscation" ../2012/hou/README.md
+grep -Hc "^# Best short program" ../2012/kang/README.md
+grep -Hc "^# Best one liner" ../2012/konno/README.md
+grep -Hc "^# Most surreptitious" ../2012/omoikane/README.md
+grep -Hc "^# Most functional" ../2012/tromp/README.md
+grep -Hc "^# Best use of cocoa - Bronze award" ../2012/vik/README.md
+grep -Hc "^# Balanced use of obfuscation - Gold award" ../2012/zeitak/README.md
+grep -Hc "^# Best painting tool" ../2013/birken/README.md
+grep -Hc "^# Most partisan 1-liner" ../2013/cable1/README.md
+grep -Hc "^# Best of show" ../2013/cable2/README.md
+grep -Hc "^# Largest small system emulator" ../2013/cable3/README.md
+grep -Hc "^# Best sparkling utility" ../2013/dlowe/README.md
+grep -Hc "^# Most lazy SKIer" ../2013/endoh1/README.md
+grep -Hc "^# Most recyclable" ../2013/endoh2/README.md
+grep -Hc "^# Most tweetable 1-liner" ../2013/endoh3/README.md
+grep -Hc "^# Most solid" ../2013/endoh4/README.md
+grep -Hc "^# Best use of 1 Infinite Loop" ../2013/hou/README.md
+grep -Hc "^# Most timely rendered" ../2013/mills/README.md
+grep -Hc "^# Most catty" ../2013/misaka/README.md
+grep -Hc "^# Smallest large system simulator" ../2013/morgan1/README.md
+grep -Hc "^# Most playfully versatile" ../2013/morgan2/README.md
+grep -Hc "^# Most poetic use of strings" ../2013/robison/README.md
+grep -Hc "^# Best use of port 1701" ../2014/birken/README.md
+grep -Hc "^# Most underscored argument" ../2014/deak/README.md
+grep -Hc "^# Most square (YODA award)" ../2014/endoh1/README.md
+grep -Hc "^# Best use of bioinformatics" ../2014/endoh2/README.md
+grep -Hc "^# Homage to a classic game" ../2014/maffiodo1/README.md
+grep -Hc "^# Most tweetable entry" ../2014/maffiodo2/README.md
+grep -Hc "^# Most likely to succeed" ../2014/morgan/README.md
+grep -Hc "^# Best choice of optimization" ../2014/sinon/README.md
+grep -Hc "^# Most dynamic" ../2014/skeggs/README.md
+grep -Hc "^# Best handling of beeps" ../2014/vik/README.md
+grep -Hc "^# Most functional" ../2014/wiedijk/README.md
+grep -Hc "^# Most Useful" ../2015/burton/README.md
+grep -Hc "^# Most Crafty" ../2015/dogon/README.md
+grep -Hc "^# Best Handwriting" ../2015/duble/README.md
+grep -Hc "^# Most Diffused Reaction" ../2015/endoh1/README.md
+grep -Hc "^# Most Overlooked Obfuscation" ../2015/endoh2/README.md
+grep -Hc "^# Back to the Future Award" ../2015/endoh3/README.md
+grep -Hc "^# Best One-liner" ../2015/endoh4/README.md
+grep -Hc "^# Most Well-rounded Hash" ../2015/hou/README.md
+grep -Hc "^# Most Different" ../2015/howe/README.md
+grep -Hc "^# \"For the Birds!\" Award" ../2015/mills1/README.md
+grep -Hc "^# Most Compact" ../2015/mills2/README.md
+grep -Hc "^# Most Complete Use of CPP" ../2015/muth/README.md
+grep -Hc "^# Best Documented" ../2015/schweikhardt/README.md
+grep -Hc "^# Most Pointed Reaction" ../2015/yang/README.md
+grep -Hc "^# Most cacophonic" ../2018/algmyr/README.md
+grep -Hc "^# Most able to divine code gaps" ../2018/anderson/README.md
+grep -Hc "^# Most inflationary" ../2018/bellard/README.md
+grep -Hc "^# Best one-liner" ../2018/burton1/README.md
+grep -Hc "^# Best abuse of the rules" ../2018/burton2/README.md
+grep -Hc "^# Most likely to be awarded" ../2018/ciura/README.md
+grep -Hc "^# Best tool to reveal holes" ../2018/endoh1/README.md
+grep -Hc "^# Best use of python" ../2018/endoh2/README.md
+grep -Hc "^# Best use of weasel words" ../2018/ferguson/README.md
+grep -Hc "^# Most unstable" ../2018/giles/README.md
+grep -Hc "^# Most likely to top the charts" ../2018/hou/README.md
+grep -Hc "^# Best of show" ../2018/mills/README.md
+grep -Hc "^# Most stellar" ../2018/poikola/README.md
+grep -Hc "^# Most connected" ../2018/vokes/README.md
+grep -Hc "^# Most shifty" ../2018/yang/README.md
+grep -Hc "^# Most functional interpreter" ../2019/adamovsky/README.md
+grep -Hc "^# Best one-liner" ../2019/burton/README.md
+grep -Hc "^# Most alphabetic" ../2019/ciura/README.md
+grep -Hc "^# Best small program" ../2019/diels-grabsch1/README.md
+grep -Hc "^# Most self-aware" ../2019/diels-grabsch2/README.md
+grep -Hc "^# Best use of space and time" ../2019/dogon/README.md
+grep -Hc "^# Best collaborative graphics" ../2019/duble/README.md
+grep -Hc "^# Most in need of debugging" ../2019/endoh/README.md
+grep -Hc "^# Most in need of wide space" ../2019/giles/README.md
+grep -Hc "^# Most in need of whitespace" ../2019/karns/README.md
+grep -Hc "^# Most functional compiler" ../2019/lynn/README.md
+grep -Hc "^# Most in need to be tweeted" ../2019/mills/README.md
+grep -Hc "^# Most calendrical" ../2019/poikola/README.md
+grep -Hc "^# Most in need of transparency" ../2019/yang/README.md
+grep -Hc "^# Best one-liner" ../2020/burton/README.md
+grep -Hc "^# Best of show - abuse of libc" ../2020/carlini/README.md
+grep -Hc "^# Most explosive" ../2020/endoh1/README.md
+grep -Hc "^# Best perspective" ../2020/endoh2/README.md
+grep -Hc "^# Most head-turning" ../2020/endoh3/README.md
+grep -Hc "^# Don't tread on me award" ../2020/ferguson1/README.md
+grep -Hc "^# Most enigmatic" ../2020/ferguson2/README.md
+grep -Hc "^# Most phony" ../2020/giles/README.md
+grep -Hc "^# Best utility" ../2020/kurdyukov1/README.md
+grep -Hc "^# Least detailed" ../2020/kurdyukov2/README.md
+grep -Hc "^# Bset slaml prragom" ../2020/kurdyukov3/README.md
+grep -Hc "^# Best abuse of lámatyávë" ../2020/kurdyukov4/README.md
+grep -Hc "^# Most percussive" ../2020/otterness/README.md
+grep -Hc "^# Most misleading indentation" ../2020/tsoj/README.md
+grep -Hc "^# Best abuse of CPP" ../2020/yang/README.md

--- a/tmp/src/Makefile
+++ b/tmp/src/Makefile
@@ -44,7 +44,7 @@ CFLAGS= -O3 -g3 --pedantic -Wall
 # target information #
 ######################
 
-TARGETS= winner_name
+TARGETS= winner_name ioccc_status
 
 ######################################
 # all - default rule - must be first #

--- a/tmp/src/ioccc_status/.gitignore
+++ b/tmp/src/ioccc_status/.gitignore
@@ -1,0 +1,1 @@
+ioccc_status

--- a/tmp/src/ioccc_status/Makefile
+++ b/tmp/src/ioccc_status/Makefile
@@ -1,0 +1,67 @@
+#!/usr/bin/env make
+#
+# ioccc_status - quickly update status.json file
+#
+# Written by Cody Boone Ferguson in 2023
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# Share and enjoy! :-)
+
+#############
+# utilities #
+#############
+
+CC= cc
+CHMOD= chmod
+CP= cp
+INSTALL= install
+RM= rm
+SHELL= bash
+
+#CFLAGS= -O3 -g3 --pedantic -Wall -Werror
+CFLAGS= -O3 -g3 --pedantic -Wall
+
+######################
+# target information #
+######################
+
+DESTDIR= ../../bin
+
+TARGETS= ioccc_status
+
+######################################
+# all - default rule - must be first #
+######################################
+
+all: ${TARGETS}
+	@:
+
+ioccc_status: ioccc_status.sh
+	${RM} -f -v $@
+	${CP} -f -v $? $@
+	${CHMOD} +x $@
+
+#################################################
+# .PHONY list of rules that do not create files #
+#################################################
+
+.PHONY: all configure clean clobber install
+
+###################################
+# standard Makefile utility rules #
+###################################
+
+configure:
+	@:
+
+clean:
+	@:
+
+clobber: clean
+	rm -f ${TARGETS}
+
+install: all
+	${INSTALL} -m 0555 ${TARGETS} ${DESTDIR}

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# 
+# ioccc_status.sh - quickly update status.json file
+#
+# Written by Cody Boone Ferguson in 2023
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# The script is at this just point a proof of concept but it does work, allowing
+# one to update the date of the latest news, the date of the status, the status
+# version and the status of the contest. It's not required to update all or for
+# that matter any of them.
+#
+# If that is not clear: it might or might not be needed or desired and that is
+# perfectly okay. If it's used but modified that's also okay. It gave me
+# something to do and whether or not it's useful it has served a purpose.
+#
+# If -s option is used, the status field is updated, providing that the status
+# arg is either "closed" or "open".
+#
+# If the -d or -n flags are used then it will update the status_date or
+# latest_news fields, respectively.
+# 
+# If the -I status_ver option is used the IOCCC_status_version field will be
+# updated.
+#
+export IOCCC_STATUS_VERSION="0.0.1-0 2023-10-02" # major.minor.release-patch YYYY-MM-DD
+
+USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-I status_ver] status.json
+
+    -h			    print help and exit
+    -V			    print version and exit
+    -v level		    set verbosity level
+    -s statue		    set contest status to open or closed
+    -d			    update status_date
+    -n			    update latest_news date
+    -I status_ver	    update IOCCC_status_version
+			    
+				NOTE: status_ver must be one of \"open\" or \"closed\"
+
+    status.json		    the file to update
+
+status version: $IOCCC_STATUS_VERSION"
+
+export UPDATE_DATE=""
+export UPDATE_NEWS=""
+export UPDATE_IOCCC_STATUS_VERSION=""
+export IOCCC_STATUS_VERSION=""
+export VERBOSITY=0
+export STATUS_JSON_FILE=""
+export STATUS_FLAG=""
+export STATUS="closed" # default closed
+
+# parse args
+#
+while getopts :hVv:s:dnI: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$IOCCC_STATUS_VERSION" 1>&2
+	exit 2
+	;;
+    v)	VERBOSITY="$OPTARG";
+	;;
+    s)	STATUS_FLAG="-s"
+	STATUS="$OPTARG";
+	;;
+    d)	UPDATE_DATE="-d"
+	;;
+    n)	UPDATE_NEWS="-n"
+	;;
+    I)  UPDATE_IOCCC_STATUS_VERSION="-I"
+	IOCCC_STATUS_VERSION="$OPTARG"
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+   *)
+	;;
+    esac
+done
+
+#
+# remove the options
+#
+shift $(( OPTIND - 1 ));
+#
+# verify arg count
+#
+if [[ $# -gt 1 ]]; then
+    echo "$0: ERROR: expected 0 or 1 args, found: $#" 1>&2
+    echo "$USAGE" 1>&2
+    exit 3
+fi
+#
+# parse args
+#
+if [[ $# -gt 0 ]]; then
+    export STATUS_JSON_FILE="$1"
+fi
+
+# firewall STATUS_JSON_FILE must be a readable file
+#
+if [[ ! -e $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json does not exist: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+if [[ ! -f $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json not a file: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+if [[ ! -r $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json not a readable file: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+
+# check that if -s used that the status ($STATUS) is either 'open' or 'closed'
+if [[ -n "$STATUS_FLAG" ]]; then
+    if [[ "$STATUS" != "open" && "$STATUS" != "closed" ]]; then
+	echo "$0: ERROR: status must be 'open' or 'closed'" 1>&2
+	exit 1
+    fi
+fi
+
+if [[ "$VERBOSITY" -gt 1 ]]; then
+    echo "$0: status.json file: $STATUS_JSON_FILE" 1>&2
+    if [[ -n "$STATUS_FLAG" ]]; then
+	echo "$0: will update contest status to: \"$STATUS\"" 1>&2
+    fi
+    if [[ -n "$UPDATE_DATE" ]]; then
+	echo "$0: will update status_date to: $(date)" 1>&2
+    fi
+    if [[ -n "$UPDATE_NEWS" ]]; then
+	echo "$0: will update latest_news to: $(date)" 1>&2
+    fi
+    if [[ -n "$UPDATE_IOCCC_STATUS_VERSION" ]]; then
+	echo "$0: will update IOCCC_status_version to: $IOCCC_STATUS_VERSION" 1>&2
+    fi
+fi
+
+# first status_date if requested
+if [[ -n "$UPDATE_DATE" ]]; then
+    sed -i'' "s/\"status_date\" : \".*[^\"]\"/\"status_date\" : \"$(date)\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated status_date to: $(date)" 1>&2
+    fi
+fi
+
+# then update latest_news date if requested
+if [[ -n "$UPDATE_NEWS" ]]; then
+    sed -i'' "s/\"latest_news\" : \".*[^\"]\"/\"latest_news\" : \"$(date)\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated latest_news to: $(date)" 1>&2
+    fi
+fi
+
+# then update IOCCC_STATUS_VERSION if requested
+if [[ -n "$UPDATE_IOCCC_STATUS_VERSION" ]]; then
+    sed -i'' "s/\"IOCCC_status_version\" : \".*[^\"]\"/\"IOCCC_status_version\" : \"$IOCCC_STATUS_VERSION\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated IOCCC_status_version to: \"$IOCCC_STATUS_VERSION\"" 1>&2
+    fi
+fi
+
+# finally if we need to change the status of the contest do so
+if [[ -n "$STATUS_FLAG" ]]; then
+    sed -i'' "s/\"contest\" : \".*[^\"]\"/\"contest\" : \"$STATUS\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated contest status to: \"$STATUS\"" 1>&2
+    fi
+fi

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -33,12 +33,13 @@ USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-I st
     -h			    print help and exit
     -V			    print version and exit
     -v level		    set verbosity level
-    -s statue		    set contest status to open or closed
+    -s status		    set contest status to open or closed
+
+				NOTE: status must be one of \"open\" or \"closed\"
+
     -d			    update status_date
     -n			    update latest_news date
     -I status_ver	    update IOCCC_status_version
-			    
-				NOTE: status_ver must be one of \"open\" or \"closed\"
 
     status.json		    the file to update
 


### PR DESCRIPTION

This was done quickly to give me something to do but if it's useful in
any form then so much the better but it seems it's more ideal to update
the status.json file automatically rather than having to do it manually.

The script does not have to update every field in the status.json file.
It doesn't even have to update any for that matter. The usage is:

    usage: ioccc_status [-h] [-V] [-v level] [-s status] [-d] [-n] [-I status_ver] status.json

        -h                          print help and exit
        -V                          print version and exit
        -v level                    set verbosity level
        -s statue                   set contest status to open or closed
        -d                          update status_date
        -n                          update latest_news date
        -I status_ver               update IOCCC_status_version

                                        NOTE: status_ver must be one of "open" or "closed"

        status.json                 the file to update

    status version: 0.0.1-0 2023-10-02

Again if this is not useful that's perfectly okay: it gave me something
to do and it seems useful but there certainly are other ways that it
could be done, better, worse or just different.

Obviously this script does not first verify that it is valid json or the
correct format. If the format is incorrect it will not be updated.

Added to tmp/src/ioccc_status and updated the tmp/src/Makefile.

Added to tmp/src/ioccc_status/.gitignore ioccc_status: the file in the
repo is ioccc_status.sh.
