### PR TITLE
Add alt code to 2014/vik

### DIFF
--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -128,6 +128,7 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	@echo "NOTE: for macOS use the alternate code through make alt. See README.md for details."
 
 # alternative executable
 #

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -14,8 +14,9 @@ Germany
 make all
 ```
 
-An alternate version for this entry works with macOS. See the Alternate code
-section below for more details.
+There is an alternate version of this entry that will work with macOS. See the
+[Alternate code](#alternate-code) section below for details on how it works and
+how to use it.
 
 
 ## To run:
@@ -24,46 +25,85 @@ section below for more details.
 ./schweikh1
 ```
 
+NOTE: a limitation with the entry was that it required `gcc` but this limitation
+has been removed to make it more portable, requiring only `cc`.
+
 ### Alternate code:
 
-As noted above the alternate version works with macOS but there are some
-important notes as well as a description of how it works (spoilers for the
-original version as well).
+As noted above this entry will not work as it stands for macOS and there are
+some important notes as well as a description of how the fixed version works
+(the details of which are relevant to the original entry that no longer works as
+well as the fixed version but are described in the context of the macOS
+adjustments).
 
-With a MacBook Pro Max with the M1 chip some header files report an
-unsupported architecture and unsupported compiler (error, warning).
-However the defines are still found okay.
+#### macOS changes:
 
-For this alternate version you will need the command line tools which you can
-install like:
+As an aside: if you have a Mac with the Apple chip, some of the header files
+will report an unsupported architecture and unsupported compiler (error,
+warning). This will not make the program abort, however, but even with an Intel
+CPU though, the original entry will not work in macOS as it stands because
+`/usr/include` is hard-coded in the code and macOS does not have it.
+
+Nevertheless, although some of it would not work in other systems where
+`/usr/include` exists, the `#define`s would still be found okay, at least until
+a file was not found (this limitation was removed in both versions, see
+[thanks-for-fixes.md](/thanks-for-fixes.md) for details).
+
+However, as noted, macOS does **not** have `/usr/include` so this would not ever
+work for macOS without some changes, described next. For macOS you will need the
+command line tools installed which can be done like:
 
 ```sh
 sudo xcode-select --install
 ```
 
-Finally as far as how this works if you look at line 55 you see a funny command.
-This goes for both versions. Now the key are two magic numbers, one on a
-different line shortly below the string. In the original the numbers are,
-respectively, 44 and 46.  But how does this work? Well the string is:
+An important point is that the original version hard-coded `gcc` but just like
+the entry, the alternate version has also removed this limitation despite `gcc`
+existing (though it's `clang`) in macOS.
+
+Now as far as how this works if you look at the code of
+[schweikh1.c](schweikh1.c), on line 55 you'll see a funny command (this goes for
+the alternate version as well but a bit different).
+
+Now the key is two magic numbers, one (two of this exist) on a different line shortly below the
+string and the other a couple lines further below.
+
+In the original the numbers are, respectively, 44 and 46, but with the gcc
+limitation removed the numbers now are 43 and 45. But how does this work? Well
+the command is:
 
 ```
 "0gcc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
 ```
 
-The first number means: the length starting from 0 up through the `>`. The
-second number is the same starting point but up through the `\0` which is why
-it's +2. But what happens if only the first number is updated? Most of the
-output will be just `#define` by itself; in the cases where there was text after
-that it was macros that certainly were not defined.  There might have been other
-errors as well.
+which has been changed to be:
 
-This allows for opening the right files. The problem with the macOS is
-`/usr/include` does not exist: instead it's
+```
+"0cc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
+```
+
+Shortly below that you will see, as noted above, the numbers:
+
+```c
+if ((H = fopen (__FILE__+43, 43+__FILE__)))
+while ((fgets (L, (int)sizeof L, H)) != 0) {
+	I[strcspn (I, 45+__FILE__)] = O = 0;
+```
+
+The first number in the above C means the length starting from 0 up through the
+`>`. The second number is the same starting point but up through the `\0` which
+is why it's `+2`. But what happens if only the first number is updated (from the
+original)? Most of the output will be just `#define` by itself; in the cases
+where there was text after that it was macros that certainly were not defined.
+There might have been other errors as well.
+
+Changing this for macOS allows for opening the right files; the problem with the
+macOS is `/usr/include` does not exist: instead it's
 `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include` which is why
-the different command line and the different numbers.
+the different command line and the different numbers. The change of the numbers
+can be found in the alternate code and the explanation is the same.
 
 To use this version use:
-
 
 ```sh
 make alt
@@ -71,13 +111,14 @@ make alt
 
 Use `schweikh1.alt` as you would `schweikh1` above.
 
+Bonus exercise: modify the code to provide a different compiler.
 
 ## Judges' remarks:
 
 What does it do?  It seems to print a list of system headers, perhaps
 with words after them.  Curiously, if you look at the list of words
 defined in a given standard header, they are never printed directly
-after that header's name.  Ah-hah!  It's a conformance test for the
+after that header's name.  Aha!  It's a conformance test for the
 standard headers.
 
 This code is a wonder; it's a wonder that it compiles.  I wonder
@@ -90,15 +131,17 @@ Do not read them if you want to figure this out yourself.  "Amendment
 One" refers to "NA1", the add-on to C89 which added some fairly
 crufty internationalization support.
 
-NOTE: Some non-gcc compilers that are not fully ANSI standard do not
-compile this entry correctly.  Using cc by default is not helpful
-most of the time on this entry, because the program has a hardcoded
+#### Historical note:
+
+Some non-gcc compilers that were not fully ANSI standard did not
+compile this entry correctly.  Using cc by default was not helpful
+most of the time on this entry, because the program had a hardcoded
 gcc invocation anyway.  Anyone who uses egcs and has no plain gcc
 will need to frob the source anyway and can be expected to do the
-right thing with `${CC}`. So use gcc.
+right thing with `${CC}`. So one should have used gcc.
 
 
-## Author's remarks
+## Author's remarks:
 
 Important! This program, if it compiles at all, is mis-compiled by many
 compilers due to compiler bugs. It could be the "least likely

--- a/1998/schweikh1/schweikh1.alt.c
+++ b/1998/schweikh1/schweikh1.alt.c
@@ -3,9 +3,9 @@
 /*#include H(dlib)*/
 /*#include H(ring)*/
 
-#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
-#define X(x) __LINE__ x __LINE__
-#define t(a)\
+#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
+#define X(x) __LINE__ x __LINE__
+#define t(a)\
 for (c = 0; c <n##a; ++c) { \
   if (strchr (a[c], 0[__FILE__])) { if (*a[c] == 0[__FILE__]) { \
       if (strcmp (a[c]+__LINE__, I + strlen (I) + __LINE__ - strlen (a[c]) x else { \
@@ -16,11 +16,11 @@ for (c = 0; c <n##a; ++c) { \
 	int
 main (int C, char **V)
 {
-	FILE *G;
+	FILE *H;
 	int c, ne, nn, S = C < 2 ? 060 : *V[1];
 
 	char f[__LINE__][X(*)], K[(X(*))*4], L[4*X(<<)],
-	e[X(<<)][3*__LINE__], n[X(<<)][3*__LINE__], F[__LINE__];
+	e[X(<<)][3*__LINE__], n[X(<<)][4*__LINE__], F[__LINE__];
 
 	if (freopen (__FILE__, "r", stdin) == 0) return __LINE__-13;
 	for (c = 0;;) {
@@ -52,17 +52,17 @@ O:
 #line				8 "<%s>:\n"
 				char *I = L + __LINE__;
 				int O = printf (__FILE__, n[nn]) +
-#line				2 "0gcc -ansi -E -dM -undef %s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/%s>r\0 ("
+#line				2 "0cc -ansi -E -dM -undef %s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/%s>r\0 ("
 				sprintf (K, 1+__FILE__, f[S-*__FILE__] + __LINE__, n[nn]);
 				O += system (K);
-				if ((G = fopen (__FILE__+95, "r")))
-				while ((fgets (L, (int)sizeof L, G)) != 0) {
-					I[strcspn (I, 97+__FILE__)] = O = 0;
+				if ((H = fopen (__FILE__+94, __FILE__+94)))
+				while ((fgets (L, (int)sizeof L, H)) != 0) {
+					I[strcspn (I, 96+__FILE__)] = O = 0;
 #line					1 "*r"
 					t (n) t (e)
 					if (0 == O) O = puts (L);
 				}
-				if (G != NULL) nn = fclose (G);
+				if (H != NULL) nn = fclose (H);
 			}
 		}
 	}

--- a/1998/schweikh1/schweikh1.c
+++ b/1998/schweikh1/schweikh1.c
@@ -3,9 +3,9 @@
 /*#include H(dlib)*/
 /*#include H(ring)*/
 
-#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
-#define X(x) __LINE__ x __LINE__
-#define t(a)\
+#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
+#define X(x) __LINE__ x __LINE__
+#define t(a)\
 for (c = 0; c <n##a; ++c) { \
   if (strchr (a[c], 0[__FILE__])) { if (*a[c] == 0[__FILE__]) { \
       if (strcmp (a[c]+__LINE__, I + strlen (I) + __LINE__ - strlen (a[c]) x else { \
@@ -16,7 +16,7 @@ for (c = 0; c <n##a; ++c) { \
 	int
 main (int C, char **V)
 {
-	FILE *G;
+	FILE *H;
 	int c, ne, nn, S = C < 2 ? 060 : *V[1];
 
 	char f[__LINE__][X(*)], K[(X(*))*4], L[4*X(<<)],
@@ -52,17 +52,17 @@ O:
 #line				8 "<%s>:\n"
 				char *I = L + __LINE__;
 				int O = printf (__FILE__, n[nn]) +
-#line				2 "0gcc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
+#line				2 "0cc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
 				sprintf (K, 1+__FILE__, f[S-*__FILE__] + __LINE__, n[nn]);
 				O += system (K);
-				if ((G = fopen (__FILE__+44, "r")))
-				while ((fgets (L, (int)sizeof L, G)) != 0) {
-					I[strcspn (I, 46+__FILE__)] = O = 0;
+				if ((H = fopen (__FILE__+43, 43+__FILE__)))
+				while ((fgets (L, (int)sizeof L, H)) != 0) {
+					I[strcspn (I, 45+__FILE__)] = O = 0;
 #line					1 "*r"
 					t (n) t (e)
 					if (0 == O) O = puts (L);
 				}
-				if (G != NULL) nn = fclose (G);
+				if (H != NULL) nn = fclose (H);
 			}
 		}
 	}

--- a/2001/README.md
+++ b/2001/README.md
@@ -20,7 +20,7 @@ systems the Makefile needs to be changed.  See the Makefile for details.
 
 Read over the Makefile for compile/build issues.  Your system may
 require certain changes (add or remove a library, add or remove a
-#define).
+`#define` i.e. the `-D` flag).
 
 Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
@@ -32,60 +32,57 @@ local compiler.
 There were some outstanding entries that did not win.  Unfortunately
 some very good entries lost because they:
 
-    + depended too much on non-portable side effects in expressions;
-    + depended too much on a particular byte order;
-    + required the use of a special script, data file or pseudo-machine
-      language that was not supplied with the entry.
+- depended too much on non-portable side effects in expressions;
+- depended too much on a particular byte order;
+- required the use of a special script, data file or pseudo-machine
+  language that was not supplied with the entry.
 
 We hope the authors of some of those entries will fix and re-submit
 them for the next IOCCC.
 
-We believe you will be impressed with this year's winners.  The Best of Show
-is a fine example of obfuscation.  But don't ignore the other winners!
-There are games, programs that speak, ones that compile code and one that
-might run binaries you already have!
+We believe you will be impressed with this year's winners.  The [Best of
+Show](ollinger/README.md) is a fine example of obfuscation.  But don't ignore
+the other winners!  There are games, programs that speak, ones that compile code
+and [one that might run binaries you already have](2001/anonymous/README.md).
 
-The Worst Abuse of the Rules is technically allowed by the rules.  This year
-we awarded it again, but don't assume you can get away with using the same
-technique next time ... :-)
+The [Best/Worst Abuse of the Rules](bellard/README.md) is technically allowed by the
+[rules](rules.txt).  This year we awarded it again, but don't assume you can get
+away with using the same technique next time ... :-)
 
 This year there were several repeat winners.  This is understating the
-achievement a little - one person has won 8 times before!  (Please note that
-judging is done completely anonymously).
+achievement a little - [one
+person](https://www.ioccc.org/winners.html#Brian_Westley) has won 8 times
+before! (Please note that judging is done completely anonymously.)
 
 
-Why has it taken so long to post the winning source?
-----------------------------------------------------
+## Why has it taken so long to post the winning source?
 
-This is somewhat my (Simon Cooper) fault.  I do apologize to the IOCCC
+This is somewhat my (Simon Cooper's) fault.  I do apologize to the IOCCC
 community for this!  Judging does take quite a lot of time, and I
 over-committed myself several times this year.  Without divulging too much,
 we do look at and work out what every entry does.
 
 
-Final Comments
---------------
+## Final Comments
 
 Please send us comments and suggestions what we have expressed above.
 Also include anything else that you would like to see in future contests.
 Send such email to:
 
-	questions@ioccc.org
+```
+questions@ioccc.org
+```
 
 If you use, distribute or publish these entries in some way, please drop
 us a line.  We enjoy seeing who, where and how the contest is used.
 
-You must include the words ``ioccc question'' in the subject of your email
+You must include the words 'ioccc question' in the subject of your email
 message when sending email to the judges.
 
 If you have problems with any of the entries, AND YOU HAVE A FIX, please
 email the fix (patch file or the entire changed file) to the above address.
 
-Watch:
-
-	https://www.ioccc.org/
-
-for news of the next contest.
+Watch <https://www.ioccc.org/> for news of the next contest.
 
 =-=
 

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -59,7 +59,7 @@ rm 1.txt 2.txt
 
 ## INABIAF - it's not a bug it's a feature! :-)
 
-This program will very likely crash or draw something funny with 0 args. Then
+This program will possibly crash or draw something funny with 0 args. Then
 again it might not. :-) This is not a bug and should NOT be fixed.
 
 Ask yourself the following questions: when will it crash, when will it draw

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -81,6 +81,7 @@ The usage is simple: you just have to wrap Lazy K program with `#include
 [2]: https://tromp.github.io/cl/lazy-k.html
 [3]: https://github.com/irori/lazyk
 [4]: http://en.wikipedia.org/wiki/Polyglot_%28computing%29
+
 ### Obfuscation
 
 ... is inherent in SKI combinator calculus :-)

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -32,13 +32,24 @@ There are also some other musical samples, twinkle.abc and menuet.abc.
 
 ## Judges' remarks:
 
-This endoh3ram can tweet out a tune and is small enough to tweet.
+This program can toot out a tune that is small enough to posted to most social
+media platforms that have small message length limits.
+
+This endoh3ram can toot out a tune that is small enough.
+
+### A modern day (2023) note about the award 'Most tweetable 1-liner' and twitter:
+
+The IOCCC no longer endorses the use of what was once twitter, or whatever it
+might be called today. We recommend that you pick a responsible social media
+platform to post the program's output on. Nevertheless the award of this entry
+will remain the same for historical purposes.
 
 ## Author's remarks:
 
 ### Remarks
 
-This is a sound synthesizer for a subset of [ABC music notation](http://en.wikipedia.org/wiki/ABC_notation).
+This is a sound synthesizer for a subset of [ABC music
+notation](http://en.wikipedia.org/wiki/ABC_notation).
 
 Try:
 
@@ -54,14 +65,14 @@ as `padsp` or `aoss`:
 echo "CDEFGABc" | ./endoh3 | padsp tee /dev/dsp > /dev/null
 ```
 
-If you are using Mac OS X, try [sox](http://sox.sourceforge.net/):
+If you are using Mac OS X, try [sox](http://sox.sourceforge.net/) like so:
 
 ```sh
 echo "CDEFGABc" | ./endoh3 | sox -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
 ```
 
-If they do not work, use the attached script to convert the output
-into a wave file format:
+If that does not work, use the attached script to convert the output into a wave
+file format:
 
 ```sh
 echo "CDEFGABc" | ./endoh3 | ruby wavify.rb > cde.wav
@@ -69,19 +80,28 @@ echo "CDEFGABc" | ./endoh3 | ruby wavify.rb > cde.wav
 
 and play `cde.wav`.
 
-You can enjoy some music scores that I attached:
+
+You can also enjoy some music scores that I attached. With `/dev/dsp` you can
+do so like:
+
 
 ```sh
 cat twinkle.abc | ./endoh3 > /dev/dsp
 cat menuet.abc | ./endoh3 > /dev/dsp
 ```
 
+but you should be able to modify it a way to meet your system requirements as
+described above.
+
+
 ### Obfuscation
 
-The following sequence of questions may be helpful to understand the endoh3ram.
+The following sequence of questions may be helpful to understand the `endoh3ram`
+program:
 
 - How does it convert ABC notes into the frequency?
-- What is `89/84.`?  I found it by using Stern-Brocot tree.
+- What is `89/84.`?  I found it by using the [Stern-Brocot
+tree](https://en.wikipedia.org/wiki/Stern-Brocot_tree).
 - How does it generate a wave?  Hint: it generates a saw wave.
 
 ### Limitation
@@ -98,7 +118,7 @@ The following features are supported:
   - `A3` (a dotted quarter note)
   - `A4` (a half note)
 
-The following features are *not* supported:
+The following features are *NOT* supported:
 
 - Sharp and flat: `^C` `_C`
   - But it is possible to emit the half tones.  Do you see how?
@@ -110,10 +130,12 @@ The following features are *not* supported:
 
 ### Known Bugs
 
-You can *not* write a note length immediately followed by a note `E`,
+You can *NOT* write a note length immediately followed by a note `E`,
 such as `C2E2`.
-Can you know why?
-You can work it around by inserting a whitespace: `C2 E2`.
+
+Can you figure out why?
+
+A workaround is inserting a whitespace: `C2 E2`.
 
 ### Portability
 
@@ -130,61 +152,70 @@ I did write a score of the Happy Birthday song too.
 (It does not matter because the song is out-of-copyright in my country.)
 But I do not attach it to protect you from W\*\*\*\*r.
 
-For the same reason, do not play a score that contains only `z1092`.
+For the same reason, do not post a score that contains only `z1092`.
 You know, it is ["the famous song"](http://en.wikipedia.org/wiki/4%E2%80%B233%E2%80%B3).
 
-### Spoiler (rot13)
+### Spoiler
 
-Urer vf n zntvpny rkcerffvba juvpu V sbhaq ol oehgr-sbepr:
+Here is a magical expression which I found by brute-force:
 
 ```c
-(p % 32 + 5) * 9 / 5 % 13 + a / 32 * 12 - 22
+(c % 32 + 5) * 9 / 5 % 13 + n / 32 * 12 - 22
 ```
 
-Vagrerfgvatyl, vg pbairegf na NFPVV ahzore bs NOP abgrf
-gb gur pbeerfcbaqvat gbar ahzore.
+Interestingly, it converts an ASCII number of ABC notes
+to the corresponding tone number.
 
-    'P' (NFPVV  67) =>  3
-    'Q' (NFPVV  68) =>  5
-    'R' (NFPVV  69) =>  7
-    'S' (NFPVV  70) =>  9
-    'T' (NFPVV  71) => 10
-    'N' (NFPVV  65) => 12
-    'O' (NFPVV  66) => 14
-    'p' (NFPVV  99) => 15
-    'q' (NFPVV 100) => 17
-    'r' (NFPVV 101) => 19
-    's' (NFPVV 102) => 20
-    't' (NFPVV 103) => 22
-    'n' (NFPVV  97) => 24
-    'o' (NFPVV  98) => 26
+```
+'C' (ASCII  67) =>  3
+'D' (ASCII  68) =>  5
+'E' (ASCII  69) =>  7
+'F' (ASCII  70) =>  9
+'G' (ASCII  71) => 10
+'A' (ASCII  65) => 12
+'B' (ASCII  66) => 14
+'c' (ASCII  99) => 15
+'d' (ASCII 100) => 17
+'e' (ASCII 101) => 19
+'f' (ASCII 102) => 20
+'g' (ASCII 103) => 22
+'a' (ASCII  97) => 24
+'b' (ASCII  98) => 26
+```
 
-Ol gur jnl, lbh pna jevgr n unys-gbar ol gur sbyybjvat punenpgref.
+By the way, you can write a half-tone by the following characters.
 
-    'X' =>  4 (= P#)
-    'Y' =>  6 (= Q#)
-    'H' =>  8 (= S#)
-    'I' => 11 (= T#)
-    'C' => 13 (= N#)
+```
+'K' =>  4 (= C#)
+'L' =>  6 (= D#)
+'U' =>  8 (= F#)
+'V' => 11 (= G#)
+'P' => 13 (= A#)
+```
 
-Abgr gung gur gbar ahzoref fvzcyl rahzrengr gur frzv-gbar fgrcf.
-Fb jr pna pnyphyngr gur serdhrapl rnfvyl: `cbj(2, a / 12.0)`.
-Gura, ubj pna jr pnyphyngr `cbj` jvgubhg `zngu.u`?
-`cbj(2, 1.0 / 12.0)` vf nccebkvzngrq ol `89/84.`.
-(V sbhaq guvf nccebkvzngvba ol hfvat [Fgrea-Oebpbg gerr](uggc://ra.jvxvcrqvn.bet/jvxv/Fgrea%R2%80%93Oebpbg_gerr).)
-Jr pna tnva gur serdhrapl ol zhygvcylvat gur inyhr `a` gvzrf.
+Note that the tone numbers simply enumerate the semi-tone steps.  So we can
+calculate the frequency easily: `pow(2, n / 12.0)`.  Then, how can we calculate
+`pow` without `math.h`?  `pow(2, 1.0 / 12.0)` is approximated by `89/84.`.  (I
+found this approximation by using the [Stern-Brocot
+tree](http://en.wikipedia.org/wiki/Stern%E2%80%93Brocot_tree).) We can gain the
+frequency by multiplying the value by `n` times.
 
-Svanyyl, gur sbyybjvat pbqr trarengrf n fnj jnir:
+Finally, the following code generates a saw wave:
 
-    sbe(p = 0; p < yra; p++) chgpune(n = a * Q);
+```c
+for(c = 0; c < len; c++) putchar(a = n * D);
+```
 
-jurer `Q` vf n serdhrapl naq `n` vf n inevnoyr jubfr glcr vf pune.
-Ol nffvtavat sybng gb pune inevnoyr, gur vzcyvpvg glcr pbairegvba vf cresbezrq sebz sybng gb pune (zbqhyb 256).
-(Fgevpgyl fcrnxvat, guvf orunivbe vf haqrsvarq nppbeqvat gb 6.3.1.4 va P99;
-lbh pna ercynpr vg jvgu `(ybat)(a*Q)` vs lbh ner crqnagvp.)
+where `D` is a frequency and `a` is a variable whose type is char.  By assigning
+float to char variable, the implicit type conversion is performed from float to
+char (modulo 256).
 
-Nyy gung jnf yrsg jnf gb pbzovar naq pbaqrafr gur pbzcbaragf.
-Gur xrl vf fdhnfuvat gurz vagb whfg bar sbe-ybbc.
+(Strictly speaking, this behavior is undefined according to 6.3.1.4 in C99; you
+can replace it with `(long)(n*D)` if you are pedantic.)
+
+All that was left was to combine and condense the components.  The key is
+squashing them into just one for-loop.
+
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2014/vik/.gitignore
+++ b/2014/vik/.gitignore
@@ -1,4 +1,5 @@
 audio_file.raw
 prog
+prog.alt
 prog.raw
 prog.orig

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -13,13 +13,15 @@ US
 make
 ```
 
-
 ## To run:
 
 ```sh
 ./prog > foo.c
 ```
 
+There is an alternate version that will theoretically work with Windows
+compilers (if anything in Windows works :-) ). See the [Alternate
+code](#alternate-code) section below.
 
 ## Try:
 
@@ -28,6 +30,18 @@ echo 'Want to hear me beep?' | ./prog > audio_file.raw
 
 echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
 ```
+
+### Alternate code:
+
+The alternate code, [prog.alt.c](prog.alt.c), is based on the author's
+instructions on how to get it to work with Windows. This has not been tested but
+in order to use it you can do:
+
+```sh
+make alt
+```
+
+Use `prog.alt` as you would `prog` above as well as below.
 
 
 ## Judges' remarks:
@@ -59,7 +73,7 @@ I can tell, there are at least six chocolate references in this program.
 This program can convert text to Morse to a raw 44.1kHz stereo audio file.
 Via streaming to mplayer, you can listen to the Morse audio.
 
-Don't forget the last '-' as it makes mplayer read from stdin.
+Don't forget the last '`-`' as it makes mplayer read from stdin.
 
 
 ## Convert audio file with Morse signals to text
@@ -85,6 +99,8 @@ declaration in order for the program to run correctly:
 ```c
 _setmode(_fileno(stdout), 0x8000);
 ```
+
+NOTE: see the [alternate code](prog.alt.c) for this.
 
 ### Known Issues
 

--- a/2014/vik/prog.alt.c
+++ b/2014/vik/prog.alt.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <string.h>
+#include <io.h>
+
+char X[] =
+  " ETIANMSURWDKGOHVF:L:PJBXCYZQ::54:3:::2&:+::::16=/:::(:7:::8:90"
+  "::::::::::::?_::::\"::.::::@:::'::-::::::::;!:):::::,:::::";
+
+int j,w,h,f,u,d,g,e,n,i,l,a,r,p,c,m,o,t,s,Q=32,T[32],W[32],I=13000;
+
+int main(int v, char** b) {
+
+  _setmode(_fileno(stdout), 0x8000);
+  for (i=0;v>0&&v<5&&(v*=t=fread(X,1,1,stdin));)
+
+  for (v-1&&101==*1[b]?++g%1500?u+=(g&1^1)*(*X<0?-*X:*X):(f=e,e=w,w=d,d=u,
+    m=(1 - h%2* 2  )*(d -f)/ (d<f  ?d|1 : 1|f) >  5?T[ h%Q] =o+l  , l=W[
+    h++%Q]=o,o=0:m,o++,u=main(0,b)):(c=strrchr(X,~(Q&*X&*X/2)&*X)-X,j=255);
+    v==1&&(c*j||main(*X-Q?8:24,b));j/=2)c<j?0:main(9+(c-j)/(j/2+1)%2*10,b);
+
+  for (a=u=0;i<=Q*Q&&!v;j>7&&j<13?s=c*s+T[i/Q]/2,s/=++c:0)
+    !(i++%Q)?a=c>a?u=s,c:a,c=s=0:0,j=T[i%Q],j=j?T[i/Q]*10/j:0,j*=(j<5)*2+1;
+
+  for (r+=(h-r)/Q*Q;i<v/4*I;putchar((i/I<v%4)*i%2*85<<(i%176/88)),i++);
+
+  for (g*=!!v;r+t!=h+1&&h>5&&!v;r+t!=h+1?(W[r%Q]>2*u||r==h?p=n=n>6?0:
+    putchar(X[p-1+(1<<n)])&0:0,W[r++%Q]>6*u?putchar(Q):0):0)
+    *X=Q,p=r%2?++n,2*p+(W[r++%Q]>2*u):p;
+
+  return 0;
+}

--- a/bugs.md
+++ b/bugs.md
@@ -1865,7 +1865,7 @@ Do you have it? Please provide it!
 ## [2013/dlowe](2013/dlowe/dlowe.c) ([README.md](2013/dlowe/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
-This program will very likely crash or draw something strange with 0 args. Then
+This program will possibly crash or draw something strange with 0 args. Then
 again it might not. :-) This is easy to fix but would add bytes and since the
 author noted it is a feature and not a bug. You of course can try and fix it
 yourself but please do NOT open a pull request for this: just do it as an
@@ -1889,7 +1889,7 @@ Hou :-) ) yourself. This should not be fixed.
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) discovered a bug that
 shows itself in some cases (it works in others) when working on his winning
-[2020 Enigma machine](2020/ferguson2/prog.c) ('Most enigmatic) entry. See his
+[2020 Enigma machine](2020/ferguson2/prog.c) ('Most enigmatic') entry. See his
 [README.md](2020/ferguson2/README.md) for details (search for `vik` in the
 file).
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -5,8 +5,8 @@
 
 ## Thank you honor roll
 
-There are several people who have contributed to the above mentioned
-several thousand changes and important improvements.
+There are several people who have contributed several thousand changes, fixes
+and important improvements.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1790,12 +1790,18 @@ implicitly (linux doesn't seem to but macOS does).
 Cody fixed the build for this entry: it does not require SDL2 but SDL1 so there
 were linking errors.
 
+## [2014/vik](2014/vik/prog.c) ([README.md](2014/vik/README.md))
+
+Cody added an alternate version that is based on the author's remarks that will
+theoretically work for Microsoft Windows compilers (if anything works in Windows
+:-) ). We have no way of testing this and if anything has changed since 2014
+that would break it we do not know.
 
 ## [2015/endoh3](2015/endoh3/prog.c) ([README.md](2015/endoh3/README.md]))
 
 Cody fixed this to compile with linux which was having a problem with duplicate
-symbols of `main()`. The fix is through the option `-fcommon` which will let it
-compile like it does with macOS.
+symbols of `main()`. The fix is through the compiler option `-fcommon` which
+will let it compile like it does with macOS.
 
 Cody also made it easier to enjoy the theme of [Back to the
 Future](https://en.wikipedia.org/wiki/Back_to_the_Future) using this entry by

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -17,13 +17,13 @@ bug fixes** such as [2001/anonymous](2001/anonymous/README.md) and
 compile with clang, fixing entries to work with macOS (some of which are **very
 complicated** such as [1998/schweikh1](1998/schweikh1/README.md)), fixing code
 to work with both 32-bit and 64-bit (such as
-[2001/herrmann2](2001/herrmann2/README.md)) which can be **quite complicated**
-(though not always even if it seems it), providing alternate code where useful
-or necessary, fixing where possible dead links and otherwise removing them, typo
-and consistency fixes, improving **ALL _Makefiles_** and writing the [sgit
-tool](https://github.com/xexyl/sgit) that we installed locally and have used to
-easily run `sed` on files in the repository to help build the website. Thank
-you **very much** for your extensive efforts in helping improve the IOCCC
+[2001/herrmann2](2001/herrmann2/README.md)) which *can be* **quite complicated
+too** (though not always even if it seems it), providing alternate code where
+useful or necessary, fixing where possible dead links and otherwise removing
+them, typo and consistency fixes, improving **ALL _Makefiles_** and writing the
+[sgit tool](https://github.com/xexyl/sgit) that we installed locally and have
+used to easily run `sed` on files in the repository to help build the website.
+Thank you **very much** for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC winners and making many many past entries work with
 modern systems!
 
@@ -921,20 +921,60 @@ segfault fixes should be made because the program is so beautiful.
 
 ## [1998/schweikh1](1998/schweikh1/schweikh1.c) ([README.md](1998/schweikh1/README.md]))
 
-Cody fixed this for modern systems (it did not work at all). He also made it so
-that if a file fails to open it does not return but rather skips the reading of
-the file. Without this fix the entry did not work.
+Cody fixed this for modern systems (it did not work at all) and added an
+alternate version that works with macOS. Cody also made it ever so slightly more
+portable by removing the hard-coding of `gcc`, instead hard-coding it `cc`. Doing
+this not only lets it work with systems without `gcc` (though in macOS it does
+exist but is actually `clang`) as `cc` always should.
 
-What was wrong? The call to `freopen()` was incorrect with the second arg (the
-mode) being instead `5+__FILE__`. It now is `"r"`. There was also a call to
-`fopen()` that was wrong where the mode was instead `44+__FILE__`. Interestingly
-enough though this did not seem to be an issue though I cannot explain why. He
-notes that it works fine with `clang` as well as `gcc` (which is what is used
-but in macOS - see below for alternate code - `gcc` is clang).
+Getting this entry to work was quite complicated but is also very interesting.
+To see how the macOS fixes works, see the README.md but do note that this
+includes spoilers for both versions! The fixes to get it to work at all are
+described next.
 
-Additionally Cody provided an alternate version for macOS. The fix is
-rather complicated but very interesting. See the README.md file for details on
-how it works and how to use it.
+So what was wrong with the original?
+
+The call to `freopen()` was incorrect with the second arg (the mode) being
+`5+__FILE__`; it is now `"r"`. (Observe that the mode to the `fopen()`
+call is: `44+__FILE__`. This might seem incorrect and indeed it can be changed
+to `"r"` as well but this was not actually necessary so once this was noticed it
+was changed back to the original.)
+
+Another important change is that the files are only closed if the `FILE *H` is
+`!= NULL`. Without this check, because it's almost certain that some files will
+not exist, it would dereference a NULL pointer and very likely crash or halt and
+catch fire :-), preventing the entry from working. Notice how `H` is a funny
+macro defined as:
+
+```c
+%:define H(x) <st%:%:x##.h>
+```
+
+and yet the `FILE *` can be called `H`! This might or might not make sense to
+you but if it doesn't can you figure out why?
+
+Another fix is that previously the program would `return 1` if a file failed to
+open but for the same reason as above, it being very likely some files will not
+exist, the return was removed so that if the statement of the `if` is true the
+`while` loop run, rather than having the loop by itself. It was done this way to
+make it as close to the original as possible and to maintain the obfuscation as
+close as possible as well.
+
+Also crucial, and the final fixes to make it work, is that the arrays `K` and
+`L` had to be increased in size. They were originally (somewhat bewildering at
+first glance) defined as `K[X(*)], L[X(<<)]` but they were changed to
+`K[(X(*))*4], L[4*X(<<)]` though it is no longer clear just how necessary this
+might be.
+
+As noted, a limitation of `gcc` existing was removed by Cody to make it so that
+`gcc` is not required as `cc` should exist in every system with a C compiler and
+as the author stated: as long as the options `-E -dM` of the compiler prints out
+the macros in the form of `gcc -dM` i.e. the lines are in the form `#define
+MACRO value` it will work, assuming that compiler can run, of course.
+
+As for the version for macOS, the even more complicated details are described in
+the [Alternate code](1998/schweikh1/README#alternate-code) section of the
+README.md file as these changes pertain to the described version therein.
 
 
 ## [1998/schweikh2](1998/schweikh2/schweikh2.c) ([README.md](1998/schweikh2/README.md]))


### PR DESCRIPTION

This is based on the author's remarks and it theoretically will work 
with Microsoft Windows compilers (assuming that anything works with 
Windows, of course :-) ). It's not been tested because I'm blessed
enough to not have a way to test it but it should be fine unless
something has changed since 2014.

As I was updating the thanks file I made a simple clarification for
another entry as well but it has no relation to this commit - it's just
in the way because I saw it and wanted to fix it and since it's not
anything other than slight rewording I don't see that it needs a
separate commit.