### PR TITLE
Mass typo fix in Makefiles

### DIFF
--- a/1984/anonymous/Makefile
+++ b/1984/anonymous/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1984/laman/Makefile
+++ b/1984/laman/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -193,7 +193,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1985/applin/Makefile
+++ b/1985/applin/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/applin/Makefile
+++ b/1986/applin/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/august/Makefile
+++ b/1986/august/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/bright/Makefile
+++ b/1986/bright/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/hague/Makefile
+++ b/1986/hague/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/holloway/Makefile
+++ b/1986/holloway/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/pawka/Makefile
+++ b/1986/pawka/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/stein/Makefile
+++ b/1986/stein/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/biggar/Makefile
+++ b/1987/biggar/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/hines/Makefile
+++ b/1987/hines/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/korn/Makefile
+++ b/1987/korn/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -195,7 +195,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -197,7 +197,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -209,7 +209,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/isaak/Makefile
+++ b/1988/isaak/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/litmaath/Makefile
+++ b/1988/litmaath/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/phillipps/Makefile
+++ b/1988/phillipps/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/reddy/Makefile
+++ b/1988/reddy/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/robison/Makefile
+++ b/1988/robison/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/fubar/Makefile
+++ b/1989/fubar/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/jar.2/Makefile
+++ b/1989/jar.2/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/paul/Makefile
+++ b/1989/paul/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/robison/Makefile
+++ b/1989/robison/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/roemer/Makefile
+++ b/1989/roemer/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -195,7 +195,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/vanb/Makefile
+++ b/1989/vanb/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -206,7 +206,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/cmills/Makefile
+++ b/1990/cmills/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/dds/Makefile
+++ b/1990/dds/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/dg/Makefile
+++ b/1990/dg/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -195,7 +195,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/pjr/Makefile
+++ b/1990/pjr/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/scjones/Makefile
+++ b/1990/scjones/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -210,7 +210,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/davidguy/Makefile
+++ b/1991/davidguy/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1991/westley/Makefile
+++ b/1991/westley/Makefile
@@ -239,7 +239,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -233,7 +233,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/albert/Makefile
+++ b/1992/albert/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/ant/Makefile
+++ b/1992/ant/Makefile
@@ -197,7 +197,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -217,7 +217,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/imc/Makefile
+++ b/1992/imc/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/lush/Makefile
+++ b/1992/lush/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/ant/Makefile
+++ b/1993/ant/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/dgibson/Makefile
+++ b/1993/dgibson/Makefile
@@ -193,7 +193,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/ejb/Makefile
+++ b/1993/ejb/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/jonth/Makefile
+++ b/1993/jonth/Makefile
@@ -193,7 +193,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/schnitzi/Makefile
+++ b/1993/schnitzi/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1993/vanb/Makefile
+++ b/1993/vanb/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/dodsond1/Makefile
+++ b/1994/dodsond1/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/imc/Makefile
+++ b/1994/imc/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/shapiro/Makefile
+++ b/1994/shapiro/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/smr/Makefile
+++ b/1994/smr/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/dodsond1/Makefile
+++ b/1995/dodsond1/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/dodsond2/Makefile
+++ b/1995/dodsond2/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/esde/Makefile
+++ b/1995/esde/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/heathbar/Makefile
+++ b/1995/heathbar/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/leo/Makefile
+++ b/1995/leo/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/schnitzi/Makefile
+++ b/1995/schnitzi/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/spinellis/Makefile
+++ b/1995/spinellis/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1995/vanschnitz/Makefile
+++ b/1995/vanschnitz/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/august/Makefile
+++ b/1996/august/Makefile
@@ -194,7 +194,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/dalbec/Makefile
+++ b/1996/dalbec/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -193,7 +193,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/huffman/Makefile
+++ b/1996/huffman/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/jonth/Makefile
+++ b/1996/jonth/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/rcm/Makefile
+++ b/1996/rcm/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/schweikh1/Makefile
+++ b/1996/schweikh1/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/schweikh2/Makefile
+++ b/1996/schweikh2/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/bas1/Makefile
+++ b/1998/bas1/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/bas2/Makefile
+++ b/1998/bas2/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/chaos/Makefile
+++ b/1998/chaos/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/df/Makefile
+++ b/1998/df/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/dlowe/Makefile
+++ b/1998/dlowe/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/dorssel/Makefile
+++ b/1998/dorssel/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -128,6 +128,7 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	@echo "NOTE: for macOS use the alternate code through make alt. See README.md for details."
 
 # alternative executable
 #

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -14,8 +14,9 @@ Germany
 make all
 ```
 
-An alternate version for this entry works with macOS. See the Alternate code
-section below for more details.
+There is an alternate version of this entry that will work with macOS. See the
+[Alternate code](#alternate-code) section below for details on how it works and
+how to use it.
 
 
 ## To run:
@@ -24,46 +25,85 @@ section below for more details.
 ./schweikh1
 ```
 
+NOTE: a limitation with the entry was that it required `gcc` but this limitation
+has been removed to make it more portable, requiring only `cc`.
+
 ### Alternate code:
 
-As noted above the alternate version works with macOS but there are some
-important notes as well as a description of how it works (spoilers for the
-original version as well).
+As noted above this entry will not work as it stands for macOS and there are
+some important notes as well as a description of how the fixed version works
+(the details of which are relevant to the original entry that no longer works as
+well as the fixed version but are described in the context of the macOS
+adjustments).
 
-With a MacBook Pro Max with the M1 chip some header files report an
-unsupported architecture and unsupported compiler (error, warning).
-However the defines are still found okay.
+#### macOS changes:
 
-For this alternate version you will need the command line tools which you can
-install like:
+As an aside: if you have a Mac with the Apple chip, some of the header files
+will report an unsupported architecture and unsupported compiler (error,
+warning). This will not make the program abort, however, but even with an Intel
+CPU though, the original entry will not work in macOS as it stands because
+`/usr/include` is hard-coded in the code and macOS does not have it.
+
+Nevertheless, although some of it would not work in other systems where
+`/usr/include` exists, the `#define`s would still be found okay, at least until
+a file was not found (this limitation was removed in both versions, see
+[thanks-for-fixes.md](/thanks-for-fixes.md) for details).
+
+However, as noted, macOS does **not** have `/usr/include` so this would not ever
+work for macOS without some changes, described next. For macOS you will need the
+command line tools installed which can be done like:
 
 ```sh
 sudo xcode-select --install
 ```
 
-Finally as far as how this works if you look at line 55 you see a funny command.
-This goes for both versions. Now the key are two magic numbers, one on a
-different line shortly below the string. In the original the numbers are,
-respectively, 44 and 46.  But how does this work? Well the string is:
+An important point is that the original version hard-coded `gcc` but just like
+the entry, the alternate version has also removed this limitation despite `gcc`
+existing (though it's `clang`) in macOS.
+
+Now as far as how this works if you look at the code of
+[schweikh1.c](schweikh1.c), on line 55 you'll see a funny command (this goes for
+the alternate version as well but a bit different).
+
+Now the key is two magic numbers, one (two of this exist) on a different line shortly below the
+string and the other a couple lines further below.
+
+In the original the numbers are, respectively, 44 and 46, but with the gcc
+limitation removed the numbers now are 43 and 45. But how does this work? Well
+the command is:
 
 ```
 "0gcc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
 ```
 
-The first number means: the length starting from 0 up through the `>`. The
-second number is the same starting point but up through the `\0` which is why
-it's +2. But what happens if only the first number is updated? Most of the
-output will be just `#define` by itself; in the cases where there was text after
-that it was macros that certainly were not defined.  There might have been other
-errors as well.
+which has been changed to be:
 
-This allows for opening the right files. The problem with the macOS is
-`/usr/include` does not exist: instead it's
+```
+"0cc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
+```
+
+Shortly below that you will see, as noted above, the numbers:
+
+```c
+if ((H = fopen (__FILE__+43, 43+__FILE__)))
+while ((fgets (L, (int)sizeof L, H)) != 0) {
+	I[strcspn (I, 45+__FILE__)] = O = 0;
+```
+
+The first number in the above C means the length starting from 0 up through the
+`>`. The second number is the same starting point but up through the `\0` which
+is why it's `+2`. But what happens if only the first number is updated (from the
+original)? Most of the output will be just `#define` by itself; in the cases
+where there was text after that it was macros that certainly were not defined.
+There might have been other errors as well.
+
+Changing this for macOS allows for opening the right files; the problem with the
+macOS is `/usr/include` does not exist: instead it's
 `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include` which is why
-the different command line and the different numbers.
+the different command line and the different numbers. The change of the numbers
+can be found in the alternate code and the explanation is the same.
 
 To use this version use:
-
 
 ```sh
 make alt
@@ -71,13 +111,14 @@ make alt
 
 Use `schweikh1.alt` as you would `schweikh1` above.
 
+Bonus exercise: modify the code to provide a different compiler.
 
 ## Judges' remarks:
 
 What does it do?  It seems to print a list of system headers, perhaps
 with words after them.  Curiously, if you look at the list of words
 defined in a given standard header, they are never printed directly
-after that header's name.  Ah-hah!  It's a conformance test for the
+after that header's name.  Aha!  It's a conformance test for the
 standard headers.
 
 This code is a wonder; it's a wonder that it compiles.  I wonder
@@ -90,15 +131,17 @@ Do not read them if you want to figure this out yourself.  "Amendment
 One" refers to "NA1", the add-on to C89 which added some fairly
 crufty internationalization support.
 
-NOTE: Some non-gcc compilers that are not fully ANSI standard do not
-compile this entry correctly.  Using cc by default is not helpful
-most of the time on this entry, because the program has a hardcoded
+#### Historical note:
+
+Some non-gcc compilers that were not fully ANSI standard did not
+compile this entry correctly.  Using cc by default was not helpful
+most of the time on this entry, because the program had a hardcoded
 gcc invocation anyway.  Anyone who uses egcs and has no plain gcc
 will need to frob the source anyway and can be expected to do the
-right thing with `${CC}`. So use gcc.
+right thing with `${CC}`. So one should have used gcc.
 
 
-## Author's remarks
+## Author's remarks:
 
 Important! This program, if it compiles at all, is mis-compiled by many
 compilers due to compiler bugs. It could be the "least likely

--- a/1998/schweikh1/schweikh1.alt.c
+++ b/1998/schweikh1/schweikh1.alt.c
@@ -3,9 +3,9 @@
 /*#include H(dlib)*/
 /*#include H(ring)*/
 
-#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
-#define X(x) __LINE__ x __LINE__
-#define t(a)\
+#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
+#define X(x) __LINE__ x __LINE__
+#define t(a)\
 for (c = 0; c <n##a; ++c) { \
   if (strchr (a[c], 0[__FILE__])) { if (*a[c] == 0[__FILE__]) { \
       if (strcmp (a[c]+__LINE__, I + strlen (I) + __LINE__ - strlen (a[c]) x else { \
@@ -16,11 +16,11 @@ for (c = 0; c <n##a; ++c) { \
 	int
 main (int C, char **V)
 {
-	FILE *G;
+	FILE *H;
 	int c, ne, nn, S = C < 2 ? 060 : *V[1];
 
 	char f[__LINE__][X(*)], K[(X(*))*4], L[4*X(<<)],
-	e[X(<<)][3*__LINE__], n[X(<<)][3*__LINE__], F[__LINE__];
+	e[X(<<)][3*__LINE__], n[X(<<)][4*__LINE__], F[__LINE__];
 
 	if (freopen (__FILE__, "r", stdin) == 0) return __LINE__-13;
 	for (c = 0;;) {
@@ -52,17 +52,17 @@ O:
 #line				8 "<%s>:\n"
 				char *I = L + __LINE__;
 				int O = printf (__FILE__, n[nn]) +
-#line				2 "0gcc -ansi -E -dM -undef %s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/%s>r\0 ("
+#line				2 "0cc -ansi -E -dM -undef %s /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/%s>r\0 ("
 				sprintf (K, 1+__FILE__, f[S-*__FILE__] + __LINE__, n[nn]);
 				O += system (K);
-				if ((G = fopen (__FILE__+95, "r")))
-				while ((fgets (L, (int)sizeof L, G)) != 0) {
-					I[strcspn (I, 97+__FILE__)] = O = 0;
+				if ((H = fopen (__FILE__+94, __FILE__+94)))
+				while ((fgets (L, (int)sizeof L, H)) != 0) {
+					I[strcspn (I, 96+__FILE__)] = O = 0;
 #line					1 "*r"
 					t (n) t (e)
 					if (0 == O) O = puts (L);
 				}
-				if (G != NULL) nn = fclose (G);
+				if (H != NULL) nn = fclose (H);
 			}
 		}
 	}

--- a/1998/schweikh1/schweikh1.c
+++ b/1998/schweikh1/schweikh1.c
@@ -3,9 +3,9 @@
 /*#include H(dlib)*/
 /*#include H(ring)*/
 
-#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
-#define X(x) __LINE__ x __LINE__
-#define t(a)\
+#define x ) == 0 ?__LINE__:0){O =__LINE__;break;} }
+#define X(x) __LINE__ x __LINE__
+#define t(a)\
 for (c = 0; c <n##a; ++c) { \
   if (strchr (a[c], 0[__FILE__])) { if (*a[c] == 0[__FILE__]) { \
       if (strcmp (a[c]+__LINE__, I + strlen (I) + __LINE__ - strlen (a[c]) x else { \
@@ -16,7 +16,7 @@ for (c = 0; c <n##a; ++c) { \
 	int
 main (int C, char **V)
 {
-	FILE *G;
+	FILE *H;
 	int c, ne, nn, S = C < 2 ? 060 : *V[1];
 
 	char f[__LINE__][X(*)], K[(X(*))*4], L[4*X(<<)],
@@ -52,17 +52,17 @@ O:
 #line				8 "<%s>:\n"
 				char *I = L + __LINE__;
 				int O = printf (__FILE__, n[nn]) +
-#line				2 "0gcc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
+#line				2 "0cc -ansi -E -dM -undef %s /usr/include/%s>r\0 ("
 				sprintf (K, 1+__FILE__, f[S-*__FILE__] + __LINE__, n[nn]);
 				O += system (K);
-				if ((G = fopen (__FILE__+44, "r")))
-				while ((fgets (L, (int)sizeof L, G)) != 0) {
-					I[strcspn (I, 46+__FILE__)] = O = 0;
+				if ((H = fopen (__FILE__+43, 43+__FILE__)))
+				while ((fgets (L, (int)sizeof L, H)) != 0) {
+					I[strcspn (I, 45+__FILE__)] = O = 0;
 #line					1 "*r"
 					t (n) t (e)
 					if (0 == O) O = puts (L);
 				}
-				if (G != NULL) nn = fclose (G);
+				if (H != NULL) nn = fclose (H);
 			}
 		}
 	}

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/1998/tomtorfs/Makefile
+++ b/1998/tomtorfs/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/anderson/Makefile
+++ b/2000/anderson/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/bellard/Makefile
+++ b/2000/bellard/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/bmeyer/Makefile
+++ b/2000/bmeyer/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/dhyang/Makefile
+++ b/2000/dhyang/Makefile
@@ -212,7 +212,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/dlowe/Makefile
+++ b/2000/dlowe/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/jarijyrki/Makefile
+++ b/2000/jarijyrki/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/natori/Makefile
+++ b/2000/natori/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/primenum/Makefile
+++ b/2000/primenum/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/rince/Makefile
+++ b/2000/rince/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/robison/Makefile
+++ b/2000/robison/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/schneiderwent/Makefile
+++ b/2000/schneiderwent/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -195,7 +195,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2000/tomx/Makefile
+++ b/2000/tomx/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/README.md
+++ b/2001/README.md
@@ -20,7 +20,7 @@ systems the Makefile needs to be changed.  See the Makefile for details.
 
 Read over the Makefile for compile/build issues.  Your system may
 require certain changes (add or remove a library, add or remove a
-#define).
+`#define` i.e. the `-D` flag).
 
 Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
@@ -32,60 +32,57 @@ local compiler.
 There were some outstanding entries that did not win.  Unfortunately
 some very good entries lost because they:
 
-    + depended too much on non-portable side effects in expressions;
-    + depended too much on a particular byte order;
-    + required the use of a special script, data file or pseudo-machine
-      language that was not supplied with the entry.
+- depended too much on non-portable side effects in expressions;
+- depended too much on a particular byte order;
+- required the use of a special script, data file or pseudo-machine
+  language that was not supplied with the entry.
 
 We hope the authors of some of those entries will fix and re-submit
 them for the next IOCCC.
 
-We believe you will be impressed with this year's winners.  The Best of Show
-is a fine example of obfuscation.  But don't ignore the other winners!
-There are games, programs that speak, ones that compile code and one that
-might run binaries you already have!
+We believe you will be impressed with this year's winners.  The [Best of
+Show](ollinger/README.md) is a fine example of obfuscation.  But don't ignore
+the other winners!  There are games, programs that speak, ones that compile code
+and [one that might run binaries you already have](2001/anonymous/README.md).
 
-The Worst Abuse of the Rules is technically allowed by the rules.  This year
-we awarded it again, but don't assume you can get away with using the same
-technique next time ... :-)
+The [Best/Worst Abuse of the Rules](bellard/README.md) is technically allowed by the
+[rules](rules.txt).  This year we awarded it again, but don't assume you can get
+away with using the same technique next time ... :-)
 
 This year there were several repeat winners.  This is understating the
-achievement a little - one person has won 8 times before!  (Please note that
-judging is done completely anonymously).
+achievement a little - [one
+person](https://www.ioccc.org/winners.html#Brian_Westley) has won 8 times
+before! (Please note that judging is done completely anonymously.)
 
 
-Why has it taken so long to post the winning source?
-----------------------------------------------------
+## Why has it taken so long to post the winning source?
 
-This is somewhat my (Simon Cooper) fault.  I do apologize to the IOCCC
+This is somewhat my (Simon Cooper's) fault.  I do apologize to the IOCCC
 community for this!  Judging does take quite a lot of time, and I
 over-committed myself several times this year.  Without divulging too much,
 we do look at and work out what every entry does.
 
 
-Final Comments
---------------
+## Final Comments
 
 Please send us comments and suggestions what we have expressed above.
 Also include anything else that you would like to see in future contests.
 Send such email to:
 
-	questions@ioccc.org
+```
+questions@ioccc.org
+```
 
 If you use, distribute or publish these entries in some way, please drop
 us a line.  We enjoy seeing who, where and how the contest is used.
 
-You must include the words ``ioccc question'' in the subject of your email
+You must include the words 'ioccc question' in the subject of your email
 message when sending email to the judges.
 
 If you have problems with any of the entries, AND YOU HAVE A FIX, please
 email the fix (patch file or the entire changed file) to the above address.
 
-Watch:
-
-	https://www.ioccc.org/
-
-for news of the next contest.
+Watch <https://www.ioccc.org/> for news of the next contest.
 
 =-=
 

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -237,7 +237,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/cheong/Makefile
+++ b/2001/cheong/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/dgbeards/Makefile
+++ b/2001/dgbeards/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/herrmann1/Makefile
+++ b/2001/herrmann1/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/jason/Makefile
+++ b/2001/jason/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/ollinger/Makefile
+++ b/2001/ollinger/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/rosten/Makefile
+++ b/2001/rosten/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/schweikh/Makefile
+++ b/2001/schweikh/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -203,7 +203,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/anonymous/Makefile
+++ b/2004/anonymous/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/arachnid/Makefile
+++ b/2004/arachnid/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/gavin/Makefile
+++ b/2004/gavin/Makefile
@@ -212,7 +212,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/hibachi/Makefile
+++ b/2004/hibachi/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/hoyle/Makefile
+++ b/2004/hoyle/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/kopczynski/Makefile
+++ b/2004/kopczynski/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/newbern/Makefile
+++ b/2004/newbern/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/omoikane/Makefile
+++ b/2004/omoikane/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/schnitzi/Makefile
+++ b/2004/schnitzi/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/sds/Makefile
+++ b/2004/sds/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/vik1/Makefile
+++ b/2004/vik1/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2004/vik2/Makefile
+++ b/2004/vik2/Makefile
@@ -211,7 +211,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/aidan/Makefile
+++ b/2005/aidan/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/anon/Makefile
+++ b/2005/anon/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/boutines/Makefile
+++ b/2005/boutines/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/chia/Makefile
+++ b/2005/chia/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -194,7 +194,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/jetro/Makefile
+++ b/2005/jetro/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/klausler/Makefile
+++ b/2005/klausler/Makefile
@@ -205,7 +205,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/mikeash/Makefile
+++ b/2005/mikeash/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/mynx/Makefile
+++ b/2005/mynx/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/timwi/Makefile
+++ b/2005/timwi/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/toledo/Makefile
+++ b/2005/toledo/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/vik/Makefile
+++ b/2005/vik/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2005/vince/Makefile
+++ b/2005/vince/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/birken/Makefile
+++ b/2006/birken/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/borsanyi/Makefile
+++ b/2006/borsanyi/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/grothe/Makefile
+++ b/2006/grothe/Makefile
@@ -181,7 +181,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/hamre/Makefile
+++ b/2006/hamre/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/meyer/Makefile
+++ b/2006/meyer/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/night/Makefile
+++ b/2006/night/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/stewart/Makefile
+++ b/2006/stewart/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/sykes1/Makefile
+++ b/2006/sykes1/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/sykes2/Makefile
+++ b/2006/sykes2/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/toledo1/Makefile
+++ b/2006/toledo1/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2006/toledo3/Makefile
+++ b/2006/toledo3/Makefile
@@ -194,7 +194,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -207,7 +207,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/blakely/Makefile
+++ b/2011/blakely/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/borsanyi/Makefile
+++ b/2011/borsanyi/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/dlowe/Makefile
+++ b/2011/dlowe/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/eastman/Makefile
+++ b/2011/eastman/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/fredriksson/Makefile
+++ b/2011/fredriksson/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/goren/Makefile
+++ b/2011/goren/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/hamaji/Makefile
+++ b/2011/hamaji/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/hou/Makefile
+++ b/2011/hou/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/konno/Makefile
+++ b/2011/konno/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/richards/Makefile
+++ b/2011/richards/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/toledo/Makefile
+++ b/2011/toledo/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/vik/Makefile
+++ b/2011/vik/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2011/zucker/Makefile
+++ b/2011/zucker/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/blakely/Makefile
+++ b/2012/blakely/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/deckmyn/Makefile
+++ b/2012/deckmyn/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/dlowe/Makefile
+++ b/2012/dlowe/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -203,7 +203,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/endoh2/Makefile
+++ b/2012/endoh2/Makefile
@@ -343,7 +343,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/grothe/Makefile
+++ b/2012/grothe/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/hou/Makefile
+++ b/2012/hou/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/konno/Makefile
+++ b/2012/konno/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/tromp/Makefile
+++ b/2012/tromp/Makefile
@@ -195,7 +195,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/cable1/Makefile
+++ b/2013/cable1/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/cable2/Makefile
+++ b/2013/cable2/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/cable3/Makefile
+++ b/2013/cable3/Makefile
@@ -196,7 +196,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/dlowe/Makefile
+++ b/2013/dlowe/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -59,7 +59,7 @@ rm 1.txt 2.txt
 
 ## INABIAF - it's not a bug it's a feature! :-)
 
-This program will very likely crash or draw something funny with 0 args. Then
+This program will possibly crash or draw something funny with 0 args. Then
 again it might not. :-) This is not a bug and should NOT be fixed.
 
 Ask yourself the following questions: when will it crash, when will it draw

--- a/2013/endoh1/Makefile
+++ b/2013/endoh1/Makefile
@@ -197,7 +197,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -81,6 +81,7 @@ The usage is simple: you just have to wrap Lazy K program with `#include
 [2]: https://tromp.github.io/cl/lazy-k.html
 [3]: https://github.com/irori/lazyk
 [4]: http://en.wikipedia.org/wiki/Polyglot_%28computing%29
+
 ### Obfuscation
 
 ... is inherent in SKI combinator calculus :-)

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -225,7 +225,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -32,13 +32,24 @@ There are also some other musical samples, twinkle.abc and menuet.abc.
 
 ## Judges' remarks:
 
-This endoh3ram can tweet out a tune and is small enough to tweet.
+This program can toot out a tune that is small enough to posted to most social
+media platforms that have small message length limits.
+
+This endoh3ram can toot out a tune that is small enough.
+
+### A modern day (2023) note about the award 'Most tweetable 1-liner' and twitter:
+
+The IOCCC no longer endorses the use of what was once twitter, or whatever it
+might be called today. We recommend that you pick a responsible social media
+platform to post the program's output on. Nevertheless the award of this entry
+will remain the same for historical purposes.
 
 ## Author's remarks:
 
 ### Remarks
 
-This is a sound synthesizer for a subset of [ABC music notation](http://en.wikipedia.org/wiki/ABC_notation).
+This is a sound synthesizer for a subset of [ABC music
+notation](http://en.wikipedia.org/wiki/ABC_notation).
 
 Try:
 
@@ -54,14 +65,14 @@ as `padsp` or `aoss`:
 echo "CDEFGABc" | ./endoh3 | padsp tee /dev/dsp > /dev/null
 ```
 
-If you are using Mac OS X, try [sox](http://sox.sourceforge.net/):
+If you are using Mac OS X, try [sox](http://sox.sourceforge.net/) like so:
 
 ```sh
 echo "CDEFGABc" | ./endoh3 | sox -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
 ```
 
-If they do not work, use the attached script to convert the output
-into a wave file format:
+If that does not work, use the attached script to convert the output into a wave
+file format:
 
 ```sh
 echo "CDEFGABc" | ./endoh3 | ruby wavify.rb > cde.wav
@@ -69,19 +80,28 @@ echo "CDEFGABc" | ./endoh3 | ruby wavify.rb > cde.wav
 
 and play `cde.wav`.
 
-You can enjoy some music scores that I attached:
+
+You can also enjoy some music scores that I attached. With `/dev/dsp` you can
+do so like:
+
 
 ```sh
 cat twinkle.abc | ./endoh3 > /dev/dsp
 cat menuet.abc | ./endoh3 > /dev/dsp
 ```
 
+but you should be able to modify it a way to meet your system requirements as
+described above.
+
+
 ### Obfuscation
 
-The following sequence of questions may be helpful to understand the endoh3ram.
+The following sequence of questions may be helpful to understand the `endoh3ram`
+program:
 
 - How does it convert ABC notes into the frequency?
-- What is `89/84.`?  I found it by using Stern-Brocot tree.
+- What is `89/84.`?  I found it by using the [Stern-Brocot
+tree](https://en.wikipedia.org/wiki/Stern-Brocot_tree).
 - How does it generate a wave?  Hint: it generates a saw wave.
 
 ### Limitation
@@ -98,7 +118,7 @@ The following features are supported:
   - `A3` (a dotted quarter note)
   - `A4` (a half note)
 
-The following features are *not* supported:
+The following features are *NOT* supported:
 
 - Sharp and flat: `^C` `_C`
   - But it is possible to emit the half tones.  Do you see how?
@@ -110,10 +130,12 @@ The following features are *not* supported:
 
 ### Known Bugs
 
-You can *not* write a note length immediately followed by a note `E`,
+You can *NOT* write a note length immediately followed by a note `E`,
 such as `C2E2`.
-Can you know why?
-You can work it around by inserting a whitespace: `C2 E2`.
+
+Can you figure out why?
+
+A workaround is inserting a whitespace: `C2 E2`.
 
 ### Portability
 
@@ -130,61 +152,70 @@ I did write a score of the Happy Birthday song too.
 (It does not matter because the song is out-of-copyright in my country.)
 But I do not attach it to protect you from W\*\*\*\*r.
 
-For the same reason, do not play a score that contains only `z1092`.
+For the same reason, do not post a score that contains only `z1092`.
 You know, it is ["the famous song"](http://en.wikipedia.org/wiki/4%E2%80%B233%E2%80%B3).
 
-### Spoiler (rot13)
+### Spoiler
 
-Urer vf n zntvpny rkcerffvba juvpu V sbhaq ol oehgr-sbepr:
+Here is a magical expression which I found by brute-force:
 
 ```c
-(p % 32 + 5) * 9 / 5 % 13 + a / 32 * 12 - 22
+(c % 32 + 5) * 9 / 5 % 13 + n / 32 * 12 - 22
 ```
 
-Vagrerfgvatyl, vg pbairegf na NFPVV ahzore bs NOP abgrf
-gb gur pbeerfcbaqvat gbar ahzore.
+Interestingly, it converts an ASCII number of ABC notes
+to the corresponding tone number.
 
-    'P' (NFPVV  67) =>  3
-    'Q' (NFPVV  68) =>  5
-    'R' (NFPVV  69) =>  7
-    'S' (NFPVV  70) =>  9
-    'T' (NFPVV  71) => 10
-    'N' (NFPVV  65) => 12
-    'O' (NFPVV  66) => 14
-    'p' (NFPVV  99) => 15
-    'q' (NFPVV 100) => 17
-    'r' (NFPVV 101) => 19
-    's' (NFPVV 102) => 20
-    't' (NFPVV 103) => 22
-    'n' (NFPVV  97) => 24
-    'o' (NFPVV  98) => 26
+```
+'C' (ASCII  67) =>  3
+'D' (ASCII  68) =>  5
+'E' (ASCII  69) =>  7
+'F' (ASCII  70) =>  9
+'G' (ASCII  71) => 10
+'A' (ASCII  65) => 12
+'B' (ASCII  66) => 14
+'c' (ASCII  99) => 15
+'d' (ASCII 100) => 17
+'e' (ASCII 101) => 19
+'f' (ASCII 102) => 20
+'g' (ASCII 103) => 22
+'a' (ASCII  97) => 24
+'b' (ASCII  98) => 26
+```
 
-Ol gur jnl, lbh pna jevgr n unys-gbar ol gur sbyybjvat punenpgref.
+By the way, you can write a half-tone by the following characters.
 
-    'X' =>  4 (= P#)
-    'Y' =>  6 (= Q#)
-    'H' =>  8 (= S#)
-    'I' => 11 (= T#)
-    'C' => 13 (= N#)
+```
+'K' =>  4 (= C#)
+'L' =>  6 (= D#)
+'U' =>  8 (= F#)
+'V' => 11 (= G#)
+'P' => 13 (= A#)
+```
 
-Abgr gung gur gbar ahzoref fvzcyl rahzrengr gur frzv-gbar fgrcf.
-Fb jr pna pnyphyngr gur serdhrapl rnfvyl: `cbj(2, a / 12.0)`.
-Gura, ubj pna jr pnyphyngr `cbj` jvgubhg `zngu.u`?
-`cbj(2, 1.0 / 12.0)` vf nccebkvzngrq ol `89/84.`.
-(V sbhaq guvf nccebkvzngvba ol hfvat [Fgrea-Oebpbg gerr](uggc://ra.jvxvcrqvn.bet/jvxv/Fgrea%R2%80%93Oebpbg_gerr).)
-Jr pna tnva gur serdhrapl ol zhygvcylvat gur inyhr `a` gvzrf.
+Note that the tone numbers simply enumerate the semi-tone steps.  So we can
+calculate the frequency easily: `pow(2, n / 12.0)`.  Then, how can we calculate
+`pow` without `math.h`?  `pow(2, 1.0 / 12.0)` is approximated by `89/84.`.  (I
+found this approximation by using the [Stern-Brocot
+tree](http://en.wikipedia.org/wiki/Stern%E2%80%93Brocot_tree).) We can gain the
+frequency by multiplying the value by `n` times.
 
-Svanyyl, gur sbyybjvat pbqr trarengrf n fnj jnir:
+Finally, the following code generates a saw wave:
 
-    sbe(p = 0; p < yra; p++) chgpune(n = a * Q);
+```c
+for(c = 0; c < len; c++) putchar(a = n * D);
+```
 
-jurer `Q` vf n serdhrapl naq `n` vf n inevnoyr jubfr glcr vf pune.
-Ol nffvtavat sybng gb pune inevnoyr, gur vzcyvpvg glcr pbairegvba vf cresbezrq sebz sybng gb pune (zbqhyb 256).
-(Fgevpgyl fcrnxvat, guvf orunivbe vf haqrsvarq nppbeqvat gb 6.3.1.4 va P99;
-lbh pna ercynpr vg jvgu `(ybat)(a*Q)` vs lbh ner crqnagvp.)
+where `D` is a frequency and `a` is a variable whose type is char.  By assigning
+float to char variable, the implicit type conversion is performed from float to
+char (modulo 256).
 
-Nyy gung jnf yrsg jnf gb pbzovar naq pbaqrafr gur pbzcbaragf.
-Gur xrl vf fdhnfuvat gurz vagb whfg bar sbe-ybbc.
+(Strictly speaking, this behavior is undefined according to 6.3.1.4 in C99; you
+can replace it with `(long)(n*D)` if you are pedantic.)
+
+All that was left was to combine and condense the components.  The key is
+squashing them into just one for-loop.
+
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/mills/Makefile
+++ b/2013/mills/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -260,7 +260,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/misaka/README.md
+++ b/2013/misaka/README.md
@@ -1,8 +1,8 @@
 # Most catty
 
-    Don Yang  
-    <omoikane@uguu.org>  
-    <http://uguu.org/>  
+Don Yang<br>
+<omoikane@uguu.org><br>
+<http://uguu.org/>  
 
 ## To build:
 
@@ -10,7 +10,8 @@
 make
 ```
 
-This will build a bunch of versions of the code. See the author's details for information on all of these builds.
+This will build a bunch of versions of the code. See the author's details for
+information on all of these builds.
 
 ## To run:
 
@@ -42,6 +43,12 @@ seq 1 12 | ./horizontal_cat - - -
 seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c
 ```
 
+Alternately you can just try:
+
+```sh
+./demo.sh
+```
+
 NOTE: Use - for standard input.  For example:
 
 ```sh
@@ -50,31 +57,32 @@ NOTE: Use - for standard input.  For example:
 
 ## Judges' remarks:
 
-There is more to cat than [mere cats](http://cheezburger.com/1680494336).  
-Be they tall, fat, long or squat, this source code is sure to amuse.
+There is more to cat than [mere cats](http://cheezburger.com/1680494336).  Be
+they tall, fat, long or squat, this source code is sure to amuse.
 
 #### Slight diversion
 
 While one of the judges was reviewing this entry on the stern of the 
 [Island Sky](http://www.noble-caledonia.co.uk/information/detail.asp?id=2&spid=76)
-in the middle of the Atlantic Ocean waiting the
+in the middle of the Atlantic Ocean waiting for the
 [total solar eclipse of 2013](http://en.wikipedia.org/wiki/Solar_eclipse_of_November_3,_2013)
-the judge was stuck by a
+the judge was struck by a
 [flying fish](http://en.wikipedia.org/wiki/Flying_fish).
-While result the impact was that the
-[Port](http://en.wikipedia.org/wiki/Port_wine) from Portugal was lost, the
-[Grog](http://www.travelforpassion.com/grog-factory-cape-verde-santo-antao-cape-verde-1602-photo) from Cape Verde
-and the laptop containing this entry was saved.
+While the result of the impact was that the
+[Port](http://en.wikipedia.org/wiki/Port_wine) from Portugal was lost, but the
+[Grog](https://web.archive.org/web/20130702003043/http://www.travelforpassion.com/grog-factory-cape-verde-santo-antao-cape-verde-1602-photo)
+from Cape Verde and the laptop containing this entry was saved.
 
-While I'm sure most cats would have preferred otherwise,
-the flying fish was returned to *em*swim with the fishes*em*. :-)
-No cats were harmed in the process of judging this entry.
+While I'm sure most [cats](https://rationalwiki.org/wiki/Fun:Cat) would have
+preferred otherwise, the flying fish was returned to *swim with the fishes*. :-)
+No [cats](https://rationalwiki.org/wiki/Fun:Cat) were harmed in the process of
+judging this entry.
 
 ## Author's remarks:
 
 ### Overview
 
-Misaka is a file concatenation utility, with at least two modes of
+`Misaka` is a file concatenation utility, with at least two modes of
 operation:
 
 ```sh
@@ -86,16 +94,17 @@ cc misaka2.c -o vertical_cat
 ./vertical_cat [files...] > [output]
 ```
 
-Where [files...] are a list of text file names.  Use "-" to read from stdin.
+Where `[files...]` are a list of text file names.  Use `-` to read from stdin.
 
 ### Details
 
 ### Horizontal cat
 
-One of my favorite unix utilities is *cat*.  The best thing about it was
-that it was named "cat".  That, and it's useful for quickly showing contents
-of a file.  Though it was primary meant for concatenating files, that
-function only seem to work if I wanted to concatenate files vertically.
+One of my favorite unix utilities is `cat`.  The best thing about it was that it
+was named "[cat](https://rationalwiki.org/wiki/Fun:Cat)".  That, and it's useful
+for quickly showing contents of a file.  Though it was primary meant for
+concatenating files, that function only seem to work if I wanted to concatenate
+files vertically.
 
 I thought the lack of horizontal concatenation must have been an oversight,
 so I implemented this utility:
@@ -105,15 +114,15 @@ cc misaka.c -o horizontal_cat
 ./horizontal_cat files...
 ```
 
-*horizontal_cat* concatenates files horizontally and write the output to
-stdout.  Each input file is padded with spaces on the right so that the
+`horizontal_cat` concatenates files horizontally and write the output to
+`stdout`.  Each input file is padded with spaces on the right so that the
 original text alignments are preserved.
 
-If "-" is specified as a file name, *horizontal_cat* will read from stdin.
-Unlike *cat*, *horizontal_cat* loads all input to memory first.  Thus you
-can specify "-" multiple times to get stdin multiplied horizontally.  For
-example, if you have seq(1) in your shell, you can add line numbers to both
-sides of misaka.c like this:
+If `-` is specified as a file name, `horizontal_cat` will read from `stdin`.
+Unlike `cat`, `horizontal_cat` loads all input to memory first.  Thus you
+can specify `-` multiple times to get stdin multiplied horizontally.  For
+example, if you have `seq(1)` in your shell, you can add line numbers to both
+sides of [misaka.c](misaka.c) like this:
 
 ```sh
 seq -f '  %.0f  ' 45 | ./horizontal_cat - misaka.c -
@@ -121,12 +130,12 @@ seq -f '  %.0f  ' 45 | ./horizontal_cat - misaka.c -
 
 ### Vertical cat
 
-Because *horizontal_cat* must know the maximum width of all files before
+Because `horizontal_cat` must know the maximum width of all files before
 writing any output, all files must be processed at least twice.  To support
-stdin, file must be buffered to memory.  This lead to the feature that
-*horizontal_cat* can be used to duplicate stdin.
+`stdin`, file must be buffered to memory.  This lead to the feature that
+`horizontal_cat` can be used to duplicate `stdin`.
 
-Seems like the stdin doubling feature might be useful even for concatenating
+Seems like the `stdin` doubling feature might be useful even for concatenating
 files vertically, so I included a vertical mode.  But supporting vertical
 mode with command line options would be no fun.  Instead, vertical mode is
 enabled by concatenating the source code horizontally:
@@ -137,8 +146,8 @@ gcc misaka2.c -o vertical_cat
 ./vertical_cat files...
 ```
 
-*vertical_cat* works more or less like *cat*, except you can use
-*vertical_cat* to duplicate stdin:
+`vertical_cat` works more or less like `cat`, except you can use
+`vertical_cat` to duplicate `stdin`:
 
 ```sh
 ./vertical_cat - -
@@ -146,9 +155,10 @@ gcc misaka2.c -o vertical_cat
 
 ### Long cat
 
-After *horizontal_cat* and *vertical_cat*, I thought, maybe all I really
-wanted was just more cats.  So I implemented one more mode, this one is
-enabled by concatenating misaka.c vertically:
+After `horizontal_cat` and `vertical_cat`, I thought, maybe all I really wanted
+was just more [cats](https://rationalwiki.org/wiki/Fun:Cat).  So I implemented
+one more mode, this one is enabled by concatenating [misaka.c](misaka.c)
+vertically:
 
 ```sh
 ./vertical_cat misaka.c misaka.c > misaka3.c
@@ -156,9 +166,9 @@ gcc misaka3.c -o long_cat
 ./long_cat
 ```
 
-*long_cat* outputs ASCII art of a cat to stdout.  You can make this cat
+`long_cat` outputs ASCII art of a cat to `stdout`.  You can make this cat
 exponentially longer by concatenating more files vertically (up to 31 levels
-high, depending on sizeof(int) for your compiler):
+high, depending on `sizeof(int)` for your compiler):
 
 ```sh
 ./vertical_cat misaka.c misaka.c misaka.c > misaka4.c
@@ -190,9 +200,10 @@ triangle like the following will not have horizontally expanded output:
 gcc misaka9.c -o same_as_long_cat
 ```
 
-Finally, if you lost track of how many misaka.c you have stacked together,
-you can feed the source to a brainfuck interpreter to get a overview of how
-the programs are stacked.  Example:
+Finally, if you lost track of how many [misaka.c](misaka.c) you have stacked
+together, you can feed the source to a
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) interpreter to get an
+overview of how the programs are stacked.  Example:
 
 ```sh
 perl bf.pl misaka9.c
@@ -200,43 +211,44 @@ perl bf.pl misaka9.c
 
 This outputs:
 
-    MISAKA
-    MISAKA MISAKA
+```
+MISAKA
+MISAKA MISAKA
+```
 
 ### Return value
 
-*horizontal_cat* and *vertical_cat* will exit with zero status on success.
+`horizontal_cat` and `vertical_cat` will exit with zero status on success.
 
-If any input file fails to open, *horizontal_cat* and *vertical_cat* will
-report the offending file name to stdout, and exit with nonzero status.
+If any input file fails to open, `horizontal_cat` and `vertical_cat` will
+report the offending file name to `stdout`, and exit with nonzero status.
 
-If *horizontal_cat* and *vertical_cat* ran out of memory, they will exit
+If `horizontal_cat` and `vertical_cat` ran out of memory, they will exit
 with nonzero status without outputting anything.
 
 ### Compatibility
 
-*horizontal_cat* makes the following assumptions about input files:
+`horizontal_cat` makes the following assumptions about input files:
 
-   * ASCII with LF end of line sequences.  If CR-LF sequences are used, CR
-     characters will appear in the middle of output lines.
-   * All characters are of equal width, even tab characters.
+* ASCII with LF end of line sequences.  If CR-LF sequences are used, CR
+ characters will appear in the middle of output lines.
+* All characters are of equal width, even tab characters.
 
-Misaka has been verified to work on these following compiler+OS
-combinations:
+`Misaka` has been verified to work on these following compiler+OS combinations:
 
-   * gcc 4.6.3 on Linux 3.5.0-41
-   * gcc 4.4.5 on Linux 2.6.32-5
-   * gcc 4.3.5 on JS/Linux 2.6.20
-   * gcc 4.8.1 on Windows (Cygwin and MingW)
+* gcc 4.6.3 on Linux 3.5.0-41
+* gcc 4.4.5 on Linux 2.6.32-5
+* gcc 4.3.5 on JS/Linux 2.6.20
+* gcc 4.8.1 on Windows (Cygwin and MingW)
 
-Misaka requires a C99 compiler due to the use of single line comments.
-Misaka does not depend on any other C99 features.
+`Misaka` requires a C99 compiler due to the use of single line comments.
+`Misaka` does not depend on any other C99 features.
 
 ### Obfuscation
 
 Main obfuscation is in having a C program that compiles when tiled
 horizontally and vertically, while using single line comments in less than
-half of the lines.  *And* maintaining a meaningful layout while doing that.
+half of the lines *and* maintaining a meaningful layout while doing that.
 
 There are other challenges too, of course, like getting a Brainfuck program
 to tile horizontally and vertically.  Really, tiling code of any sort
@@ -245,12 +257,12 @@ once.
 
 Other features to look for:
 
-   * Peculiar bits that switches horizontal cat to vertical cat.
-   * Run-length encoded long cat.
-   * Symmetric and recycled variable names.
-   * CRC of the source code in the source code.
+* Peculiar bits that switches horizontal cat to vertical cat.
+* Run-length encoded long cat.
+* Symmetric and recycled variable names.
+* CRC of the source code in the source code.
 
-"gcc -Wall" should provide a hint to where the mode switch happens, it
+`gcc -Wall` should provide a hint to where the mode switch happens, it
 does not output any irrelevant other warnings (verified on 4.6.3).
 
 ### Extra files
@@ -258,16 +270,16 @@ does not output any irrelevant other warnings (verified on 4.6.3).
 Extra files included in my submission are informational only, they are not
 needed for the program to work.
 
-   * bf.pl = a brainfuck interpreter, in case if you don't have one handy.
-   * spoiler.html = making of this program.
+* [bf.pl](bf.pl) - a brainfuck interpreter, in case you don't have one handy.
+* [spoiler.html](spoiler.html) - making of this program.
 
-### About Misaka
+### About `Misaka`
 
-The name, layout, and functionality of Misaka is inspired by a particular
+The name, layout, and functionality of `Misaka` is inspired by a particular
 stackable figure:
 
-   * [Google images](http://google.co.jp/search?q=%E3%83%9F%E3%82%B5%E3%82%AB%E7%9B%9B%E3%82%8A&tbm=isch)
-   * [Kotobukiya](http://main.kotobukiya.co.jp/figure/tsubucole_tmi_misakamori/)
+* [Google images](http://google.co.jp/search?q=%E3%83%9F%E3%82%B5%E3%82%AB%E7%9B%9B%E3%82%8A&tbm=isch)
+* [Kotobukiya](http://main.kotobukiya.co.jp/figure/tsubucole_tmi_misakamori/)
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2013/misaka/demo.sh
+++ b/2013/misaka/demo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# make sure code compiled
+make all || exit 1
+
+echo "$ seq 1 12 | ./horizontal_cat - - -"
+seq 1 12 | ./horizontal_cat - - -
+sleep 1
+
+echo "$ ./long_cat"
+./long_cat
+sleep 1
+
+echo "$ ./long_faat_cat"
+./long_faat_cat
+sleep 1
+
+echo "$ ./long_fat_cat"
+./long_fat_cat
+sleep 1
+
+echo "$ ./loong_cat"
+./loong_cat
+sleep 1
+
+echo "$ ./loooong_cat"
+./loooong_cat
+sleep 1
+
+echo "$ ./loooooooong_cat"
+./loooooooong_cat
+sleep 1
+
+echo "$ seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c"
+seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c

--- a/2013/morgan1/Makefile
+++ b/2013/morgan1/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/morgan1/README.md
+++ b/2013/morgan1/README.md
@@ -1,7 +1,7 @@
 # Smallest large system simulator
 
-    Yves-Marie Morgan  
-    <yves-marie.morgan@parrot.com>  
+Yves-Marie Morgan<br>
+<yves-marie.morgan@parrot.com>
 
 ## To build:
 
@@ -37,33 +37,36 @@ observing site.
 
 ### Instructions
 
-It displays the position of the 8 planets of the solar system around the sun.
+It displays the position of the 8 planets of the solar system around the Sun.
 The date given in the command line is in the format YYYY/MM/DD (year, month and
 day). The direction keys can be used to move in time :
 
-    Left  : go back 1 day.
-    Right : go forward 1 day.
-    Down  : go back 20 days.
-    Up    : go forward 20 days.
+* Left  : go back 1 day.
+* Right : go forward 1 day.
+* Down  : go back 20 days.
+* Up    : go forward 20 days.
 
-It handles correctly all leap years and the switch between julian calendar and
-gregorian calendar (10 days missing between 1582/10/04 and 1582/10/15).
+It handles correctly all leap years and the switch between [Julian
+calendar](https://en.wikipedia.org/wiki/Julian_calendar) and
+[Gregorian calendar](https://en.wikipedia.org/wiki/Gregorian_calendar) (10 days
+missing between 1582/10/04 and 1582/10/15).
 
 The scale is logarithmic to be able to display the 8 planets without having
-Mercury, Venus, Earth and Mars squizzed around the sun.
+Mercury, Venus, Earth and Mars squeezed around the Sun.
 
-The size is not proportinal either.
+The size is not proportional either.
 
 ### Bonus
 
-It also displays the position of 2 famous comets during their last approach :
-- The first one arround the third IOCCC.
+It also displays the position of 2 famous comets during their last approach:
+
+- The first one around the third IOCCC.
 - The second one between the thirteenth and fourteenth IOCCC.
 
 ### Limitations
 
 * ASCII character set is assumed.
-* a c99 compiler is required (for some math.h functions).
+* A C99 compiler is required (for some `math.h` functions).
 * The position should be correct for years between (-1000; +3000)
 * The approximations done in the formula are OK for displaying the
   position around the sun but not for other applications like ephemeride or
@@ -72,33 +75,40 @@ It also displays the position of 2 famous comets during their last approach :
 ### Obfuscation
 
 * Reuse of 1 letter variables.
-* Only the main function with some for loops.
+* Only the main function with some `for` loops.
 * Constants for orbital elements encoded in a string.
-* Hexadecimal and decimal values used inconsitentely.
-* Comparisons order are not consitent.
+* Hexadecimal and decimal values used inconsistently.
+* Comparisons order are not consistent.
 * A lot of stuff is done in the different parts of the for loop.
 
 ### Compilation warnings
 
-with gcc 4.7.2 on Linux Ubuntu 12.10 :
-* prog.c:38:3: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
-* prog.c:40:34: warning: value computed is not used [-Wunused-value]
-* prog.c:56:6: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
-* prog.c:58:50: warning: value computed is not used [-Wunused-value]
-* prog.c:61:5: warning: suggest parentheses around ‘-’ inside ‘>>’ [-Wparentheses]
+With gcc 4.7.2 on Linux Ubuntu 12.10:
 
-with clang 3.1 on Linux Ubuntu 12.10 :
-* prog.c:38:49: warning: '&&' within '||' [-Wlogical-op-parentheses]
-* prog.c:38:27: warning: '&&' within '||' [-Wlogical-op-parentheses]
-* prog.c:55:13: warning: '&&' within '||' [-Wlogical-op-parentheses]
-* prog.c:56:14: warning: '&&' within '||' [-Wlogical-op-parentheses]
+```
+prog.c:38:3: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+prog.c:40:34: warning: value computed is not used [-Wunused-value]
+prog.c:56:6: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+prog.c:58:50: warning: value computed is not used [-Wunused-value]
+prog.c:61:5: warning: suggest parentheses around ‘-’ inside ‘>>’ [-Wparentheses]
+```
 
-Due to most parentheses and braces removed when unecessary.
+With clang 3.1 on Linux Ubuntu 12.10 :
+
+```
+prog.c:38:49: warning: '&&' within '||' [-Wlogical-op-parentheses]
+prog.c:38:27: warning: '&&' within '||' [-Wlogical-op-parentheses]
+prog.c:55:13: warning: '&&' within '||' [-Wlogical-op-parentheses]
+prog.c:56:14: warning: '&&' within '||' [-Wlogical-op-parentheses]
+```
+
+This is due to most of the parentheses and braces being removed when
+unnecessary.
 
 To verify the display, you can look at one of this programs :
-* xephem : http://www.clearskyinstitute.com/xephem/
-* homeplanet : http://www.fourmilab.ch/homeplanet/
-* http://www.theplanetstoday.com/
+* xephem : https://web.archive.org/web/20130310133219/http://www.clearskyinstitute.com/xephem/
+* homeplanet : https://www.fourmilab.ch/homeplanet/
+* https://www.theplanetstoday.com
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2013/morgan1/README.md
+++ b/2013/morgan1/README.md
@@ -86,20 +86,20 @@ It also displays the position of 2 famous comets during their last approach:
 With gcc 4.7.2 on Linux Ubuntu 12.10:
 
 ```
-prog.c:38:3: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
-prog.c:40:34: warning: value computed is not used [-Wunused-value]
-prog.c:56:6: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
-prog.c:58:50: warning: value computed is not used [-Wunused-value]
-prog.c:61:5: warning: suggest parentheses around ‘-’ inside ‘>>’ [-Wparentheses]
+morgan1.c:38:3: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+morgan1.c:40:34: warning: value computed is not used [-Wunused-value]
+morgan1.c:56:6: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+morgan1.c:58:50: warning: value computed is not used [-Wunused-value]
+morgan1.c:61:5: warning: suggest parentheses around ‘-’ inside ‘>>’ [-Wparentheses]
 ```
 
 With clang 3.1 on Linux Ubuntu 12.10 :
 
 ```
-prog.c:38:49: warning: '&&' within '||' [-Wlogical-op-parentheses]
-prog.c:38:27: warning: '&&' within '||' [-Wlogical-op-parentheses]
-prog.c:55:13: warning: '&&' within '||' [-Wlogical-op-parentheses]
-prog.c:56:14: warning: '&&' within '||' [-Wlogical-op-parentheses]
+morgan1.c:38:49: warning: '&&' within '||' [-Wlogical-op-parentheses]
+morgan1.c:38:27: warning: '&&' within '||' [-Wlogical-op-parentheses]
+morgan1.c:55:13: warning: '&&' within '||' [-Wlogical-op-parentheses]
+morgan1.c:56:14: warning: '&&' within '||' [-Wlogical-op-parentheses]
 ```
 
 This is due to most of the parentheses and braces being removed when

--- a/2013/morgan2/Makefile
+++ b/2013/morgan2/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/morgan2/README.md
+++ b/2013/morgan2/README.md
@@ -1,7 +1,7 @@
 # Most playfully versatile
 
-    Yves-Marie Morgan  
-    <yves-marie.morgan@parrot.com>  
+Yves-Marie Morgan<br>
+<yves-marie.morgan@parrot.com>
 
 ## To build:
 
@@ -31,15 +31,16 @@ echo "Do or do not. There is no try."
 
 ## Judges' remarks:
 
-The judges enjoyed playing the game almost to completion; if we remember correctly, 
-we managed to place 59 or 60 dominoes. We wonder, what would be faster: to play the game to completion
-or to write an unobfuscated version of it?
+The judges enjoyed playing the game almost to completion; if we remember
+correctly, we managed to place 59 or 60 dominoes. We wonder, what would be
+faster: to play the game to completion or to write an unobfuscated version of
+it?
 
 ## Author's remarks:
 
 This program is a domino game. The goal is to place dominoes on the 8x8 grid.
-Each domino is made of 6 squares of the color red or green. To place a domino,
-at least one of it side shall match the other side of another domino.
+Each domino is made of 6 squares of the colour red or green. To place a domino,
+at least one of its side shall match the other side of another domino.
 
 ### How to play
 
@@ -47,14 +48,14 @@ at least one of it side shall match the other side of another domino.
 
 At the start of the game, the first domino is placed randomly on the grid. You
 get another domino to place by selecting one empty position in the stack on the
-right. You can have to 8 dominoes pending at any time.
+right. You can have up to 8 dominoes pending at any time.
 
 ### Moving in the stack
 
 Use `Up` and `Down` key to move the cursor in the stack. Press `Enter` to either
 
-* reveal a new domino if the position was empty.
-* select the domino to try to place it if the position was not empty.
+* Reveal a new domino if the position was empty.
+* Select the domino to try to place it if the position was not empty.
 
 The currently selected domino is indicated on the top right.
 
@@ -66,19 +67,20 @@ to place the domino.
 
 To go back to selection mode, press `Enter` on an occupied position.
 
-The domino can be place in an empty position if all its neighbour have matching
+The domino can be placed in an empty position if all its neighbour have matching
 sides and the domino has at least one neighbour.
 
 ### Scoring
 
 First, depending on the number of dominoes pending in the stack, a bonus is
 accorded :
+
 * 1 domino in the stack : 8 points.
 * 2 dominoes in the stack : 4 points.
 * 3 or 4 dominoes in the stack : 2 points.
-* 5 or more dominoes in the stack : 0 point.
+* 5 or more dominoes in the stack : 0 points.
 
-Then the bonus is multiplied by the number of matching neighbor the placed domino
+Then the bonus is multiplied by the number of matching neighbours the placed domino
 has (1, 2, 3 or 4). This is added to the score.
 
 Finally, the total score is divided by the number of dominoes placed (1 - 64).
@@ -88,24 +90,25 @@ final score (total score divided by fill count).
 
 ### End of the game
 
-The game is finished when no more domino can be placed and you either :
-* filled the complete grid.
-* have 8 pending dominoes in the stack.
-* no more domino can be revealed in the stack (more than 56 dominoes placed on
+The game is finished when no more dominos can be placed and you either :
+
+* Completely filled the grid.
+* Have 8 pending dominoes in the stack.
+* No more domino can be revealed in the stack (more than 56 dominoes placed on
   the grid).
 
-**Note** There is no real end of game detection implemented in the program,
+**Note**: There is no real end of game detection implemented in the program,
 simply press `q` when you have finished...
 
 ### Strategy
 
-* Try to minimize the number of dominoes revealed in the stack. The lower the number,
-the higher the bonus.
-* Each domino is unique and all combination of colors exists, so keep track
-  of what is already place and what is left.
-* Make sure you don't render dead some positions by preventing a future placement
-  If the corner of domino does not match another corner in diagonal, the move
-  is valid but will prevent some future moves.
+* Try to minimize the number of dominoes revealed in the stack. The lower the
+  number, the higher the bonus.
+* Each domino is unique and all combination of colours exists, so keep track
+  of what is already placed and what is left.
+* Make sure you don't render dead some positions by preventing a future
+  placement. If the corner of a domino does not match another corner diagonally,
+  the move is valid but will prevent some future moves.
 
 ### Limitations
 
@@ -118,15 +121,22 @@ the higher the bonus.
 * 1 letter identifier, reused when possible.
 * 1 algorithm, 2 different kind of display (ncurses and X11) mixed.
 * No parameters to functions, all variables are global and shared.
-* Some variables are not initialized if they have a known value at the time of use.
+* Some variables are not initialized if they have a known value at the time of
+  use.
 
 ### Compilation warnings
 
-with gcc 4.7.2 on Linux Ubuntu 12.10 :
-* prog.c:46:65: warning: value computed is not used [-Wunused-value]
+With gcc 4.7.2 on Linux Ubuntu 12.10 :
 
-with clang 3.1 on Linux Ubuntu 12.10 :
-* prog.c:23:24: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
+```
+morgan2.c:46:65: warning: value computed is not used [-Wunused-value]
+```
+
+With clang 3.1 on Linux Ubuntu 12.10 :
+
+```
+morgan2.c:23:24: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
+```
 
 **!!!!! HAVE FUN !!!!!**
 

--- a/2013/robison/Makefile
+++ b/2013/robison/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2013/robison/README.md
+++ b/2013/robison/README.md
@@ -1,7 +1,7 @@
 # Most poetic use of strings
 
-    Arch D. Robison  
-    <arch.d.robison@gmail.com>  
+Arch D. Robison<br>
+<arch.d.robison@gmail.com>  
 
 ## To build:
 
@@ -24,17 +24,17 @@ echo '100000000000000000000*(20*(1+(99477941840441*50)))/31664812345028528' | ./
 
 ## Judges' remarks:
 
-Of integers this prog does a lot,
-plus minus, div times (and what not).
+Of integers this prog does a lot,  
+plus minus, div times (and what not).  
 
-And modulus if remainders the needing,
-on standard input percent be feeding.
+And modulus if remainders the needing,  
+on standard input percent be feeding.  
 
-More than one line can thru give input,
-when interactive one values more than throughput.
+More than one line can thru give input,  
+when interactive one values more than throughput.  
 
-With cut and paste and some time,
-one can compute M(23209).
+With cut and paste and some time,  
+one can compute M(23209).  
 
 ## Author's remarks:
 
@@ -64,7 +64,7 @@ So how to go back, to be Turing complete?
 From standard dot H, to the rescue, q SORT!  
 
 My fixation might hint at a textual bent.          
-Does my program compose a tatoo for your shin?     
+Does my program compose a tattoo for your shin?     
 Play crosswords or translate from Urdu to Tzouby?  
 To give it a whirl, just punch 2 + 2 in.  
 
@@ -73,8 +73,8 @@ Take unary minus and also subtract.
 Summing hairs of a walrus?  No longer a fuss.  
 Parenthetical grouping -- no pushing a stack!  
 
-Try dividing a googol by one forty three,    
-Subtract an octillion - it's simply divine.  
+Try dividing a [googol](https://en.wikipedia.org/wiki/Googol) by one forty three,    
+Subtract an [octillion](https://en.wikipedia.org/wiki/Names_of_large_numbers) - it's simply divine.  
 To compute a remainder, inscribe a percent.  
 For the sign of the answer, see C ninety nine!    
 
@@ -93,14 +93,14 @@ Divide *babbage* (in base seventeen) by *cafe* --
 a nice *fad*, but avoid a division by nix:          
 No errant result, but you could wait all day!       
 
-To grok the internals, ask Queen Cleopatra,  
-or King Tutankhamun; for him it's a romp.    
+To grok the internals, ask [Queen Cleopatra](https://en.wikipedia.org/wiki/Cleopatra),  
+or [King Tutankhamun](https://en.wikipedia.org/wiki/Tutankhamun); for him it's a romp.    
 Addition by cats, and if given two figures,  
 to tell which is bigger, sort down and string CMP!  
 
 Unlawful subtraction, a grade school infraction,   
 starts at the left and works to the right.    
-Yet more innovation: like Henry Ford's cars,  
+Yet more innovation: like [Henry Ford's cars](https://en.wikipedia.org/wiki/Ford_Motor_Company),  
 With a pound and define, mass production of vars!  
 
 The moral is clear, for programmers out there:   

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -1,11 +1,12 @@
 # Best use of port 1701
 
-    Michael Birken  
-    <o__1@hotmail.com>  
-    <http://www.meatfighter.com/>  
-
-    Alexander Prishchepov  
-    <https://github.com/sans17/>  
+Michael Birken<br>
+<o__1@hotmail.com><br>  
+<http://www.meatfighter.com/><br>
+<br>
+Alexander Prishchepov<br>
+<alepov-github@yahoo.com><br>
+<https://github.com/sans17/><br>
 
 ## To build:
 
@@ -24,10 +25,27 @@ make
 ## Try:
 
 ```sh
-./prog
+./prog < README.md
+```
 
+or maybe:
+
+```sh
+echo "IOCCC 2014!" | ./prog
+```
+
+Next, try in another terminal, as the above one is running:
+
+```sh
 ./prog http://127.0.0.1:1701
 ```
+
+What happens if you specify instead of a regular file something like
+`/dev/null` ?
+
+
+But there's more! Try opening in a browser the same address and then see what
+happens. This is explained by the authors when explaining their inspiration.
 
 ## Judges' remarks:
 
@@ -42,11 +60,16 @@ binary content communicated between client and server.
 So how does this program do it?  A trek though the cloak of
 obfuscation awaits the reader of the source!
 
-## Author's remarks:
+## Authors' remarks:
 
 ### Abstract
 
-When launched in web server mode, this application appears to deliver nothing more than a static HTML page.  But, in actuality, it provides covert file transfer over the Internet.  This is demonstrated by starting the application as a client-side downloader.  The hidden transmitted data cannot be reconstructed or even detected from the binary content of the traffic between the client and the server.
+When launched in web server mode, this application appears to deliver nothing
+more than a static HTML page.  But, in actuality, it provides covert file
+transfer over the Internet.  This is demonstrated by starting the application as
+a client-side downloader.  The hidden transmitted data cannot be reconstructed
+or even detected from the binary content of the traffic between the client and
+the server.
 
 ## To run web server
 
@@ -66,15 +89,18 @@ Try using the program's source code as the secret file:
 ./prog http://host[:port]
 ```
 
-The optional port defaults to 1701.  If the web server instance is started on the same box, try:
+The optional port defaults to 1701.  If the web server instance is started on
+the same box, try:
 
 ```sh
 ./prog http://127.0.0.1:1701
 ```
 
-It will incrementally display the contents of the hidden file at a rate of approximately 1 baud.
+It will incrementally display the contents of the hidden file at a rate of
+approximately 1 baud.
 
-The client-side downloader will automatically terminate if the web server is bounced.
+The client-side downloader will automatically terminate if the web server is
+bounced.
 
 ### HTML content
 
@@ -82,46 +108,95 @@ Plug the URL into a browser to view a static HTML page containing ASCII artwork.
 
 ### Exploration
 
-Studying the network traffic will reveal that the HTML content is static and immutable, the HTTP request and response fields do not contain anything remarkable, HTTP status and error codes are not exploited, no unusual or deprecated features of HTTP are used, and while the cookie is based on a timestamp, its value also remains unchanged throughout the session.  As mentioned in the abstract, the data is not transmitted within the binary content communicated between the client and the server.  A full explanation of the protocol appears below, but feel free to explore before reading further.
+Studying the network traffic will reveal that the HTML content is static and
+immutable, the HTTP request and response fields do not contain anything
+remarkable, HTTP status and error codes are not exploited, no unusual or
+deprecated features of HTTP are used, and while the cookie is based on a
+timestamp, its value also remains unchanged throughout the session.  As
+mentioned in the abstract, the data is not transmitted within the binary content
+communicated between the client and the server.  A full explanation of the
+protocol appears below, but feel free to explore before reading further.
 
 ### Inspiration
 
-The inspiration for this program comes from _Star Trek VI: The Undiscovered Country_, specifically the final confrontation between the _Enterprise_ and the enhanced prototype Klingon Bird of Prey.  The definitive feature of the prototype was its ability to fire while cloaked.  But, perhaps even more impressive was its able to keep an open communication channel with the _Enterprise_ throughout the battle, enabling the antagonist Chang to taunt Captain Kirk with Shakespearian quotes while he slowly pelted his ship with torpedoes.  Normally, cloaked vessels must maintain silent running to avoid detection.
+The inspiration for this program comes from _Star Trek VI: The Undiscovered
+Country_, specifically the final confrontation between the _Enterprise_ and the
+enhanced prototype Klingon Bird of Prey. The definitive feature of the
+prototype was its ability to fire while cloaked. But, perhaps even more
+impressive was its ability to keep an open communication channel with the
+_Enterprise_ throughout the battle, enabling the antagonist Chang to taunt
+Captain Kirk with Shakespearian quotes while he slowly pelted his ship with
+torpedoes.  Normally, cloaked vessels must maintain silent running to avoid
+detection.
 
-The battle is commemorated in the form of ASCII artwork depicting the ships faced head-to-head in the page delivered by the web server.  Plus, the program source code is formatted in the shape of a Klingon Bird of Prey.  The code itself includes a number of Star Trek references: the registry number of the _Enterprise_ (NCC-1701) is defined as a constant; variable names spell out Cpt. James T. Kirk and Odo (the Deep Space 9 character was played by René Auberjonois who also appeared as Colonel West in _Star Trek VI_); the STARDATE constant makes timing configurable; and, the constant k stands for Khan (in the final engagement in _Star Trek II: The Wrath of Khan_, the damaged _Enterprise_ managed to disable the USS _Reliant_’s shield generator by accessing its prefix code: 16309).
+The battle is commemorated in the form of ASCII artwork depicting the ships
+faced head-to-head in the page delivered by the web server.  Plus, the program
+source code is formatted in the shape of a Klingon Bird of Prey.  The code
+itself includes a number of Star Trek references: the registry number of the
+_Enterprise_ (NCC-1701) is defined as a constant; variable names spell out Cpt.
+James T. Kirk and Odo (the Deep Space 9 character was played by René Auberjonois
+who also appeared as Colonel West in _Star Trek VI_); the `STARDATE` constant
+makes timing configurable; and, the constant `k` stands for Khan (in the final
+engagement in _Star Trek II: The Wrath of Khan_, the damaged _Enterprise_
+managed to disable the USS _Reliant_’s shield generator by accessing its prefix
+code: 16309).
 
 ### Secondary size limit
 
-As obligated by a program that employs 23rd century cloaking technology, when the source is fed as input to IOCCC size tool version 2014-09-23-v19, and the -i command line option is used, the value printed is 0.
+As obligated by a program that employs 23rd century cloaking technology, when
+the source is fed as input to IOCCC size tool version 2014-09-23-v19, and the
+`-i` command line option is used, the value printed is 0.
 
 ### Transmission protocol revealed
 
-The client-side downloader relies on the response time of the web server rather than the binary content of the response.  The server transmits 1 nibble at a time by counting to the nibble value via a sequence of rapid responses terminated by a long response.  For instance, the value 5 would be transmitted by making a series of requests that result in 5 near instantaneous responses followed by a half-second delayed response.  The long delay is skipped in the case of 15, the maximal nibble value.  With the aid of an ASCII table, it is actually possible to read the nibbles by repeatedly pressing the refresh button within a browser and observing the page refresh delay.
+The client-side downloader relies on the response time of the web server rather
+than the binary content of the response.  The server transmits 1 nibble at a
+time by counting to the nibble value via a sequence of rapid responses
+terminated by a long response.  For instance, the value 5 would be transmitted
+by making a series of requests that result in 5 near instantaneous responses
+followed by a half-second delayed response.  The long delay is skipped in the
+case of 15, the maximal nibble value.  With the aid of an ASCII table, it is
+actually possible to read the nibbles by repeatedly pressing the refresh button
+within a browser and observing the page refresh delay.
 
-Nibble Count Coding (file transfer protocol NCC-1701) is faster than transmitting each individual bit as a short or long delay because it sends each byte with 2 long delays whereas communicating individual bits requires 8 long delays in the worst case scenario.  In fact, Nibble Count Coding is faster than applying Huffman Coding since that is designed to produce compact codes under the assumption that the bit value does not affect transmission time.
+Nibble Count Coding (file transfer protocol NCC-1701) is faster than
+transmitting each individual bit as a short or long delay because it sends each
+byte with 2 long delays whereas communicating individual bits requires 8 long
+delays in the worst case scenario.  In fact, Nibble Count Coding is faster than
+applying Huffman Coding since that is designed to produce compact codes under
+the assumption that the bit value does not affect transmission time.
 
-The server relies on the cookie to identify each client uniquely, enabling it to transfer the sequence independently to each client.
+The server relies on the cookie to identify each client uniquely, enabling it to
+transfer the sequence independently to each client.
 
 ### Configuration
 
-As with all network communication, accurate transmission of data relies on the nature of hardware revealed through statistics and timeouts set accordingly.  The long delay is arbitrarily set to 0.5 seconds.  This is microsecond tunable via the STARDATE constant defined at the top of the source code.  Increase the value in the event of transmission errors.  Decrease the value to download faster and less reliably.
+As with all network communication, accurate transmission of data relies on the
+nature of hardware revealed through statistics and timeouts set accordingly.
+The long delay is arbitrarily set to `0.5` seconds.  This is microsecond tunable
+via the `STARDATE` constant defined at the top of the source code.  Increase the
+value in the event of transmission errors.  Decrease the value to download
+faster and less reliably.
 
 The NCC constant is the web server port number.
 
 ### Obfuscations
 
 * The ASCII artwork is compressed using run-length encoding.
-* One long string stores a series of strings concatenated together and referenced via pointers.
+* One long string stores a series of strings concatenated together and
+referenced via pointers.
 * The long string is shift encrypted.
 * Short and meaningless identifiers are used throughout.
 * Reversed array indexing was applied immoderately.
 * Minus is used in place of not-equals.
-* O and l were selected for their resemblance to 0 and 1 respectively.
-* Standard constants and ASCII characters were replaced with their respective numerical values.
+* `O` and `l` were selected for their resemblance to `0` and `1` respectively.
+* Standard constants and ASCII characters were replaced with their respective
+numerical values.
 
 ### Compiler warnings
 
-For space considerations, the following include statements were dropped resulting in compiler warnings:
+For space considerations, the following include statements were dropped
+resulting in compiler warnings:
 
 ```c
 #include <asm/byteorder.h>

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -200,7 +200,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/vik/.gitignore
+++ b/2014/vik/.gitignore
@@ -1,4 +1,5 @@
 audio_file.raw
 prog
+prog.alt
 prog.raw
 prog.orig

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -13,13 +13,15 @@ US
 make
 ```
 
-
 ## To run:
 
 ```sh
 ./prog > foo.c
 ```
 
+There is an alternate version that will theoretically work with Windows
+compilers (if anything in Windows works :-) ). See the [Alternate
+code](#alternate-code) section below.
 
 ## Try:
 
@@ -28,6 +30,18 @@ echo 'Want to hear me beep?' | ./prog > audio_file.raw
 
 echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
 ```
+
+### Alternate code:
+
+The alternate code, [prog.alt.c](prog.alt.c), is based on the author's
+instructions on how to get it to work with Windows. This has not been tested but
+in order to use it you can do:
+
+```sh
+make alt
+```
+
+Use `prog.alt` as you would `prog` above as well as below.
 
 
 ## Judges' remarks:
@@ -59,7 +73,7 @@ I can tell, there are at least six chocolate references in this program.
 This program can convert text to Morse to a raw 44.1kHz stereo audio file.
 Via streaming to mplayer, you can listen to the Morse audio.
 
-Don't forget the last '-' as it makes mplayer read from stdin.
+Don't forget the last '`-`' as it makes mplayer read from stdin.
 
 
 ## Convert audio file with Morse signals to text
@@ -85,6 +99,8 @@ declaration in order for the program to run correctly:
 ```c
 _setmode(_fileno(stdout), 0x8000);
 ```
+
+NOTE: see the [alternate code](prog.alt.c) for this.
 
 ### Known Issues
 

--- a/2014/vik/prog.alt.c
+++ b/2014/vik/prog.alt.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <string.h>
+#include <io.h>
+
+char X[] =
+  " ETIANMSURWDKGOHVF:L:PJBXCYZQ::54:3:::2&:+::::16=/:::(:7:::8:90"
+  "::::::::::::?_::::\"::.::::@:::'::-::::::::;!:):::::,:::::";
+
+int j,w,h,f,u,d,g,e,n,i,l,a,r,p,c,m,o,t,s,Q=32,T[32],W[32],I=13000;
+
+int main(int v, char** b) {
+
+  _setmode(_fileno(stdout), 0x8000);
+  for (i=0;v>0&&v<5&&(v*=t=fread(X,1,1,stdin));)
+
+  for (v-1&&101==*1[b]?++g%1500?u+=(g&1^1)*(*X<0?-*X:*X):(f=e,e=w,w=d,d=u,
+    m=(1 - h%2* 2  )*(d -f)/ (d<f  ?d|1 : 1|f) >  5?T[ h%Q] =o+l  , l=W[
+    h++%Q]=o,o=0:m,o++,u=main(0,b)):(c=strrchr(X,~(Q&*X&*X/2)&*X)-X,j=255);
+    v==1&&(c*j||main(*X-Q?8:24,b));j/=2)c<j?0:main(9+(c-j)/(j/2+1)%2*10,b);
+
+  for (a=u=0;i<=Q*Q&&!v;j>7&&j<13?s=c*s+T[i/Q]/2,s/=++c:0)
+    !(i++%Q)?a=c>a?u=s,c:a,c=s=0:0,j=T[i%Q],j=j?T[i/Q]*10/j:0,j*=(j<5)*2+1;
+
+  for (r+=(h-r)/Q*Q;i<v/4*I;putchar((i/I<v%4)*i%2*85<<(i%176/88)),i++);
+
+  for (g*=!!v;r+t!=h+1&&h>5&&!v;r+t!=h+1?(W[r%Q]>2*u||r==h?p=n=n>6?0:
+    putchar(X[p-1+(1<<n)])&0:0,W[r++%Q]>6*u?putchar(Q):0):0)
+    *X=Q,p=r%2?++n,2*p+(W[r++%Q]>2*u):p;
+
+  return 0;
+}

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/burton/Makefile
+++ b/2015/burton/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/dogon/Makefile
+++ b/2015/dogon/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/duble/Makefile
+++ b/2015/duble/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/endoh1/Makefile
+++ b/2015/endoh1/Makefile
@@ -245,7 +245,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/endoh2/Makefile
+++ b/2015/endoh2/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/endoh3/Makefile
+++ b/2015/endoh3/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/endoh4/Makefile
+++ b/2015/endoh4/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -191,7 +191,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/howe/Makefile
+++ b/2015/howe/Makefile
@@ -194,7 +194,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -345,7 +345,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/mills2/Makefile
+++ b/2015/mills2/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/muth/Makefile
+++ b/2015/muth/Makefile
@@ -200,7 +200,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/schweikhardt/Makefile
+++ b/2015/schweikhardt/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2015/yang/Makefile
+++ b/2015/yang/Makefile
@@ -211,7 +211,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/algmyr/Makefile
+++ b/2018/algmyr/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/anderson/Makefile
+++ b/2018/anderson/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/bellard/Makefile
+++ b/2018/bellard/Makefile
@@ -186,7 +186,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/burton1/Makefile
+++ b/2018/burton1/Makefile
@@ -187,7 +187,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/burton2/Makefile
+++ b/2018/burton2/Makefile
@@ -220,7 +220,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/ciura/Makefile
+++ b/2018/ciura/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/endoh1/Makefile
+++ b/2018/endoh1/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -207,7 +207,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -194,7 +194,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/giles/Makefile
+++ b/2018/giles/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/hou/Makefile
+++ b/2018/hou/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/mills/Makefile
+++ b/2018/mills/Makefile
@@ -242,7 +242,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -190,7 +190,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/vokes/Makefile
+++ b/2018/vokes/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2018/yang/Makefile
+++ b/2018/yang/Makefile
@@ -304,7 +304,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -202,7 +202,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -197,7 +197,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/ciura/Makefile
+++ b/2019/ciura/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -194,7 +194,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -266,7 +266,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -197,7 +197,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -370,7 +370,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -189,7 +189,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -207,7 +207,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/carlini/Makefile
+++ b/2020/carlini/Makefile
@@ -182,7 +182,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/endoh1/Makefile
+++ b/2020/endoh1/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/endoh3/Makefile
+++ b/2020/endoh3/Makefile
@@ -193,7 +193,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -216,7 +216,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/giles/Makefile
+++ b/2020/giles/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/kurdyukov1/Makefile
+++ b/2020/kurdyukov1/Makefile
@@ -185,7 +185,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -192,7 +192,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/kurdyukov3/Makefile
+++ b/2020/kurdyukov3/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/kurdyukov4/Makefile
+++ b/2020/kurdyukov4/Makefile
@@ -188,7 +188,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/otterness/Makefile
+++ b/2020/otterness/Makefile
@@ -183,7 +183,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/tsoj/Makefile
+++ b/2020/tsoj/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2020/yang/Makefile
+++ b/2020/yang/Makefile
@@ -184,7 +184,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no intent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, ident $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/author/Alexander_Prishchepov.json
+++ b/author/Alexander_Prishchepov.json
@@ -6,7 +6,7 @@
     "sort_word" : "prishchepov",
     "location_code" : "US",
     "location_name" : "United States of America",
-    "email" : "student.00x@gmail.com",
+    "email" : "alepov-github@yahoo.com",
     "url" : "https://github.com/sans17/",
     "alt_url" : null,
     "deprecated_twitter_handle" : null,

--- a/bugs.md
+++ b/bugs.md
@@ -1865,7 +1865,7 @@ Do you have it? Please provide it!
 ## [2013/dlowe](2013/dlowe/dlowe.c) ([README.md](2013/dlowe/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
-This program will very likely crash or draw something strange with 0 args. Then
+This program will possibly crash or draw something strange with 0 args. Then
 again it might not. :-) This is easy to fix but would add bytes and since the
 author noted it is a feature and not a bug. You of course can try and fix it
 yourself but please do NOT open a pull request for this: just do it as an
@@ -1889,7 +1889,7 @@ Hou :-) ) yourself. This should not be fixed.
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) discovered a bug that
 shows itself in some cases (it works in others) when working on his winning
-[2020 Enigma machine](2020/ferguson2/prog.c) ('Most enigmatic) entry. See his
+[2020 Enigma machine](2020/ferguson2/prog.c) ('Most enigmatic') entry. See his
 [README.md](2020/ferguson2/README.md) for details (search for `vik` in the
 file).
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -5,8 +5,8 @@
 
 ## Thank you honor roll
 
-There are several people who have contributed to the above mentioned
-several thousand changes and important improvements.
+There are several people who have contributed several thousand changes, fixes
+and important improvements.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1779,6 +1779,13 @@ Further, after the file 2013/hou/doc/example.markdown was moved to
 this broke `make` which Cody also fixed.
 
 
+## [2013/misaka](2013/misaka/misaka.c) ([README.md)[2013/misaka/README.md))
+
+As there are a lot of commands to try, Cody added the
+[demo.sh](2013/misaka/demo.sh) script to do this, sleeping for approximately 1
+second between commands.
+
+
 ## [2013/morgan1](2013/morgan1/morgan1.c) ([README.md](2013/morgan1/README.md))
 
 Cody added explicit linking of libm (`-lm`) as not all systems do this

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1790,12 +1790,18 @@ implicitly (linux doesn't seem to but macOS does).
 Cody fixed the build for this entry: it does not require SDL2 but SDL1 so there
 were linking errors.
 
+## [2014/vik](2014/vik/prog.c) ([README.md](2014/vik/README.md))
+
+Cody added an alternate version that is based on the author's remarks that will
+theoretically work for Microsoft Windows compilers (if anything works in Windows
+:-) ). We have no way of testing this and if anything has changed since 2014
+that would break it we do not know.
 
 ## [2015/endoh3](2015/endoh3/prog.c) ([README.md](2015/endoh3/README.md]))
 
 Cody fixed this to compile with linux which was having a problem with duplicate
-symbols of `main()`. The fix is through the option `-fcommon` which will let it
-compile like it does with macOS.
+symbols of `main()`. The fix is through the compiler option `-fcommon` which
+will let it compile like it does with macOS.
 
 Cody also made it easier to enjoy the theme of [Back to the
 Future](https://en.wikipedia.org/wiki/Back_to_the_Future) using this entry by

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -17,13 +17,13 @@ bug fixes** such as [2001/anonymous](2001/anonymous/README.md) and
 compile with clang, fixing entries to work with macOS (some of which are **very
 complicated** such as [1998/schweikh1](1998/schweikh1/README.md)), fixing code
 to work with both 32-bit and 64-bit (such as
-[2001/herrmann2](2001/herrmann2/README.md)) which can be **quite complicated**
-(though not always even if it seems it), providing alternate code where useful
-or necessary, fixing where possible dead links and otherwise removing them, typo
-and consistency fixes, improving **ALL _Makefiles_** and writing the [sgit
-tool](https://github.com/xexyl/sgit) that we installed locally and have used to
-easily run `sed` on files in the repository to help build the website. Thank
-you **very much** for your extensive efforts in helping improve the IOCCC
+[2001/herrmann2](2001/herrmann2/README.md)) which *can be* **quite complicated
+too** (though not always even if it seems it), providing alternate code where
+useful or necessary, fixing where possible dead links and otherwise removing
+them, typo and consistency fixes, improving **ALL _Makefiles_** and writing the
+[sgit tool](https://github.com/xexyl/sgit) that we installed locally and have
+used to easily run `sed` on files in the repository to help build the website.
+Thank you **very much** for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC winners and making many many past entries work with
 modern systems!
 
@@ -921,20 +921,60 @@ segfault fixes should be made because the program is so beautiful.
 
 ## [1998/schweikh1](1998/schweikh1/schweikh1.c) ([README.md](1998/schweikh1/README.md]))
 
-Cody fixed this for modern systems (it did not work at all). He also made it so
-that if a file fails to open it does not return but rather skips the reading of
-the file. Without this fix the entry did not work.
+Cody fixed this for modern systems (it did not work at all) and added an
+alternate version that works with macOS. Cody also made it ever so slightly more
+portable by removing the hard-coding of `gcc`, instead hard-coding it `cc`. Doing
+this not only lets it work with systems without `gcc` (though in macOS it does
+exist but is actually `clang`) as `cc` always should.
 
-What was wrong? The call to `freopen()` was incorrect with the second arg (the
-mode) being instead `5+__FILE__`. It now is `"r"`. There was also a call to
-`fopen()` that was wrong where the mode was instead `44+__FILE__`. Interestingly
-enough though this did not seem to be an issue though I cannot explain why. He
-notes that it works fine with `clang` as well as `gcc` (which is what is used
-but in macOS - see below for alternate code - `gcc` is clang).
+Getting this entry to work was quite complicated but is also very interesting.
+To see how the macOS fixes works, see the README.md but do note that this
+includes spoilers for both versions! The fixes to get it to work at all are
+described next.
 
-Additionally Cody provided an alternate version for macOS. The fix is
-rather complicated but very interesting. See the README.md file for details on
-how it works and how to use it.
+So what was wrong with the original?
+
+The call to `freopen()` was incorrect with the second arg (the mode) being
+`5+__FILE__`; it is now `"r"`. (Observe that the mode to the `fopen()`
+call is: `44+__FILE__`. This might seem incorrect and indeed it can be changed
+to `"r"` as well but this was not actually necessary so once this was noticed it
+was changed back to the original.)
+
+Another important change is that the files are only closed if the `FILE *H` is
+`!= NULL`. Without this check, because it's almost certain that some files will
+not exist, it would dereference a NULL pointer and very likely crash or halt and
+catch fire :-), preventing the entry from working. Notice how `H` is a funny
+macro defined as:
+
+```c
+%:define H(x) <st%:%:x##.h>
+```
+
+and yet the `FILE *` can be called `H`! This might or might not make sense to
+you but if it doesn't can you figure out why?
+
+Another fix is that previously the program would `return 1` if a file failed to
+open but for the same reason as above, it being very likely some files will not
+exist, the return was removed so that if the statement of the `if` is true the
+`while` loop run, rather than having the loop by itself. It was done this way to
+make it as close to the original as possible and to maintain the obfuscation as
+close as possible as well.
+
+Also crucial, and the final fixes to make it work, is that the arrays `K` and
+`L` had to be increased in size. They were originally (somewhat bewildering at
+first glance) defined as `K[X(*)], L[X(<<)]` but they were changed to
+`K[(X(*))*4], L[4*X(<<)]` though it is no longer clear just how necessary this
+might be.
+
+As noted, a limitation of `gcc` existing was removed by Cody to make it so that
+`gcc` is not required as `cc` should exist in every system with a C compiler and
+as the author stated: as long as the options `-E -dM` of the compiler prints out
+the macros in the form of `gcc -dM` i.e. the lines are in the form `#define
+MACRO value` it will work, assuming that compiler can run, of course.
+
+As for the version for macOS, the even more complicated details are described in
+the [Alternate code](1998/schweikh1/README#alternate-code) section of the
+README.md file as these changes pertain to the described version therein.
 
 
 ## [1998/schweikh2](1998/schweikh2/schweikh2.c) ([README.md](1998/schweikh2/README.md]))


### PR DESCRIPTION

With the make indent rule there was a typo for indent as 'intent'. This
was fixed with my sgit tool like:

    sgit -e 's/no intent\( tool found\)/no indent\1/g' '*Makefile'
