### PR TITLE
Improve 2013/endoh2/Makefile rule check

### DIFF
--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -146,6 +146,29 @@ jpeg.jpg: jpeg
 
 check: ${DATA}
 	${RM} -f jpeg2.c
+	@if ! type -P convert >/dev/null 2>&1; then \
+	    echo "The 'convert' tool from ImageMagick could not be found." 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "See the following website for ImageMagick:" 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "    https://imagemagick.org/script/download.php"; 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "or use your OS package manager to install it." 1>&2; \
+	fi
+	@if ! type -P ${RUBY} >/dev/null 2>&1; then \
+	    echo "${RUBY} language could not be found." 1>&2; \
+	    echo "${RUBY} must be installed in order to run the $@ rule." 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "See the following website for ${RUBY}:" 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "    https://www.ruby-lang.org/"; 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "or use your OS package manager to install it." 1>&2; \
+	    ERROR=1; \
+	fi
+	@if type -P ${RUBY} >/dev/null 2>&1 || ! type -P convert >/dev/null 2>&1; then \
+	    exit 1; \
+	fi
 	${RUBY} ocr.rb jpeg.jpg > jpeg2.c
 	${DIFF} jpeg.c jpeg2.c && echo Check succeeded
 

--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -17,7 +17,14 @@ make
 make check
 ```
 
-You'll need to have Ruby installed to run all the automated checks.
+You'll need to have both [Ruby](https://www.ruby-lang.org) and
+[ImageMagick](https://imagemagick.org/) installed to run all the automated
+checks.
+
+If you do not have both, however, you can still do the below in the [try](#try)
+section to enjoy the entry. The [Makefile](Makefile) `check` rule will check if
+you have both and if either is not found it will report it and tell you where to
+download one or both before exiting.
 
 ## Try:
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1654,6 +1654,26 @@ symlink is created.
 Cody also added the [demo.sh](2013/dlowe/demo.sh) script to more easily try the
 program.
 
+## [2013/endoh2](2013/endoh2/endoh2.c) ([README.md](2013/endoh2/README.md))
+
+Cody fixed the Makefile `check` rule so that it `checks` :-) that both
+[Ruby](https://www.ruby-lang.org) and [ImageMagick](https://imagemagick.org) are
+installed before trying to run the ruby script. To be more technically correct:
+it checks that the `convert` tool of ImageMagick is available (via `type -P`)
+because `convert` is part of the ImageMagick suite.
+
+This is useful because the Ruby script tries to run (via `IO.popen()`) the
+`convert` tool but without ImageMagick being installed, if one is unaware of
+where it comes from it will appear to be an error in the Ruby script (it might
+also appear to be an issue with the script even if you know of `convert`: it was
+another day that Cody remembered it and why it wasn't installed on his MacBook
+Pro even though in the past it had been and is indeed now).
+
+The rule will report the tools not installed and where to find them, if they are
+not installed, and after checking these requirements it will exit if either is
+not found.
+
+The entry can still be enjoyed if you do not have these tools, however.
 
 ## [2013/endoh4](2013/endoh4/endoh4.c) ([README.md](2013/endoh4/README.md))
 


### PR DESCRIPTION
The fact it uses ruby is clear but the ruby script uses (via IO.popen()) the convert tool from the ImageMagick suite. When I first looked at it and had the error it was not very clear to me what was going on. It was not until another day when I looked at it again that I recalled that convert is a tool that comes from ImageMagick which had previously been on my MacBook Pro but hasn't been (until now) since macOS Sonoma was installed.

Now the Makefile rule checks that both ruby and ImageMagick (via checking for 'convert') are installed. If either aren't it will report where they can be found and then after doing that if either are not installed it exits 1. Otherwise if both are found it will run the script.