### PR TITLE
Fix 1987/lievaart - check for invalid input

### DIFF
--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -14,7 +14,7 @@ bz,lv=60,*x,*y,m,t;S(d,v,f,a,b)l*v;{l c=0,*n=v+100,bw=d<u-1?a:-9000,w,z,i,zb,q=
 ){zb=z;bw=w;if(w>=b||w>=8003)Y w;}}}if(!c){bz=0;C;Y-S(d+1,n,q,-b,-bw);}bz=zb;Y
 d>=u-1?bw+(c<<3):bw;}main(){R(;t<1100;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88
 ||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;I("Level:");s(u);e(lv>0){do{I("Yo\
-u:");s(m);}e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
+u:");s(m);if(t<1)break;}e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
 ;I("Value:%d\n",S(0,V,1,-9000,9000));I("move: %d\n",(lv-=GZ(V,bz,1,0),bz));}}GZ
 (v,z,f,o)l*v;{l*j,q=3-f,g=0,i,h,*k=v+z;if(*k==0)R(i=7;i>=0;i--){j=k+(h=r[i]);e(
 *j==q)j+=h;if(*j==f&&j-h!=k){if(!g){g=1;C;}e(j!=k)*((j-=h)+o)=f;}}Y g;}

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -18,7 +18,7 @@ t==q?50:0;Y w;}H(z,0){W(E(v,z,f,100)){c++;w= -S(d+1,n,q,0,-b,-j);W(w>j){g=bz=z;
 j=w;W(w>=b||w>=8003)Y w;}}}W(!c){g=0;W(_){H(x,v)c+= *x==f?1:*x==3-f?-1:0;Y c>0?
 8000+c:c-8000;}C;j= -S(d+1,n,q,1,-b,-j);}bz=g;Y d>=u-1?j+(c<<3):j;}main(){R(;t<
 1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;I("Level:");V[44]
-=V[55]=1;V[45]=V[54]=2;s(u);e(lv>0){Z do{I("You:");s(m);}e(!E(V,m,2,0)&&m!=99);
+=V[55]=1;V[45]=V[54]=2;s(u);e(lv>0){Z do{I("You:");s(m);if(t<1)break;}e(!E(V,m,2,0)&&m!=99);
 W(m!=99)lv--;W(lv<15&&u<10)u+=2;U("Wait\n");I("Value:%d\n",S(0,V,1,0,-9000,9000
 ));I("move: %d\n",(lv-=E(V,bz,1,0),bz));}}E(v,z,f,o)l*v;{l*j,q=3-f,g=0,i,w,*k=v
 +z;W(*k==0)R(i=7;i>=0;i--){j=k+(w=r[i]);e(*j==q)j+=w;W(*j==f&&j-w!=k){W(!g){g=1

--- a/bugs.md
+++ b/bugs.md
@@ -537,12 +537,16 @@ or any others.
 # 1987
 
 ## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
-## STATUS: INABIAF - please **DO NOT** fix
+## STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
 
-Two issues to be aware of: if you input invalid input (as in invalid characters
-like `.`) it might enter an infinite loop printing the same thing over and over.
-Also if you don't enter a valid number it will prompt you again.
+Cody fixed this to not enter an infinite loop (it was documented to detect this
+but it no longer worked). However this will forfeit the game for the user and
+it's not clear at this time if it was supposed to just act like you input `99`
+(see the README.md for details here) but that seems probable.
 
+Another issue might be that certain input when prompted for input will just
+prompt you again for input but it might be that I (Cody) do not remember how to
+play the game and it's expected this way.
 
 # 1988
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -290,7 +290,10 @@ that for System V we had to do this) Cody added to the Makefile
 
 ## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
 
-Cody made this ever so slightly like the original code by adding back the
+Cody fixed two infinite loops showing just `You:` by detecting invalid input
+which the program was documented to do. But see [bugs.md](/bugs.md).
+
+Cody also made this ever so slightly like the original code by adding back the
 `#define D define` even though it's unused. This was done for both versions as
 well (the one with the board and the one without, the entry itself with the
 limitations of the contest).


### PR DESCRIPTION
It was documented that the program detected invalid input but it actually (now - it used to work) printed in an infinite loop 'You:'. Now doing invalid input forfeits the game which is better than flooding the screen. It is not yet clear if it should act like you put in 99 (see the README.md for details) so this is in bugs.md just in case. If it is supposed to just skip a move then this can be fixed but otherwise it can be removed from bugs.md without any change in the code. This fix applies to both versions, the one with the board display and the original entry (with contest restrictions on size of code).