### PR TITLE
Minor rewording in some YYYY/README.md files

### DIFF
--- a/1988/isaak/README.md
+++ b/1988/isaak/README.md
@@ -31,7 +31,7 @@ The original entry starts with the line:
 This works on some systems.  Why?  Note that `#include <stdio.h>` is given on
 the last line.  Why is this needed?  Note the unusual calls to sprintf.
 
-This version also relied on being able to define define to something else and
+This version also relied on being able to define `#define` to something else and
 using that macro for `#define`. This version will not likely work on modern
 systems if you can even get it to compile.
 
@@ -39,8 +39,9 @@ systems if you can even get it to compile.
 ## Judges' remarks:
 
 NOTE:  The program relies heavily on ASCII.  Don't even think of running it on
-an EBCDIC machine.  If you name the file anything other than "isaak.c", you must
-change the `#include` on line 7.
+an EBCDIC machine.  If you named the file anything other than [isaak.c](isaak.c),
+you had to change the `#include` on line 6. This limitation has been fixed by
+using the `__FILE__` macro.
 
 NOTE: The use of null comments to separate macros to construct different tokens
 from a single macro (e.g., `"O/**/O"` creates either `++` or `--` by defining

--- a/2000/README.md
+++ b/2000/README.md
@@ -1,11 +1,10 @@
-2000 marked the "The Fifteenth International Obfuscated C Code Contest"
+# 2000 marked the "The Fifteenth International Obfuscated C Code Contest"
 
 
-Standard IOCCC stuff
---------------------
+## Standard IOCCC stuff
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 

--- a/2001/README.md
+++ b/2001/README.md
@@ -4,8 +4,8 @@
 Standard IOCCC stuff
 --------------------
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 

--- a/2006/README.md
+++ b/2006/README.md
@@ -5,8 +5,8 @@
 Standard IOCCC stuff
 --------------------
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 

--- a/2011/README.md
+++ b/2011/README.md
@@ -5,8 +5,8 @@
 Standard IOCCC stuff
 --------------------
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 

--- a/2012/README.md
+++ b/2012/README.md
@@ -5,8 +5,8 @@
 Standard IOCCC stuff
 --------------------
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 

--- a/2013/README.md
+++ b/2013/README.md
@@ -1,62 +1,66 @@
-2013 marked the "The Twenty Second International Obfuscated C Code Contest"
-===========================================================================
+# 2013 marked the "The Twenty Second International Obfuscated C Code Contest"
 
+## Standard IOCCC stuff
 
-Standard IOCCC stuff
---------------------
-
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
-Look at the winning source and try to figure how it does what it does!
-You may then wish to look at the Author's remarks for even more details.
+Look at the README.md file for the given winning entry for information on how to
+compile the entry and how to run the winning program.  Look at the winning
+source and try to figure how it does what it does!  You may then wish to look at
+the Author's remarks for even more details.
 
 The IOCCC has a web site and now has a number of international mirrors.
-The primary site can be found at,
+The primary site can be found at: <https://www.ioccc.org/>
 
->	<https://www.ioccc.org/>
+Use make to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
-Use make to compile entries.  It is possible that on non-Un\*x / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
-
-Read over the makefile for compile/build issues.  Your system may require
-certain changes (add or remove a library, add or remove a #define).
+Read over the Makefile for compile/build issues.  Your system might require
+certain changes (add or remove a library, add or remove a `#define` i.e. `-D`
+flag).
 
 Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
-Remarks on some of the entries
-------------------------------
+## Remarks on some of the entries
 
 We believe you will again be impressed with this year's winners.
 
-This year, several 8 people won 9 people won 15 awards.  For the
-first time in the history of the contest, one person, Yusuke Endoh,
-won 4 times while Adrian Cable won 3 times!  It is also worth noting
-that Chris Mills previous win was in 1993.  Welcome back Chris!
+This year, 9 won 15 awards.  For the first time in the history of the contest,
+one person, [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) won
+4 times while [Adrian Cable](https://www.ioccc.org/winners.html#Adrian_Cable)
+won 3 times!  It is also worth noting that [Chris
+Mills](https://www.ioccc.org/winners.html#Christopher_Mills) last win was in 1993.
+Welcome back Chris!
 
 We, the judges, were very surprised by this as many of the multiple
 winners submitted very different styles of entries.
 
 This year was the first time the IOCCC size tool was used.  Entries
-had to print a value 2053 or less when the -i flag was used.
+had to print a value 2053 or less when the `-i` flag was used.
 
 Several people discovered an undocumented feature in that
 certain comments such as:
 
+```c
 	///*
+```
 
 or:
 
+```c
 	*\
 	/
+```
 
 were not correctly parsed by the tool.  The guidelines stated:
 
-    In cases where the above summary and the algorithm implemented by
-    the IOCCC size tool source code conflict, the algorithm implemented
-    by the IOCCC size tool source code is preferred by the judges.
+
+```
+In cases where the above summary and the algorithm implemented by
+the IOCCC size tool source code conflict, the algorithm implemented
+by the IOCCC size tool source code is preferred by the judges.
+```
 
 so this abuse was allowed (and encouraged).  The judges hope that
 the IOCCC size tool author will patch the tool to block this kind
@@ -65,32 +69,26 @@ of size abuse in future contests.
 There were some outstanding entries that did not win.  Unfortunately
 some very good entries lost because they:
 
-+ were way way oversize and didn't even attempt to justify their
+* were way way oversized and didn't even attempt to justify their
   excess by a clever abuse of the rules
+* depended on a single obfuscation trick
+* could only be run on a particular vendor's platform
+* were very similar to previous winners
+* didn't work as documented
 
-+ depend on a single obfuscation trick
+We hope that the authors of some of those entries will fix and resubmit them
+for the next IOCCC.
 
-+ could only be run on a particular vendor's platform
+There is a risk in submitting an entry that is similar to a well used theme by
+previous winners. Previous winners set a very high bar. A new winner must not
+only compete against other submissions from the current year but they must also
+excel over similar previous winners in some particularly impressive way.
 
-+ were very similar to previous winners
+## Final Comments
 
-+ didn't work as documented
-
-We hope the authors of some of those entries will fix and re-submit
-them for the next IOCCC.
-
-There is a risk in submitting an entry that is similar to a well
-used theme by previous winners.  Previous winners set a very high
-bar.  A new winner must not only compete against other submissions
-from the current year, they must also excel over similar winners
-in some particularly impressive way.
-
-Final Comments
---------------
-
-Please feel free to send us comments and suggestions about the
-competition, this README or anything else that you would like to see in
-future contests.
+Please feel free to send us comments and suggestions about the competition, this
+[README.md](README.md) or anything else that you would like to see in future
+contests.
 
 If you use, distribute or publish these entries in some way, please drop
 us a line.  We enjoy seeing who, where and how the contest is used.
@@ -98,13 +96,10 @@ us a line.  We enjoy seeing who, where and how the contest is used.
 If you have problems with any of the entries, AND YOU HAVE A FIX, please
 send us the fix (patch file or the entire changed file).
 
-For the latest information on how to contact the IOCCC Judges please visit
+For the latest information on how to contact the IOCCC Judges please visit:
+<https://www.ioccc.org/contact.html>.
 
->	<https://www.ioccc.org/contact.html>
-
-For news of the next contest watch:
-
->	<https://www.ioccc.org/>
+For news of the next contest watch: <https://www.ioccc.org/>.
 
 =-=
 

--- a/2019/README.md
+++ b/2019/README.md
@@ -5,8 +5,8 @@
 Standard IOCCC stuff
 --------------------
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 

--- a/2020/README.md
+++ b/2020/README.md
@@ -3,8 +3,8 @@
 
 ## Standard IOCCC stuff
 
-Look at the README.md file for the given winner for information
-on how to compile the winner and how to run the winning program.
+Look at the README.md file for the given winning entry for information
+on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 


### PR DESCRIPTION

This change was already applied in the README.md files of the years <
2000, yesterday, but I got tired of doing it manually as I do each year
so I used my sgit tool (https://github.com/xexyl/sgit) like:
    
    sgit -e 's/\(Look at the README.md file for the given\) winner/\1 winning entry/g' -e \
    's/\(on how to compile\) the winner/\1 it/g' .
 
which changed the text:

    ... for the given winner 

and

    on how to compile the winner

to

    ... for the winning entry

and

    ... on how to compile it

This felt useful because the winner is not the entry itself but the 
author (and in some cases authors). This should be clearer now. When I 
do a final pass I will check for any consistency issues in the ones 
changed manually.

In this commit the year 2013/README.md was format fixed as the change 
was done in this file, manually, yesterday, when I did format fixes but
which was not committed as I wanted to do it with the years 2000+.
