### PR TITLE
Add script primes.sh to 1985/august for fun

### DIFF
--- a/1985/august/README.md
+++ b/1985/august/README.md
@@ -21,12 +21,15 @@ make all
 ./august | head -n 10
 ```
 
-If you have the `primes(6)` tool (sometimes part of BSD Games) you can see
-what of the output in the first `N` (say `15`) lines are primes:
+If you have the `primes(6)` tool (sometimes part of [BSD
+Games](https://github.com/vattam/BSDGames)) you can see
+what of the output in the first `N` (say `15` or `25`) lines are primes:
 
 ```sh
-while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n 15 ))
+./primes.sh # 15
+./primes.sh 25
 ```
+
 
 ## Judges' remarks:
 
@@ -37,6 +40,9 @@ action of the program?
 If you let it, the program will continue to print a numerical sequence (can you
 guess in what base it is printed by looking at the code?) until you run out of
 memory or until they sell your computer, whichever comes first.
+
+If you use the [primes.sh](primes.sh) script can you figure out if there's
+anything funny going on with the output?
 
 ## Author's remarks:
 

--- a/1985/august/primes.sh
+++ b/1985/august/primes.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+make everything || exit 1
+
+PRIMES=$(type -P primes)
+
+COUNT=15
+if [[ "$#" -ge 1 ]]; then
+    COUNT="$1"
+    if ! [[ $COUNT =~ ^[0-9]+$ ]] ; then
+	echo "not a number: $COUNT" 1>&2	
+	exit 1
+    fi
+fi
+
+if [[ -n "$PRIMES" ]]; then
+    while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n "$COUNT" ))
+else
+    echo "primes not installed" 1>&2
+    echo "See the following GitHub repo:" 1>&2
+    echo "" 1>&2
+    echo "	https://github.com/vattam/BSDGames"
+    exit 1
+fi

--- a/1985/august/primes.sh
+++ b/1985/august/primes.sh
@@ -8,14 +8,14 @@ PRIMES=$(type -P primes)
 COUNT=15
 if [[ "$#" -ge 1 ]]; then
     COUNT="$1"
-    if ! [[ $COUNT =~ ^[0-9]+$ ]] ; then
+    if ! [[ $COUNT =~ ^[0-9]+$ ]]; then
 	echo "not a number: $COUNT" 1>&2	
 	exit 1
     fi
 fi
 
 if [[ -n "$PRIMES" ]]; then
-    while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n "$COUNT" ))
+    while read -r n; do primes "$n" $((n + 1)); done < <((./august | head -n "$COUNT" ))
 else
     echo "primes not installed" 1>&2
     echo "See the following GitHub repo:" 1>&2

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -144,12 +144,13 @@ The crash was because it destructively rewrites string literals. However with
 `strdup()` it's safe.
 
 The problem with macOS is that although it didn't crash, it printed `H????` in a
-seemingly infinite loop, each time printing another `?`, probably until it ran
+seemingly infinite loop, each time printing another `?`, probably until it runs
 out of memory.
 
 The fix for macOS is that there was no prototype for `execlp()` and macOS has
 problems with missing prototypes for some functions (this was also seen when
-Cody fixed [1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well).
+Cody fixed [1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well). As
+this is a one-liner the include of `unistd.h` was done in the Makefile.
 Ironically this fix was discovered through linux!
 
 NOTE: originally this entry did not print a newline prior to returning to the
@@ -157,6 +158,12 @@ shell, after the output (despite having `\n` in the string - can you figure out
 why?) but to make it more friendly to users Cody made it print a `\n` prior to
 returning to the shell. The original version does not have this change.
 
+## [1985/august](1985/august/august.c) ([README.md](1985/august/README.md))
+
+Cody added the script [primes.sh](1985/august/primes.sh) which allows one to
+check the output for the first N prime numbers of the output, where N is either
+the default or user specified. The inspiration was the previous 'try' command he
+gave to have fun with finding primes that might seem unusual in a way.
 
 ## [1985/lycklama](1985/lycklama/lycklama.c) ([README.md](1985/lycklama/README.md]))
 


### PR DESCRIPTION
The inspiration of the script is based on a 'try' command I added to the README.md a while back to have more fun with the entry. The difference is that it allows you to specify the number of lines to print (or up to the number of lines).

There might be some misleading output in a way but this is a mystery for users to solve.