### PR TITLE
Fix make and makefile in README.md files

### DIFF
--- a/2000/README.md
+++ b/2000/README.md
@@ -8,10 +8,10 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
-Read over the makefile for compile/build issues.  Your system may
+Read over the Makefile for compile/build issues.  Your system may
 require certain changes (add or remove a library, add or remove a
 #define).
 

--- a/2001/README.md
+++ b/2001/README.md
@@ -10,10 +10,10 @@ You may then wish to look at the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.  The
 primary site can be found at <https://www.ioccc.org>.
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
-Read over the makefile for compile/build issues.  Your system may
+Read over the Makefile for compile/build issues.  Your system may
 require certain changes (add or remove a library, add or remove a
 #define).
 
@@ -22,8 +22,7 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
-Remarks on some of the entries
-------------------------------
+## Remarks on some of the entries
 
 There were some outstanding entries that did not win.  Unfortunately
 some very good entries lost because they:

--- a/2006/README.md
+++ b/2006/README.md
@@ -15,13 +15,13 @@ The primary site can be found at,
 
 >	<https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
 This year we included most of the information included by the submitters
 in the README.md files.
 
-Read over the makefile for compile/build issues.  Your system may require
+Read over the Makefile for compile/build issues.  Your system may require
 certain changes (add or remove a library, add or remove a #define).
 
 Some ANSI C compilers are not quite as good as they should be.  If

--- a/2011/README.md
+++ b/2011/README.md
@@ -15,13 +15,13 @@ The primary site can be found at,
 
 >	<https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
 This year we included most of the information included by the submitters
 in the README.md files.
 
-Read over the makefile for compile/build issues.  Your system may require
+Read over the Makefile for compile/build issues.  Your system may require
 certain changes (add or remove a library, add or remove a #define).
 
 Some ANSI C compilers are not quite as good as they should be.  If

--- a/2012/README.md
+++ b/2012/README.md
@@ -15,10 +15,10 @@ The primary site can be found at,
 
 >	<https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
-Read over the makefile for compile/build issues.  Your system may require
+Read over the Makefile for compile/build issues.  Your system may require
 certain changes (add or remove a library, add or remove a #define).
 
 Some ANSI C compilers are not quite as good as they should be.  If

--- a/2013/README.md
+++ b/2013/README.md
@@ -10,7 +10,7 @@ the Author's remarks for even more details.
 The IOCCC has a web site and now has a number of international mirrors.
 The primary site can be found at: <https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed.  See the Makefile for details.
 
 Read over the Makefile for compile/build issues.  Your system might require

--- a/2018/README.md
+++ b/2018/README.md
@@ -13,15 +13,15 @@ The primary IOCCC web site can be found at,
 
 >	<https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
 Look at the source and try to figure out what the programs do, and run
 them with various inputs.  If you want to, look at the hints files for
 spoilers - this year we included most of the information included
 by the submitter.
 
-Read over the makefile for compile/build issues.  Your system may require
+Read over the Makefile for compile/build issues.  Your system may require
 certain changes (add or remove a library, add or remove a #define).
 
 Some C compilers are not quite as good as they should be.  If yours is

--- a/2019/README.md
+++ b/2019/README.md
@@ -14,10 +14,10 @@ The primary IOCCC web site can be found at,
 
 >	<https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
-Read over the makefile for compile/build issues.  Your system may require
+Read over the Makefile for compile/build issues.  Your system may require
 certain changes (add or remove a library, add or remove a #define).
 
 Some C compilers are not quite as good as they should be.  If yours is

--- a/2020/README.md
+++ b/2020/README.md
@@ -12,10 +12,10 @@ The primary IOCCC web site can be found at,
 
 >	<https://www.ioccc.org/>
 
-Use make to compile entries.  It is possible that on non-Unix / non-Linux
-systems the makefile needs to be changed.  See the Makefile for details.
+Use `make` to compile entries.  It is possible that on non-Unix / non-Linux
+systems the Makefile needs to be changed.  See the Makefile for details.
 
-Read over the makefile for compile/build issues.  Your system may require
+Read over the Makefile for compile/build issues.  Your system may require
 certain changes (add or remove a library, add or remove a #define).
 
 Some C compilers are not quite as good as they should be.  If yours is
@@ -46,7 +46,7 @@ A few entries were violating the "2053 significant bytes" rule. If an entry coul
 compliance within a few seconds of looking at the source, it was disqualified.
 
 One entry tried to get around the size limit by putting the code into
-makefile variables and using -D. This is already called out as discouraged
+Makefile variables and using -D. This is already called out as discouraged
 technique in the guidelines, but it is worth a reminder.
 
 Several promising entries attempted to make use of the `syscall` function using literal syscall numbers.


### PR DESCRIPTION

That is

    sgit -e 's/Use make\( to compile\)/Use `make`\1/g' -e \ 
     's/makefile/Makefile/g'  '20[0-9][0-9]/README.md'

This way 'make' is formatted with a code block (or whatever the term is
in markdown terminology) and 'makefile' is changed to Makefile.

BTW: fun fact: Landon was part of the recommendation of naming Makefiles 
Makefile instead of makefile which is shown in the man page make(1):
    
    Normally you should call your makefile either makefile or Makefile.
    (We recommend Makefile because it appears prominently near the
    beginning of a directory listing, right near other important files
    such as README.) The first name checked, GNUmakefile, is not 
    recommended for most makefiles.  You should use this name if you
    have a makefile that is specific to GNU Make, and will not be
    understood by other versions of make.  If makefile is '-', the
    standard input is read.
