### PR TITLE
Mass typo fixes

### DIFF
--- a/1984/Makefile
+++ b/1984/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1984/anonymous/Makefile
+++ b/1984/anonymous/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1984/laman/Makefile
+++ b/1984/laman/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1985/Makefile
+++ b/1985/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1985/applin/Makefile
+++ b/1985/applin/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/Makefile
+++ b/1986/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/applin/Makefile
+++ b/1986/applin/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/august/Makefile
+++ b/1986/august/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/bright/Makefile
+++ b/1986/bright/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/hague/Makefile
+++ b/1986/hague/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/holloway/Makefile
+++ b/1986/holloway/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/pawka/Makefile
+++ b/1986/pawka/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/stein/Makefile
+++ b/1986/stein/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/Makefile
+++ b/1987/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/biggar/Makefile
+++ b/1987/biggar/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/hines/Makefile
+++ b/1987/hines/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/korn/Makefile
+++ b/1987/korn/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/Makefile
+++ b/1988/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -40,6 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-expansion-to-defined -Wno-implicit-int -Wno-strict-prototypes
 
+
 # Common C compiler warning flags
 #
 CWARN= -Wall -Wextra -pedantic ${CSILENCE}
@@ -83,7 +84,7 @@ CC= cc
 #
 ifeq ($(CC),clang)
 #
-CSILENCE+= -Wno-poison-system-directories
+CSILENCE+= -Wno-poison-system-directories -Wno-gnu-line-marker
 #
 CWARN+= -Weverything
 #
@@ -154,8 +155,8 @@ ${ALT_TARGET}: ${PROG}.alt.c
 # not an official entry
 #
 # The 'zsmall.c' program was obtained from 'applin.c' by reducing its recursion
-# and running it thru the initial /lib/cpp.  That is, 'zsmall.c' is a small
-# version of the 'large.c' file as produced by the 'applin' make rule below.
+# and running it through the initial /lib/cpp.  That is, 'zsmall.c' is a small
+# version of the 'large.c' file as produced by the 'applin' make rule above.
 zsmall: zsmall.c
 	${CC} ${CFLAGS} zsmall.c -o $@
 

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -7,7 +7,7 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
 #	http://www.ioccc.org/bugs.md

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/isaak/Makefile
+++ b/1988/isaak/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/litmaath/Makefile
+++ b/1988/litmaath/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/phillipps/Makefile
+++ b/1988/phillipps/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/reddy/Makefile
+++ b/1988/reddy/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/robison/Makefile
+++ b/1988/robison/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/Makefile
+++ b/1989/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/fubar/Makefile
+++ b/1989/fubar/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/jar.2/Makefile
+++ b/1989/jar.2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/paul/Makefile
+++ b/1989/paul/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/robison/Makefile
+++ b/1989/robison/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/roemer/Makefile
+++ b/1989/roemer/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/vanb/Makefile
+++ b/1989/vanb/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/Makefile
+++ b/1990/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/cmills/Makefile
+++ b/1990/cmills/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/dds/Makefile
+++ b/1990/dds/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/dg/Makefile
+++ b/1990/dg/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/pjr/Makefile
+++ b/1990/pjr/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/scjones/Makefile
+++ b/1990/scjones/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/Makefile
+++ b/1991/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/davidguy/Makefile
+++ b/1991/davidguy/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1991/westley/Makefile
+++ b/1991/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/Makefile
+++ b/1992/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/albert/Makefile
+++ b/1992/albert/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/ant/Makefile
+++ b/1992/ant/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/guidelines.txt
+++ b/1992/guidelines.txt
@@ -522,7 +522,7 @@ FOR MORE INFORMATION:
 
     See the official IOCCC web site:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     for more updated information.
 

--- a/1992/imc/Makefile
+++ b/1992/imc/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/lush/Makefile
+++ b/1992/lush/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/rules.txt
+++ b/1992/rules.txt
@@ -167,7 +167,7 @@ FOR MORE INFORMATION:
 
     See the official IOCCC web site:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     for more updated information.
 

--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/Makefile
+++ b/1993/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/ant/Makefile
+++ b/1993/ant/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/dgibson/Makefile
+++ b/1993/dgibson/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/ejb/Makefile
+++ b/1993/ejb/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/jonth/Makefile
+++ b/1993/jonth/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/schnitzi/Makefile
+++ b/1993/schnitzi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1993/vanb/Makefile
+++ b/1993/vanb/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/Makefile
+++ b/1994/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/dodsond1/Makefile
+++ b/1994/dodsond1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/imc/Makefile
+++ b/1994/imc/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/shapiro/Makefile
+++ b/1994/shapiro/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/smr/Makefile
+++ b/1994/smr/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/Makefile
+++ b/1995/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/dodsond1/Makefile
+++ b/1995/dodsond1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/dodsond2/Makefile
+++ b/1995/dodsond2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/esde/Makefile
+++ b/1995/esde/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/heathbar/Makefile
+++ b/1995/heathbar/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/leo/Makefile
+++ b/1995/leo/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/rules.txt
+++ b/1995/rules.txt
@@ -203,7 +203,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:					       |
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).  |
 

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/schnitzi/Makefile
+++ b/1995/schnitzi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/spinellis/Makefile
+++ b/1995/spinellis/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1995/vanschnitz/Makefile
+++ b/1995/vanschnitz/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/Makefile
+++ b/1996/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/README.md
+++ b/1996/README.md
@@ -11,7 +11,7 @@ You may then wish to look at the Author's remarks for even more details.
 
 The IOCCC has an official home page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
 containing previous winning entries, information about the judges,
 announcements and much more.

--- a/1996/august/Makefile
+++ b/1996/august/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/dalbec/Makefile
+++ b/1996/dalbec/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/guidelines.txt
+++ b/1996/guidelines.txt
@@ -768,7 +768,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/1996/huffman/Makefile
+++ b/1996/huffman/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/jonth/Makefile
+++ b/1996/jonth/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/rcm/Makefile
+++ b/1996/rcm/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/rules.txt
+++ b/1996/rules.txt
@@ -209,7 +209,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/1996/schweikh1/Makefile
+++ b/1996/schweikh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/schweikh2/Makefile
+++ b/1996/schweikh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/Makefile
+++ b/1998/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/README.md
+++ b/1998/README.md
@@ -11,7 +11,7 @@ You may then wish to look at the Author's remarks for even more details.
 
 The IOCCC has its own domain.  The IOCCC has an official home page is now:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
 Use make to compile entries.  It is possible that on BSD or non-unix
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -42,7 +42,7 @@ Landon selected Leonid A. Broukhis, a two time IOCCC winner, as a
 co-judge.   Landon and Leo together selected Jeremy Horn and Peter
 Seebach.  The four judges:
 
-	http://www.ioccc.org/judges.html
+	https://www.ioccc.org/judges.html
 
 together worked thru-out the 1998 IOCCC season.
 
@@ -121,7 +121,7 @@ email the fix (patch file or the entire changed file) to the above address.
 
 The next IOCCC is planned to start towards the end of 1999.  Watch:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
 for news of the next contest.
 

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/bas1/Makefile
+++ b/1998/bas1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/bas2/Makefile
+++ b/1998/bas2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/chaos/Makefile
+++ b/1998/chaos/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/df/Makefile
+++ b/1998/df/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/dlowe/Makefile
+++ b/1998/dlowe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/dorssel/Makefile
+++ b/1998/dorssel/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/guidelines.txt
+++ b/1998/guidelines.txt
@@ -33,9 +33,9 @@ WHAT IS NEW IN 1998:
     different.  Contest entries (in the proper form) go to entry@ioccc.org     |
     and questions to the judges go to questions@ioccc.org.		       |
 
-    There is a new web URL:   http://www.ioccc.org			       |
+    There is a new web URL:   https://www.ioccc.org			       |
 
-    We have a new IOCCC judging team.  See http://www.ioccc.org/judges.html    |
+    We have a new IOCCC judging team.  See https://www.ioccc.org/judges.html    |
     for more information.
 
     We added a more explicit comment against using gzip to get around the      |
@@ -791,7 +791,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org						       |
+	https://www.ioccc.org						       |
 
     It has rules, guidelines and winners of previous contests (1984 to date).  |
 

--- a/1998/mkentry.c
+++ b/1998/mkentry.c
@@ -61,7 +61,7 @@
  *  year.  You should be sure you have the current rules and guidelines
  *  prior to submitting entries.  To obtain them, visit the following URL:
  *
- *	http://www.ioccc.org
+ *	https://www.ioccc.org
  *
  * Because contest rules change from year to year, one should only use this
  * program for the year that it was intended.

--- a/1998/rules.txt
+++ b/1998/rules.txt
@@ -209,6 +209,6 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:    |
 
-	http://www.ioccc.org						       |
+	https://www.ioccc.org						       |
 
     It has rules, guidelines and winners of previous contests (1984 to date).

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/1998/tomtorfs/Makefile
+++ b/1998/tomtorfs/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/Makefile
+++ b/2000/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/README.md
+++ b/2000/README.md
@@ -99,7 +99,7 @@ email the fix (patch file or the entire changed file) to the above address.
 
 The next IOCCC is planned to start towards early spring 2001.  Watch:
 
-	http://www.ioccc.org/
+	https://www.ioccc.org/
 
 for news of the next contest.
 

--- a/2000/anderson/Makefile
+++ b/2000/anderson/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/bellard/Makefile
+++ b/2000/bellard/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/bmeyer/Makefile
+++ b/2000/bmeyer/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/dhyang/Makefile
+++ b/2000/dhyang/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/dlowe/Makefile
+++ b/2000/dlowe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/guidelines.txt
+++ b/2000/guidelines.txt
@@ -756,7 +756,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2000/jarijyrki/Makefile
+++ b/2000/jarijyrki/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/mkentry.c
+++ b/2000/mkentry.c
@@ -54,7 +54,7 @@
  *  year.  You should be sure you have the current rules and guidelines
  *  prior to submitting entries.  To obtain them, visit the following URL:
  *
- *	http://www.ioccc.org
+ *	https://www.ioccc.org
  *
  * Because contest rules change from year to year, one should only use this
  * program for the year that it was intended.

--- a/2000/natori/Makefile
+++ b/2000/natori/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/primenum/Makefile
+++ b/2000/primenum/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/rince/Makefile
+++ b/2000/rince/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/robison/Makefile
+++ b/2000/robison/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/rules.txt
+++ b/2000/rules.txt
@@ -208,7 +208,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:    
 
-	http://www.ioccc.org						       
+	https://www.ioccc.org						       
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2000/schneiderwent/Makefile
+++ b/2000/schneiderwent/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/tomx/Makefile
+++ b/2000/tomx/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2000/tomx/mkentry.c
+++ b/2000/tomx/mkentry.c
@@ -54,7 +54,7 @@
  *  year.  You should be sure you have the current rules and guidelines
  *  prior to submitting entries.  To obtain them, visit the following URL:
  *
- *	http://www.ioccc.org
+ *	https://www.ioccc.org
  *
  * Because contest rules change from year to year, one should only use this
  * program for the year that it was intended.

--- a/2001/Makefile
+++ b/2001/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/README.md
+++ b/2001/README.md
@@ -12,7 +12,7 @@ You may then wish to look at the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.  The
 primary site can be found at,
 
-     http://www.ioccc.org
+     https://www.ioccc.org
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -83,7 +83,7 @@ email the fix (patch file or the entire changed file) to the above address.
 
 Watch:
 
-	http://www.ioccc.org/
+	https://www.ioccc.org/
 
 for news of the next contest.
 

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/cheong/Makefile
+++ b/2001/cheong/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/dgbeards/Makefile
+++ b/2001/dgbeards/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/guidelines.txt
+++ b/2001/guidelines.txt
@@ -389,7 +389,7 @@ ENTRY FORMAT:
 									       |
     NOTE: A copy of the mkentry program may be found at:		       |
 									       |
-	http://www.ioccc.org/official/mkentry.c				       |
+	https://www.ioccc.org/official/mkentry.c				       |
 
     You are not required to use mkentry.  It is convenient, however,
     as it attempts to uuencode the needed files, and attempt to check
@@ -646,7 +646,7 @@ end
 
     Again, you may want to use the mkentry program may be found at:	       |
 									       |
-	http://www.ioccc.org/official/mkentry.c				       |
+	https://www.ioccc.org/official/mkentry.c				       |
 									       |
     to format your entry.						       |
 
@@ -771,7 +771,7 @@ ANNOUNCEMENT OF WINNERS:
     won, the name of their award, and a very brief description of the	       |
     winning entry on the IOCCC web site:				       |
 									       |
-	    http://www.ioccc.org/whowon.html				       |
+	    https://www.ioccc.org/whowon.html				       |
 									       |
     We will also submit a brief announcement story to /.:		       |
 									       |
@@ -788,7 +788,7 @@ ANNOUNCEMENT OF WINNERS:
     the winners has been completed (perhaps Feb or Mar 2002), the winning      |
     source will be posted to the IOCCC web site:		               |
 									       |
-	    http://www.ioccc.org/years.html				       |
+	    https://www.ioccc.org/years.html				       |
 									       |
     	    NOTE: previous winners are available at that URL		       |
 									       |
@@ -830,7 +830,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2001/herrmann1/Makefile
+++ b/2001/herrmann1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/jason/Makefile
+++ b/2001/jason/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/mkentry.c
+++ b/2001/mkentry.c
@@ -60,7 +60,7 @@
  *  year.  You should be sure you have the current rules and guidelines
  *  prior to submitting entries.  To obtain them, visit the following URL:
  *
- *	http://www.ioccc.org
+ *	https://www.ioccc.org
  *
  * Because contest rules change from year to year, one should only use this
  * program for the year that it was intended.

--- a/2001/ollinger/Makefile
+++ b/2001/ollinger/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/rosten/Makefile
+++ b/2001/rosten/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/rules.txt
+++ b/2001/rules.txt
@@ -225,10 +225,10 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 									       |
     NOTE: A copy of the mkentry program may be found at:		       |
 									       |
-	http://www.ioccc.org/official/mkentry.c				       |
+	https://www.ioccc.org/official/mkentry.c				       |

--- a/2001/schweikh/Makefile
+++ b/2001/schweikh/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/Makefile
+++ b/2004/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/README.md
+++ b/2004/README.md
@@ -74,7 +74,7 @@ For the latest information on how to contact the [IOCCC
 Judges](https://www.ioccc.org/judges.html) please visit
 <https://www.ioccc.org/contact.html>.
 
-    http://www.ioccc.org/contact.html
+    https://www.ioccc.org/contact.html
 
 For news of the next contest watch <https://www.ioccc.org/>.
 

--- a/2004/anonymous/Makefile
+++ b/2004/anonymous/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/arachnid/Makefile
+++ b/2004/arachnid/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/gavin/Makefile
+++ b/2004/gavin/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/guidelines.txt
+++ b/2004/guidelines.txt
@@ -30,7 +30,7 @@ ABOUT THIS FILE:
     An online submission mechanism will be available after
     26-Jan-2004, 00:00 UTC.  See the following for details,
 
-       http://www.ioccc.org/2004/submit
+       https://www.ioccc.org/2004/submit
 
 HINTS AND SUGGESTIONS:
 
@@ -479,11 +479,11 @@ ANNOUNCEMENT OF WINNERS:
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 									  
-	    http://www.ioccc.org/whowon.html				  
+	    https://www.ioccc.org/whowon.html				  
 									  
     We will also submit a brief announcement story to /.:		  
 
-	    http://slashdot.org
+	    https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -496,7 +496,7 @@ ANNOUNCEMENT OF WINNERS:
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-	    http://www.ioccc.org/years.html
+	    https://www.ioccc.org/years.html
 
     	    NOTE: previous winners are available at that URL
 
@@ -537,7 +537,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2004/hibachi/Makefile
+++ b/2004/hibachi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/hibachi/src/localhost/index.html
+++ b/2004/hibachi/src/localhost/index.html
@@ -62,7 +62,7 @@ Snert . Com - Software - Hibachi
 host and CGI support. It is a limited implementation of <a href="reference/rfc2616.html">RFC 2616</a>
 and the <a href="http://www.w3.org/CGI/">CGI/1.1 Specification</a>.
 <span class="hibachi">HIBACHI</span> was written as an entry for the
-<a href="http://www.ioccc.org/">International Obfuscated C Code Contest</a> and works
+<a href="https://www.ioccc.org/">International Obfuscated C Code Contest</a> and works
 for any Unix variant including the <a href="http://sources.redhat.com/cygwin/">Cygwin</a>
 environment for Windows.
 </p>
@@ -82,7 +82,7 @@ the script's responsibility to send the HTTP status line and necessary headers d
 <p>
 Virtual host support is implemented as subdirectories of the <span class="hibachi">HIBACHI</span>
 document tree, where the directory name is the domain name publish in a URL. For example to setup
-a virtual host by name or IP for http://www.ioccc.org/, assuming the <span class="hibachi">HIBACHI</span>
+a virtual host by name or IP for https://www.ioccc.org/, assuming the <span class="hibachi">HIBACHI</span>
 document tree is rooted at /usr/local/share/hibachi, then:
 </p>
 
@@ -118,7 +118,7 @@ bundled with CDROMS that require a means of presenting dynamic web pages.
 <li>Is a dedicated process-forking server that does not use inetd.</li>
 <li>Is secure against relative path file snooping.</li>
 <li>Is secure against directory searches.</li>
-<li>~155 lines of source, 1940 bytes long by <a href="http://www.ioccc.org/">IOCCC</a> 2004 rules, ~6KB compiled &amp; stripped on FreeBSD.</li>
+<li>~155 lines of source, 1940 bytes long by <a href="https://www.ioccc.org/">IOCCC</a> 2004 rules, ~6KB compiled &amp; stripped on FreeBSD.</li>
 <li>Superior &amp; smaller than <a href="http://www.acme.com/software/micro_httpd/">micro_httpd</a> from <a href="http://www.acme.com/">ACME</a>.</li>
 <li>And has a really cool animated logo too.</li>
 </ul>
@@ -213,7 +213,7 @@ you should be able to access the server from the Internet using an IP or host na
 
 <blockquote><pre>
 http://64.81.251.233:8008/
-http://www.ioccc.org:8008/
+https://www.ioccc.org:8008/
 </pre></blockquote>
 
 
@@ -365,7 +365,7 @@ when Ruby is installed.
 
 <p>
 In accordance with the
-<a href="http://www.ioccc.org/">International Obfuscated C Code Contest</a>
+<a href="https://www.ioccc.org/">International Obfuscated C Code Contest</a>
 this is an original work and placed in the public domain. 
 </p>
 

--- a/2004/hoyle/Makefile
+++ b/2004/hoyle/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/kopczynski/Makefile
+++ b/2004/kopczynski/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/mkentry.c
+++ b/2004/mkentry.c
@@ -60,7 +60,7 @@
  *  year.  You should be sure you have the current rules and guidelines
  *  prior to submitting entries.  To obtain them, visit the following URL:
  *
- *	http://www.ioccc.org
+ *	https://www.ioccc.org
  *
  * Because contest rules change from year to year, one should only use this
  * program for the year that it was intended.

--- a/2004/newbern/Makefile
+++ b/2004/newbern/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/omoikane/Makefile
+++ b/2004/omoikane/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/rules.txt
+++ b/2004/rules.txt
@@ -40,7 +40,7 @@ RULES:
 
     3) Submissions should be performed using the instructions outlined at,
 
-       http://www.ioccc.org/2004/submit
+       https://www.ioccc.org/2004/submit
 
        NOTE: After 26-Jan-2004, 00:00 UTC an online submission mechanism will
        be available.  See the above URL for details.
@@ -137,10 +137,10 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 
     Detail of how to submit your entry are located at,
 
-        http://www.ioccc.org/2004/submit
+        https://www.ioccc.org/2004/submit

--- a/2004/schnitzi/Makefile
+++ b/2004/schnitzi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/sds/Makefile
+++ b/2004/sds/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/vik1/Makefile
+++ b/2004/vik1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2004/vik2/Makefile
+++ b/2004/vik2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/Makefile
+++ b/2005/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/aidan/Makefile
+++ b/2005/aidan/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/anon/Makefile
+++ b/2005/anon/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/boutines/Makefile
+++ b/2005/boutines/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/chia/Makefile
+++ b/2005/chia/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/guidelines.txt
+++ b/2005/guidelines.txt
@@ -30,7 +30,7 @@ ABOUT THIS FILE:
 |   We will only accept online submissions this year.
     See the following for details,
 
-|	http://www.ioccc.org/2005/submit
+|	https://www.ioccc.org/2005/submit
 
 |  Most of the changes in the rules and guidelines for this year have been
 |  marked with a "|" character on the left hand side.
@@ -486,11 +486,11 @@ ANNOUNCEMENT OF WINNERS:
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 									  
-	    http://www.ioccc.org/whowon.html				  
+	    https://www.ioccc.org/whowon.html				  
 									  
     We will also submit a brief announcement story to /.:		  
 
-	    http://slashdot.org
+	    https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -503,7 +503,7 @@ ANNOUNCEMENT OF WINNERS:
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-	    http://www.ioccc.org/years.html
+	    https://www.ioccc.org/years.html
 
     	    NOTE: previous winners are available at that URL
 
@@ -544,7 +544,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2005/jetro/Makefile
+++ b/2005/jetro/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/klausler/Makefile
+++ b/2005/klausler/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/mikeash/Makefile
+++ b/2005/mikeash/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/mynx/Makefile
+++ b/2005/mynx/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -39,7 +39,7 @@ As noted this will not work for https. This is because it does not scan for
 https but also a secure connection needs to be set up before http commands can
 be sent. One would also have to specify a port in the URL. Fortunately or
 unfortunately many more websites use https nowadays so this entry will not work
-as well as it used to.  If one were to try and connect to `http://www.ioccc.org`
+as well as it used to.  If one were to try and connect to `https://www.ioccc.org`
 with this entry they'll just get a 301 error.
 
 In case someone can come up with a clever pipeline or some other hack or

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/rules.txt
+++ b/2005/rules.txt
@@ -40,7 +40,7 @@ RULES:
 
     3) Submissions should be performed using the instructions outlined at,
 
-|      http://www.ioccc.org/2005/submit
+|      https://www.ioccc.org/2005/submit
 
     4) If your entry is selected as a winner, it will be modified as follows:
 
@@ -137,13 +137,13 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 
     Details of how to submit your entry are located at,
 
-|	http://www.ioccc.org/2005/submit
+|	https://www.ioccc.org/2005/submit
 
 Leonid A. Broukhis
 Simon Cooper

--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/timwi/Makefile
+++ b/2005/timwi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/toledo/Makefile
+++ b/2005/toledo/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/vik/Makefile
+++ b/2005/vik/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2005/vince/Makefile
+++ b/2005/vince/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/Makefile
+++ b/2006/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/README.md
+++ b/2006/README.md
@@ -13,7 +13,7 @@ You may then wish to look at the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.
 The primary site can be found at,
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -70,11 +70,11 @@ send us the fix (patch file or the entire changed file).
 
 For the latest information on how to contact the IOCCC Judges please visit
 
->	<http://www.ioccc.org/contact.html>
+>	<https://www.ioccc.org/contact.html>
 
 For news of the next contest watch:
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 =-=
 

--- a/2006/birken/Makefile
+++ b/2006/birken/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/borsanyi/Makefile
+++ b/2006/borsanyi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/grothe/Makefile
+++ b/2006/grothe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/guidelines.txt
+++ b/2006/guidelines.txt
@@ -30,7 +30,7 @@ ABOUT THIS FILE:
 |   Only online submissions will be accepted this year.
     See the following for details,
 
-|	http://www.ioccc.org/2006/submit
+|	https://www.ioccc.org/2006/submit
 
 |  Most of the changes in the rules and guidelines for this year have been
 |  marked with a "|" character on the left hand side.
@@ -489,11 +489,11 @@ ANNOUNCEMENT OF WINNERS:
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 									  
-	    http://www.ioccc.org/whowon.html				  
+	    https://www.ioccc.org/whowon.html				  
 									  
     We will also submit a brief announcement story to /.:		  
 
-	    http://slashdot.org
+	    https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -506,7 +506,7 @@ ANNOUNCEMENT OF WINNERS:
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-	    http://www.ioccc.org/years.html
+	    https://www.ioccc.org/years.html
 
     	    NOTE: previous winners are available at that URL
 
@@ -547,7 +547,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2006/hamre/Makefile
+++ b/2006/hamre/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/meyer/Makefile
+++ b/2006/meyer/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/night/Makefile
+++ b/2006/night/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/rules.txt
+++ b/2006/rules.txt
@@ -40,7 +40,7 @@ RULES:
 
     3) Submissions should be performed using the instructions outlined at,
 
-|      http://www.ioccc.org/2006/submit
+|      https://www.ioccc.org/2006/submit
 
     4) If your entry is selected as a winner, it will be modified as follows:
 
@@ -137,13 +137,13 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 
     Details of how to submit your entry are located at,
 
-|	http://www.ioccc.org/2006/submit
+|	https://www.ioccc.org/2006/submit
 
 Leonid A. Broukhis
 Simon Cooper

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/stewart/Makefile
+++ b/2006/stewart/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/sykes1/Makefile
+++ b/2006/sykes1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/sykes2/Makefile
+++ b/2006/sykes2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/toledo1/Makefile
+++ b/2006/toledo1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2006/toledo3/Makefile
+++ b/2006/toledo3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/Makefile
+++ b/2011/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/README.md
+++ b/2011/README.md
@@ -13,7 +13,7 @@ You may then wish to look at the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.
 The primary site can be found at,
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -68,11 +68,11 @@ send us the fix (patch file or the entire changed file).
 
 For the latest information on how to contact the IOCCC Judges please visit
 
->	<http://www.ioccc.org/contact.html>
+>	<https://www.ioccc.org/contact.html>
 
 For news of the next contest watch:
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 =-=
 

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/blakely/Makefile
+++ b/2011/blakely/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/borsanyi/Makefile
+++ b/2011/borsanyi/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/dlowe/Makefile
+++ b/2011/dlowe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/eastman/Makefile
+++ b/2011/eastman/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/fredriksson/Makefile
+++ b/2011/fredriksson/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/goren/Makefile
+++ b/2011/goren/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/guidelines.txt
+++ b/2011/guidelines.txt
@@ -525,11 +525,11 @@ ANNOUNCEMENT OF WINNERS:
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 									  
-	    http://www.ioccc.org/whowon.html				  
+	    https://www.ioccc.org/whowon.html				  
 									  
     We will also submit a brief announcement story to /.:		  
 
-	    http://slashdot.org
+	    https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -542,7 +542,7 @@ ANNOUNCEMENT OF WINNERS:
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-	    http://www.ioccc.org/years.html
+	    https://www.ioccc.org/years.html
 
     	    NOTE: previous winners are available at that URL
 
@@ -579,7 +579,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2011/hamaji/Makefile
+++ b/2011/hamaji/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/hou/Makefile
+++ b/2011/hou/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/konno/Makefile
+++ b/2011/konno/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/richards/Makefile
+++ b/2011/richards/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/rules.txt
+++ b/2011/rules.txt
@@ -138,7 +138,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2011/toledo/Makefile
+++ b/2011/toledo/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/vik/Makefile
+++ b/2011/vik/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2011/zucker/Makefile
+++ b/2011/zucker/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/Makefile
+++ b/2012/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/README.md
+++ b/2012/README.md
@@ -13,7 +13,7 @@ You may then wish to look at the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.
 The primary site can be found at,
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -120,11 +120,11 @@ send us the fix (patch file or the entire changed file).
 
 For the latest information on how to contact the IOCCC Judges please visit
 
->	<http://www.ioccc.org/contact.html>
+>	<https://www.ioccc.org/contact.html>
 
 For news of the next contest watch:
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 =-=
 

--- a/2012/blakely/Makefile
+++ b/2012/blakely/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/deckmyn/Makefile
+++ b/2012/deckmyn/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/dlowe/Makefile
+++ b/2012/dlowe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/endoh2/Makefile
+++ b/2012/endoh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/grothe/Makefile
+++ b/2012/grothe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/guidelines.txt
+++ b/2012/guidelines.txt
@@ -33,7 +33,7 @@ ABOUT THIS FILE:
 |   reminders, and changes to the rules and these guidelines.  While we
 |   try to post use news at:
 |
-|	http://www.ioccc.org/index.html#news
+|	https://www.ioccc.org/index.html#news
 |
 |   such postings may be delayed or obscured by slow to respond mirrors.
 |
@@ -657,11 +657,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-	    http://www.ioccc.org/whowon.html
+	    https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-	    http://slashdot.org
+	    https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -674,7 +674,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-	    http://www.ioccc.org/years.html
+	    https://www.ioccc.org/years.html
 
     	    NOTE: previous winners are available at that URL
 
@@ -727,7 +727,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/hou/Makefile
+++ b/2012/hou/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/hou/markdown.txt
+++ b/2012/hou/markdown.txt
@@ -1,6 +1,6 @@
 ###[^#]([ -~]+\n)+\n <h3>%s</h3>
 ##[^#]([ -~]+\n)+\n <h2>%s</h2>
-#[^#]([ -~]+\n)+\n <html><head><title>%s</title><link rel="stylesheet" type="text/css" href="http://www.ioccc.org/2011/hint.css"><body><h1>%s</h1>
+#[^#]([ -~]+\n)+\n <html><head><title>%s</title><link rel="stylesheet" type="text/css" href="https://www.ioccc.org/2011/hint.css"><body><h1>%s</h1>
 \n"- "[ -~]* <li>%s</li>
 ("    "[!-~][ -~]*\n)+\n <pre><code>%s</code></pre>
 ([ -~]+\n)+\n <p>%s</p>

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/konno/Makefile
+++ b/2012/konno/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/rules.txt
+++ b/2012/rules.txt
@@ -187,7 +187,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-	http://www.ioccc.org
+	https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2012/tromp/Makefile
+++ b/2012/tromp/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/Makefile
+++ b/2013/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/README.md
+++ b/2013/README.md
@@ -13,7 +13,7 @@ You may then wish to look at the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.
 The primary site can be found at,
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -100,11 +100,11 @@ send us the fix (patch file or the entire changed file).
 
 For the latest information on how to contact the IOCCC Judges please visit
 
->	<http://www.ioccc.org/contact.html>
+>	<https://www.ioccc.org/contact.html>
 
 For news of the next contest watch:
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 =-=
 

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/cable1/Makefile
+++ b/2013/cable1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/cable2/Makefile
+++ b/2013/cable2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/cable3/Makefile
+++ b/2013/cable3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/dlowe/Makefile
+++ b/2013/dlowe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/endoh1/Makefile
+++ b/2013/endoh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/guidelines.txt
+++ b/2013/guidelines.txt
@@ -54,7 +54,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -150,7 +150,7 @@ HINTS AND SUGGESTIONS:
 |   Rule 2 (the size rule) has been changed.  In particular rule 2 refers to
 |   the use of an IOCCC size tool.  The source for this tool is found at:
 
-|       http://www.ioccc.org/2013/iocccsize.c
+|       https://www.ioccc.org/2013/iocccsize.c
 
 |   The IOCCC size tool should be compiled as:
 
@@ -771,11 +771,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -788,7 +788,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -842,7 +842,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/mills/Makefile
+++ b/2013/mills/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/morgan1/Makefile
+++ b/2013/morgan1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/morgan2/Makefile
+++ b/2013/morgan2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/robison/Makefile
+++ b/2013/robison/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2013/rules.txt
+++ b/2013/rules.txt
@@ -47,7 +47,7 @@ RULES:
 
 |      The source to the current IOCCC size tool is found at this URL:
 
-|         http://www.ioccc.org/2013/iocccsize.c
+|         https://www.ioccc.org/2013/iocccsize.c
 
     3) Submissions should be performed using the instructions outlined at:
 
@@ -195,7 +195,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2014/Makefile
+++ b/2014/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/guidelines.txt
+++ b/2014/guidelines.txt
@@ -54,7 +54,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -147,7 +147,7 @@ HINTS AND SUGGESTIONS:
     Rule 2 (the size rule) has been changed.  In particular rule 2 refers to
     the use of an IOCCC size tool.  The source for this tool is found at:
 
-|       http://www.ioccc.org/2014/iocccsize.c
+|       https://www.ioccc.org/2014/iocccsize.c
 
     The IOCCC size tool should be compiled as:
 
@@ -757,11 +757,11 @@ ANNOUNCEMENT OF WINNERS:
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
 
@@ -775,7 +775,7 @@ ANNOUNCEMENT OF WINNERS:
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -829,7 +829,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/rules.txt
+++ b/2014/rules.txt
@@ -52,7 +52,7 @@ RULES:
 
        The source to the current IOCCC size tool is found at this URL:
 
-|         http://www.ioccc.org/2014/iocccsize.c
+|         https://www.ioccc.org/2014/iocccsize.c
 
     3) Submissions should be performed using the instructions outlined at:
 
@@ -213,7 +213,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/Makefile
+++ b/2015/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/burton/Makefile
+++ b/2015/burton/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/burton/README.md
+++ b/2015/burton/README.md
@@ -89,7 +89,7 @@ written on an iDevice), but sanity prevailed.
 
 Printed in 8 pt Courier, it makes aesthetically pleasing 8.5 x 11 wall art.
 
-[1]: http://www.ioccc.org/2011/hou/hint.html "Hou Qiming"
+[1]: https://www.ioccc.org/2011/hou/hint.html "Hou Qiming"
 
 ### prog.c vs prog.alt.c
 

--- a/2015/dogon/Makefile
+++ b/2015/dogon/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/duble/Makefile
+++ b/2015/duble/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/endoh1/Makefile
+++ b/2015/endoh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/endoh2/Makefile
+++ b/2015/endoh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/endoh3/Makefile
+++ b/2015/endoh3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/endoh4/Makefile
+++ b/2015/endoh4/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/guidelines.txt
+++ b/2015/guidelines.txt
@@ -54,7 +54,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -81,7 +81,7 @@ End of important 2023 update to this historic note.
 |   on the official IOCCC web site on or slightly before start of this IOCCC.
 |   Please check the IOCCC web site "How to enter" link:
 |
-|	http://www.ioccc.org/index.html#enter
+|	https://www.ioccc.org/index.html#enter
 |
 |   on or after the start of this IOCCC to be sure you are using the correct
 |   versions of these items before using the IOCCC entry submission URL.
@@ -163,7 +163,7 @@ HINTS AND SUGGESTIONS:
     Rule 2 (the size rule) has been changed.  In particular rule 2 refers to
     the use of an IOCCC size tool.  The source for this tool is found at:
 
-|       http://www.ioccc.org/2015/iocccsize.c
+|       https://www.ioccc.org/2015/iocccsize.c
 
     The IOCCC size tool should be compiled as:
 
@@ -852,11 +852,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -869,7 +869,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -923,7 +923,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/howe/Makefile
+++ b/2015/howe/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/mills2/Makefile
+++ b/2015/mills2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/muth/Makefile
+++ b/2015/muth/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/muth/machine_gcd.h
+++ b/2015/muth/machine_gcd.h
@@ -1,7 +1,7 @@
 /*
  * greatest common divisor
  *
- * based on http://www.ioccc.org/2001/herrmann1/herrmann1.gcd
+ * based on https://www.ioccc.org/2001/herrmann1/herrmann1.gcd
  */
 
 // try tape_15_50.h or tape_77_55.h

--- a/2015/muth/machine_times2.h
+++ b/2015/muth/machine_times2.h
@@ -1,7 +1,7 @@
 /*
  * multiply by 2
  *
- * based on http://www.ioccc.org/2001/herrmann1/herrmann1.times2
+ * based on https://www.ioccc.org/2001/herrmann1/herrmann1.times2
  */
  
 // try tape_five.h

--- a/2015/rules.txt
+++ b/2015/rules.txt
@@ -48,7 +48,7 @@ GOALS OF THE CONTEST:
 |   on the official IOCCC web site on or slightly before start of this IOCCC.
 |   Please check the IOCCC web site "How to enter" link:
 |
-|	http://www.ioccc.org/index.html#enter
+|	https://www.ioccc.org/index.html#enter
 |
 |   on or after the start of this IOCCC to be sure you are using the correct
 |   versions of these items before using the IOCCC entry submission URL.
@@ -68,7 +68,7 @@ RULES:
 
        The source to the current IOCCC size tool is found at this URL:
 
-|         http://www.ioccc.org/2015/iocccsize.c
+|         https://www.ioccc.org/2015/iocccsize.c
 
     3) Submissions should be performed using the instructions outlined at:
 
@@ -240,7 +240,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2015/schweikhardt/Makefile
+++ b/2015/schweikhardt/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2015/yang/Makefile
+++ b/2015/yang/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/Makefile
+++ b/2018/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/algmyr/Makefile
+++ b/2018/algmyr/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/anderson/Makefile
+++ b/2018/anderson/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/bellard/Makefile
+++ b/2018/bellard/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/burton1/Makefile
+++ b/2018/burton1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/burton2/Makefile
+++ b/2018/burton2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/burton2/README.md
+++ b/2018/burton2/README.md
@@ -37,7 +37,7 @@ man ./tac.man
 
 ## Judges' remarks:
 
-They say size isn't everything, and in the case of IOCCC [iocccsize.c](http://www.ioccc.org/2018/iocccsize.c)
+They say size isn't everything, and in the case of IOCCC [iocccsize.c](https://www.ioccc.org/2018/iocccsize.c)
 that is saying something!  What is this program weighing and how much does it weigh?
 
 ## Author's remarks:
@@ -167,10 +167,10 @@ determine which tool was correct when there were differences.
 > Nevertheless, the more clearly written code remains a spoiler for this entry.
 
 NB: `iocccsize` gets a different answer from `tac` on its own
-([iocccsize.c]([iocccsize.c](http://www.ioccc.org/2018/iocccsize.c)) source code;
+([iocccsize.c]([iocccsize.c](https://www.ioccc.org/2018/iocccsize.c)) source code;
 `tac` gets the correct answer.  This is due to the aforementioned bugs within `iocccsize`,
 proved by fixing
-[iocccsize.c](http://www.ioccc.org/2018/iocccsize.c) with the included patch, so `iocccsize` reports
+[iocccsize.c](https://www.ioccc.org/2018/iocccsize.c) with the included patch, so `iocccsize` reports
 the correct answer for itself.
 
 ### But wait... There's More!
@@ -293,7 +293,7 @@ sed 's/^# .*$//' | sed 's/^#//' |
 * The code describes its function by careful arrangement of variables up front...
 * ...coupled with a description of the typical IOCCC contestant, or at least the author
 * Why shouldn't trigraph parsing be written in trigraph?
-* Where [iocccsize.c](http://www.ioccc.org/2018/iocccsize.c) mocks, this code flaunts:
+* Where [iocccsize.c](https://www.ioccc.org/2018/iocccsize.c) mocks, this code flaunts:
   "_no matter how well you may think you understand this code, you don't, so don't mess with it. :-)_"
 * `O,0,l,1` are used to confusing effect, local names obscure global names.
 * Globals are used to pass information between routines: don't reorder "unrelated" statements....
@@ -336,7 +336,7 @@ The following reserved word files are included:
 	ioccc.kw.freq   c11 + additional words, sorted on frequency of occurrence in ioccc winners
 
 
-NB: The keyword file used in this code is derived from the list in [iocccsize.c](http://www.ioccc.org/2018/iocccsize.c),
+NB: The keyword file used in this code is derived from the list in [iocccsize.c](https://www.ioccc.org/2018/iocccsize.c),
 which is neither complete (`#define`, `#ifndef`, `#undef` are missing
 -- yes, Virginia knows about `#define` omitted on purpose),
 nor correct (many more are added: `I`, `true`, `bool`, `compl`, ...):

--- a/2018/ciura/Makefile
+++ b/2018/ciura/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/endoh1/Makefile
+++ b/2018/endoh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/giles/Makefile
+++ b/2018/giles/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/guidelines.txt
+++ b/2018/guidelines.txt
@@ -55,7 +55,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -87,7 +87,7 @@ End of important 2023 update to this historic note.
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -169,7 +169,7 @@ HINTS AND SUGGESTIONS:
     Rule 2 (the size rule) has been changed.  In particular rule 2 refers to
     the use of an IOCCC size tool.  The source for this tool is found at:
 
-|       http://www.ioccc.org/2018/iocccsize.c
+|       https://www.ioccc.org/2018/iocccsize.c
 
 |   To further clarify rule 2, we subdivided it into two parts, 2a and 2b.
 |   Your entry must satisfy both the maximum size rule 2a AND your entry
@@ -920,11 +920,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -937,7 +937,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -991,7 +991,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2018/hou/Makefile
+++ b/2018/hou/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/mills/Makefile
+++ b/2018/mills/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/rules.txt
+++ b/2018/rules.txt
@@ -48,7 +48,7 @@ GOALS OF THE CONTEST:
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -70,7 +70,7 @@ RULES:
 
        The source to the current IOCCC size tool is found at this URL:
 
-|         http://www.ioccc.org/2018/iocccsize.c
+|         https://www.ioccc.org/2018/iocccsize.c
 
     3) Submissions should be performed using the instructions outlined at:
 
@@ -253,7 +253,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2018/vokes/Makefile
+++ b/2018/vokes/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2018/yang/Makefile
+++ b/2018/yang/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/Makefile
+++ b/2019/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/README.md
+++ b/2019/README.md
@@ -12,7 +12,7 @@ You may then wish to look at the Author's remarks for even more details.
 
 The primary IOCCC web site can be found at,
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -87,11 +87,11 @@ send us the fix (patch file or the entire changed file).
 
 For the latest information on how to contact the IOCCC Judges please visit
 
->	<http://www.ioccc.org/contact.html>
+>	<https://www.ioccc.org/contact.html>
 
 For news of the next contest watch:
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 =-=
 

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/ciura/Makefile
+++ b/2019/ciura/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/diels-grabsch1/guidelines.txt
+++ b/2019/diels-grabsch1/guidelines.txt
@@ -55,7 +55,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -89,7 +89,7 @@ End of important 2023 update to this historic note.
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -171,7 +171,7 @@ HINTS AND SUGGESTIONS:
     Rule 2 (the size rule) has been changed.  In particular rule 2 refers to
     the use of an IOCCC size tool.  The source for this tool is found at:
 
-|       http://www.ioccc.org/2019/iocccsize.c
+|       https://www.ioccc.org/2019/iocccsize.c
 
     To further clarify rule 2, we subdivided it into two parts, 2a and 2b.
     Your entry must satisfy both the maximum size rule 2a AND your entry
@@ -920,11 +920,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -937,7 +937,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -991,7 +991,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/guidelines.txt
+++ b/2019/guidelines.txt
@@ -55,7 +55,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -89,7 +89,7 @@ End of important 2023 update to this historic note.
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -171,7 +171,7 @@ HINTS AND SUGGESTIONS:
     Rule 2 (the size rule) has been changed.  In particular rule 2 refers to
     the use of an IOCCC size tool.  The source for this tool is found at:
 
-|       http://www.ioccc.org/2019/iocccsize.c
+|       https://www.ioccc.org/2019/iocccsize.c
 
     To further clarify rule 2, we subdivided it into two parts, 2a and 2b.
     Your entry must satisfy both the maximum size rule 2a AND your entry
@@ -928,11 +928,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -945,7 +945,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -999,7 +999,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2019/rules.txt
+++ b/2019/rules.txt
@@ -49,7 +49,7 @@ GOALS OF THE CONTEST:
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -71,7 +71,7 @@ RULES:
 
        The source to the current IOCCC size tool is found at this URL:
 
-|         http://www.ioccc.org/2019/iocccsize.c
+|         https://www.ioccc.org/2019/iocccsize.c
 
     3) Submissions should be performed using the instructions outlined at:
 
@@ -256,7 +256,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/Makefile
+++ b/2020/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/README.md
+++ b/2020/README.md
@@ -10,7 +10,7 @@ You may then wish to look at the Author's remarks for even more details.
 
 The primary IOCCC web site can be found at,
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
 systems the makefile needs to be changed.  See the Makefile for details.
@@ -76,11 +76,11 @@ send us the fix (patch file or the entire changed file).
 
 For the latest information on how to contact the IOCCC Judges please visit
 
->	<http://www.ioccc.org/contact.html>
+>	<https://www.ioccc.org/contact.html>
 
 For news of the next contest watch:
 
->	<http://www.ioccc.org/>
+>	<https://www.ioccc.org/>
 
 =-=
 

--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/carlini/Makefile
+++ b/2020/carlini/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/endoh1/Makefile
+++ b/2020/endoh1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/endoh3/Makefile
+++ b/2020/endoh3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/ferguson1/bugs.md
+++ b/2020/ferguson1/bugs.md
@@ -333,6 +333,6 @@ but it is very much appreciated and it means a great deal to me. Cheers.)
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson1/chocolate-cake.md
+++ b/2020/ferguson1/chocolate-cake.md
@@ -192,6 +192,6 @@ bowl can sit in.
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson1/gameplay.md
+++ b/2020/ferguson1/gameplay.md
@@ -892,6 +892,6 @@ years ago but I know it's true now. **Believe in yourself. Always.**
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson1/spoilers.md
+++ b/2020/ferguson1/spoilers.md
@@ -967,6 +967,6 @@ matter having a 'o' at 0,0 isn't either).
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson1/terminals.md
+++ b/2020/ferguson1/terminals.md
@@ -374,6 +374,6 @@ but I do not know for certain.
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson1/troubleshooting.md
+++ b/2020/ferguson1/troubleshooting.md
@@ -463,6 +463,6 @@ is 0 and I limit the size to be no bigger than the max size.
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -827,9 +827,9 @@ don't think there need be any addition to the recode program - at least not
 that.
 
 
-[1992 Worst Abuse of the Rules]: http://www.ioccc.org/1992/nathan/README.md
-[1998 ASCII / Morse code translator]: http://www.ioccc.org/1998/dorssel/README.md
-[2014 Morse audio transcoder]: http://www.ioccc.org/2014/vik/README.md
+[1992 Worst Abuse of the Rules]: https://www.ioccc.org/1992/nathan/README.md
+[1998 ASCII / Morse code translator]: https://www.ioccc.org/1998/dorssel/README.md
+[2014 Morse audio transcoder]: https://www.ioccc.org/2014/vik/README.md
 [Enigma Message Procedures]: https://web.archive.org/web/20200710094321/http://users.telenet.be/d.rijmenants/en/enigmaproc.htm
 [Interactive Enigma Machine]: http://enigmaco.de/enigma/enigma.html
 [enigma.1]: enigma.1

--- a/2020/ferguson2/obfuscation.md
+++ b/2020/ferguson2/obfuscation.md
@@ -241,6 +241,6 @@ variables in recode.c, move them to prog.c, compile and expect it to work right.
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/ferguson2/recode.md
+++ b/2020/ferguson2/recode.md
@@ -637,6 +637,6 @@ BTW: What's the middle of a list with even numbered items anyway?
 (c) Copyright 1984-2020, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
 This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-[judges]: http://www.ioccc.org/judges.html
+[judges]: https://www.ioccc.org/judges.html
 [cc]: http://creativecommons.org/licenses/by-sa/3.0/
 -----------------------------------------------------------------------------------------------------

--- a/2020/giles/Makefile
+++ b/2020/giles/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/guidelines.txt
+++ b/2020/guidelines.txt
@@ -55,7 +55,7 @@ End of important 2023 update to this historic note.
 
     While we try to post use news at:
 
-        http://www.ioccc.org/index.html#news
+        https://www.ioccc.org/index.html#news
 
     such postings may be delayed or obscured by slow to respond mirrors.
 
@@ -90,7 +90,7 @@ End of important 2023 update to this historic note.
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -172,7 +172,7 @@ HINTS AND SUGGESTIONS:
 |   Rule 2 (the size rule) refers to the use of an IOCCC size tool.
 |   The source for this tool is found at:
 
-|       http://www.ioccc.org/2020/iocccsize.c
+|       https://www.ioccc.org/2020/iocccsize.c
 
     To further clarify rule 2, we subdivided it into two parts, 2a and 2b.
 |   Your entry must satisfy BOTH the maximum size rule 2a AND your entry
@@ -963,11 +963,11 @@ End of important 2023 update to this historic note.
     of their award, and a very brief description of the winning entry
     on the IOCCC web site:
 
-        http://www.ioccc.org/whowon.html
+        https://www.ioccc.org/whowon.html
 
     We will also attempt to submit a brief announcement story to /.:
 
-        http://slashdot.org
+        https://slashdot.org
 
     that, depending on the willingness of the /. editors, may be posted
     to their site at the same time.
@@ -980,7 +980,7 @@ End of important 2023 update to this historic note.
     by the winners has been completed, the winning source will be
     posted to the IOCCC web site:
 
-        http://www.ioccc.org/years.html
+        https://www.ioccc.org/years.html
 
         NOTE: previous winners are available at that URL
 
@@ -1034,7 +1034,7 @@ FOR MORE INFORMATION:
 
     Check out the IOCCC Web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2020/kurdyukov1/Makefile
+++ b/2020/kurdyukov1/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/kurdyukov3/Makefile
+++ b/2020/kurdyukov3/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/kurdyukov4/Makefile
+++ b/2020/kurdyukov4/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/otterness/Makefile
+++ b/2020/otterness/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/rules.txt
+++ b/2020/rules.txt
@@ -49,7 +49,7 @@ GOALS OF THE CONTEST:
     on the official IOCCC web site on or slightly before start of this IOCCC.
     Please check the IOCCC web site "How to enter" link:
 
- 	http://www.ioccc.org/index.html#enter
+ 	https://www.ioccc.org/index.html#enter
 
     on or after the start of this IOCCC to be sure you are using the correct
     versions of these items before using the IOCCC entry submission URL.
@@ -71,7 +71,7 @@ RULES:
 
        The source to the current IOCCC size tool is found at this URL:
 
-|         http://www.ioccc.org/2020/iocccsize.c
+|         https://www.ioccc.org/2020/iocccsize.c
 
     3) Submissions should be performed using the instructions outlined at:
 
@@ -256,7 +256,7 @@ FOR MORE INFORMATION:
     year.  You should be sure you have the current rules and guidelines
     prior to submitting entries.  To obtain them, visit the IOCCC web page:
 
-        http://www.ioccc.org
+        https://www.ioccc.org
 
     It has rules, guidelines and winners of previous contests (1984 to date).
 

--- a/2020/tsoj/Makefile
+++ b/2020/tsoj/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/2020/yang/Makefile
+++ b/2020/yang/Makefile
@@ -7,10 +7,10 @@
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
 # and worked in the past may no longer be the liked/allowed or compile/run today.
 #
-# Bug fixes, corrections and typo fixes for VERY WELCOME.  If you see a problem,
+# Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:
 #
-#	http://www.ioccc.org/bugs.md
+#	https://www.ioccc.org/bugs.md
 #
 # GitHub pull requests are welcome!  Please see the above URL for details.
 #

--- a/archive/README.md
+++ b/archive/README.md
@@ -5,7 +5,7 @@ winning source code that was available on the [official IOCCC web
 site](https://www.ioccc.org) as of 2020 Dec 28.  These zip2 compressed
 tarballs represent the "_released_" IOCCC winning source,
 as modified by the IOCCC judges and winning authors
-as of [2020 Dec 28](https://web.archive.org/web/20201228005211/http://www.ioccc.org/).
+as of [2020 Dec 28](https://web.archive.org/web/20201228005211/https://www.ioccc.org/).
 
 Yuo smight wish to note that the `archive/archive-all.tar.bz2` file
 found in this archive produces a somewhat newer version of the
@@ -25,7 +25,7 @@ as well as a newer version of 2012/tromp hint files.
 For your convenience we keep an archive of the zip2 compressed
 tarballs as found in the [Internet Archive Wayback
 Machine](https://web.archive.org) as of [2022 Dec
-28)(https://web.archive.org/web/20201228005211/http://www.ioccc.org/).
+28)(https://web.archive.org/web/20201228005211/https://www.ioccc.org/).
 
 *HINT*: To uncompress a given bzip2 compressed tarball file, use:
 

--- a/www-history.md
+++ b/www-history.md
@@ -8,10 +8,10 @@ viewed at the [Internet Wayback Machine Wayback Machine](https://web.archive.org
 One can view several thousand snapshots showing how the [IOCCC web site has
 evolved](https://web.archive.org/web/20230000000000*/www.ioccc.org) going back
 as far as [1998 Dec 12
-www.ioccc.org](https://web.archive.org/web/19981212030016/http://www.ioccc.org/).
+www.ioccc.org](https://web.archive.org/web/19981212030016/https://www.ioccc.org/).
 
 On 2020 Dec 31, the IOCCC source tree was moved to the [IOCCC winner
-repo](https://web.archive.org/web/20210101211346/http://www.ioccc.org/) on
+repo](https://web.archive.org/web/20210101211346/https://www.ioccc.org/) on
 [GitHub](https://github.com).  From this point on, the [official IOCCC web
 site](https://www.ioccc.org) became a [GitHub Pages](https://pages.github.com)
 web site.
@@ -25,7 +25,7 @@ and the individual years are in the form `archive/archive-YYYY.tar.bz2`.
 
 These files were obtained from the [Internet Wayback
 Machine](https://web.archive.org) from the [snapshot of the website on 2020 Dec
-28](https://web.archive.org/web/20201228005211/http://www.ioccc.org/).  See
+28](https://web.archive.org/web/20201228005211/https://www.ioccc.org/).  See
 `archive/README.md` for details about these bzip2 compressed tarballs.
 
 **XXX**: Change the references to _temp-test-ioccc_ to _winners_


### PR DESCRIPTION

This is a HUGE commit:

    417 files changed, 874 insertions(+), 874 deletions(-)

As the IOCCC website now is https enabled I have updated the
'http://www.ioccc' to 'https://www.ioccc'.

There was also a typo in Makefiles where it said 'for VERY WELCOME' when
it should be 'are VERY WELCOME'.

Finally slashdot.org is also https enabled so references to
'http://slashdot' were changed to 'https://slashdot'.

This was done by my sgit tool (see https://github.com/xexyl/sgit)
like:

    sgit -e 's,http://www.ioccc,https://www.ioccc,g' -e 's/for VERY WELCOME/are VERY WELCOME/g' -e  .

but because I didn't have a list of files that should be modified I had
to be careful which files to commit as I had files that were changed but
not ready to be committed. Since I did it in steps, finding typos as I
went along, I actually ran sgit three times but to simplify the above
(and to show that it's possible to do more than one sed command) I made
it all as one. Since I did not have a list of files ahead of time I had
to determine what files to commit, first going through them like:
        
    for j in $(for i in $(git status|grep modified|cut -d: -f2); do \
        git grep 'https://www.ioccc' "$i"; done|cut -d: -f1|sort|uniq); \
        do git diff "$j"; done|less -r 

(I had to pipe through less because of a strange problem with the git
diff which appears to be because of a terminal problem maybe due to the
command above but it was all I could come up with in a very tired head.)

The above and

    git status | grep modified:

showed that some C files had been modified which obviously should not be
done so I had to do:

    git co '*c'

to undo those changes.

Finally to commit the correct files I did:

    for i in $(git status|grep modified|cut -d: -f2); do \
        git grep -E 'https://www.ioccc|https://slashdot|are VERY WELCOME' "$i"; \
        done |cut -d: -f1|sort|uniq|xargs git commit -v

or so (with any formatting issues or typos here due to typos in the log
due to the terminal (in)sanity issue described).
