### PR TITLE
Minor updates to 1988/isaak/README.md

### DIFF
--- a/1988/isaak/README.md
+++ b/1988/isaak/README.md
@@ -31,7 +31,7 @@ The original entry starts with the line:
 This works on some systems.  Why?  Note that `#include <stdio.h>` is given on
 the last line.  Why is this needed?  Note the unusual calls to sprintf.
 
-This version also relied on being able to define define to something else and
+This version also relied on being able to define `#define` to something else and
 using that macro for `#define`. This version will not likely work on modern
 systems if you can even get it to compile.
 
@@ -39,8 +39,9 @@ systems if you can even get it to compile.
 ## Judges' remarks:
 
 NOTE:  The program relies heavily on ASCII.  Don't even think of running it on
-an EBCDIC machine.  If you name the file anything other than "isaak.c", you must
-change the `#include` on line 7.
+an EBCDIC machine.  If you named the file anything other than [isaak.c](isaak.c),
+you had to change the `#include` on line 6. This limitation has been fixed by
+using the `__FILE__` macro.
 
 NOTE: The use of null comments to separate macros to construct different tokens
 from a single macro (e.g., `"O/**/O"` creates either `++` or `--` by defining

--- a/faq.md
+++ b/faq.md
@@ -95,16 +95,23 @@ because of alarming warnings that can be displayed, in some systems at runtime
 interspersed with the output of the program.
 
 For instance in macOS the entry [1990/tbr](1990/tbr/README.md) would output the
-warning in such a way that caused confusing output for the entry.
+warning in such a way that caused confusing output for the entry, looking like:
 
-In some cases this is not so easy to fix and in one case at least there is an
-alternate version that has the fix instead due to a problem it creates (correct
-output but segfaults after the output in one of the forms of input).
+```sh
+$ ./tbr
+$ warning: this program uses gets(), which is unsafe.
+# nothing here, what to do?
+```
 
-In some cases it is not possible to fix or at least highly unlikely and so those
-have mainly not been touched except one that has had the buffer size increased
-(which could be done for others that are not possible to change to `fgets()` but
-this has not been done).
+In some cases changing the code to use `fgets()` is not so easy to fix and in
+one case at least there is an alternate version that has the fix instead due to
+a problem it creates (correct output but segfaults after the output in one of
+the forms of input).
+
+In some cases it is not possible to fix or at least it is highly unlikely and so
+those have mainly not been touched except one that has had the buffer size
+increased (which could be done for others that are not possible to change to
+`fgets()` though this has not been done).
 
 Some entries can be made to look almost identical to the original entry. For
 instance the fix to [1988/reddy](1988/reddy/README.md) required only a single
@@ -115,7 +122,8 @@ these problems.
 
 NOTE: due to 'compatibility reasons' `fgets()` stores the newline and `gets()`
 does not. We're not sure how this is compatibility but either way it can cause a
-problem and it is this that has complicated some fixes.
+problem and it is this that has complicated most of the fixes though again some
+can look almost identical.
 
 
 ## Q: I cannot get entry XYZZY from year 19xx to compile!


### PR DESCRIPTION

The README.md pointed out that not having the file name being 'isaak.c' 
(see the source code why) would cause a problem but this was fixed by
use of the '__FILE__' macro, prior my fix to the entry itself and so the
README.md now points out that this feature (some might say 'defect' or
'limitation') no longer exists.