### PR TITLE
Format and typo fix 2013/endoh4/README.md

### DIFF
--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -14,28 +14,35 @@ make
 ## To run:
 
 ```sh
-./endoh4
+./endoh4 < file
+./run.sh file
 ```
+
+The second form is preferable as it will temporarily make the cursor invisible
+as recommended by the author. If no file is specified in `run.sh` command line
+it will feed to the program [endoh4.c](endoh4.c).
 
 ## Try:
 
 ```sh
-./endoh4 < cube.txt
+./run.sh cube.txt
 ```
+
+Hit ctrl-c to end the program.
 
 The author recommends the use of xterm.
 
-For example, if you are a soccer fan, try:
+For an example, if you are a football/soccer fan, try:
 
 ```sh
-./endoh4 < solids/archimedian-solid/a11-truncated-icosahedron.txt
+./run.sh solids/archimedian-solid/a11-truncated-icosahedron.txt
 ```
 
 ## Judges' remarks:
 
-This program is formatted as the net for a tetrahedron. (hint, try feeding the
-program it's own source code).  When it runs there is an animation for the
-computation to work out the convex hull.
+This program is formatted as the net for a tetrahedron (hint: try feeding the
+program it's own source code like `./run.sh`).  When it runs there is an
+animation for the computation to work out the convex hull.
 
 ## Author's remarks:
 
@@ -43,7 +50,7 @@ computation to work out the convex hull.
 
 This is a convex polyhedron viewer, which:
 
-1. reads three-dimentional vertices (3N float values) from stdin,
+1. reads three-dimensional vertices (3N float values) from `stdin`,
 2. calculates a convex hull of them, and
 3. renders it.
 
@@ -51,8 +58,8 @@ This simple spec involves many details.
 
 * 3D convex hull calculation
   * recursive gift wrapping algorithm
-  * automatical merging of (almost) co-planar faces
-    (i.e., faces are not triangulated)
+  * automatic merging of (almost) co-planar faces (i.e., faces are not
+  triangulated)
   * random perturbation for robustness
 * 3D rendering
   * perspective projection
@@ -63,18 +70,23 @@ This simple spec involves many details.
 
 ### Portability
 
-I think it conforms with both C89 and C99.
-I confirmed that it worked on gcc, clang, and tcc.
-It should not be warned with -pedantic and -Wextra.
+I think it conforms with both C89 and C99.  I confirmed that it worked on gcc,
+clang, and tcc.  It should not be warned with `-pedantic` and `-Wextra`.
 
 ### Tips
 
-You may want to use `tput` to hide a terminal cursor.
+You may want to use `tput` to hide the terminal cursor.
 
 ```sh
 tput civis
 ./endoh4 < cube.txt
 tput cnorm
+```
+
+or
+
+```sh
+./run.sh cube.txt
 ```
 
 ### Bonuses
@@ -89,24 +101,24 @@ The shape of this code is the geometric net of a regular tetrahedron.
 So, try:
 
 ```sh
-./endoh4 < endoh4.c
+./endoh4 < endoh4.c # or ./run.sh
 ```
 
-The solids.tbz2 file includes various solid data:
-[Platonic solids](http://en.wikipedia.org/wiki/Platonic_solid),
-[Archimedean solids](http://en.wikipedia.org/wiki/Archimedean_solid),
-[Prisms](http://en.wikipedia.org/wiki/Prism_%28geometry%29),
-[Antiprisms](http://en.wikipedia.org/wiki/Antiprism),
-[Bipyramids](http://en.wikipedia.org/wiki/Bipyramid),
-[Trapezohedrons](http://en.wikipedia.org/wiki/Trapezohedron), and
-[Johnson solids](http://en.wikipedia.org/wiki/Johnson_solid).
+The [solids/](solids/) directory includes various solid data:
+
+- [Platonic solids](http://en.wikipedia.org/wiki/Platonic_solid)
+- [Archimedean solids](http://en.wikipedia.org/wiki/Archimedean_solid)
+- [Prisms](http://en.wikipedia.org/wiki/Prism_%28geometry%29)
+- [Antiprisms](http://en.wikipedia.org/wiki/Antiprism)
+- [Bipyramids](http://en.wikipedia.org/wiki/Bipyramid)
+- [Trapezohedrons](http://en.wikipedia.org/wiki/Trapezohedron)
+- [Johnson solids](http://en.wikipedia.org/wiki/Johnson_solid)
 
 I created the files by using the POV-Ray scripts
 ([1](http://en.wikipedia.org/wiki/File:Poly.pov) and
- [2](http://en.wikipedia.org/wiki/User:AndrewKepert/poly.pov))
-in Wikipedia.
-They are copyrighted in CC BY-SA 3.0
-by "User:Cyp" and "User:AndrewKepert".
+[2](http://en.wikipedia.org/wiki/User:AndrewKepert/poly.pov)) in Wikipedia.
+They are copyrighted in CC BY-SA 3.0 by "User:Cyp" and "User:AndrewKepert".
+
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2013/endoh4/run.sh
+++ b/2013/endoh4/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+make all || exit 1
+
+# set it so that when program is terminated through various signals we re-enable
+# the cursor
+trap "tput cnorm;echo" 0 1 2 3 15
+
+# temporarily disable cursor
+tput civis
+
+# run program attempting to feed it a file, if specified
+if [[ "$#" -eq 1 ]]; then
+    ./endoh4 < "$1"
+else
+    # otherwise feed the source code of the program to the program
+    ./endoh4 < endoh4.c
+fi
+
+# explicitly set cursor back just in case it's not terminated through one of the
+# above signals
+tput cnorm

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1629,6 +1629,14 @@ symlink is created.
 Cody also added the [demo.sh](2013/dlowe/demo.sh) script to more easily try the
 program.
 
+## [2013/endoh4](2013/endoh4/endoh4.c) ([README.md](2013/endoh4/README.md))
+
+Cody added the [run.sh](2013/endoh4/run.sh) script which temporarily turns off
+the cursor as suggested by the author, with the addition that if no file is
+specified it will feed the source code [endoh4.c](2013/endoh4/endoh4.c) to the
+program rather than the file specified. It does not try and detect if the file
+exists or can be read as that will be handled by the shell/program.
+
 ## [2013/hou](2013/hou/hou.c) ([README.md](2013/hou/README.md))
 
 After the file 2013/hou/doc/example.markdown was moved to


### PR DESCRIPTION
Format fixes and additions to 2013/endoh4


Based on the author's suggestions I added a script run.sh which 
temporarily disables the cursor, using trap to set it back (it also 
explicitly sets it back in case the signals specified are not sent to 
the program). If no arg is specified it will feed the source code of the
program into the program; otherwise it'll use the arg specified. It does
not check if the file exists and is readable or anything else as the 
shell/program will do that.
