### PR TITLE
Minor fixes in 2015/endoh3/README.md

### DIFF
--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -120,8 +120,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG} ${PROG}.ten ${PROG}.ten.64 ${PROG}.bed ${PROG}.bed.64
 #
-ALT_OBJ= ${PROG}.ten.64.o
-ALT_TARGET= ${PROG}.ten.64
+ALT_OBJ= ${PROG}.ten.64.o ${PROG}.bed.64.o
+ALT_TARGET= ${PROG}.ten.64 ${PROG}.bed.64
 
 
 #################

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -17,17 +17,6 @@ make
 ./anonymous x86_program
 ```
 
-For fun and so that there's another program that is a bit different (it uses a `char
-*[]` array for example) that this program will still work on. To use:
-
-```sh
-make anonymous.bed # if able to use -m32
-./anonymous anonymous.bed
-
-make anonymous.bed.64 # if unable to use -m32
-./anonymous.bed.64
-```
-
 
 ## Try:
 
@@ -37,6 +26,20 @@ make anonymous.bed.64 # if unable to use -m32
 ./anonymous anonymous.bed # if able to use -m32
 ```
 
+NOTE: if the 32-bit version cannot be compiled the script will at least compile
+[anonymous.ten](anonymous.ten.c) as a 64-bit program and run it directly.
+
+For fun and so that there's another program that is a bit different (it uses a `char
+*[]` array for example) that this program will still work on:
+
+```sh
+make anonymous.bed # if able to use -m32
+./anonymous anonymous.bed
+
+make anonymous.bed.64 # if unable to use -m32
+./anonymous.bed.64
+```
+
 What happens if the x86 program has already been modified by this program? The
 judges' remarks below might give you a hint!
 
@@ -44,14 +47,6 @@ What happens if you try it on another file like [anonymous.c](anonymous.c)? Can
 you recompile it okay? What if you run it on `anonymous` itself? Can you run the
 program successfully after it without recompiling?
 
-NOTE: if the 32-bit version cannot be compiled the script will at least run the
-alternate version of the [anonymous.ten](anonymous.ten.c) program.
-
-
-## Judges' remarks:
-
-Is emulation the sincerest form of flattery?  This small program does
-quite a lot of bit twiddling.
 
 ### INABIAF - it's not a bug it's a feature! :-)
 
@@ -64,18 +59,21 @@ that :-(
 If the program cannot be run (for instance under macOS as an ELF file) then
 the program will fail to execute it and might not even touch it.
 
-### WARNING on note from the author
+### A 2023 note about the warning from the author:
 
-The author suggested that this will somewhat destroy the binaries this touches
-but others did not observe this. It does indeed modify the files as the script
-below will show you (though not all files are modified: can you figure out why
-that is?) but others did not notice any problems in using them. Perhaps it's
-something he's not aware of possibly including the fact that the modification
-might or might not be complete. If you follow the try commands below you will
-notice that although the binaries do differ it's not many differences and the
-output of the supplementary program both before and after is the same. See the
-author's warning about this in their remarks.
+The author suggested that this *might* somewhat destroy the binaries this
+touches but after the fix of 2023 this was not observed (yet?). It does indeed
+modify the files (though not all files are modified: can you figure out why that
+is?) but using them after did not result in any problems. It could be that it's
+no longer known exactly what is supposed to happen and possibly that the
+modification might not be entirely correct for that reason though it does appear
+to be correct.
 
+
+## Judges' remarks:
+
+Is emulation the sincerest form of flattery?  This small program does
+quite a lot of bit twiddling.
 
 ## Author's remarks:
 

--- a/2015/endoh3/README.md
+++ b/2015/endoh3/README.md
@@ -21,7 +21,7 @@ make
 
 ## Try:
 
-To see the original [1984/mullender](/1984/mullender/mullender.c) in action:
+To see the original [mullender](mullender.c) in action:
 
 ```sh
 cc -o prog prog.c mullender.c # or make mullender or make back_to
@@ -93,7 +93,7 @@ hijack the `main()` function call.  And then it interprets `main()` as an
 instruction sequence.
 
 It supports the minimal subset of instructions and addressing modes which are
-needed for [mullender.c](/1984/mullender/mullender.c) to work:
+needed for [mullender.c](mullender.c) to work:
 
 * Instructions
   * BR: branch
@@ -110,7 +110,7 @@ needed for [mullender.c](/1984/mullender/mullender.c) to work:
   * 4: Auto-decrement deferred
   * 6: Index (incomplete)
 
-### Limitation
+### Limitations
 
 Non-trivial combination of instruction and addressing mode may cause undefined
 behavior (unsequenced modification), such as attempting to auto-increment a
@@ -120,7 +120,7 @@ register).
 
 ### One more thing
 
-Note: this program writes a binary file to stdout.
+Note: this program writes a binary file to `stdout`:
 
 ```
 short main[]={5568,1,-30460,12,2782,0,-29921,2056,-4864,6873,770,30054,11886,

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1005,9 +1005,9 @@ other version in.
 Cody fixed both the supplementary program and the program itself (both of which
 segfaulted and once that was fixed only the binary was modified; it was not run
 but according to the author's remarks it should be executed). He managed to do
-this with linux but it will not work with macOS Catalina (10.15). See
-[bugs.md](/bugs.md) for why this is); _this is **not** a bug, it's a feature_
-inherent in what it does!
+this with linux but it will not work with any system that does not allow one to
+compile 32-bit binaries such as macOS. See [bugs.md](/bugs.md) for why this is;
+_this is **not** a bug, it's a feature_ inherent in what it does!
 
 Below is what it took to fix.
 
@@ -1022,14 +1022,17 @@ binary. But again see [bugs.md](/bugs.md) here.
 These also had to be done:
 
 - when `open()`ing the file the file descriptor had to be saved so it could be
-closed prior to executing the program.
-- `munmap()` also had to be called prior to executing the program.
+closed prior to executing the program. This is the `f` variable which is of type
+`l`, a `#define` for `int *`.
+- `munmap()` also had to be called prior to executing the program. This involved
+a new `off_t N` so which was added in the `mmap()` call which was then used in
+the `munmap()` call.
 
 Without those changes the program was not executed after modification which it
-was supposed to do, instead reporting text file busy error.
+was supposed to do; instead it reported text file busy error.
 
-Notice that the location of the calls to `munmap()` and `close()` followed by
-`execv()` _does matter_!
+Notice that the location of `munmap()` and `close()` followed by `execv()` _does
+matter_!
 
 To get this to compile with clang, `main()` had to change from:
 
@@ -1044,7 +1047,8 @@ int main (int cka, char **k) { char *ck = (char *)cka; /* ... */ }
 ```
 
 The following change was also made to be more portable, in case the constants
-`PROT_READ` and/or `PROT_WRITE` are not standardised:
+`PROT_READ` and/or `PROT_WRITE` are not standardised or some platform does not
+follow it:
 
 Change `3` in the call to `mmap()` to be `PROT_READ|PROT_WRITE`: just in case
 `PROT_READ|PROT_WRITE` does not equal 3 (though it seems to be equal in both
@@ -1072,6 +1076,9 @@ Cody also added a [program](anonymous.bed.c) like [anonymous.ten.c](anonymous.te
 [Ten Green Bottles](https://en.wikipedia.org/wiki/Ten_Green_Bottles) but which
 sings [Ten in the Bed](https://allnurseryrhymes.com/ten-in-the-bed/).
 
+As well he added the [try.me.sh](2001/anonymous/try.me.sh) so that one can
+attempt to use the program as it was designed but if compiling as 32-bit fails
+it will at least run the supplementary program as a 64-bit program directly.
 
 ## [2001/bellard](2001/bellard/bellard.c) ([README.md](2001/bellard/README.md]))
 


### PR DESCRIPTION

Change (except in author's remarks in the wget command) the 
/1984/mullender/mullender.c to be just mullender.c as it's in the entry
directory itself.

Format fixes in README.md as well.