### PR TITLE
Make 1987/westley more symmetrical after fix

### DIFF
--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -1,10 +1,6 @@
 # Worst Style
 
-Spencer Hines  
-OnLine Computer Systems  
-4200 Farragut Street  
-Hyattsville, MD  
-20781  
+Spencer Hines<br>
 US  
 
 ## To build:
@@ -27,8 +23,8 @@ make all
 
 ### Alternate code:
 
-An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older compilers you
-can try the alt version:
+An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older
+compilers you can try the alt version:
 
 ```sh
 make alt
@@ -39,11 +35,12 @@ Use `hines.alt` as you would `hines` above.
 ## Judges' remarks:
 
 This program was designed to maximize the bother function for
-structured programmers.  This program takes goto statements to their
+structured programmers.  This program takes `goto` statements to their
 logical conclusion.  The layout and choice of names are classic.
 
 We consider this to be a beautiful counter-example for Frank Rubin's
-letter to ACM form titled: _"'GOTO Considered Harmful' Considered Harmful"_.
+letter to ACM form titled: _["'GOTO Considered Harmful' Considered
+Harmful"](https://web.archive.org/web/20090320002214/http://www.ecn.purdue.edu/ParaMount/papers/rubin87goto.pdf)_.
 See the Communications of the ACM, March 1987, Page 195-196.
 
 

--- a/1987/korn/README.md
+++ b/1987/korn/README.md
@@ -1,10 +1,6 @@
 # Best One Liner
 
 David Korn   
-AT&T Bell Labs  
-MH 3C-526B, AT&T Bell Labs   
-Murray Hill, NJ   
-07974   
 US   
 
 ## To build:
@@ -13,15 +9,21 @@ US
 make all
 ```
 
+## To use:
+
+```sh
+./korn
+```
+
 ## Judges' remarks:
 
 The Judges believe that this is the best one line entry ever received.
-Compile on a `UNIX` system, or at least using a C implementation that
+Compile on a UNIX system, or at least one using a C implementation that
 fakes it.  Very few people are able to determine what this program
 does by visual inspection.  I suggest that you stop reading this
 section right now and see if you are one of the few people who can.
 
-Several points are important to understand in this program:
+Several points are important to understand this program:
 
 1. What is the symbol `unix` and what is its value in the program?  Clearly
 `unix` is not a function, and since `unix` is not declared to be a data type
@@ -34,9 +36,8 @@ characters, or `'h'`, or a string)  Consider the fact that:
 	    char *x;  
 
 
-  defines a pointer to a character (i.e. an address), and that the `=` assigns
+  defines a pointer to a `char` (i.e. an address), and that the `=` assigns
   things of compatible types.  Since:
-
 
         x = "have";
 
@@ -53,8 +54,12 @@ characters, or `'h'`, or a string)  Consider the fact that:
 
     ?
 
-David Korn's `/bin/ksh` provides us with a greatly improved version of
-the /bin/sh.  The source for v7's /bin/sh greatly inspired this contest.
+[David
+Korn](https://news.slashdot.org/story/01/02/06/2030205/david-korn-tells-all)'s
+[/bin/ksh](https://en.wikipedia.org/wiki/KornShell) provides us with a greatly
+improved version of the [/bin/sh](https://en.wikipedia.org/wiki/Bourne_shell).
+The source for [v7](https://en.wikipedia.org/wiki/Version_7_Unix)'s /bin/sh
+greatly inspired this contest.
 
 ## Author's remarks:
 

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -9,8 +9,8 @@ Netherlands
 make all
 ```
 
-NOTE: The original entry may be built with "make alt" if you have an old enough
-compiler.
+There is [Alternate code](#alternate-code) available for if you have an old
+enough compiler.
 
 ## To run:
 
@@ -18,12 +18,6 @@ compiler.
 ./lievaart
 # enter a level and start playing as described below
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-If you enter invalid input the program will enter an infinite loop displaying a
-string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
-incorrect value it will prompt you again until you input a proper value.
 
 ## Try:
 
@@ -34,30 +28,46 @@ To see what it would have looked like without the size restrictions:
 # enter a level and start playing as described below
 ```
 
+## Alternate code:
+
+If you have an old enough compiler you might wish to try using it. To use:
+
+```sh
+make alt
+```
+
+Use `./lievaart.alt` as you would `./lievaart` above.
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+If you enter invalid input the program will enter an infinite loop displaying a
+string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
+incorrect value it will prompt you again until you input a proper value.
 
 ## Judges' remarks:
 
 We believe that you too will be amazed at just how much power Mr. Lievaart
 packed into 1024 bytes!
 
-This Plays the game of Reversi (Othello)!  Compile and run.  It then
+This Plays the game of [Reversi
+(Othello)](https://en.wikipedia.org/wiki/Reversi)!  Compile and run.  It then
 asks for a playing level. Enter 0-10 (easy-hard).  It then asks for
-your move. A move is a number within 11-88, or a 99 to pass.  Illegal
+your move. A move is a number within 11-88, or 99 to pass.  Illegal
 moves (except for an illegal pass) are rejected.  Then the computer
 does its move (or a 0 to pass), until the board is full.
 
-It plays rather well, for such a small program!  Lievaart had to leave out the
+It plays rather well, for such a small program! Lievaart had to leave out the
 board printing routine, so you'll have to take a real game board to play it (or
 see below). ...  Also due to space-limitations (the rules for 1987 had a limit
 of 1024 byes), Lievaart took out the passing-handler, which makes its
-ending-game rather poor.  But further it knows all the rules, uses alpha-beta
-pruning, and it plays f.i. on mobility(!).  Most important: it can play a pretty
-good game of Reversi!
+ending-game rather poor.  But further it knows all the rules, uses [alpha-beta
+pruning](https://en.wikipedia.org/wiki/Alpha-beta_pruning), and it plays for
+instance on mobility(!).  Most important: it can play a pretty good game of Reversi!
 
 The Author was kind enough to supply the fully functional version of the
-program.  The file lievaart2.c contains what the program would have
-been without the size restriction.  This version has the full end game 
-logic and displays the board after each move!
+program.  The file [lievaart2.c](lievaart2.c) contains what the program would
+have been without the size restriction.  This version has the full end game
+logic and displays the board after each move! See above for how to use this.
 
 
 ## Author's remarks:

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -1,3 +1,4 @@
+#define D define
 #define Y return
 #define R for
 #define e while

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -1,3 +1,4 @@
+#define D define
 #define Y return
 #define R for
 #define e while

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -1,6 +1,6 @@
 # Most Useful Obfuscation
 
-Larry Wall  
+Larry Wall<br>
 US
 
 ## To build:
@@ -59,12 +59,12 @@ quit # for the cat version
 ## Judges' remarks:
 
 
-What we found amazing was how the flow of control was transferred
-between subroutines.  Careful inspection will show that the array of
-pointers to functions named `vi` refers to functions which seem to not
-be directly called.  Even so, these pointers to functions are being
-used as an argument to `signal()` (used both with and without an arg - but
-how?).  Can you determine why this is being done and how it is being exploited?
+What we found amazing was how the flow of control was transferred between
+subroutines.  Careful inspection will show that the array of pointers to
+functions named `vi` refers to functions which seem to not be directly called.
+Even so, these pointers to functions are being used as an argument to
+`signal(3)` (used both with and without an arg - but how?).  Can you determine
+why this is being done and how it is being exploited?
 
 Some compilers complained about this file, so we changed: `=++I` to `= ++I`.
 

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-for-loop-analysis -Wno-unused-value \
-	-Wno-deprecated-non-prototype -Wno-strict-prototypes
+	-Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -62,7 +62,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 
 # Optimization
 #

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -31,12 +31,10 @@ Use `westley.alt` as you would `westley` above.
 ## Judges' remarks:
 
 `putchar()` must exist in the C library and not just as a macro.
-If it fails to compile, add the line:  `#include <stdio.h>`  at the
-top of the program.
+If it fails to compile, bug your OS/compiler vendor.
 
 Line by line symmetry performed better than any C beautifier.  Think
 of if it as a C ink blot.  :-)
-
 
 ## Author's remarks:
 

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -30,7 +30,7 @@ Use `westley.alt` as you would `westley` above.
 
 ## Judges' remarks:
 
-Putchar must exist in the C library and not just as a macro.
+`putchar()` must exist in the C library and not just as a macro.
 If it fails to compile, add the line:  `#include <stdio.h>`  at the
 top of the program.
 

--- a/1987/westley/westley.c
+++ b/1987/westley/westley.c
@@ -26,11 +26,11 @@
 		           ,LACEDx0 = 0xDECAL,
 				rof ; for
 			     (;(int) (tni);)
-			    /* (int)*/(tni)
+			          (tni)
 			  = reviled ; deliver =
 				redivider
 				    ;
-for ((int)(tni)++,++reviled;reviled* *deliver;deliver++,++/*(int)*/(tni)) rof
+     for ((tni)++,++reviled;reviled**deliver;deliver++,++(tni)) rof
 			            =
 			     (int) -1- (tni)
 		          ;reviled--;--deliver;

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
-	-Wno-int-conversion -Wno-pointer-to-int-cast -Wno-implicit-int
+	-Wno-int-conversion -Wno-pointer-to-int-cast -Wno-implicit-int -Wno-parentheses \
+	-Wno-return-type -Wno-deprecated-non-prototype -Wno-disabled-macro-expansion
 
 # Common C compiler warning flags
 #
@@ -94,7 +95,7 @@ endif
 #
 ifeq ($(CC),gcc)
 #
-#CSILENCE+=
+CSILENCE+= -Wno-missing-parameter-type
 #
 #CWARN+=
 #

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+#
+# demo.sh - script to demonstrate IOCCC entry 1991/fine
+#
 
 make all || exit 1
 

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -6,7 +6,7 @@
 make all || exit 1
 
 echo -n "Green terra <-> "
-echo "Green terra" |./fine
+echo "Green terra" | ./fine
 
 echo -n "Vex <-> "
 echo "Vex" | ./fine

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -2,22 +2,22 @@
 
 make all || exit 1
 
-echo -n "Green terra: "
+echo -n "Green terra <->  "
 echo "Green terra" |./fine
 
-echo -n "Vex: "
+echo -n "Vex <->  "
 echo "Vex" | ./fine
 
-echo -n "Tang: "
+echo -n "Tang <->  "
 echo "Tang" | ./fine
 
-echo -n "Vend onyx: "
+echo -n "Vend onyx <->  "
 echo "Vend onyx" | ./fine
-echo -n "Cheryl be flashy: "
+echo -n "Cheryl be flashy <->  "
 echo "Cheryl be flashy" | ./fine
-echo -n "Rail: "
+echo -n "Rail <->  "
 echo "Rail" | ./fine
-echo -n "Clerk: "
+echo -n "Clerk <->  "
 echo "Clerk" | ./fine
-echo -n "The rug gary lenT: "
+echo -n "The rug gary lenT <->  "
 echo "The rug gary lenT" | ./fine

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -2,22 +2,22 @@
 
 make all || exit 1
 
-echo -n "Green terra <->  "
+echo -n "Green terra <-> "
 echo "Green terra" |./fine
 
-echo -n "Vex <->  "
+echo -n "Vex <-> "
 echo "Vex" | ./fine
 
-echo -n "Tang <->  "
+echo -n "Tang <-> "
 echo "Tang" | ./fine
 
-echo -n "Vend onyx <->  "
+echo -n "Vend onyx <-> "
 echo "Vend onyx" | ./fine
-echo -n "Cheryl be flashy <->  "
+echo -n "Cheryl be flashy <-> "
 echo "Cheryl be flashy" | ./fine
-echo -n "Rail <->  "
+echo -n "Rail <-> "
 echo "Rail" | ./fine
-echo -n "Clerk <->  "
+echo -n "Clerk <-> "
 echo "Clerk" | ./fine
-echo -n "The rug gary lenT <->  "
+echo -n "The rug gary lenT <-> "
 echo "The rug gary lenT" | ./fine

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -283,6 +283,12 @@ of `strings.h` and because it's identical in use to `strchr(3)` (and we noted
 that for System V we had to do this) Cody added to the Makefile
 `-Dindex=strchr`.
 
+## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
+
+Cody made this ever so slightly like the original code by adding back the
+`#define D define` even though it's unused. This was done for both versions as
+well (the one with the board and the one without, the entry itself with the
+limitations of the contest).
 
 ## [1987/wall](1987/wall/wall.c) ([README.md](1987/wall/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -309,6 +309,8 @@ Cody fixed this for modern systems. The problem was `'assignment to cast is
 illegal, lvalue casts are not supported'`. For the original file see the
 README.md file.
 
+Cody also added to the Makefile `-include stdio.h` in the nowadays very
+unlikely(?) but nevertheless suggested case that `putchar()` is not available.
 
 ## [1988/dale](1988/dale/dale.c) ([README.md](1988/dale/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -307,7 +307,12 @@ the code can refer to `gets()` instead.
 
 Cody fixed this for modern systems. The problem was `'assignment to cast is
 illegal, lvalue casts are not supported'`. For the original file see the
-README.md file.
+README.md file. Unfortunately this ruins some symmetry. To try and resolve this
+as much as possible at first code was commented out but later on the commented
+out code was removed and another part changed so that, although it has some code
+no longer there, it has a closer match in symmetry and since the code was
+commented out it's probably not a big deal to have it removed instead as it does
+look more symmetrical now.
 
 Cody also added to the Makefile `-include stdio.h` in the nowadays very
 unlikely(?) but nevertheless suggested case that `putchar()` is not available.


### PR DESCRIPTION

With the compilation fix of the code some symmetry was unfortunately 
destroyed. To try and keep it as close as possible to the original I had
just commented out the code. But looking at it again today it occurred 
to me that I can make it look more symmetrical by removing the commented
out code and then formatting the code a bit differently (another cast
was removed to do this). It is not any less authentic but it now has 
more symmetry which was an important part of the entry's layout.