### PR TITLE
Add item to FAQ about cb

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -178,6 +178,22 @@ If the entry requires gcc and you did not explicitly install gcc in macOS you
 will not be able to run or use these entries. This is because macOS gcc is
 actually clang, even `/usr/bin/gcc`.
 
+That being said many (if not most) of these entries have been fixed and some
+others will be looked at, when found.
+
+## Q: What is `cb` that is mentioned in some of the older entries?
+
+This was a C beautifier for Plan 9. There exists a man page and the source code
+can be found
+[here](https://github.com/plan9foundation/plan9/tree/main/sys/src/cmd/cb) at the
+[Plan 9 History, from 1992-09-21 to 2015-01-10 GitHub
+repository](https://github.com/plan9foundation/plan9).
+
+The man page rendered as html can be found
+[here](https://9p.io/magic/man2html/1/cb).
+
+If there is a version for Unix or Linux it cannot be found now.
+
 ## Q: I can't get XYZZY entry to compile with clang. What can I do?
 
 Although we have fixed numerous entries to work with clang (sometimes in an alt

--- a/faq.md
+++ b/faq.md
@@ -106,12 +106,17 @@ have mainly not been touched except one that has had the buffer size increased
 (which could be done for others that are not possible to change to `fgets()` but
 this has not been done).
 
+Some entries can be made to look almost identical to the original entry. For
+instance the fix to [1988/reddy](1988/reddy/README.md) required only a single
+`#define` be added.
+
 In the future we, the judges, would prefer that entries use `fgets()` to prevent
 these problems.
 
 NOTE: due to 'compatibility reasons' `fgets()` stores the newline and `gets()`
 does not. We're not sure how this is compatibility but either way it can cause a
 problem and it is this that has complicated some fixes.
+
 
 ## Q: I cannot get entry XYZZY from year 19xx to compile!
 


### PR DESCRIPTION

Includes Plan 9 source code and a html rendered man page. If there was a
unix or linux version the code can no longer be found.

Some README.md files refer to this tool. When an author's remarks it 
will not be removed or updated but if in the judges' remarks it might be
moved to a historical note subsection. This will happen in time with 
additional passes of the README.md files - for most it should be the 
final pass but the years 2011+ will need a pass before that.