### PR TITLE
Improvements and fixes to 2013/dlowe

### DIFF
--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -24,17 +24,9 @@ make
 ./dlowe 16 32 64 128
 ./dlowe 16 32 64 128 256
 ./dlowe 16 32 64 128 256 512
-
-echo "sparkline of file sizes: $(wc -c * | awk '{print $1}' | xargs ./dlowe)" # or ./slen.sh
-
 ./dlowe 0 
 
-echo "sparkline of file sizes: $(wc -c * | awk '{print $1}' | xargs ./dlowe)" # or ./slen.sh
-```
-
-./dlowe 0 
-
-echo "sparkline of file sizes: $(wc -c * | awk '{print $1}' | xargs ./dlowe)" # or ./slen.sh
+echo "sparkline of file sizes: $(wc -c * | awk '{print $1}' | xargs ./dlowe)" # or ./sflen.sh
 ```
 
 Alternatively, for the lazy or those short on time, try:
@@ -51,10 +43,9 @@ echo 'IOCCC 2013' > ioccc.txt
 rm -f ioccc.txt
 ```
 
-
 ?
 
-To make it simpler to see try showing just the last two lines:
+To make it simpler to see try showing just the different line like:
 
 ```sh
 ./demo.sh | tail -n 2 > 1.txt
@@ -79,8 +70,8 @@ something funny (or will it ? :-) ) and when will it do nothing?
 
 We liked how this entry used Unicode, specifically UTF-8, in a somewhat obfuscated way. 
 
-Also, why doesn't it crash, and produces a correct output when called with one argument
-or when all arguments are equal?
+Also, why doesn't it crash but instead produces a correct output when called
+with one argument or when all arguments are equal?
 
 For extra fun, compile and run [fun.c](fun.c):
 
@@ -106,7 +97,7 @@ and with clang (3.3), we get
 -2147483648 0 2147483647
 ```
 
-and with Apple clang version 15.0.0 (clang-1500.0.40.1) we get:
+and with Apple clang version 15.0.0 (clang-1500.0.40.1) in 2023, we get:
 
 ```
 1840985120 -2033041452 35979112
@@ -116,7 +107,6 @@ Which one is correct? :)
 
 NOTE: `make all` will compile [fun.c](fun.c) but to provide a different compiler
 you can do something like:
-
 
 ```sh
 make CC=clang fun
@@ -140,10 +130,10 @@ $ echo "sparkline of file lengths: $(wc -c * | awk '{print $1}' | xargs ./sparkl
 sparkline of file sizes: ▁▁▁▃▃▂▁▂▁▁▉
 ```
 
-NOTE: this has been provided in [slen.sh](slen.sh) so you can try:
+NOTE: this has been provided in [sflen.sh](sflen.sh) so you can try:
 
 ```sh
-./slen.sh
+./sflen.sh
 ```
 
 instead.

--- a/2013/dlowe/demo.sh
+++ b/2013/dlowe/demo.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-make clobber all || exit 1
-
+make all || exit 1
 echo "$ ./dlowe 0 1 2 3 4 5 6 7"
 ./dlowe 0 1 2 3 4 5 6 7
 echo
@@ -17,5 +16,5 @@ echo
 echo "$ ./dlowe 0"
 ./dlowe 0
 echo
-echo "$ ./slen.sh"
-./slen.sh
+echo "$ ./sflen.sh"
+./sflen.sh

--- a/2013/dlowe/sflen.sh
+++ b/2013/dlowe/sflen.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+make all || exit 1
+ln -sf dlowe sparkl
 echo "sparkline of file lengths: $(wc -c ./* | awk '{print $1}' | xargs ./sparkl)"

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -146,6 +146,29 @@ jpeg.jpg: jpeg
 
 check: ${DATA}
 	${RM} -f jpeg2.c
+	@if ! type -P convert >/dev/null 2>&1; then \
+	    echo "The 'convert' tool from ImageMagick could not be found." 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "See the following website for ImageMagick:" 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "    https://imagemagick.org/script/download.php"; 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "or use your OS package manager to install it." 1>&2; \
+	fi
+	@if ! type -P ${RUBY} >/dev/null 2>&1; then \
+	    echo "${RUBY} language could not be found." 1>&2; \
+	    echo "${RUBY} must be installed in order to run the $@ rule." 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "See the following website for ${RUBY}:" 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "    https://www.ruby-lang.org/"; 1>&2; \
+	    echo ""; 1>&2; \
+	    echo "or use your OS package manager to install it." 1>&2; \
+	    ERROR=1; \
+	fi
+	@if type -P ${RUBY} >/dev/null 2>&1 || ! type -P convert >/dev/null 2>&1; then \
+	    exit 1; \
+	fi
 	${RUBY} ocr.rb jpeg.jpg > jpeg2.c
 	${DIFF} jpeg.c jpeg2.c && echo Check succeeded
 

--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -17,7 +17,14 @@ make
 make check
 ```
 
-You'll need to have Ruby installed to run all the automated checks.
+You'll need to have both [Ruby](https://www.ruby-lang.org) and
+[ImageMagick](https://imagemagick.org/) installed to run all the automated
+checks.
+
+If you do not have both, however, you can still do the below in the [try](#try)
+section to enjoy the entry. The [Makefile](Makefile) `check` rule will check if
+you have both and if either is not found it will report it and tell you where to
+download one or both before exiting.
 
 ## Try:
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1654,6 +1654,26 @@ symlink is created.
 Cody also added the [demo.sh](2013/dlowe/demo.sh) script to more easily try the
 program.
 
+## [2013/endoh2](2013/endoh2/endoh2.c) ([README.md](2013/endoh2/README.md))
+
+Cody fixed the Makefile `check` rule so that it `checks` :-) that both
+[Ruby](https://www.ruby-lang.org) and [ImageMagick](https://imagemagick.org) are
+installed before trying to run the ruby script. To be more technically correct:
+it checks that the `convert` tool of ImageMagick is available (via `type -P`)
+because `convert` is part of the ImageMagick suite.
+
+This is useful because the Ruby script tries to run (via `IO.popen()`) the
+`convert` tool but without ImageMagick being installed, if one is unaware of
+where it comes from it will appear to be an error in the Ruby script (it might
+also appear to be an issue with the script even if you know of `convert`: it was
+another day that Cody remembered it and why it wasn't installed on his MacBook
+Pro even though in the past it had been and is indeed now).
+
+The rule will report the tools not installed and where to find them, if they are
+not installed, and after checking these requirements it will exit if either is
+not found.
+
+The entry can still be enjoyed if you do not have these tools, however.
 
 ## [2013/endoh4](2013/endoh4/endoh4.c) ([README.md](2013/endoh4/README.md))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1641,15 +1641,16 @@ Cody added the source code that we suggested one should compile and run with
 different compilers as [fun.c](2013/dlowe/fun.c). He modified the Makefile so
 that running `make all` will compile it, saving you the effort.
 
-He also provided the script [slen.sh](2013/dlowe/slen.sh) which is based on the
-author's remarks, giving a script that shows the spark line of the file lengths
-(as in `wc -c`), fixing it for shellcheck. These fixes were applied in the
-author's remarks as well.
+He also provided the script [sflen.sh](2013/dlowe/sflen.sh), fixing it for
+shellcheck,  which is based on the author's remarks, giving a script that shows
+the spark line of the file lengths (as in `wc -c`). These fixes were applied in
+the author's remarks as well.
 
 Since the author called the program `sparkl` Cody modified the Makefile so that
 running `make all` will create a symlink to `dlowe` as `sparkl`. Running `make
 clobber` will delete both and running `make clobber all` will ensure that the
-symlink is created.
+symlink is created. The `sflen.sh` script also explicitly makes sure to create
+the symlink as it uses it, even though it runs `make clobber all`.
 
 Cody also added the [demo.sh](2013/dlowe/demo.sh) script to more easily try the
 program.


### PR DESCRIPTION

The README.md format was messed up (extraneous and erroneous '```'s) due
to the nightmare (or perhaps daymare :-) ) of the many merging conflicts
of yesterday which required repeatedly resolving conflicts in GitHub.
 
I also renamed 'slen.sh' to 'sflen.sh' as it shows the sparkle OF the
length of all the files rather than a sparkle length. References to 
slen.sh have been changed to sflen.sh instead.

The demo.sh script and the sflen.sh script now run:

    make all || exit 1

before proceeding. It does not do make clobber before because this only
clutters the output and is unnecessary if everything is already
compiled.

Oh and just for those who wonder if daymare is or is not really a word:
it is but I redefined it; literally it refers to a frightening hallucinatory
experience whilst awake (though perhaps GitHub was hallucinating :-) that
there were conflicts (well there were but there shouldn't have been)).
