### PR TITLE
Format/typo check 1988/applin

### DIFF
--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -21,7 +21,7 @@ int dup, signal;
 	goto _0;
 
 _O: while (!(k['a'] <<= - dup)) {	/*/*\*/
-	static struct tag u = {4};
+	union tag u x{4};
   }
 }
 

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -103,6 +103,7 @@ ifeq ($(CC),gcc)
 #
 #CWARN+=
 #
+CFLAGS+= -traditional-cpp
 endif
 
 
@@ -136,8 +137,11 @@ ${PROG}: ${PROG}.c
 
 # alternative executable
 #
-alt: data ${ALT_TARGET}
+alt: ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -26,9 +26,14 @@ might enjoy looking at the original source in [wall.alt.c](wall.alt.c).
 # if you have an old enough compiler:
 make alt
 
-# or with gcc:
+# or if you have gcc:
+make CC=gcc alt
+
+# or if you have a compiler that supports -traditional-cpp that's not gcc:
 make CFLAGS+="-traditional-cpp" alt
 ```
+
+NOTE: gcc in macOS is actually clang even the binary `/usr/bin/gcc`.
 
 Use `./wall.alt` as you would `./wall`.
 

--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -1,10 +1,6 @@
 # Worst Style
 
-Spencer Hines  
-OnLine Computer Systems  
-4200 Farragut Street  
-Hyattsville, MD  
-20781  
+Spencer Hines<br>
 US  
 
 ## To build:
@@ -27,8 +23,8 @@ make all
 
 ### Alternate code:
 
-An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older compilers you
-can try the alt version:
+An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older
+compilers you can try the alt version:
 
 ```sh
 make alt
@@ -39,11 +35,12 @@ Use `hines.alt` as you would `hines` above.
 ## Judges' remarks:
 
 This program was designed to maximize the bother function for
-structured programmers.  This program takes goto statements to their
+structured programmers.  This program takes `goto` statements to their
 logical conclusion.  The layout and choice of names are classic.
 
 We consider this to be a beautiful counter-example for Frank Rubin's
-letter to ACM form titled: _"'GOTO Considered Harmful' Considered Harmful"_.
+letter to ACM form titled: _["'GOTO Considered Harmful' Considered
+Harmful"](https://web.archive.org/web/20090320002214/http://www.ecn.purdue.edu/ParaMount/papers/rubin87goto.pdf)_.
 See the Communications of the ACM, March 1987, Page 195-196.
 
 

--- a/1987/korn/README.md
+++ b/1987/korn/README.md
@@ -1,10 +1,6 @@
 # Best One Liner
 
 David Korn   
-AT&T Bell Labs  
-MH 3C-526B, AT&T Bell Labs   
-Murray Hill, NJ   
-07974   
 US   
 
 ## To build:
@@ -13,15 +9,21 @@ US
 make all
 ```
 
+## To use:
+
+```sh
+./korn
+```
+
 ## Judges' remarks:
 
 The Judges believe that this is the best one line entry ever received.
-Compile on a `UNIX` system, or at least using a C implementation that
+Compile on a UNIX system, or at least one using a C implementation that
 fakes it.  Very few people are able to determine what this program
 does by visual inspection.  I suggest that you stop reading this
 section right now and see if you are one of the few people who can.
 
-Several points are important to understand in this program:
+Several points are important to understand this program:
 
 1. What is the symbol `unix` and what is its value in the program?  Clearly
 `unix` is not a function, and since `unix` is not declared to be a data type
@@ -34,9 +36,8 @@ characters, or `'h'`, or a string)  Consider the fact that:
 	    char *x;  
 
 
-  defines a pointer to a character (i.e. an address), and that the `=` assigns
+  defines a pointer to a `char` (i.e. an address), and that the `=` assigns
   things of compatible types.  Since:
-
 
         x = "have";
 
@@ -53,8 +54,12 @@ characters, or `'h'`, or a string)  Consider the fact that:
 
     ?
 
-David Korn's `/bin/ksh` provides us with a greatly improved version of
-the /bin/sh.  The source for v7's /bin/sh greatly inspired this contest.
+[David
+Korn](https://news.slashdot.org/story/01/02/06/2030205/david-korn-tells-all)'s
+[/bin/ksh](https://en.wikipedia.org/wiki/KornShell) provides us with a greatly
+improved version of the [/bin/sh](https://en.wikipedia.org/wiki/Bourne_shell).
+The source for [v7](https://en.wikipedia.org/wiki/Version_7_Unix)'s /bin/sh
+greatly inspired this contest.
 
 ## Author's remarks:
 

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -9,8 +9,8 @@ Netherlands
 make all
 ```
 
-NOTE: The original entry may be built with "make alt" if you have an old enough
-compiler.
+There is [Alternate code](#alternate-code) available for if you have an old
+enough compiler.
 
 ## To run:
 
@@ -18,12 +18,6 @@ compiler.
 ./lievaart
 # enter a level and start playing as described below
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-If you enter invalid input the program will enter an infinite loop displaying a
-string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
-incorrect value it will prompt you again until you input a proper value.
 
 ## Try:
 
@@ -34,30 +28,46 @@ To see what it would have looked like without the size restrictions:
 # enter a level and start playing as described below
 ```
 
+## Alternate code:
+
+If you have an old enough compiler you might wish to try using it. To use:
+
+```sh
+make alt
+```
+
+Use `./lievaart.alt` as you would `./lievaart` above.
+
+### INABIAF - it's not a bug it's a feature! :-)
+
+If you enter invalid input the program will enter an infinite loop displaying a
+string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
+incorrect value it will prompt you again until you input a proper value.
 
 ## Judges' remarks:
 
 We believe that you too will be amazed at just how much power Mr. Lievaart
 packed into 1024 bytes!
 
-This Plays the game of Reversi (Othello)!  Compile and run.  It then
+This Plays the game of [Reversi
+(Othello)](https://en.wikipedia.org/wiki/Reversi)!  Compile and run.  It then
 asks for a playing level. Enter 0-10 (easy-hard).  It then asks for
-your move. A move is a number within 11-88, or a 99 to pass.  Illegal
+your move. A move is a number within 11-88, or 99 to pass.  Illegal
 moves (except for an illegal pass) are rejected.  Then the computer
 does its move (or a 0 to pass), until the board is full.
 
-It plays rather well, for such a small program!  Lievaart had to leave out the
+It plays rather well, for such a small program! Lievaart had to leave out the
 board printing routine, so you'll have to take a real game board to play it (or
 see below). ...  Also due to space-limitations (the rules for 1987 had a limit
 of 1024 byes), Lievaart took out the passing-handler, which makes its
-ending-game rather poor.  But further it knows all the rules, uses alpha-beta
-pruning, and it plays f.i. on mobility(!).  Most important: it can play a pretty
-good game of Reversi!
+ending-game rather poor.  But further it knows all the rules, uses [alpha-beta
+pruning](https://en.wikipedia.org/wiki/Alpha-beta_pruning), and it plays for
+instance on mobility(!).  Most important: it can play a pretty good game of Reversi!
 
 The Author was kind enough to supply the fully functional version of the
-program.  The file lievaart2.c contains what the program would have
-been without the size restriction.  This version has the full end game 
-logic and displays the board after each move!
+program.  The file [lievaart2.c](lievaart2.c) contains what the program would
+have been without the size restriction.  This version has the full end game
+logic and displays the board after each move! See above for how to use this.
 
 
 ## Author's remarks:

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -1,3 +1,4 @@
+#define D define
 #define Y return
 #define R for
 #define e while

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -1,3 +1,4 @@
+#define D define
 #define Y return
 #define R for
 #define e while

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -1,6 +1,6 @@
 # Most Useful Obfuscation
 
-Larry Wall  
+Larry Wall<br>
 US
 
 ## To build:
@@ -59,12 +59,12 @@ quit # for the cat version
 ## Judges' remarks:
 
 
-What we found amazing was how the flow of control was transferred
-between subroutines.  Careful inspection will show that the array of
-pointers to functions named `vi` refers to functions which seem to not
-be directly called.  Even so, these pointers to functions are being
-used as an argument to `signal()` (used both with and without an arg - but
-how?).  Can you determine why this is being done and how it is being exploited?
+What we found amazing was how the flow of control was transferred between
+subroutines.  Careful inspection will show that the array of pointers to
+functions named `vi` refers to functions which seem to not be directly called.
+Even so, these pointers to functions are being used as an argument to
+`signal(3)` (used both with and without an arg - but how?).  Can you determine
+why this is being done and how it is being exploited?
 
 Some compilers complained about this file, so we changed: `=++I` to `= ++I`.
 

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-for-loop-analysis -Wno-unused-value \
-	-Wno-deprecated-non-prototype -Wno-strict-prototypes
+	-Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -62,7 +62,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 
 # Optimization
 #

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -31,12 +31,10 @@ Use `westley.alt` as you would `westley` above.
 ## Judges' remarks:
 
 `putchar()` must exist in the C library and not just as a macro.
-If it fails to compile, add the line:  `#include <stdio.h>`  at the
-top of the program.
+If it fails to compile, bug your OS/compiler vendor.
 
 Line by line symmetry performed better than any C beautifier.  Think
 of if it as a C ink blot.  :-)
-
 
 ## Author's remarks:
 

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -30,7 +30,7 @@ Use `westley.alt` as you would `westley` above.
 
 ## Judges' remarks:
 
-Putchar must exist in the C library and not just as a macro.
+`putchar()` must exist in the C library and not just as a macro.
 If it fails to compile, add the line:  `#include <stdio.h>`  at the
 top of the program.
 

--- a/1987/westley/westley.c
+++ b/1987/westley/westley.c
@@ -26,11 +26,11 @@
 		           ,LACEDx0 = 0xDECAL,
 				rof ; for
 			     (;(int) (tni);)
-			    /* (int)*/(tni)
+			          (tni)
 			  = reviled ; deliver =
 				redivider
 				    ;
-for ((int)(tni)++,++reviled;reviled* *deliver;deliver++,++/*(int)*/(tni)) rof
+     for ((tni)++,++reviled;reviled**deliver;deliver++,++(tni)) rof
 			            =
 			     (int) -1- (tni)
 		          ;reviled--;--deliver;

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -131,9 +131,9 @@ all: data ${TARGET}
 #
 # This entry took 75 minutes to compile on a Amdahl 5980-300E
 # (a 55658 Dhyrstone/sec/cpu machine) using the System V cpp.
-# (The GNU cpp when defined as BIG_CPP took only 45 seconds)
+# (The GNU cpp when defined as BIG_CPP took only 45 seconds.)
 # Your cpp may not be able to compile it due to a common bug
-# that results in ${CPP} running out of space.  The routine
+# that results in cpp running out of space.  The routine
 # 'zsmall' is a smaller version of the applin.c entry.
 #
 ${PROG}: ${PROG}.c

--- a/1988/applin/README.md
+++ b/1988/applin/README.md
@@ -1,7 +1,7 @@
 # Best of show
 
-Jack Applin  
-US  
+Jack Applin<br>
+US<br>
 <https://www.cs.colostate.edu/~applin/>
 
 ## To build:
@@ -10,9 +10,10 @@ US
 make all
 ```
 
-A smaller version, originally called `zsmall.c`, of [applin.c](applin.c) can be
-found in [applin.alt.c](applin.alt.c).  Your machine may have an easier time
-with this program.  See the Alternate code section below for details.
+A smaller version, originally called `zsmall.c` (and still exists as such, as
+the source of the alt code), of [applin.c](applin.c), can be found in
+[applin.alt.c](applin.alt.c).  Your machine may have an easier time with this
+program.  See the [Alternate code](#alternate-code) section below for details.
 
 ## Try:
 
@@ -22,8 +23,10 @@ with this program.  See the Alternate code section below for details.
 
 ### Alternate code:
 
-As noted above a smaller version can be used in case your cpp has a hard time
-with this entry. To use:
+As noted above a smaller version can be used in case your `cpp` has a hard time
+with this entry.
+
+#### To build:
 
 ```sh
 make alt
@@ -31,22 +34,34 @@ make alt
 
 Use `applin.alt` as you would `applin` above.
 
+#### History about the smaller version:
+
+Way back in 1988 ..
+
+This entry took 75 minutes to compile on a Amdahl 5980-300E (a 55658
+Dhyrstone/sec/cpu machine) using the System V `cpp`.  (The GNU `cpp` when defined as
+`BIG_CPP` took only 45 seconds.)
+
+Your `cpp` may not be able to compile it due to a common bug that results in
+`cpp` running out of space.  The routine [zsmall](zsmall.c) is a smaller version
+of the [applin.c](applin.c) entry.
+
 
 ## Judges' remarks:
 
 This entry is by far the most unusual abuse of the C preprocessor that
 we have received thus far.  Nearly all of the real work is done in the
-preprocessor!
+C preprocessor!
 
 When we compiled [applin.c](applin.c) on an
 [Amdahl](https://en.wikipedia.org/wiki/Amdahl_Corporation) 5890-300E, we found that it
 spent over 75 minutes in the System V C preprocessor!  Besides showing that the
-standard System V cpp is slow, it showed that it contained a memory usage
+standard System V `cpp` is slow, it showed that it contained a memory usage
 problem.  The [applin.c](applin.c) only uses 29 different preprocessor symbols
 (besides `stdio.h`) and yet the preprocessor ran out of space!
 
-The GNU C preprocessor took less than 45 seconds to perform the 2nd pass 
-on the Amdahl 5890-300E.  But due to the ANSI-likeness of GNU cpp (v. 1-21), 
+The GNU C preprocessor took under 45 seconds to perform the 2nd pass
+on the Amdahl 5890-300E.  But due to the ANSI-likeness of GNU `cpp` (v. 1-21),
 it was not able to cleanly substitute a symbol that began with a '#'.
 Clearly the GNU C preprocessor is faster.
 

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -1,6 +1,6 @@
 # Best abuse of system calls
 
-Paul Dale  
+Paul Dale<br>
 Australia  
 
 ## To build:
@@ -40,7 +40,8 @@ If you have an old enough compiler you can try the original version in
 make clobber alt
 ```
 
-Use `dale.alt` as you would `dale` above.
+Use `dale.alt` as you would `dale` above. To understand the differences in more
+detail, see [thanks-for-fixes.md](/thanks-for-fixes.md).
 
 
 ## Judges' remarks

--- a/1988/isaak/README.md
+++ b/1988/isaak/README.md
@@ -1,17 +1,17 @@
 # Best visuals
 
-Mark Isaak  
-Imagen Corporation  
-2650 San Tomas Expy.  
-Santa Clara, CA   
-95052-8101  
-US  
+Mark Isaak<br>
+US
 
 ## To build:
 
 ```sh
 make all
 ```
+
+There is an alternate version, the original, that can't be compiled in modern
+systems but can be if you have an old enough compiler. See [Alternate
+code](#alternate-code) below.
 
 ## To run:
 
@@ -29,28 +29,41 @@ The original entry starts with the line:
 ```
 
 This works on some systems.  Why?  Note that `#include <stdio.h>` is given on
-the last line.  Why is this needed?  Note the unusual calls to sprintf.
+the last line.  Why is this needed?  Note the unusual calls to `sprintf(3)`.
 
 This version also relied on being able to define `#define` to something else and
-using that macro for `#define`. This version will not likely work on modern
-systems if you can even get it to compile.
+using that macro for `#define`.
 
+This version will not likely work on modern systems if you can even get it to
+compile.
+
+#### To build:
+
+```sh
+make alt
+```
+
+Use `isaak.alt` as you would `isaak` above.
 
 ## Judges' remarks:
 
-NOTE:  The program relies heavily on ASCII.  Don't even think of running it on
-an EBCDIC machine.  If you named the file anything other than [isaak.c](isaak.c),
-you had to change the `#include` on line 6. This limitation has been fixed by
-using the `__FILE__` macro.
+The program relies heavily on ASCII.  Don't even think of running it on
+an EBCDIC machine.
+
+### Historical notes about the original entry:
+
+NOTE: If you named the file anything other than [isaak.c](isaak.c), you had to
+change the `#include` on line 6. This limitation has been fixed by using the
+`__FILE__` macro.
 
 NOTE: The use of null comments to separate macros to construct different tokens
 from a single macro (e.g., `"O/**/O"` creates either `++` or `--` by defining
 `O` to be `+` or `-`) may cause some strict ANSI C preprocessors to object.
 
 NOTE: Most System V machines were not be able to execute this program correctly
-due to the fact that BSD style systems have an sprintf() that returns a `char *`.
-Due to the above problems, we placed the output of this program in the file:
-isaak.encode.  To read this file do:
+due to the fact that BSD style systems have an `sprintf(3)` that returns a `char
+*`.  Due to the above problems, we placed the output of this program in the
+file: isaak.encode.  To read this file do.
 
 ```sh
 uudecode < isaak.encode
@@ -58,7 +71,7 @@ cat isaak.output
 ```
 
 Since this was fixed, this file is not strictly necessary. See the
-[isaak.orig.c](isaak.orig.c) for the original source.
+[isaak.alt.c](isaak.alt.c) for the original source.
 
 FYI: We are likely to be more strict about portability in the future.
 

--- a/1988/litmaath/README.md
+++ b/1988/litmaath/README.md
@@ -1,6 +1,6 @@
 # Best small program
 
-Maarten Litmaath  
+Maarten Litmaath<br>
 The Netherlands  
 
 ## To build:
@@ -15,7 +15,8 @@ make
 ./litmaath some text
 ```
 
-There is an alternate version provided. See the Alternate code section below.
+There is an alternate version provided. See the [Alternate
+code](#alternate-code) section below.
 
 ## Try:
 
@@ -25,9 +26,13 @@ There is an alternate version provided. See the Alternate code section below.
 
 ### Alternate code:
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) added the
-[litmaath.alt.c](litmaath.alt.c) which we described in our remarks below. To
-use:
+
+This alternate code, added to help understand the entry and for fun, is code
+that we suggested at the time of the entry publication but which we never put in
+a file.
+
+#### To build:
+
 
 ```sh
 make alt
@@ -35,7 +40,11 @@ make alt
 
 Use `litmaath.alt` as you would `litmaath` above.
 
-Thank you Cody!
+#### Try:
+
+```sh
+./litmaath.alt six was afraid of seven because seven eight nine
+```
 
 
 ## Judges' remarks:
@@ -50,10 +59,12 @@ while (<condition>)
 
 Did you notice that the body is empty?
 
+Furthermore, it's interesting to note that only two variables are
+used to achieve everything.
 
 The best one can do to understand how the program works is to give it
 two small strings as arguments, and follow the program closely.  One
-could make the body of the 'while' loop an 'fprintf' with interesting
+could make the body of the `while` loop an `fprintf` with interesting
 variables like:
 
 
@@ -64,14 +75,12 @@ fprintf(stderr,
      (long) argv[1], argv[1] && *argv[1] ? *argv[1] : '@', argc);
 ```
 
+... which is what the [alternate code](#alternate-code) is.
 
-Furthermore, it's interesting to note that only two variables are
-used to achieve everything.
 
 ## Author's remarks:
 
 No remarks were provided by the author.
-
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
-	-Wno-int-conversion -Wno-pointer-to-int-cast -Wno-implicit-int
+	-Wno-int-conversion -Wno-pointer-to-int-cast -Wno-implicit-int -Wno-parentheses \
+	-Wno-return-type -Wno-deprecated-non-prototype -Wno-disabled-macro-expansion
 
 # Common C compiler warning flags
 #
@@ -94,7 +95,7 @@ endif
 #
 ifeq ($(CC),gcc)
 #
-#CSILENCE+=
+CSILENCE+= -Wno-missing-parameter-type
 #
 #CWARN+=
 #

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+#
+# demo.sh - script to demonstrate IOCCC entry 1991/fine
+#
 
 make all || exit 1
 

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -6,7 +6,7 @@
 make all || exit 1
 
 echo -n "Green terra <-> "
-echo "Green terra" |./fine
+echo "Green terra" | ./fine
 
 echo -n "Vex <-> "
 echo "Vex" | ./fine

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -2,22 +2,22 @@
 
 make all || exit 1
 
-echo -n "Green terra: "
+echo -n "Green terra <->  "
 echo "Green terra" |./fine
 
-echo -n "Vex: "
+echo -n "Vex <->  "
 echo "Vex" | ./fine
 
-echo -n "Tang: "
+echo -n "Tang <->  "
 echo "Tang" | ./fine
 
-echo -n "Vend onyx: "
+echo -n "Vend onyx <->  "
 echo "Vend onyx" | ./fine
-echo -n "Cheryl be flashy: "
+echo -n "Cheryl be flashy <->  "
 echo "Cheryl be flashy" | ./fine
-echo -n "Rail: "
+echo -n "Rail <->  "
 echo "Rail" | ./fine
-echo -n "Clerk: "
+echo -n "Clerk <->  "
 echo "Clerk" | ./fine
-echo -n "The rug gary lenT: "
+echo -n "The rug gary lenT <->  "
 echo "The rug gary lenT" | ./fine

--- a/1991/fine/demo.sh
+++ b/1991/fine/demo.sh
@@ -2,22 +2,22 @@
 
 make all || exit 1
 
-echo -n "Green terra <->  "
+echo -n "Green terra <-> "
 echo "Green terra" |./fine
 
-echo -n "Vex <->  "
+echo -n "Vex <-> "
 echo "Vex" | ./fine
 
-echo -n "Tang <->  "
+echo -n "Tang <-> "
 echo "Tang" | ./fine
 
-echo -n "Vend onyx <->  "
+echo -n "Vend onyx <-> "
 echo "Vend onyx" | ./fine
-echo -n "Cheryl be flashy <->  "
+echo -n "Cheryl be flashy <-> "
 echo "Cheryl be flashy" | ./fine
-echo -n "Rail <->  "
+echo -n "Rail <-> "
 echo "Rail" | ./fine
-echo -n "Clerk <->  "
+echo -n "Clerk <-> "
 echo "Clerk" | ./fine
-echo -n "The rug gary lenT <->  "
+echo -n "The rug gary lenT <-> "
 echo "The rug gary lenT" | ./fine

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -11,21 +11,22 @@ contributed thousands, that we wish to thank.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
-responsible for many of the improvements including many, many **very complicated
-bug fixes** ([1988/phillipps](1988/phillipps/README.md),
-[2001/anonymous](2001/anonymous/README.md), [2004/burley](2004/burley/README.md)
-and others) making entries not require `-traditional-cpp` (which are **very
-complicated fixes**), fixing entries to compile with clang, fixing entries to
-work with macOS (some being **very complicated** like
-[1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit/64-bit which *can be* **very complicated** (like
-[2001/herrmann2](2001/herrmann2/README.md)), providing alternate code where
-useful/necessary, fixing where possible dead links or removing them,
-typo/consistency fixes, improving **ALL _Makefiles_** and writing
-[sgit](https://github.com/xexyl/sgit) that we installed locally and used to
-easily run `sed` on files in the repo to help build the website. **Thank you
-very much** for your extensive efforts in helping improve the IOCCC presentation
-of past IOCCC winners and fixing so many for modern systems!
+responsible for many of the improvements including many **very complicated bug
+fixes** like [1988/phillipps](1988/phillipps/README.md),
+[2001/anonymous](2001/anonymous/README.md) and
+[2004/burley](2004/burley/README.md), making entries like
+[1986/wall](1986/wall/README.md) not require `-traditional-cpp` (all **very
+complicated fixes**), fixing entries to compile with clang, porting entries to
+macOS, some being **very complicated** like
+[1998/schweikh1](1998/schweikh1/README.md), fixing code like
+[2001/herrmann2](2001/herrmann2/README.md) to work in both 32-bit/64-bit which
+*can be* **very complicated**, providing alternate code where useful/necessary,
+fixing where possible dead links or removing them, typo/consistency fixes,
+improving **ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit)
+that we installed locally to easily run `sed` on files in the repo to help build
+the website. **Thank you very much** for your extensive efforts in helping
+improve the IOCCC presentation of past IOCCC winners and fixing almost all for
+modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those
@@ -261,15 +262,16 @@ noted earlier, very complicated, but we encourage you to look at [original
 code](1986/wall/wall.orig.c) to see how different C was in 1986.
 
 Yusuke originally patched this to use `strdup()` on two strings and this let it
-work with gcc but it still requires `-traditional-cpp`. The [alternate
+work with gcc but it still required `-traditional-cpp`. The [alternate
 code](1986/wall/wall.alt.c) is the version patched by Yusuke should you wish to
-try it with a compiler that has the `-traditional-cpp`.
+try it with a compiler that has the `-traditional-cpp`. See the README.md file
+for details.
 
 If you'd like to see the difference between the version that requires
 `-traditional-cpp` and the fixed version, try:
 
 ```sh
-git diff 82cbf069a781d64802fc59b36778c0b02be4043e..a74abb69b7e9b87e305b529941bf46f97ffff341 1986/wall/wall.c
+diff 1986/wall/wall.alt.c 1986/wall/wall.c
 ```
 
 ## [1987/heckbert](1987/heckbert/heckbert.c) ([README.md](1987/heckbert/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -283,6 +283,12 @@ of `strings.h` and because it's identical in use to `strchr(3)` (and we noted
 that for System V we had to do this) Cody added to the Makefile
 `-Dindex=strchr`.
 
+## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
+
+Cody made this ever so slightly like the original code by adding back the
+`#define D define` even though it's unused. This was done for both versions as
+well (the one with the board and the one without, the entry itself with the
+limitations of the contest).
 
 ## [1987/wall](1987/wall/wall.c) ([README.md](1987/wall/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -127,6 +127,10 @@ char x {sizeof(
 
 and changing the type of `k` to be an `int`.
 
+Additionally, because of the `#define union static struct` there is no need to
+have in the code `static struct` as we can have it like the original code which
+has it as `union`.
+
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -16,17 +16,16 @@ bug fixes** ([1988/phillipps](1988/phillipps/README.md),
 [2001/anonymous](2001/anonymous/README.md), [2004/burley](2004/burley/README.md)
 and others) making entries not require `-traditional-cpp` (which are **very
 complicated fixes**), fixing entries to compile with clang, fixing entries to
-work with macOS (some of which are **very complicated** like
+work with macOS (some being **very complicated** like
 [1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit and 64-bit (e.g.  [2001/herrmann2](2001/herrmann2/README.md)) which *can
-be* **quite complicated**, providing alternate code where useful/necessary,
-fixing where possible dead links or removing them, typo/consistency fixes,
-improving **ALL _Makefiles_** and writing the [sgit
-tool](https://github.com/xexyl/sgit) that we installed locally and have used to
-easily run `sed` on files in the repository to help build the website.  **Thank
-you very much** for your extensive efforts in helping improve the IOCCC
-presentation of past IOCCC winners and making many many past entries work with
-modern systems!
+32-bit/64-bit (e.g. [2001/herrmann2](2001/herrmann2/README.md)) which *can be*
+**quite complicated**, providing alternate code where useful/necessary, fixing
+where possible dead links or removing them, typo/consistency fixes, improving
+**ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit) that we
+installed locally and used to easily run `sed` on files in the repository to
+help build the website.  **Thank you very much** for your extensive efforts in
+helping improve the IOCCC presentation of past IOCCC winners and making many
+many past entries work with modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -309,6 +309,8 @@ Cody fixed this for modern systems. The problem was `'assignment to cast is
 illegal, lvalue casts are not supported'`. For the original file see the
 README.md file.
 
+Cody also added to the Makefile `-include stdio.h` in the nowadays very
+unlikely(?) but nevertheless suggested case that `putchar()` is not available.
 
 ## [1988/dale](1988/dale/dale.c) ([README.md](1988/dale/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -18,14 +18,14 @@ and others) making entries not require `-traditional-cpp` (which are **very
 complicated fixes**), fixing entries to compile with clang, fixing entries to
 work with macOS (some being **very complicated** like
 [1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit/64-bit (e.g. [2001/herrmann2](2001/herrmann2/README.md)) which *can be*
-**quite complicated**, providing alternate code where useful/necessary, fixing
-where possible dead links or removing them, typo/consistency fixes, improving
-**ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit) that we
-installed locally and used to easily run `sed` on files in the repository to
-help build the website. **Thank you very much** for your extensive efforts in
-helping improve the IOCCC presentation of past IOCCC winners and fixing many
-many past entries for modern systems!
+32-bit/64-bit which *can be* **very complicated** like
+[2001/herrmann2](2001/herrmann2/README.md) , providing alternate code where
+useful/necessary, fixing where possible dead links or removing them,
+typo/consistency fixes, improving **ALL _Makefiles_** and writing
+[sgit](https://github.com/xexyl/sgit) that we installed locally and used to
+easily run `sed` on files in the repo to help build the website. **Thank you
+very much** for your extensive efforts in helping improve the IOCCC presentation
+of past IOCCC winners and fixing so many past entries for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -408,6 +408,10 @@ function, a redefinition of `exit()`, was not being called in main(). The
 original version is in [1988/isaak/isaak.alt.c](1988/isaak/isaak.alt.c). See the
 README.md file for more details.
 
+## [1988/litmaath](1988/litmaath/litmaath.c) ([README.md](1988/litmaath/README.md))
+
+Cody added the alt code which is code that we suggested at the time of
+publication, in the remarks, to help understand the entry, and for fun.
 
 ## [1988/phillipps](1988/phillipps/phillipps.c) ([README.md](1988/phillipps/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -379,16 +379,19 @@ modern compilers do not allow directives like:
 
 ```c
 #define _ define
-+#_ P char
-+#_ p int
-+#_ O close(
-...
+#_ P char
+#_ p int
+#_ O close(
+/* ... */
 ```
 
 so Cody changed the lines to be in the form of:
 
 ```c
-#define foo bar
+#define P char
+#define p int
+#define O close(
+/* ... */
 ```
 
 However, to keep the entry as close to as possible in look, Cody kept the `_`

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -25,7 +25,7 @@ typo/consistency fixes, improving **ALL _Makefiles_** and writing
 [sgit](https://github.com/xexyl/sgit) that we installed locally and used to
 easily run `sed` on files in the repo to help build the website. **Thank you
 very much** for your extensive efforts in helping improve the IOCCC presentation
-of past IOCCC winners and fixing so many past entries for modern systems!
+of past IOCCC winners and fixing so many for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -307,7 +307,12 @@ the code can refer to `gets()` instead.
 
 Cody fixed this for modern systems. The problem was `'assignment to cast is
 illegal, lvalue casts are not supported'`. For the original file see the
-README.md file.
+README.md file. Unfortunately this ruins some symmetry. To try and resolve this
+as much as possible at first code was commented out but later on the commented
+out code was removed and another part changed so that, although it has some code
+no longer there, it has a closer match in symmetry and since the code was
+commented out it's probably not a big deal to have it removed instead as it does
+look more symmetrical now.
 
 Cody also added to the Makefile `-include stdio.h` in the nowadays very
 unlikely(?) but nevertheless suggested case that `putchar()` is not available.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -12,19 +12,19 @@ contributed thousands, that we wish to thank.
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
 responsible for many of the improvements including many, many **very complicated
-bug fixes** such as [2001/anonymous](2001/anonymous/README.md) and
-[2004/burley](2004/burley/README.md), making entries not require
-`-traditional-cpp` (which are **very complicated fixes**), fixing entries to
-compile with clang, fixing entries to work with macOS (some of which are **very
-complicated** such as [1998/schweikh1](1998/schweikh1/README.md)), fixing code
-to work with both 32-bit and 64-bit (such as
-[2001/herrmann2](2001/herrmann2/README.md)) which *can be* **quite complicated
-too** (though not always even if it seems it), providing alternate code where
-useful or necessary, fixing where possible dead links and otherwise removing
-them, typo and consistency fixes, improving **ALL _Makefiles_** and writing the
-[sgit tool](https://github.com/xexyl/sgit) that we installed locally and have
-used to easily run `sed` on files in the repository to help build the website.
-Thank you **very much** for your extensive efforts in helping improve the IOCCC
+bug fixes** ([1988/phillipps](1988/phillipps/README.md),
+[2001/anonymous](2001/anonymous/README.md), [2004/burley](2004/burley/README.md)
+and others) making entries not require `-traditional-cpp` (which are **very
+complicated fixes**), fixing entries to compile with clang, fixing entries to
+work with macOS (some of which are **very complicated** like
+[1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
+32-bit and 64-bit (e.g.  [2001/herrmann2](2001/herrmann2/README.md)) which *can
+be* **quite complicated**, providing alternate code where useful/necessary,
+fixing where possible dead links or removing them, typo/consistency fixes,
+improving **ALL _Makefiles_** and writing the [sgit
+tool](https://github.com/xexyl/sgit) that we installed locally and have used to
+easily run `sed` on files in the repository to help build the website.  **Thank
+you very much** for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC winners and making many many past entries work with
 modern systems!
 
@@ -32,7 +32,7 @@ modern systems!
 number of important bug fixes to a number of past IOCCC winners. Some of those
 fixes were **very technically challenging** such as
 [1989/robison](1989/robison/README.md), [1990/cmills](1990/cmills/README.md),
-[1992/lush](1992/lush/README.md) and [2001/ctk](2001/ctk/README.md). Thank you **very
+[1992/lush](1992/lush/README.md) and [2001/ctk](2001/ctk/README.md). **Thank you very
 much** for your help!
 
 A good number of the [past winners of the
@@ -405,10 +405,11 @@ README.md file for more details.
 
 Cody fixed this for modern systems. It did not compile with clang because it
 requires the second and third args of `main()` to be `char **` but even before
-that with gcc it printed random characters. After fixing it for clang by
-changing `main()` to call the new function `pain()` (chosen because it's a pain
-that clang requires these args to be `char **` :-) ) with the correct args it
-now works.
+that with gcc it printed random characters.
+
+After fixing it for clang by changing `main()` to call the new function `pain()`
+(chosen because it's a pain that clang requires these args to be `char **` :-) )
+with the correct args it now works.
 
 ## [1988/reddy](1988/reddy/reddy.c) ([README.md](1988/reddy/README.md))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -18,8 +18,8 @@ and others) making entries not require `-traditional-cpp` (which are **very
 complicated fixes**), fixing entries to compile with clang, fixing entries to
 work with macOS (some being **very complicated** like
 [1998/schweikh1](1998/schweikh1/README.md)), fixing code to work with both
-32-bit/64-bit which *can be* **very complicated** like
-[2001/herrmann2](2001/herrmann2/README.md) , providing alternate code where
+32-bit/64-bit which *can be* **very complicated** (like
+[2001/herrmann2](2001/herrmann2/README.md)), providing alternate code where
 useful/necessary, fixing where possible dead links or removing them,
 typo/consistency fixes, improving **ALL _Makefiles_** and writing
 [sgit](https://github.com/xexyl/sgit) that we installed locally and used to

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -23,9 +23,9 @@ work with macOS (some being **very complicated** like
 where possible dead links or removing them, typo/consistency fixes, improving
 **ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit) that we
 installed locally and used to easily run `sed` on files in the repository to
-help build the website.  **Thank you very much** for your extensive efforts in
-helping improve the IOCCC presentation of past IOCCC winners and making many
-many past entries work with modern systems!
+help build the website. **Thank you very much** for your extensive efforts in
+helping improve the IOCCC presentation of past IOCCC winners and fixing many
+many past entries for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those


### PR DESCRIPTION

The README.md and the Makefile were both updated. The Makefile because
of typos/unclear things. The README.md had formatting fixes and also
added the historical note about 1988 from the Makefile as it's far less
likely people will see that note versus that which is in the README.md.