### PR TITLE
Minor updates and fixes to ioccc_status.sh

### DIFF
--- a/1993/rince/.gitignore
+++ b/1993/rince/.gitignore
@@ -1,4 +1,5 @@
 jkb
 rince
 rince.orig
+rince.alt
 prog.orig

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -58,7 +58,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DZ=17
 
 # Include files that are needed to compile
 #
@@ -115,8 +115,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1993/rince/README.md
+++ b/1993/rince/README.md
@@ -1,9 +1,6 @@
 # Most Well Rounded
 
 James Bonfield  
-MRC Laboratory of Molecular Biology, 
-Hills Road  
-Cambridge  
 England  
 
 
@@ -13,6 +10,8 @@ England
 make all
 ```
 
+NOTE: there is an alternate version of this program that allows one to slow down
+the game. See the Alternate code section below.
 
 ## To run:
 
@@ -21,12 +20,39 @@ make all
 ```
 
 where:
-	
+
 `[cabbage]` is a CABBAGE description file  (default: `rince.c`)
+
+### Alternate code: slowing down the game
+
+Some people may want to slow down the game by increasing the
+value 17 in the lines:
+
+
+```c
+struct timeval v= {0,1<<17} ;
+```
+
+and
+
+```c
+refresh(),c=select(k,&y,0,0,(v.tv_usec=1<<17,&v))?getch():0;
+```
+
+to another value like 18 or 19. You can do this via the alternate code like:
+
+
+```sh
+make CDEFINE="-DZ=18" clobber alt
+```
+
+Replace 18 with whatever number you wish.
+
+Use `rince.alt` as you would `rince` above.
 
 
 ## Judges' remarks:
-    
+
 The author has provided several CABBAGE files for your amusement:
 
 - [rince.data1](rince.data1) plays
@@ -72,7 +98,7 @@ should be replaced with:
 
 ```c
 select(k,&y,0,0,(v.tv_usec=1<<whatever_you_want,&v))
-```	
+```
 
 where `whatever_you_want` is some integer such as 17 or 19.
 
@@ -83,20 +109,10 @@ compiler in the first place), this program may be used to log
 out very quickly.  Unfortunately, you can't do anything else
 with it.
 
-### Slowing down the game
-
-Some people may want to slow down the game by increasing the
-value 17 in the line:
-
-
-```c
-struct timeval v= {0,1<<17} ;  
-```
-	
-to something like 18 or 19.
+### Additional notes
 
 One may also need to do a `stty sane` if you kill the program
-to restore your terminal state.
+to restore your terminal state. If that does not work try `reset`.
 
 Some people report that `rince` dumps core on their system.
 
@@ -144,7 +160,7 @@ I have compiled in on the following systems:
 
 ---
 ```
-System              OS              Compiler (and flags) 
+System              OS              Compiler (and flags)
 DECstation 5000/240 Ultrix 4.2A     c89 -std
 SPARCstation 1+     SunOS 4.1       gcc -ansi -pedantic
 SPARCstation 10/31  Solaris 2.1     gcc -ansi -pedantic     (*)

--- a/1993/rince/design.md
+++ b/1993/rince/design.md
@@ -2,7 +2,7 @@
 
 Due to the long time this has been slowly evolving, it's hard to describe
 quite whether it's been `implemented`. I think perhaps evolve is a better
-term. I basic concept behind the program is to describe a game as a simple,
+term. The basic concept behind the program is to describe a game as a simple,
 slightly cheaty, cellular automata system, with some of the transitions
 bound to key presses.
 

--- a/1993/rince/rince.alt.c
+++ b/1993/rince/rince.alt.c
@@ -1,0 +1,123 @@
+/** J.K.Bonfield **
+^	<						 	 							
+^	>						 	 							
+<			#				>						v		
+<			 				 			<					
+<			>				>			<		v		
+X			 				 			X				j
+x			 				 			X				j
+X	 						x	^						k
+^	 						 	^							
+^	#						 									
+X			 				X			X				X
+
+^	v						 	 							
+v						 	 						v		
+v						#	 									
+v						X	 						 		
+v						x	 						 		
+>				#			<						v		
+>				 			 				>				
+X				 			 				X			l
+x				 			 				X			l
+
+41 20
+########################################
+#                                      #
+#  <   <   <   <   <>  <   <   <       #
+#       >   >   >  <>   >   >   >   >  #
+#  <   <   <   <   <>  <   <   <       #
+#       >   >   >  <>   >   >   >   >  #
+#  <   <   <   <   <>  <   <   <       #
+#       >   >   >  <>   >   >   >   >  #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#                                      #
+#           X                          #
+########################################*/
+#include <stdio.h>
+#include <curses.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <sys/time.h>
+int _tty_ch;
+bool _echoit;
+bool _rawmode;
+int _tty;
+#define U char
+#define G for(
+#define I )malloc(sizeof(
+
+typedef struct z {U x[20]; struct z*y; } j; j*J[2][256];
+struct timeval v= {0,1<<Z} ;
+U**X,c,*P="noopoqqnr",d;
+
+j*a(int Q, int i) {
+    G
+    clear(),noecho(),cbreak(); ;
+)
+
+{
+    int x=0,y=0,W=Q,Q=i-1,k;
+    G;
+    y<=Q;
+    (mvaddch(y,x,X[y][x]),++x^W-1)||(x=0,y++));
+    k=y=- --x;
+    G
+    refresh(),c=select(k,&y,0,0,(v.tv_usec=1<<Z,&v))?getch():0;
+    k?++x-W||(x=1,++y-Q||(--k,x=W-1,y=Q-1)):--x||(y--,x=W-1),k|y;
+)
+
+{
+    j *t;
+    G
+    t=J[1-k][X[y][x]]; t; t=t->y) {
+	U*f=t->x;
+	if (d==f[17]|f[17]==c) {
+	    int i=k&2,u=9,k=1,w=x,_=y,T;
+	    G;
+	    --u||(d-f[8]&&(X[y][x]=f[8]),w---_--,i=0,u=8,k--);) {
+	        _+=P[T=i>u?u:i]-'o';
+	        w+=P[4+T]-'p';
+	        if(k) {
+		    if (d-f[i]&&f[i]-X[_][w]) break;
+		        i++;
+	        } else
+		    f[++i+8]-d && (X[_][w]=f[i+8]);
+}   }   }   }   }   }
+
+jmp_buf E;
+
+int main(int open, U**exit) {
+    FILE*C=fopen (
+	open-2?__FILE__:*++exit,P+8);
+	j*t;
+	volatile int Q,Y=0;
+	int i,q; d=open-2?'\t':'*'; L:
+
+	Q=0; G; setjmp(E)<256; Q--
+    )
+    longjmp(E,(J[Y][Q]=0,Q++));
+    G; ; ) {
+	if(!C)return 1;
+	if('\n'==(c=getc(C)))
+	    if(!Y++)goto L; else
+	    {	fscanf(C,"%d %d\n",&i,&q);
+		X=(U**I P++)*q*(i+1));
+	    Q=0; G; Q<q; Q++)
+        X[Q]=(U*)&X[q]+Q*i;
+    
+	fread(*X,(initscr(),q*i),1,C);
+	a(i,Q);
+    }
+    t=(j*I*a(Q--,--Q)));
+    t->y=J[Y][c]; J[Y][c]=t;
+    fgets(t->x,20,C); }
+}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -384,7 +384,8 @@ compilers to compile the code, based on the author's remarks.
 
 ## [1990/cmills](1990/cmills/cmills.c) ([README.md](1990/cmills/README.md]))
 
-Yusuke got this to work in modern systems (it resulted in a bus error).
+Yusuke got this to work in modern systems (it previously resulted in a bus
+error).
 
 To prevent alarming warnings at linking or runtime Cody made the entry use
 `fgets()` rather than `gets()`. He notes that another option would have been to
@@ -626,7 +627,7 @@ NOTE: as noted in the README.md file and the [bugs.md](/bugs.md), this program a
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
 args (2). And not that we need the help or anything for this :-) but we do
-encourage you to test this :-) This should not be fixed.
+encourage you to test this :-) This should NOT be fixed.
 
 
 ## [1993/jonth](1993/jonth/jonth.c) ([README.md](1993/jonth/README.md]))
@@ -669,6 +670,10 @@ README.md files for details.
 ## [1993/rince](1993/rince/rince.c) ([README.md](1993/rince/README.md]))
 
 Yusuke supplied a patch to get this to work in modern systems.
+
+Cody provided an alternate version to simplify slowing the game down. This was
+based on our suggestion that it might be desired to slow down but done in a way
+that makes it easy to configure at compile time. See the README.md for details.
 
 
 ## [1993/schnitzi](1993/schnitzi/schnitzi.c) ([README.md](1993/schnitzi/README.md]))

--- a/tmp/src/Makefile
+++ b/tmp/src/Makefile
@@ -44,7 +44,7 @@ CFLAGS= -O3 -g3 --pedantic -Wall
 # target information #
 ######################
 
-TARGETS= winner_name
+TARGETS= winner_name ioccc_status
 
 ######################################
 # all - default rule - must be first #

--- a/tmp/src/ioccc_status/.gitignore
+++ b/tmp/src/ioccc_status/.gitignore
@@ -1,0 +1,1 @@
+ioccc_status

--- a/tmp/src/ioccc_status/Makefile
+++ b/tmp/src/ioccc_status/Makefile
@@ -1,0 +1,67 @@
+#!/usr/bin/env make
+#
+# ioccc_status - quickly update status.json file
+#
+# Written by Cody Boone Ferguson in 2023
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# Share and enjoy! :-)
+
+#############
+# utilities #
+#############
+
+CC= cc
+CHMOD= chmod
+CP= cp
+INSTALL= install
+RM= rm
+SHELL= bash
+
+#CFLAGS= -O3 -g3 --pedantic -Wall -Werror
+CFLAGS= -O3 -g3 --pedantic -Wall
+
+######################
+# target information #
+######################
+
+DESTDIR= ../../bin
+
+TARGETS= ioccc_status
+
+######################################
+# all - default rule - must be first #
+######################################
+
+all: ${TARGETS}
+	@:
+
+ioccc_status: ioccc_status.sh
+	${RM} -f -v $@
+	${CP} -f -v $? $@
+	${CHMOD} +x $@
+
+#################################################
+# .PHONY list of rules that do not create files #
+#################################################
+
+.PHONY: all configure clean clobber install
+
+###################################
+# standard Makefile utility rules #
+###################################
+
+configure:
+	@:
+
+clean:
+	@:
+
+clobber: clean
+	rm -f ${TARGETS}
+
+install: all
+	${INSTALL} -m 0555 ${TARGETS} ${DESTDIR}

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# 
+# ioccc_status.sh - quickly update status.json file
+#
+# Written by Cody Boone Ferguson in 2023
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# The script is at this just point a proof of concept but it does work, allowing
+# one to update the date of the latest news, the date of the status, the status
+# version and the status of the contest. It's not required to update all or for
+# that matter any of them.
+#
+# If that is not clear: it might or might not be needed or desired and that is
+# perfectly okay. If it's used but modified that's also okay. It gave me
+# something to do and whether or not it's useful it has served a purpose.
+#
+# If -s option is used, the status field is updated, providing that the status
+# arg is either "closed" or "open".
+#
+# If the -d or -n flags are used then it will update the status_date or
+# latest_news fields, respectively.
+# 
+# If the -I status_ver option is used the IOCCC_status_version field will be
+# updated.
+#
+export IOCCC_STATUS_VERSION="0.0.1-0 2023-10-02" # major.minor.release-patch YYYY-MM-DD
+
+USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-I status_ver] status.json
+
+    -h			    print help and exit
+    -V			    print version and exit
+    -v level		    set verbosity level
+    -s statue		    set contest status to open or closed
+    -d			    update status_date
+    -n			    update latest_news date
+    -I status_ver	    update IOCCC_status_version
+			    
+				NOTE: status_ver must be one of \"open\" or \"closed\"
+
+    status.json		    the file to update
+
+status version: $IOCCC_STATUS_VERSION"
+
+export UPDATE_DATE=""
+export UPDATE_NEWS=""
+export UPDATE_IOCCC_STATUS_VERSION=""
+export IOCCC_STATUS_VERSION=""
+export VERBOSITY=0
+export STATUS_JSON_FILE=""
+export STATUS_FLAG=""
+export STATUS="closed" # default closed
+
+# parse args
+#
+while getopts :hVv:s:dnI: flag; do
+    case "$flag" in
+    h)	echo "$USAGE" 1>&2
+	exit 2
+	;;
+    V)	echo "$IOCCC_STATUS_VERSION" 1>&2
+	exit 2
+	;;
+    v)	VERBOSITY="$OPTARG";
+	;;
+    s)	STATUS_FLAG="-s"
+	STATUS="$OPTARG";
+	;;
+    d)	UPDATE_DATE="-d"
+	;;
+    n)	UPDATE_NEWS="-n"
+	;;
+    I)  UPDATE_IOCCC_STATUS_VERSION="-I"
+	IOCCC_STATUS_VERSION="$OPTARG"
+	;;
+    :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
+	echo 1>&2
+	echo "$USAGE" 1>&2
+	exit 3
+	;;
+   *)
+	;;
+    esac
+done
+
+#
+# remove the options
+#
+shift $(( OPTIND - 1 ));
+#
+# verify arg count
+#
+if [[ $# -gt 1 ]]; then
+    echo "$0: ERROR: expected 0 or 1 args, found: $#" 1>&2
+    echo "$USAGE" 1>&2
+    exit 3
+fi
+#
+# parse args
+#
+if [[ $# -gt 0 ]]; then
+    export STATUS_JSON_FILE="$1"
+fi
+
+# firewall STATUS_JSON_FILE must be a readable file
+#
+if [[ ! -e $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json does not exist: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+if [[ ! -f $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json not a file: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+if [[ ! -r $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json not a readable file: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+
+# check that if -s used that the status ($STATUS) is either 'open' or 'closed'
+if [[ -n "$STATUS_FLAG" ]]; then
+    if [[ "$STATUS" != "open" && "$STATUS" != "closed" ]]; then
+	echo "$0: ERROR: status must be 'open' or 'closed'" 1>&2
+	exit 1
+    fi
+fi
+
+if [[ "$VERBOSITY" -gt 1 ]]; then
+    echo "$0: status.json file: $STATUS_JSON_FILE" 1>&2
+    if [[ -n "$STATUS_FLAG" ]]; then
+	echo "$0: will update contest status to: \"$STATUS\"" 1>&2
+    fi
+    if [[ -n "$UPDATE_DATE" ]]; then
+	echo "$0: will update status_date to: $(date)" 1>&2
+    fi
+    if [[ -n "$UPDATE_NEWS" ]]; then
+	echo "$0: will update latest_news to: $(date)" 1>&2
+    fi
+    if [[ -n "$UPDATE_IOCCC_STATUS_VERSION" ]]; then
+	echo "$0: will update IOCCC_status_version to: $IOCCC_STATUS_VERSION" 1>&2
+    fi
+fi
+
+# first status_date if requested
+if [[ -n "$UPDATE_DATE" ]]; then
+    sed -i'' "s/\"status_date\" : \".*[^\"]\"/\"status_date\" : \"$(date)\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated status_date to: $(date)" 1>&2
+    fi
+fi
+
+# then update latest_news date if requested
+if [[ -n "$UPDATE_NEWS" ]]; then
+    sed -i'' "s/\"latest_news\" : \".*[^\"]\"/\"latest_news\" : \"$(date)\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated latest_news to: $(date)" 1>&2
+    fi
+fi
+
+# then update IOCCC_STATUS_VERSION if requested
+if [[ -n "$UPDATE_IOCCC_STATUS_VERSION" ]]; then
+    sed -i'' "s/\"IOCCC_status_version\" : \".*[^\"]\"/\"IOCCC_status_version\" : \"$IOCCC_STATUS_VERSION\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated IOCCC_status_version to: \"$IOCCC_STATUS_VERSION\"" 1>&2
+    fi
+fi
+
+# finally if we need to change the status of the contest do so
+if [[ -n "$STATUS_FLAG" ]]; then
+    sed -i'' "s/\"contest\" : \".*[^\"]\"/\"contest\" : \"$STATUS\"/g" "$STATUS_JSON_FILE"
+
+    if [[ "$VERBOSITY" -ge 1 ]]; then
+	echo "$0: updated contest status to: \"$STATUS\"" 1>&2
+    fi
+fi

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -33,12 +33,13 @@ USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-I st
     -h			    print help and exit
     -V			    print version and exit
     -v level		    set verbosity level
-    -s statue		    set contest status to open or closed
+    -s status		    set contest status to open or closed
+
+				NOTE: status must be one of \"open\" or \"closed\"
+
     -d			    update status_date
     -n			    update latest_news date
     -I status_ver	    update IOCCC_status_version
-			    
-				NOTE: status_ver must be one of \"open\" or \"closed\"
 
     status.json		    the file to update
 

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -28,7 +28,7 @@
 #
 export IOCCC_STATUS_VERSION="0.0.1-0 2023-10-02" # major.minor.release-patch YYYY-MM-DD
 
-USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-I status_ver] status.json
+USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-i status_ver] status.json
 
     -h			    print help and exit
     -V			    print version and exit
@@ -39,7 +39,7 @@ USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-I st
 
     -d			    update status_date
     -n			    update latest_news date
-    -I status_ver	    update IOCCC_status_version
+    -i status_ver	    update IOCCC_status_version
 
     status.json		    the file to update
 
@@ -56,7 +56,7 @@ export STATUS="closed" # default closed
 
 # parse args
 #
-while getopts :hVv:s:dnI: flag; do
+while getopts :hVv:s:dni: flag; do
     case "$flag" in
     h)	echo "$USAGE" 1>&2
 	exit 2
@@ -73,7 +73,7 @@ while getopts :hVv:s:dnI: flag; do
 	;;
     n)	UPDATE_NEWS="-n"
 	;;
-    I)  UPDATE_IOCCC_STATUS_VERSION="-I"
+    i)  UPDATE_IOCCC_STATUS_VERSION="-i"
 	IOCCC_STATUS_VERSION="$OPTARG"
 	;;
     :)	echo "$0: ERROR: option -$OPTARG requires an argument" 1>&2
@@ -146,7 +146,7 @@ fi
 
 # first status_date if requested
 if [[ -n "$UPDATE_DATE" ]]; then
-    sed -i'' "s/\"status_date\" : \".*[^\"]\"/\"status_date\" : \"$(date)\"/g" "$STATUS_JSON_FILE"
+    sed -i'' "s|\"status_date\" : \".*[^\"]\"|\"status_date\" : \"$(date)\"|g" "$STATUS_JSON_FILE"
 
     if [[ "$VERBOSITY" -ge 1 ]]; then
 	echo "$0: updated status_date to: $(date)" 1>&2
@@ -155,7 +155,7 @@ fi
 
 # then update latest_news date if requested
 if [[ -n "$UPDATE_NEWS" ]]; then
-    sed -i'' "s/\"latest_news\" : \".*[^\"]\"/\"latest_news\" : \"$(date)\"/g" "$STATUS_JSON_FILE"
+    sed -i'' "s|\"latest_news\" : \".*[^\"]\"|\"latest_news\" : \"$(date)\"|g" "$STATUS_JSON_FILE"
 
     if [[ "$VERBOSITY" -ge 1 ]]; then
 	echo "$0: updated latest_news to: $(date)" 1>&2
@@ -164,7 +164,7 @@ fi
 
 # then update IOCCC_STATUS_VERSION if requested
 if [[ -n "$UPDATE_IOCCC_STATUS_VERSION" ]]; then
-    sed -i'' "s/\"IOCCC_status_version\" : \".*[^\"]\"/\"IOCCC_status_version\" : \"$IOCCC_STATUS_VERSION\"/g" "$STATUS_JSON_FILE"
+    sed -i'' "s|\"IOCCC_status_version\" : \".*[^\"]\"|\"IOCCC_status_version\" : \"$IOCCC_STATUS_VERSION\"|g" "$STATUS_JSON_FILE"
 
     if [[ "$VERBOSITY" -ge 1 ]]; then
 	echo "$0: updated IOCCC_status_version to: \"$IOCCC_STATUS_VERSION\"" 1>&2
@@ -173,7 +173,7 @@ fi
 
 # finally if we need to change the status of the contest do so
 if [[ -n "$STATUS_FLAG" ]]; then
-    sed -i'' "s/\"contest\" : \".*[^\"]\"/\"contest\" : \"$STATUS\"/g" "$STATUS_JSON_FILE"
+    sed -i'' "s|\"contest\" : \".*[^\"]\"|\"contest\" : \"$STATUS\"|g" "$STATUS_JSON_FILE"
 
     if [[ "$VERBOSITY" -ge 1 ]]; then
 	echo "$0: updated contest status to: \"$STATUS\"" 1>&2


### PR DESCRIPTION

Change -I IOCCC_status_version to -i IOCCC_status_version.

Change sed separator of sed operations to be '|', not '/'. There still 
is the problem of if the version has a '|' in it the sed command will 
break but this might be solved by requiring a specific format (which 
might seem a good idea anyway) and then forcing it or some other way but
this will work for now. The other variables/fields would not trigger 
this problem because two use $(date) and the other is required to be 
'open' or 'closed' and nothing else.