### PR TITLE
Format/typo check 1988/dale

### DIFF
--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -21,7 +21,7 @@ int dup, signal;
 	goto _0;
 
 _O: while (!(k['a'] <<= - dup)) {	/*/*\*/
-	static struct tag u = {4};
+	union tag u x{4};
   }
 }
 

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -103,6 +103,7 @@ ifeq ($(CC),gcc)
 #
 #CWARN+=
 #
+CFLAGS+= -traditional-cpp
 endif
 
 
@@ -136,8 +137,11 @@ ${PROG}: ${PROG}.c
 
 # alternative executable
 #
-alt: data ${ALT_TARGET}
+alt: ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -26,9 +26,14 @@ might enjoy looking at the original source in [wall.alt.c](wall.alt.c).
 # if you have an old enough compiler:
 make alt
 
-# or with gcc:
+# or if you have gcc:
+make CC=gcc alt
+
+# or if you have a compiler that supports -traditional-cpp that's not gcc:
 make CFLAGS+="-traditional-cpp" alt
 ```
+
+NOTE: gcc in macOS is actually clang even the binary `/usr/bin/gcc`.
 
 Use `./wall.alt` as you would `./wall`.
 

--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -1,10 +1,6 @@
 # Worst Style
 
-Spencer Hines  
-OnLine Computer Systems  
-4200 Farragut Street  
-Hyattsville, MD  
-20781  
+Spencer Hines<br>
 US  
 
 ## To build:
@@ -27,8 +23,8 @@ make all
 
 ### Alternate code:
 
-An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older compilers you
-can try the alt version:
+An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older
+compilers you can try the alt version:
 
 ```sh
 make alt
@@ -39,11 +35,12 @@ Use `hines.alt` as you would `hines` above.
 ## Judges' remarks:
 
 This program was designed to maximize the bother function for
-structured programmers.  This program takes goto statements to their
+structured programmers.  This program takes `goto` statements to their
 logical conclusion.  The layout and choice of names are classic.
 
 We consider this to be a beautiful counter-example for Frank Rubin's
-letter to ACM form titled: _"'GOTO Considered Harmful' Considered Harmful"_.
+letter to ACM form titled: _["'GOTO Considered Harmful' Considered
+Harmful"](https://web.archive.org/web/20090320002214/http://www.ecn.purdue.edu/ParaMount/papers/rubin87goto.pdf)_.
 See the Communications of the ACM, March 1987, Page 195-196.
 
 

--- a/1987/korn/README.md
+++ b/1987/korn/README.md
@@ -1,10 +1,6 @@
 # Best One Liner
 
 David Korn   
-AT&T Bell Labs  
-MH 3C-526B, AT&T Bell Labs   
-Murray Hill, NJ   
-07974   
 US   
 
 ## To build:
@@ -13,15 +9,21 @@ US
 make all
 ```
 
+## To use:
+
+```sh
+./korn
+```
+
 ## Judges' remarks:
 
 The Judges believe that this is the best one line entry ever received.
-Compile on a `UNIX` system, or at least using a C implementation that
+Compile on a UNIX system, or at least one using a C implementation that
 fakes it.  Very few people are able to determine what this program
 does by visual inspection.  I suggest that you stop reading this
 section right now and see if you are one of the few people who can.
 
-Several points are important to understand in this program:
+Several points are important to understand this program:
 
 1. What is the symbol `unix` and what is its value in the program?  Clearly
 `unix` is not a function, and since `unix` is not declared to be a data type
@@ -34,9 +36,8 @@ characters, or `'h'`, or a string)  Consider the fact that:
 	    char *x;  
 
 
-  defines a pointer to a character (i.e. an address), and that the `=` assigns
+  defines a pointer to a `char` (i.e. an address), and that the `=` assigns
   things of compatible types.  Since:
-
 
         x = "have";
 
@@ -53,8 +54,12 @@ characters, or `'h'`, or a string)  Consider the fact that:
 
     ?
 
-David Korn's `/bin/ksh` provides us with a greatly improved version of
-the /bin/sh.  The source for v7's /bin/sh greatly inspired this contest.
+[David
+Korn](https://news.slashdot.org/story/01/02/06/2030205/david-korn-tells-all)'s
+[/bin/ksh](https://en.wikipedia.org/wiki/KornShell) provides us with a greatly
+improved version of the [/bin/sh](https://en.wikipedia.org/wiki/Bourne_shell).
+The source for [v7](https://en.wikipedia.org/wiki/Version_7_Unix)'s /bin/sh
+greatly inspired this contest.
 
 ## Author's remarks:
 

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -9,8 +9,8 @@ Netherlands
 make all
 ```
 
-NOTE: The original entry may be built with "make alt" if you have an old enough
-compiler.
+There is [Alternate code](#alternate-code) available for if you have an old
+enough compiler.
 
 ## To run:
 
@@ -18,12 +18,6 @@ compiler.
 ./lievaart
 # enter a level and start playing as described below
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-If you enter invalid input the program will enter an infinite loop displaying a
-string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
-incorrect value it will prompt you again until you input a proper value.
 
 ## Try:
 
@@ -34,30 +28,46 @@ To see what it would have looked like without the size restrictions:
 # enter a level and start playing as described below
 ```
 
+## Alternate code:
+
+If you have an old enough compiler you might wish to try using it. To use:
+
+```sh
+make alt
+```
+
+Use `./lievaart.alt` as you would `./lievaart` above.
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+If you enter invalid input the program will enter an infinite loop displaying a
+string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
+incorrect value it will prompt you again until you input a proper value.
 
 ## Judges' remarks:
 
 We believe that you too will be amazed at just how much power Mr. Lievaart
 packed into 1024 bytes!
 
-This Plays the game of Reversi (Othello)!  Compile and run.  It then
+This Plays the game of [Reversi
+(Othello)](https://en.wikipedia.org/wiki/Reversi)!  Compile and run.  It then
 asks for a playing level. Enter 0-10 (easy-hard).  It then asks for
-your move. A move is a number within 11-88, or a 99 to pass.  Illegal
+your move. A move is a number within 11-88, or 99 to pass.  Illegal
 moves (except for an illegal pass) are rejected.  Then the computer
 does its move (or a 0 to pass), until the board is full.
 
-It plays rather well, for such a small program!  Lievaart had to leave out the
+It plays rather well, for such a small program! Lievaart had to leave out the
 board printing routine, so you'll have to take a real game board to play it (or
 see below). ...  Also due to space-limitations (the rules for 1987 had a limit
 of 1024 byes), Lievaart took out the passing-handler, which makes its
-ending-game rather poor.  But further it knows all the rules, uses alpha-beta
-pruning, and it plays f.i. on mobility(!).  Most important: it can play a pretty
-good game of Reversi!
+ending-game rather poor.  But further it knows all the rules, uses [alpha-beta
+pruning](https://en.wikipedia.org/wiki/Alpha-beta_pruning), and it plays for
+instance on mobility(!).  Most important: it can play a pretty good game of Reversi!
 
 The Author was kind enough to supply the fully functional version of the
-program.  The file lievaart2.c contains what the program would have
-been without the size restriction.  This version has the full end game 
-logic and displays the board after each move!
+program.  The file [lievaart2.c](lievaart2.c) contains what the program would
+have been without the size restriction.  This version has the full end game
+logic and displays the board after each move! See above for how to use this.
 
 
 ## Author's remarks:

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -1,3 +1,4 @@
+#define D define
 #define Y return
 #define R for
 #define e while

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -1,3 +1,4 @@
+#define D define
 #define Y return
 #define R for
 #define e while

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -1,6 +1,6 @@
 # Most Useful Obfuscation
 
-Larry Wall  
+Larry Wall<br>
 US
 
 ## To build:
@@ -59,12 +59,12 @@ quit # for the cat version
 ## Judges' remarks:
 
 
-What we found amazing was how the flow of control was transferred
-between subroutines.  Careful inspection will show that the array of
-pointers to functions named `vi` refers to functions which seem to not
-be directly called.  Even so, these pointers to functions are being
-used as an argument to `signal()` (used both with and without an arg - but
-how?).  Can you determine why this is being done and how it is being exploited?
+What we found amazing was how the flow of control was transferred between
+subroutines.  Careful inspection will show that the array of pointers to
+functions named `vi` refers to functions which seem to not be directly called.
+Even so, these pointers to functions are being used as an argument to
+`signal(3)` (used both with and without an arg - but how?).  Can you determine
+why this is being done and how it is being exploited?
 
 Some compilers complained about this file, so we changed: `=++I` to `= ++I`.
 

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-for-loop-analysis -Wno-unused-value \
-	-Wno-deprecated-non-prototype -Wno-strict-prototypes
+	-Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -62,7 +62,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 
 # Optimization
 #

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -31,12 +31,10 @@ Use `westley.alt` as you would `westley` above.
 ## Judges' remarks:
 
 `putchar()` must exist in the C library and not just as a macro.
-If it fails to compile, add the line:  `#include <stdio.h>`  at the
-top of the program.
+If it fails to compile, bug your OS/compiler vendor.
 
 Line by line symmetry performed better than any C beautifier.  Think
 of if it as a C ink blot.  :-)
-
 
 ## Author's remarks:
 

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -30,7 +30,7 @@ Use `westley.alt` as you would `westley` above.
 
 ## Judges' remarks:
 
-Putchar must exist in the C library and not just as a macro.
+`putchar()` must exist in the C library and not just as a macro.
 If it fails to compile, add the line:  `#include <stdio.h>`  at the
 top of the program.
 

--- a/1987/westley/westley.c
+++ b/1987/westley/westley.c
@@ -26,11 +26,11 @@
 		           ,LACEDx0 = 0xDECAL,
 				rof ; for
 			     (;(int) (tni);)
-			    /* (int)*/(tni)
+			          (tni)
 			  = reviled ; deliver =
 				redivider
 				    ;
-for ((int)(tni)++,++reviled;reviled* *deliver;deliver++,++/*(int)*/(tni)) rof
+     for ((tni)++,++reviled;reviled**deliver;deliver++,++(tni)) rof
 			            =
 			     (int) -1- (tni)
 		          ;reviled--;--deliver;

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -1,6 +1,6 @@
 # Best abuse of system calls
 
-Paul Dale  
+Paul Dale<br>
 Australia  
 
 ## To build:
@@ -40,7 +40,8 @@ If you have an old enough compiler you can try the original version in
 make clobber alt
 ```
 
-Use `dale.alt` as you would `dale` above.
+Use `dale.alt` as you would `dale` above. To understand the differences in more
+detail, see [thanks-for-fixes.md](/thanks-for-fixes.md).
 
 
 ## Judges' remarks

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
-	-Wno-int-conversion -Wno-pointer-to-int-cast -Wno-implicit-int
+	-Wno-int-conversion -Wno-pointer-to-int-cast -Wno-implicit-int -Wno-parentheses \
+	-Wno-return-type -Wno-deprecated-non-prototype -Wno-disabled-macro-expansion
 
 # Common C compiler warning flags
 #
@@ -94,7 +95,7 @@ endif
 #
 ifeq ($(CC),gcc)
 #
-#CSILENCE+=
+CSILENCE+= -Wno-missing-parameter-type
 #
 #CWARN+=
 #

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+#
+# demo.sh - script to demonstrate IOCCC entry 1991/fine
+#
 
 make all || exit 1
 

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -6,7 +6,7 @@
 make all || exit 1
 
 echo -n "Green terra <-> "
-echo "Green terra" |./fine
+echo "Green terra" | ./fine
 
 echo -n "Vex <-> "
 echo "Vex" | ./fine

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -2,22 +2,22 @@
 
 make all || exit 1
 
-echo -n "Green terra: "
+echo -n "Green terra <->  "
 echo "Green terra" |./fine
 
-echo -n "Vex: "
+echo -n "Vex <->  "
 echo "Vex" | ./fine
 
-echo -n "Tang: "
+echo -n "Tang <->  "
 echo "Tang" | ./fine
 
-echo -n "Vend onyx: "
+echo -n "Vend onyx <->  "
 echo "Vend onyx" | ./fine
-echo -n "Cheryl be flashy: "
+echo -n "Cheryl be flashy <->  "
 echo "Cheryl be flashy" | ./fine
-echo -n "Rail: "
+echo -n "Rail <->  "
 echo "Rail" | ./fine
-echo -n "Clerk: "
+echo -n "Clerk <->  "
 echo "Clerk" | ./fine
-echo -n "The rug gary lenT: "
+echo -n "The rug gary lenT <->  "
 echo "The rug gary lenT" | ./fine

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -2,22 +2,22 @@
 
 make all || exit 1
 
-echo -n "Green terra <->  "
+echo -n "Green terra <-> "
 echo "Green terra" |./fine
 
-echo -n "Vex <->  "
+echo -n "Vex <-> "
 echo "Vex" | ./fine
 
-echo -n "Tang <->  "
+echo -n "Tang <-> "
 echo "Tang" | ./fine
 
-echo -n "Vend onyx <->  "
+echo -n "Vend onyx <-> "
 echo "Vend onyx" | ./fine
-echo -n "Cheryl be flashy <->  "
+echo -n "Cheryl be flashy <-> "
 echo "Cheryl be flashy" | ./fine
-echo -n "Rail <->  "
+echo -n "Rail <-> "
 echo "Rail" | ./fine
-echo -n "Clerk <->  "
+echo -n "Clerk <-> "
 echo "Clerk" | ./fine
-echo -n "The rug gary lenT <->  "
+echo -n "The rug gary lenT <-> "
 echo "The rug gary lenT" | ./fine

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -11,21 +11,22 @@ contributed thousands, that we wish to thank.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
-responsible for many of the improvements including many, many **very complicated
-bug fixes** ([1988/phillipps](1988/phillipps/README.md),
-[2001/anonymous](2001/anonymous/README.md), [2004/burley](2004/burley/README.md)
-and others) making entries not require `-traditional-cpp` (which are **very
-complicated fixes**), fixing entries to compile with clang, fixing entries to
-work with macOS (some being **very complicated** like
-[1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit/64-bit which *can be* **very complicated** (like
-[2001/herrmann2](2001/herrmann2/README.md)), providing alternate code where
-useful/necessary, fixing where possible dead links or removing them,
-typo/consistency fixes, improving **ALL _Makefiles_** and writing
-[sgit](https://github.com/xexyl/sgit) that we installed locally and used to
-easily run `sed` on files in the repo to help build the website. **Thank you
-very much** for your extensive efforts in helping improve the IOCCC presentation
-of past IOCCC winners and fixing so many for modern systems!
+responsible for many of the improvements including many **very complicated bug
+fixes** like [1988/phillipps](1988/phillipps/README.md),
+[2001/anonymous](2001/anonymous/README.md) and
+[2004/burley](2004/burley/README.md), making entries like
+[1986/wall](1986/wall/README.md) not require `-traditional-cpp` (all **very
+complicated fixes**), fixing entries to compile with clang, porting entries to
+macOS, some being **very complicated** like
+[1998/schweikh1](1998/schweikh1/README.md), fixing code like
+[2001/herrmann2](2001/herrmann2/README.md) to work in both 32-bit/64-bit which
+*can be* **very complicated**, providing alternate code where useful/necessary,
+fixing where possible dead links or removing them, typo/consistency fixes,
+improving **ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit)
+that we installed locally to easily run `sed` on files in the repo to help build
+the website. **Thank you very much** for your extensive efforts in helping
+improve the IOCCC presentation of past IOCCC winners and fixing almost all for
+modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those
@@ -261,15 +262,16 @@ noted earlier, very complicated, but we encourage you to look at [original
 code](1986/wall/wall.orig.c) to see how different C was in 1986.
 
 Yusuke originally patched this to use `strdup()` on two strings and this let it
-work with gcc but it still requires `-traditional-cpp`. The [alternate
+work with gcc but it still required `-traditional-cpp`. The [alternate
 code](1986/wall/wall.alt.c) is the version patched by Yusuke should you wish to
-try it with a compiler that has the `-traditional-cpp`.
+try it with a compiler that has the `-traditional-cpp`. See the README.md file
+for details.
 
 If you'd like to see the difference between the version that requires
 `-traditional-cpp` and the fixed version, try:
 
 ```sh
-git diff 82cbf069a781d64802fc59b36778c0b02be4043e..a74abb69b7e9b87e305b529941bf46f97ffff341 1986/wall/wall.c
+diff 1986/wall/wall.alt.c 1986/wall/wall.c
 ```
 
 ## [1987/heckbert](1987/heckbert/heckbert.c) ([README.md](1987/heckbert/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -283,6 +283,12 @@ of `strings.h` and because it's identical in use to `strchr(3)` (and we noted
 that for System V we had to do this) Cody added to the Makefile
 `-Dindex=strchr`.
 
+## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
+
+Cody made this ever so slightly like the original code by adding back the
+`#define D define` even though it's unused. This was done for both versions as
+well (the one with the board and the one without, the entry itself with the
+limitations of the contest).
 
 ## [1987/wall](1987/wall/wall.c) ([README.md](1987/wall/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -127,6 +127,10 @@ char x {sizeof(
 
 and changing the type of `k` to be an `int`.
 
+Additionally, because of the `#define union static struct` there is no need to
+have in the code `static struct` as we can have it like the original code which
+has it as `union`.
+
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -16,17 +16,16 @@ bug fixes** ([1988/phillipps](1988/phillipps/README.md),
 [2001/anonymous](2001/anonymous/README.md), [2004/burley](2004/burley/README.md)
 and others) making entries not require `-traditional-cpp` (which are **very
 complicated fixes**), fixing entries to compile with clang, fixing entries to
-work with macOS (some of which are **very complicated** like
+work with macOS (some being **very complicated** like
 [1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit and 64-bit (e.g.  [2001/herrmann2](2001/herrmann2/README.md)) which *can
-be* **quite complicated**, providing alternate code where useful/necessary,
-fixing where possible dead links or removing them, typo/consistency fixes,
-improving **ALL _Makefiles_** and writing the [sgit
-tool](https://github.com/xexyl/sgit) that we installed locally and have used to
-easily run `sed` on files in the repository to help build the website.  **Thank
-you very much** for your extensive efforts in helping improve the IOCCC
-presentation of past IOCCC winners and making many many past entries work with
-modern systems!
+32-bit/64-bit (e.g. [2001/herrmann2](2001/herrmann2/README.md)) which *can be*
+**quite complicated**, providing alternate code where useful/necessary, fixing
+where possible dead links or removing them, typo/consistency fixes, improving
+**ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit) that we
+installed locally and used to easily run `sed` on files in the repository to
+help build the website.  **Thank you very much** for your extensive efforts in
+helping improve the IOCCC presentation of past IOCCC winners and making many
+many past entries work with modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -309,6 +309,8 @@ Cody fixed this for modern systems. The problem was `'assignment to cast is
 illegal, lvalue casts are not supported'`. For the original file see the
 README.md file.
 
+Cody also added to the Makefile `-include stdio.h` in the nowadays very
+unlikely(?) but nevertheless suggested case that `putchar()` is not available.
 
 ## [1988/dale](1988/dale/dale.c) ([README.md](1988/dale/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -18,14 +18,14 @@ and others) making entries not require `-traditional-cpp` (which are **very
 complicated fixes**), fixing entries to compile with clang, fixing entries to
 work with macOS (some being **very complicated** like
 [1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit/64-bit (e.g. [2001/herrmann2](2001/herrmann2/README.md)) which *can be*
-**quite complicated**, providing alternate code where useful/necessary, fixing
-where possible dead links or removing them, typo/consistency fixes, improving
-**ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit) that we
-installed locally and used to easily run `sed` on files in the repository to
-help build the website. **Thank you very much** for your extensive efforts in
-helping improve the IOCCC presentation of past IOCCC winners and fixing many
-many past entries for modern systems!
+32-bit/64-bit which *can be* **very complicated** like
+[2001/herrmann2](2001/herrmann2/README.md) , providing alternate code where
+useful/necessary, fixing where possible dead links or removing them,
+typo/consistency fixes, improving **ALL _Makefiles_** and writing
+[sgit](https://github.com/xexyl/sgit) that we installed locally and used to
+easily run `sed` on files in the repo to help build the website. **Thank you
+very much** for your extensive efforts in helping improve the IOCCC presentation
+of past IOCCC winners and fixing so many past entries for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -379,16 +379,19 @@ modern compilers do not allow directives like:
 
 ```c
 #define _ define
-+#_ P char
-+#_ p int
-+#_ O close(
-...
+#_ P char
+#_ p int
+#_ O close(
+/* ... */
 ```
 
 so Cody changed the lines to be in the form of:
 
 ```c
-#define foo bar
+#define P char
+#define p int
+#define O close(
+/* ... */
 ```
 
 However, to keep the entry as close to as possible in look, Cody kept the `_`

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -25,7 +25,7 @@ typo/consistency fixes, improving **ALL _Makefiles_** and writing
 [sgit](https://github.com/xexyl/sgit) that we installed locally and used to
 easily run `sed` on files in the repo to help build the website. **Thank you
 very much** for your extensive efforts in helping improve the IOCCC presentation
-of past IOCCC winners and fixing so many past entries for modern systems!
+of past IOCCC winners and fixing so many for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -307,7 +307,12 @@ the code can refer to `gets()` instead.
 
 Cody fixed this for modern systems. The problem was `'assignment to cast is
 illegal, lvalue casts are not supported'`. For the original file see the
-README.md file.
+README.md file. Unfortunately this ruins some symmetry. To try and resolve this
+as much as possible at first code was commented out but later on the commented
+out code was removed and another part changed so that, although it has some code
+no longer there, it has a closer match in symmetry and since the code was
+commented out it's probably not a big deal to have it removed instead as it does
+look more symmetrical now.
 
 Cody also added to the Makefile `-include stdio.h` in the nowadays very
 unlikely(?) but nevertheless suggested case that `putchar()` is not available.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -12,19 +12,19 @@ contributed thousands, that we wish to thank.
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
 responsible for many of the improvements including many, many **very complicated
-bug fixes** such as [2001/anonymous](2001/anonymous/README.md) and
-[2004/burley](2004/burley/README.md), making entries not require
-`-traditional-cpp` (which are **very complicated fixes**), fixing entries to
-compile with clang, fixing entries to work with macOS (some of which are **very
-complicated** such as [1998/schweikh1](1998/schweikh1/README.md)), fixing code
-to work with both 32-bit and 64-bit (such as
-[2001/herrmann2](2001/herrmann2/README.md)) which *can be* **quite complicated
-too** (though not always even if it seems it), providing alternate code where
-useful or necessary, fixing where possible dead links and otherwise removing
-them, typo and consistency fixes, improving **ALL _Makefiles_** and writing the
-[sgit tool](https://github.com/xexyl/sgit) that we installed locally and have
-used to easily run `sed` on files in the repository to help build the website.
-Thank you **very much** for your extensive efforts in helping improve the IOCCC
+bug fixes** ([1988/phillipps](1988/phillipps/README.md),
+[2001/anonymous](2001/anonymous/README.md), [2004/burley](2004/burley/README.md)
+and others) making entries not require `-traditional-cpp` (which are **very
+complicated fixes**), fixing entries to compile with clang, fixing entries to
+work with macOS (some of which are **very complicated** like
+[1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
+32-bit and 64-bit (e.g.  [2001/herrmann2](2001/herrmann2/README.md)) which *can
+be* **quite complicated**, providing alternate code where useful/necessary,
+fixing where possible dead links or removing them, typo/consistency fixes,
+improving **ALL _Makefiles_** and writing the [sgit
+tool](https://github.com/xexyl/sgit) that we installed locally and have used to
+easily run `sed` on files in the repository to help build the website.  **Thank
+you very much** for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC winners and making many many past entries work with
 modern systems!
 
@@ -32,7 +32,7 @@ modern systems!
 number of important bug fixes to a number of past IOCCC winners. Some of those
 fixes were **very technically challenging** such as
 [1989/robison](1989/robison/README.md), [1990/cmills](1990/cmills/README.md),
-[1992/lush](1992/lush/README.md) and [2001/ctk](2001/ctk/README.md). Thank you **very
+[1992/lush](1992/lush/README.md) and [2001/ctk](2001/ctk/README.md). **Thank you very
 much** for your help!
 
 A good number of the [past winners of the
@@ -405,10 +405,11 @@ README.md file for more details.
 
 Cody fixed this for modern systems. It did not compile with clang because it
 requires the second and third args of `main()` to be `char **` but even before
-that with gcc it printed random characters. After fixing it for clang by
-changing `main()` to call the new function `pain()` (chosen because it's a pain
-that clang requires these args to be `char **` :-) ) with the correct args it
-now works.
+that with gcc it printed random characters.
+
+After fixing it for clang by changing `main()` to call the new function `pain()`
+(chosen because it's a pain that clang requires these args to be `char **` :-) )
+with the correct args it now works.
 
 ## [1988/reddy](1988/reddy/reddy.c) ([README.md](1988/reddy/README.md))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -18,8 +18,8 @@ and others) making entries not require `-traditional-cpp` (which are **very
 complicated fixes**), fixing entries to compile with clang, fixing entries to
 work with macOS (some being **very complicated** like
 [1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit/64-bit which *can be* **very complicated** like
-[2001/herrmann2](2001/herrmann2/README.md) , providing alternate code where
+32-bit/64-bit which *can be* **very complicated** (like
+[2001/herrmann2](2001/herrmann2/README.md)), providing alternate code where
 useful/necessary, fixing where possible dead links or removing them,
 typo/consistency fixes, improving **ALL _Makefiles_** and writing
 [sgit](https://github.com/xexyl/sgit) that we installed locally and used to

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -23,9 +23,9 @@ work with macOS (some being **very complicated** like
 where possible dead links or removing them, typo/consistency fixes, improving
 **ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit) that we
 installed locally and used to easily run `sed` on files in the repository to
-help build the website.  **Thank you very much** for your extensive efforts in
-helping improve the IOCCC presentation of past IOCCC winners and making many
-many past entries work with modern systems!
+help build the website. **Thank you very much** for your extensive efforts in
+helping improve the IOCCC presentation of past IOCCC winners and fixing many
+many past entries for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those


### PR DESCRIPTION

This includes the thanks-for-fixes.md file where C code was actually in
the form of a diff (which happened when I was looking for the 
differences to put in the file in the first place, forgetting to remove
the [-+] at the time).