### PR TITLE
Mass typo fix in Makefiles

### DIFF
--- a/1984/Makefile
+++ b/1984/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1984/anonymous/Makefile
+++ b/1984/anonymous/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1984/laman/Makefile
+++ b/1984/laman/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1985/Makefile
+++ b/1985/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1985/applin/Makefile
+++ b/1985/applin/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1985/august/README.md
+++ b/1985/august/README.md
@@ -21,12 +21,15 @@ make all
 ./august | head -n 10
 ```
 
-If you have the `primes(6)` tool (sometimes part of BSD Games) you can see
-what of the output in the first `N` (say `15`) lines are primes:
+If you have the `primes(6)` tool (sometimes part of [BSD
+Games](https://github.com/vattam/BSDGames)) you can see
+what of the output in the first `N` (say `15` or `25`) lines are primes:
 
 ```sh
-while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n 15 ))
+./primes.sh # 15
+./primes.sh 25
 ```
+
 
 ## Judges' remarks:
 
@@ -37,6 +40,9 @@ action of the program?
 If you let it, the program will continue to print a numerical sequence (can you
 guess in what base it is printed by looking at the code?) until you run out of
 memory or until they sell your computer, whichever comes first.
+
+If you use the [primes.sh](primes.sh) script can you figure out if there's
+anything funny going on with the output?
 
 ## Author's remarks:
 

--- a/1985/august/primes.sh
+++ b/1985/august/primes.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+make everything || exit 1
+
+PRIMES=$(type -P primes)
+
+COUNT=15
+if [[ "$#" -ge 1 ]]; then
+    COUNT="$1"
+    if ! [[ $COUNT =~ ^[0-9]+$ ]] ; then
+	echo "not a number: $COUNT" 1>&2	
+	exit 1
+    fi
+fi
+
+if [[ -n "$PRIMES" ]]; then
+    while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n "$COUNT" ))
+else
+    echo "primes not installed" 1>&2
+    echo "See the following GitHub repo:" 1>&2
+    echo "" 1>&2
+    echo "	https://github.com/vattam/BSDGames"
+    exit 1
+fi

--- a/1985/august/primes.sh
+++ b/1985/august/primes.sh
@@ -8,14 +8,14 @@ PRIMES=$(type -P primes)
 COUNT=15
 if [[ "$#" -ge 1 ]]; then
     COUNT="$1"
-    if ! [[ $COUNT =~ ^[0-9]+$ ]] ; then
+    if ! [[ $COUNT =~ ^[0-9]+$ ]]; then
 	echo "not a number: $COUNT" 1>&2	
 	exit 1
     fi
 fi
 
 if [[ -n "$PRIMES" ]]; then
-    while read -r n ; do primes "$n" $((n + 1)) ; done < <((./august | head -n "$COUNT" ))
+    while read -r n; do primes "$n" $((n + 1)); done < <((./august | head -n "$COUNT" ))
 else
     echo "primes not installed" 1>&2
     echo "See the following GitHub repo:" 1>&2

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/Makefile
+++ b/1986/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/applin/Makefile
+++ b/1986/applin/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/august/Makefile
+++ b/1986/august/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/bright/Makefile
+++ b/1986/bright/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/hague/Makefile
+++ b/1986/hague/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/holloway/Makefile
+++ b/1986/holloway/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/pawka/Makefile
+++ b/1986/pawka/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/stein/Makefile
+++ b/1986/stein/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/Makefile
+++ b/1987/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/biggar/Makefile
+++ b/1987/biggar/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/hines/Makefile
+++ b/1987/hines/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/korn/Makefile
+++ b/1987/korn/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/Makefile
+++ b/1988/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/isaak/Makefile
+++ b/1988/isaak/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/litmaath/Makefile
+++ b/1988/litmaath/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/phillipps/Makefile
+++ b/1988/phillipps/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/reddy/Makefile
+++ b/1988/reddy/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/robison/Makefile
+++ b/1988/robison/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/Makefile
+++ b/1989/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/fubar/Makefile
+++ b/1989/fubar/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/jar.2/Makefile
+++ b/1989/jar.2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/paul/Makefile
+++ b/1989/paul/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/robison/Makefile
+++ b/1989/robison/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/roemer/Makefile
+++ b/1989/roemer/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/vanb/Makefile
+++ b/1989/vanb/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/Makefile
+++ b/1990/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/cmills/Makefile
+++ b/1990/cmills/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/dds/Makefile
+++ b/1990/dds/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/dg/Makefile
+++ b/1990/dg/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/pjr/Makefile
+++ b/1990/pjr/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/scjones/Makefile
+++ b/1990/scjones/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/Makefile
+++ b/1991/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/davidguy/Makefile
+++ b/1991/davidguy/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1991/westley/Makefile
+++ b/1991/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/Makefile
+++ b/1992/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/albert/Makefile
+++ b/1992/albert/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/ant/Makefile
+++ b/1992/ant/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/imc/Makefile
+++ b/1992/imc/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/lush/Makefile
+++ b/1992/lush/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/Makefile
+++ b/1993/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/ant/Makefile
+++ b/1993/ant/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/dgibson/Makefile
+++ b/1993/dgibson/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/ejb/Makefile
+++ b/1993/ejb/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/jonth/Makefile
+++ b/1993/jonth/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/schnitzi/Makefile
+++ b/1993/schnitzi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1993/vanb/Makefile
+++ b/1993/vanb/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/Makefile
+++ b/1994/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/dodsond1/Makefile
+++ b/1994/dodsond1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/imc/Makefile
+++ b/1994/imc/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/shapiro/Makefile
+++ b/1994/shapiro/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/smr/Makefile
+++ b/1994/smr/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/Makefile
+++ b/1995/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/dodsond1/Makefile
+++ b/1995/dodsond1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/dodsond2/Makefile
+++ b/1995/dodsond2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/esde/Makefile
+++ b/1995/esde/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/heathbar/Makefile
+++ b/1995/heathbar/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/leo/Makefile
+++ b/1995/leo/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/schnitzi/Makefile
+++ b/1995/schnitzi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/spinellis/Makefile
+++ b/1995/spinellis/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1995/vanschnitz/Makefile
+++ b/1995/vanschnitz/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/Makefile
+++ b/1996/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/august/Makefile
+++ b/1996/august/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/dalbec/Makefile
+++ b/1996/dalbec/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/huffman/Makefile
+++ b/1996/huffman/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/jonth/Makefile
+++ b/1996/jonth/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/rcm/Makefile
+++ b/1996/rcm/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/schweikh1/Makefile
+++ b/1996/schweikh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/schweikh2/Makefile
+++ b/1996/schweikh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/Makefile
+++ b/1998/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/bas1/Makefile
+++ b/1998/bas1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/bas2/Makefile
+++ b/1998/bas2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/chaos/Makefile
+++ b/1998/chaos/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/df/Makefile
+++ b/1998/df/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/dlowe/Makefile
+++ b/1998/dlowe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/dorssel/Makefile
+++ b/1998/dorssel/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/1998/tomtorfs/Makefile
+++ b/1998/tomtorfs/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/Makefile
+++ b/2000/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/anderson/Makefile
+++ b/2000/anderson/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/bellard/Makefile
+++ b/2000/bellard/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/bmeyer/Makefile
+++ b/2000/bmeyer/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/dhyang/Makefile
+++ b/2000/dhyang/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/dlowe/Makefile
+++ b/2000/dlowe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/jarijyrki/Makefile
+++ b/2000/jarijyrki/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/natori/Makefile
+++ b/2000/natori/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/primenum/Makefile
+++ b/2000/primenum/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/rince/Makefile
+++ b/2000/rince/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/robison/Makefile
+++ b/2000/robison/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/schneiderwent/Makefile
+++ b/2000/schneiderwent/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2000/tomx/Makefile
+++ b/2000/tomx/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/Makefile
+++ b/2001/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/cheong/Makefile
+++ b/2001/cheong/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/dgbeards/Makefile
+++ b/2001/dgbeards/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/herrmann1/Makefile
+++ b/2001/herrmann1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/jason/Makefile
+++ b/2001/jason/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/ollinger/Makefile
+++ b/2001/ollinger/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/rosten/Makefile
+++ b/2001/rosten/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/schweikh/Makefile
+++ b/2001/schweikh/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/Makefile
+++ b/2004/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/anonymous/Makefile
+++ b/2004/anonymous/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/arachnid/Makefile
+++ b/2004/arachnid/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/gavin/Makefile
+++ b/2004/gavin/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/hibachi/Makefile
+++ b/2004/hibachi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/hoyle/Makefile
+++ b/2004/hoyle/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/kopczynski/Makefile
+++ b/2004/kopczynski/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/newbern/Makefile
+++ b/2004/newbern/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/omoikane/Makefile
+++ b/2004/omoikane/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/schnitzi/Makefile
+++ b/2004/schnitzi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/sds/Makefile
+++ b/2004/sds/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/vik1/Makefile
+++ b/2004/vik1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2004/vik2/Makefile
+++ b/2004/vik2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/Makefile
+++ b/2005/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/aidan/Makefile
+++ b/2005/aidan/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/anon/Makefile
+++ b/2005/anon/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/boutines/Makefile
+++ b/2005/boutines/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/chia/Makefile
+++ b/2005/chia/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/jetro/Makefile
+++ b/2005/jetro/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/klausler/Makefile
+++ b/2005/klausler/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/mikeash/Makefile
+++ b/2005/mikeash/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/mynx/Makefile
+++ b/2005/mynx/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/timwi/Makefile
+++ b/2005/timwi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/toledo/Makefile
+++ b/2005/toledo/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/vik/Makefile
+++ b/2005/vik/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2005/vince/Makefile
+++ b/2005/vince/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/Makefile
+++ b/2006/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/birken/Makefile
+++ b/2006/birken/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/borsanyi/Makefile
+++ b/2006/borsanyi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/grothe/Makefile
+++ b/2006/grothe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/hamre/Makefile
+++ b/2006/hamre/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/meyer/Makefile
+++ b/2006/meyer/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/night/Makefile
+++ b/2006/night/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/stewart/Makefile
+++ b/2006/stewart/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/sykes1/Makefile
+++ b/2006/sykes1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/sykes2/Makefile
+++ b/2006/sykes2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/toledo1/Makefile
+++ b/2006/toledo1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2006/toledo3/Makefile
+++ b/2006/toledo3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/Makefile
+++ b/2011/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/blakely/Makefile
+++ b/2011/blakely/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/borsanyi/Makefile
+++ b/2011/borsanyi/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/dlowe/Makefile
+++ b/2011/dlowe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/eastman/Makefile
+++ b/2011/eastman/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/fredriksson/Makefile
+++ b/2011/fredriksson/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/goren/Makefile
+++ b/2011/goren/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/hamaji/Makefile
+++ b/2011/hamaji/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/hou/Makefile
+++ b/2011/hou/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/konno/Makefile
+++ b/2011/konno/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/richards/Makefile
+++ b/2011/richards/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/toledo/Makefile
+++ b/2011/toledo/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/vik/Makefile
+++ b/2011/vik/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2011/zucker/Makefile
+++ b/2011/zucker/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/Makefile
+++ b/2012/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/blakely/Makefile
+++ b/2012/blakely/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/deckmyn/Makefile
+++ b/2012/deckmyn/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/dlowe/Makefile
+++ b/2012/dlowe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/endoh2/Makefile
+++ b/2012/endoh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/grothe/Makefile
+++ b/2012/grothe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/hou/Makefile
+++ b/2012/hou/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/konno/Makefile
+++ b/2012/konno/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/tromp/Makefile
+++ b/2012/tromp/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/Makefile
+++ b/2013/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/cable1/Makefile
+++ b/2013/cable1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/cable2/Makefile
+++ b/2013/cable2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/cable3/Makefile
+++ b/2013/cable3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/dlowe/Makefile
+++ b/2013/dlowe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/endoh1/Makefile
+++ b/2013/endoh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/mills/Makefile
+++ b/2013/mills/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/morgan1/Makefile
+++ b/2013/morgan1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/morgan2/Makefile
+++ b/2013/morgan2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2013/robison/Makefile
+++ b/2013/robison/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/Makefile
+++ b/2014/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/Makefile
+++ b/2015/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/burton/Makefile
+++ b/2015/burton/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/dogon/Makefile
+++ b/2015/dogon/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/duble/Makefile
+++ b/2015/duble/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/endoh1/Makefile
+++ b/2015/endoh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/endoh2/Makefile
+++ b/2015/endoh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/endoh3/Makefile
+++ b/2015/endoh3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/endoh4/Makefile
+++ b/2015/endoh4/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/howe/Makefile
+++ b/2015/howe/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/mills2/Makefile
+++ b/2015/mills2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/muth/Makefile
+++ b/2015/muth/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/schweikhardt/Makefile
+++ b/2015/schweikhardt/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2015/yang/Makefile
+++ b/2015/yang/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/Makefile
+++ b/2018/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/algmyr/Makefile
+++ b/2018/algmyr/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/anderson/Makefile
+++ b/2018/anderson/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/bellard/Makefile
+++ b/2018/bellard/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/burton1/Makefile
+++ b/2018/burton1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/burton2/Makefile
+++ b/2018/burton2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/ciura/Makefile
+++ b/2018/ciura/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/endoh1/Makefile
+++ b/2018/endoh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/giles/Makefile
+++ b/2018/giles/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/hou/Makefile
+++ b/2018/hou/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/mills/Makefile
+++ b/2018/mills/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/vokes/Makefile
+++ b/2018/vokes/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2018/yang/Makefile
+++ b/2018/yang/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/Makefile
+++ b/2019/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/ciura/Makefile
+++ b/2019/ciura/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/Makefile
+++ b/2020/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/carlini/Makefile
+++ b/2020/carlini/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/endoh1/Makefile
+++ b/2020/endoh1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/endoh3/Makefile
+++ b/2020/endoh3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/giles/Makefile
+++ b/2020/giles/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/kurdyukov1/Makefile
+++ b/2020/kurdyukov1/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/kurdyukov3/Makefile
+++ b/2020/kurdyukov3/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/kurdyukov4/Makefile
+++ b/2020/kurdyukov4/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/otterness/Makefile
+++ b/2020/otterness/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/tsoj/Makefile
+++ b/2020/tsoj/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/2020/yang/Makefile
+++ b/2020/yang/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ################################################################################
 #
 # IOCCC winning entry code may not work on your system.  What was liked/allowed
-# and worked in the past may no longer be the liked/allowed or compile/run today.
+# and worked in the past may no longer be liked/allowed or compile/run today.
 #
 # Bug fixes, corrections and typo fixes are VERY WELCOME.  If you see a problem,
 # first check this URL for a list of known bugs and (mis)features of IOCCC winners:

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -144,12 +144,13 @@ The crash was because it destructively rewrites string literals. However with
 `strdup()` it's safe.
 
 The problem with macOS is that although it didn't crash, it printed `H????` in a
-seemingly infinite loop, each time printing another `?`, probably until it ran
+seemingly infinite loop, each time printing another `?`, probably until it runs
 out of memory.
 
 The fix for macOS is that there was no prototype for `execlp()` and macOS has
 problems with missing prototypes for some functions (this was also seen when
-Cody fixed [1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well).
+Cody fixed [1984/anonymous](/1984/anonymous/anonymous.c) for macOS as well). As
+this is a one-liner the include of `unistd.h` was done in the Makefile.
 Ironically this fix was discovered through linux!
 
 NOTE: originally this entry did not print a newline prior to returning to the
@@ -157,6 +158,12 @@ shell, after the output (despite having `\n` in the string - can you figure out
 why?) but to make it more friendly to users Cody made it print a `\n` prior to
 returning to the shell. The original version does not have this change.
 
+## [1985/august](1985/august/august.c) ([README.md](1985/august/README.md))
+
+Cody added the script [primes.sh](1985/august/primes.sh) which allows one to
+check the output for the first N prime numbers of the output, where N is either
+the default or user specified. The inspiration was the previous 'try' command he
+gave to have fun with finding primes that might seem unusual in a way.
 
 ## [1985/lycklama](1985/lycklama/lycklama.c) ([README.md](1985/lycklama/README.md]))
 


### PR DESCRIPTION
 
There was a comment in the form of:
 
    ... the liked/allowed ...

which should instead be:

    ... liked/allowed ...
 
and this was fixed with my sgit tool like:
 
    sgit -e 's,the \(liked/allowed or compile\),\1,g' '*Makefile'
 