### PR TITLE
Silence compilation of 1985/sicherman

### DIFF
--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-comment -Wno-deprecated-non-prototype -Wno-main -Wno-pedantic \
-	-Wno-return-type -Wno-strict-prototypes -Wno-unused-parameter
+	-Wno-return-type -Wno-strict-prototypes -Wno-unused-parameter -Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/faq.md
+++ b/faq.md
@@ -800,3 +800,77 @@ exaggeration](https://books.google.com/books?id=ms3tce7BgJsC&lpg=PA134&vq=%22the
 p.s. Here is an image of F. D. C. Willard:
 
 [F D C Willard](png/F.D.C.Willard.png)
+
+## Q: Why do Makefiles use `-Weverything` with `clang`? Don't you know that its use is not recommended by clang developers?
+
+The use of `-Weverything` is limited to when one forces `CC=clang`. Users with
+clang compilers are not required to set `CC=clang` but when they do,
+`-Weverything` is enabled with all of its challenges, pedantic warnings, and
+sometimes warnings about things that do not matter, some of which are frankly
+frivolous and often downright dubious.
+
+To enable this feature:
+
+```sh
+make clobber all CC=clang
+```
+
+or:
+
+```sh
+make clobber all 'CWARN+= -Weverything'
+```
+
+though it should be noted that if one tries `-Weverything` with compilers that
+are not `clang` they might see something like:
+
+```sh
+echo 'int main(void) {}' > foo.c ; cc -Weverything foo.c -o foo
+cc: error: unrecognized command-line option '-Weverything'
+```
+
+which means that it can't even be compiled. Thus the proper way to do it is the
+first one.
+
+IOCCC authors who have access to a `clang` compiler might wish to try they their
+hand at compiling with `-Weverything` while using a minimum of `-Wno-foo`
+statements.  Sometimes there is a technical or pedantic issue that
+`-Weverything` warns about that would merit a change to your C code. Of course
+if you're running out of bytes due to rule 2[ab] one might not have much choice.
+Thus is something that obfuscators simply sometimes have to deal with!
+
+If you to try to use minimize the number of `-Wno-foo` options needed with
+`-Weverything`, please mention this in your remarks about the entry, as the
+judges note you attempt to honor it (see also below). In some cases your
+obfuscated code will issue warnings with `-Weverything` no matter what: the
+`-Wno-poison-system-directories` is a common example of this but there are
+others as well.
+
+If you do try for a warning clean `-Weverything`, keep on mind that while _your_
+compile environment might be warning free, a different clang version or a
+different build environment might still have warnings. For instance the warning
+set is different in macOS (which by default is `clang` even when run as `gcc`!)
+than linux! Given that your entry *MUST* work as documented, you may be safer to
+say that your entry keeps the number of warnings and `-Wno-foo` options while
+compiling with `clang -Weverything` at a minimum. Because if you claim zero
+warnings, and we find a warning situation, this may diminish the value of your
+entry as it is not as documented. Thus it might be wise to point this out and
+also if you can test it in multiple platforms (or versions of `clang`, see
+below note) this would be advisable.
+
+NOTE: different versions of `clang` have other differences as well. For instance
+a defect of `clang` (which was fixed in a lot of entries by [Cody Boone
+Ferguson](/winners.html#Cody_Boone_Ferguson) and some were fixed by us, the
+[judges](https://www.ioccc.org/judges.html) as well) is that it requires that
+`main()`'s arguments to be of a specific type. However some versions of `clang`
+are more strict in the number of args allowed. These reasons are part of why
+numerous entries had to be modified so that `main()` calls another function
+instead of doing it all in `main()`. Another reason was that some entries that
+recursively called `main()` caused a crash or otherwise broke the entry in
+modern systems. Some entries do not work in `clang` (or at least do not work
+completely) due to these defects, for instance
+[1989/westley](1989/westley/README.md).
+
+As you can see, using `clang` has some additional problems to work out but if
+you can get your entry to work well in `clang` it might very well be considered
+better than other entries.

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -26,7 +26,7 @@
 # If the -I status_ver option is used the IOCCC_status_version field will be
 # updated.
 #
-export IOCCC_STATUS_VERSION="0.0.1-0 2023-10-02" # major.minor.release-patch YYYY-MM-DD
+export IOCCC_STATUS_VERSION="0.0.2-0 2023-10-04" # major.minor.release-patch YYYY-MM-DD
 
 USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-i status_ver] status.json
 
@@ -40,6 +40,8 @@ USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-i st
     -d			    update status_date
     -n			    update latest_news date
     -i status_ver	    update IOCCC_status_version
+
+				NOTE: version must match the regexp: [0-9]+\.[0-9]+ [0-9]{4}-[0-9]{2}-[0-9]{2} 		
 
     status.json		    the file to update
 
@@ -120,11 +122,20 @@ if [[ ! -r $STATUS_JSON_FILE ]]; then
     exit 1
 fi
 
-# check that if -s used that the status ($STATUS) is either 'open' or 'closed'
+# check that if -s ($STATUS_FLAG) used that the status ($STATUS) is either 'open' or 'closed'
 if [[ -n "$STATUS_FLAG" ]]; then
     if [[ "$STATUS" != "open" && "$STATUS" != "closed" ]]; then
 	echo "$0: ERROR: status must be 'open' or 'closed'" 1>&2
-	exit 1
+	exit 3
+    fi
+fi
+
+# check format of IOCCC_status_version if set (-i used, $UPDATE_IOCCC_STATUS_VERSION)
+if [[ -n "$UPDATE_IOCCC_STATUS_VERSION" ]]; then
+    echo "$IOCCC_STATUS_VERSION" | grep -qE '[0-9]+\.[0-9]+ [0-9]{4}-[0-9]{2}-[0-9]{2}'
+    if [[ "${PIPESTATUS[1]}" -ne 0 ]]; then
+	echo "$0: ERROR: IOCCC_status_version must match the regexp: '[0-9]+\.[0-9]+ [0-9]{4}-[0-9]{2}-[0-9]{2}'" 1>&2
+	exit 3
     fi
 fi
 

--- a/tmp/src/ioccc_status/ioccc_status.sh
+++ b/tmp/src/ioccc_status/ioccc_status.sh
@@ -26,7 +26,7 @@
 # If the -I status_ver option is used the IOCCC_status_version field will be
 # updated.
 #
-export IOCCC_STATUS_VERSION="0.0.2-0 2023-10-04" # major.minor.release-patch YYYY-MM-DD
+export IOCCC_STATUS_SCRIPT_VERSION="0.0.2-0 2023-10-04" # major.minor.release-patch YYYY-MM-DD
 
 USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-i status_ver] status.json
 
@@ -45,7 +45,7 @@ USAGE="usage: $(basename "$0") [-h] [-V] [-v level] [-s status] [-d] [-n] [-i st
 
     status.json		    the file to update
 
-status version: $IOCCC_STATUS_VERSION"
+status version: $IOCCC_STATUS_SCRIPT_VERSION"
 
 export UPDATE_DATE=""
 export UPDATE_NEWS=""
@@ -63,7 +63,7 @@ while getopts :hVv:s:dni: flag; do
     h)	echo "$USAGE" 1>&2
 	exit 2
 	;;
-    V)	echo "$IOCCC_STATUS_VERSION" 1>&2
+    V)	echo "$IOCCC_STATUS_SCRIPT_VERSION" 1>&2
 	exit 2
 	;;
     v)	VERBOSITY="$OPTARG";


### PR DESCRIPTION

A warning that might not have been previously triggered, odd and
unlikely as it might seem, was triggered at least in macOS Sonoma and it
has now been disabled: -Wno-implicit-int.

The entry used to require in modern days -traditional-cpp but like the
others I fixed this and that did introduce new warnings as code had to
be commented out in some cases like this entry (it did not matter in
this entry if it was commented out but it had to be due to compiler
errors otherwise). Even so this warning should have been triggered
already due to main() and subr() not specifying a return type.