### PR TITLE
Swap alt/main in 1996/eldby to run/try

### DIFF
--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -3,7 +3,11 @@
 #define char k['a']
 #define union static struct
 
-int b,
+extern double floor(double);
+double (x1, y1) b;
+/*char x {sizeof(
+     double(%s,%D)(*)()) */
+int
 k['a'] = {sizeof(
     int(*)())
 ,};

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
-	-Wno-return-type -Wno-unsequenced -Wno-strict-prototypes
+	-Wno-return-type -Wno-unsequenced -Wno-strict-prototypes -Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1996/eldby/README.md
+++ b/1996/eldby/README.md
@@ -1,43 +1,52 @@
 # Best Output
 
-Thor AAge Eldby  
-European Technology Partner  
-Roedtvetvn 20                (Home address)  
-0955 Oslo  
+Thor Eldby<br>
 Norway  
 
 
 ## To build:
 
 ```sh
-make all
+make alt
 ```
 
 
 ## To run:
 
 ```sh
-./eldby 
+./eldby.alt
 ```
 
-WARNING: on modern systems this is very fast and could be a problem for those
-susceptible to photosensitivity. Please try this one with caution if this
-applies to you! The same goes for people who can be overstimulated. See below
-for alternate version if you want to see it go slower or if seeing things move
-by too fast is a problem for you.
+To see why we recommend the alternate version instead of the original version,
+see the [original code](#original-code) section. 
 
 NOTE: to reset the sanity of your terminal after this program ends try `reset`.
 
+## Try:
 
-### Alternate code:
-
-The default sleep duration is `35000` but you can change it at compilation like:
+This alternate version, which we recommend that you use in order to see what is
+happening with modern systems, and to not flash too quickly, which can be
+problematic for some people, can be configured to different speeds by way of the
+value used in `usleep()`. The default is `-DZ=35000` but you can easily change
+it. To do so try:
 
 ```sh
 make CFLAGS+="-DZ=20000" clobber alt
+./eldby.alt
 ```
 
-Use `eldby.alt` as you would `eldby`.
+### Original code:
+
+Besides the fact that modern systems make it impossible to see what this program
+does the rapid movement can be a problem for some people. It is for these
+reasons that we recommend you first try the alternate version as described
+above. If however you wish to see the original version in modern systems, try:
+
+```sh
+make all
+```
+
+Use `./eldby` as you would `./eldby.alt` above.
 
 
 ## Judges' remarks:

--- a/2014/skeggs/.gitignore
+++ b/2014/skeggs/.gitignore
@@ -1,2 +1,7 @@
 prog
 prog.orig
+err
+static_assert
+t.c
+thread_local
+volatile

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -74,7 +74,7 @@ CFLAGS= ${CSTD} ${CWARN} ${ARCH} ${CDEFINE} ${CINCLUDE} ${OPT}
 
 # Libraries needed to build
 #
-LDFLAGS=
+LDFLAGS= -ldl
 
 # C compiler to use
 #
@@ -154,7 +154,7 @@ everything: all alt
 ###############
 #
 clean:
-	${RM} -f ${OBJ} ${ALT_OBJ}
+	${RM} -f ${OBJ} ${ALT_OBJ} err static_assert t.c thread_local volatile
 	@-if [ -f indent.c ]; then \
 	    echo ${RM} -f indent.c; \
 	    ${RM} -f indent.c; \

--- a/faq.md
+++ b/faq.md
@@ -125,6 +125,45 @@ does not. We're not sure how this is compatibility but either way it can cause a
 problem and it is this that has complicated most of the fixes though again some
 can look almost identical.
 
+## Q: How can I easily see what was changed in order to get an entry to work in modern systems?
+
+Although the [thanks-for-fixes.md](/thanks-for-fixes.md) file sometimes gives
+commands to tell you how to do this, in general you can do:
+
+```sh
+diff entry.c entry.orig.c
+diff prog.c prog.orig.c
+```
+
+to see it as if you wanted to make it go back to the original and, to see the
+difference to fix it, you can do:
+
+```sh
+diff entry.orig.c entry.c
+diff prog.orig.c prog.c
+```
+
+For instance to see how [2001/anonymous](2001/anonymous/README.md) was fixed you
+can do:
+
+```sh
+diff 2001/anonymous/anonymous.orig.c 2001/anonymous/anonymous.c
+```
+
+You might be quite surprised how little some entries had to be changed and at
+the same time how much other entries had to be changed, often with quite complex
+differences! In some cases if the line is rather long, like the above mentioned
+one, it will be harder to see what changed but in other cases like
+[1984/decot](1984/decot/README.md) it's a lot easier:
+
+```sh
+diff 1984/decot/decot.orig.c 1984/decot/decot.c
+```
+
+Well, at least it's easier see the differences on a line-by-line basis but maybe
+not what actually changed, especially since it's easier to know what was fixed
+when you have compiler errors :-)
+
 
 ## Q: I cannot get entry XYZZY from year 19xx to compile!
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -115,9 +115,26 @@ A note about the fix is that the `#define`d macros that were used still exist
 but are not used; they are left in just to make it look more like the original
 entry. Nevertheless they cannot be used.
 
+Later on Cody improved the fix to make it look rather more like the original by
+bringing back an extern declaration (slightly changing it to match the symbol
+that it is i.e. `extern double floor(double);` instead of `extern int floor;`)
+and `double (x1, y1) b;`, commenting out only the code:
+
+```c
+char x {sizeof(
+     double(%s,%D)(*)())
+```
+
+and changing the type of `k` to be an `int`.
+
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.
 
+To see the difference from start to fixed:
+
+```sh
+diff 1984/decot/decot.orig.c 1984/decot/decot.c
+```
 
 ## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md]))
 
@@ -127,8 +144,8 @@ the [FAQ](faq.md) as there are some winning entries that also let one enjoy it -
 with more to them of course!
 
 Cody also added the [gentab.c](1984/mullender/gentab.c) file, fixed to compile
-with modern systems and so that it would create the proper array (it had
-unbalanced '}'s), which the author noted in their remarks (which Cody also
+and work with modern systems and so that it would create the proper array (it
+had unbalanced '}'s), which the author noted in their remarks (which Cody also
 found). As this file uses the old header file `a.out.h` that is not available in
 all modern systems, Cody found a copy of it as to what it should have been at
 the time, in the fabulous [Unix History

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -212,31 +212,45 @@ and gcc.
 
 ## [1986/marshall](1986/marshall/marshall.c) ([README.md](1986/marshall/README.md]))
 
-Cody got this to compile and work with clang. It did not work with clang because
-it is more strict about the second and third args to `main()` and the third arg
-was an `int`.  He notes that he tried to keep the ASCII art as close to the
-original as possible. The line lengths are the same but some spaces had to be
-changed to non-spaces.
+Cody got this to compile and work with clang and gcc. The optimiser being
+enabled in one compiler let it work but broke it in the other; and disabling it
+would let it work in the one that didn't work but suddenly the one that worked
+would be broken. See below and the README.md file for more details.
 
-A very funny problem occurred depending on the compiler and whether or not the
-optimiser is enabled that had to be fixed: one compiler would work fine but
+This problem was only after getting clang to compile, of course. It did not
+compile it because it is more strict about the second and third args to `main()`
+and the third arg was an `int`.  Cody notes that he tried to keep the ASCII art
+as close to the original as possible. The line lengths are the same but some
+spaces had to be changed to non-spaces.
+
+As noted above, a very funny problem occurred depending on the compiler and whether or not the
+optimiser was enabled that had to be fixed: one compiler would work fine but
 another might enter an infinite loop or segfault but then once the optimiser
 state was changed the compiler that worked no longer worked (in the same was as
-the other one not working) and the one that didn't work did! We encourage you to
-see the README.md file to see how odd this problem was and what Cody did to fix
-it!
+the other one not working) and the one that didn't work did!
+
+We encourage you to see the README.md file to see how odd this problem was and
+what Cody did to fix it!
 
 
 ## [1986/wall](1986/wall/wall.c) ([README.md](1986/wall/README.md]))
 
-We used a patch provided by Yusuke to make this work with gcc (in particular the
-patch uses `strdup()` on two strings).
-
 Cody fixed this so that it does not require `-traditional-cpp`. This took a fair
-bit of tinkering as this entry *is* strange. The original code is provided to
-allow one to easily see how different C was in those days. See the README.md
-file for details.
+bit of tinkering as this entry *is* strange; fixing `-traditional-cpp` is, as noted earlier, very
+complicated, but we encourage you to look at [original
+code](1986/wall/wall.orig.c) to see how different C was in 1986.
 
+Yusuke originally patched this to use `strdup()` on two strings and this let it
+work with gcc but it still requires `-traditional-cpp`. The [alternate
+code](1986/wall/wall.alt.c) is the version patched by Yusuke should you wish to
+try it with a compiler that has the `-traditional-cpp`.
+
+If you'd like to see the difference between the version that requires
+`-traditional-cpp` and the fixed version, try:
+
+```sh
+git diff 82cbf069a781d64802fc59b36778c0b02be4043e..a74abb69b7e9b87e305b529941bf46f97ffff341 1986/wall/wall.c
+```
 
 ## [1987/wall](1987/wall/wall.c) ([README.md](1987/wall/README.md]))
 
@@ -1856,6 +1870,24 @@ it is a file with spoilers.
 
 Cody fixed the build for this entry: it does not require SDL2 but SDL1 so there
 were linking errors.
+
+
+## [2014/skeggs](2014/skeggs/prog.c) ([README.md](2014/skeggs/README.md))
+
+Cody fixed the Makefile to compile this entry in modern systems. The problem was
+that the `CDEFINE` variable in the Makefile was missing `'`s: the `#define CC`
+is an actual string that is, in the Makefile, is `"${CC} -fPIC"`, which
+translates to whatever the compiler is followed by a space followed by `-fPIC`
+but without the `'`s it was incomplete and so would not compile. Cody didn't
+have a chance to really look at the compiler error.
+
+Yusuke suggested that one should use `-ldl` in the Makefile. This was not
+originally done because it seemed to work but since it uses `dlsym()` it was
+added later to make it more portable.
+
+The program creates files in the working directory as part of how it works (see
+the README.md file for details) so Cody made sure that `make clobber` (via `make
+clean`) removes those files and so that they are ignored by `.gitignore`.
 
 ## [2014/vik](2014/vik/prog.c) ([README.md](2014/vik/README.md))
 


### PR DESCRIPTION

This is one of the rare cases where the alternate version is preferable
in modern systems as it moves way too fast to see what is going on and
it can also be a problem for many because it flashes by too quickly.

Added to CSILENCE -Wno-implicit-int.