### PR TITLE
Typo fix and warning silence in 1988/applin

### DIFF
--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -40,6 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-expansion-to-defined -Wno-implicit-int -Wno-strict-prototypes
 
+
 # Common C compiler warning flags
 #
 CWARN= -Wall -Wextra -pedantic ${CSILENCE}
@@ -83,7 +84,7 @@ CC= cc
 #
 ifeq ($(CC),clang)
 #
-CSILENCE+= -Wno-poison-system-directories
+CSILENCE+= -Wno-poison-system-directories -Wno-gnu-line-marker
 #
 CWARN+= -Weverything
 #
@@ -154,8 +155,8 @@ ${ALT_TARGET}: ${PROG}.alt.c
 # not an official entry
 #
 # The 'zsmall.c' program was obtained from 'applin.c' by reducing its recursion
-# and running it thru the initial /lib/cpp.  That is, 'zsmall.c' is a small
-# version of the 'large.c' file as produced by the 'applin' make rule below.
+# and running it through the initial /lib/cpp.  That is, 'zsmall.c' is a small
+# version of the 'large.c' file as produced by the 'applin' make rule above.
 zsmall: zsmall.c
 	${CC} ${CFLAGS} zsmall.c -o $@
 


### PR DESCRIPTION
The rule zsmall.c comment suggested that applin rule (which is done via the ${PROG} variable which is the value of ${ENTRY} which is how every other entry Makefile is done) was below but actually it is above.

If ${CC} is clang then add to CSILENCE -Wno-gnu-line-marker. This unfortunately means one has to either have by default CC as clang or they have to specify e.g.:

    make clobber CC=clang everything

as CC tends to be just 'cc'.

The warning cannot be silenced with gcc and although it allows one to use of -Wno-gnu-line-marker it has no effect other than to say it's unrecognised because gcc (at least in some versions?) does not allow this warning to be silenced, for whatever (invalid :-) ) reason(s). Thus unless one explicitly says that CC=clang they will get the warning.

Still at least it's now silenced if one does indeed do CC=clang in the compile line.