### PR TITLE
Improve 1988/westley/demo.sh

### DIFF
--- a/1988/westley/demo.sh
+++ b/1988/westley/demo.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
 clear
+
+if [[ ! -x "westley" ]]; then
+    echo "$ cc westley.c -o westley"
+    cc -std=gnu89 -Wno-error -Wno-implicit-function-declaration -Wno-return-type    -O3 westley.c -o westley || exit 1
+fi
+
 echo "$ cat westley.c"
 cat westley.c
-
 sleep 1
-
-echo "$ cc westley.c -o westley"
-cc -std=gnu89 -Wno-error -Wno-implicit-function-declaration -Wno-return-type    -O3 westley.c -o westley || exit 1
 
 echo "$ ./westley"
 ./westley

--- a/1988/westley/demo.sh
+++ b/1988/westley/demo.sh
@@ -13,5 +13,3 @@ sleep 1
 
 echo "$ ./westley"
 ./westley
-
-echo

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -110,7 +110,7 @@ PROG= prog
 #
 OBJ= ${PROG}.o
 DATA= Rakefile alpha.rb assemble.rb ast-def.rb gen-prog.rb gen-table.rb link.rb \
-	machine.rb main.c parse.rb prog-tmpl.c read_me.md register.rb \
+	machine.rb main.c parse.rb prog-tmpl.c spoilers.md register.rb \
 	serialize.rb src.rb tool.rb vm.c
 TARGET= ${PROG} main treacle
 #


### PR DESCRIPTION

Check for executable 'westley' before compiling and only _after_ 
compilation (if necessary) is the source shown. This way if it's
already done (as likely the case) the result of the program will be
shown closer to the source code which is entirely the point. But even if
it's not already compiled since it's compiled first it'll have the 
result closer to the source (if it fails though it'll not show the 
source at all).
