### PR TITLE
Remove me from 1990/baruch/README.md thanks

### DIFF
--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -14,7 +14,7 @@ bz,lv=60,*x,*y,m,t;S(d,v,f,a,b)l*v;{l c=0,*n=v+100,bw=d<u-1?a:-9000,w,z,i,zb,q=
 ){zb=z;bw=w;if(w>=b||w>=8003)Y w;}}}if(!c){bz=0;C;Y-S(d+1,n,q,-b,-bw);}bz=zb;Y
 d>=u-1?bw+(c<<3):bw;}main(){R(;t<1100;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88
 ||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;I("Level:");s(u);e(lv>0){do{I("Yo\
-u:");s(m);}e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
+u:");s(m);if(t<1)break;}e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
 ;I("Value:%d\n",S(0,V,1,-9000,9000));I("move: %d\n",(lv-=GZ(V,bz,1,0),bz));}}GZ
 (v,z,f,o)l*v;{l*j,q=3-f,g=0,i,h,*k=v+z;if(*k==0)R(i=7;i>=0;i--){j=k+(h=r[i]);e(
 *j==q)j+=h;if(*j==f&&j-h!=k){if(!g){g=1;C;}e(j!=k)*((j-=h)+o)=f;}}Y g;}

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -18,7 +18,7 @@ t==q?50:0;Y w;}H(z,0){W(E(v,z,f,100)){c++;w= -S(d+1,n,q,0,-b,-j);W(w>j){g=bz=z;
 j=w;W(w>=b||w>=8003)Y w;}}}W(!c){g=0;W(_){H(x,v)c+= *x==f?1:*x==3-f?-1:0;Y c>0?
 8000+c:c-8000;}C;j= -S(d+1,n,q,1,-b,-j);}bz=g;Y d>=u-1?j+(c<<3):j;}main(){R(;t<
 1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;I("Level:");V[44]
-=V[55]=1;V[45]=V[54]=2;s(u);e(lv>0){Z do{I("You:");s(m);}e(!E(V,m,2,0)&&m!=99);
+=V[55]=1;V[45]=V[54]=2;s(u);e(lv>0){Z do{I("You:");s(m);if(t<1)break;}e(!E(V,m,2,0)&&m!=99);
 W(m!=99)lv--;W(lv<15&&u<10)u+=2;U("Wait\n");I("Value:%d\n",S(0,V,1,0,-9000,9000
 ));I("move: %d\n",(lv-=E(V,bz,1,0),bz));}}E(v,z,f,o)l*v;{l*j,q=3-f,g=0,i,w,*k=v
 +z;W(*k==0)R(i=7;i>=0;i--){j=k+(w=r[i]);e(*j==q)j+=w;W(*j==f&&j-w!=k){W(!g){g=1

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -68,7 +68,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT= -O3
+OPT=
 
 # Default flags for ANSI C compilation
 #

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -38,14 +38,14 @@ by chance or is killed.
 ### Alternate code:
 
 The author suggested that one varies the definition of `P` from 2 through 10. As
-it's a `#define` it's easy to set up which [Cody Boone
-Ferguson](/winners.html#Cody_Boone_Ferguson) did for us. To use try:
+it's a `#define` it's easy to set up. To use try:
 
 ```sh
 make CFLAGS="-DP=9" clobber alt
 ```
 
 Use `ovdluhe.alt` as you would `ovdluhe`.
+
 
 ## Judges' remarks:
 

--- a/1989/ovdluhe/ovdluhe.alt.c
+++ b/1989/ovdluhe/ovdluhe.alt.c
@@ -20,7 +20,7 @@ main(){ape pe,*ep=a;srand((EP)time((long)E));
 while(((*(ep++)=getchar())!=-A)&&((ep-a)<PE));
 *(ae= --ep)=E;for(ap=E;ap<=P;){APE;if(pe=PA())
 {putchar(pe);if(ap<P){p[ap]=pe;ap++;}else{
-ep=p+A;while(*ep) *(ep-A)= *(ep++); *(ep-A)=pe;}}else break;}}
+ep=p+A;while(*ep) *(ep-A)= *(ep++); *(ep-A)=pe;++ap;}}else break;}}
 PA(){EA ape pe,*ep=a,pa,Ap=E;for(ep=a;ep<ae-P;ep++)
 if(!strncmp(ep,p,ap)){e[*(ep+ap)]++;Ap++;}if(!Ap)return(Ap);
 pa=rand()%Ap+A;pe=~E,Ap=!Ap;while((Ap+=e[++pe])<pa);return(pe);}

--- a/1989/ovdluhe/ovdluhe.c
+++ b/1989/ovdluhe/ovdluhe.c
@@ -14,7 +14,7 @@ main(){ape pe,*ep=a;srand((EP)time((long)E));
 while(((*(ep++)=getchar())!=-A)&&((ep-a)<PE));
 *(ae= --ep)=E;for(ap=E;ap<=P;){APE;if(pe=PA())
 {putchar(pe);if(ap<P){p[ap]=pe;ap++;}else{
-ep=p+A;while(*ep) *(ep-A)= *(ep++); *(ep-A)=pe;}}else break;}}
+ep=p+A;while(*ep) *(ep-A)= *(ep++); *(ep-A)=pe;++ap;}}else break;}}
 PA(){EA ape pe,*ep=a,pa,Ap=E;for(ep=a;ep<ae-P;ep++)
 if(!strncmp(ep,p,ap)){e[*(ep+ap)]++;Ap++;}if(!Ap)return(Ap);
 pa=rand()%Ap+A;pe=~E,Ap=!Ap;while((Ap+=e[++pe])<pa);return(pe);}

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -18,6 +18,8 @@ Israel
 make all
 ```
 
+There is [alternate code](#alternate-code) for those using Turbo-C or MSC.
+
 ## To run:
 
 ```sh
@@ -36,21 +38,21 @@ Why is there no output?
 
 ### Alternate code:
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) provided alternate code
-for users using Turbo-C or MSC, based on the authors' remarks below, except
-that he did not change the `" #Q"` string as that showed worse looking output
-instead of improved output though he has no way to test the compilers in
-question. YMMV. Thank you Cody (though we all think <strike>[no
-one](https://en.wiktionary.org/wiki/no_one#Pronoun)</strike> [very
-few](https://en.wikipedia.org/wiki/0)
+This alternate code is for the [very few](https://en.wikipedia.org/wiki/0)
 [users](https://en.wikipedia.org/wiki/Microsoft_Windows)
-[here](https://www.ioccc.org) will need it :-) )!
+[here](https://www.ioccc.org) who will need it but nonetheless if you're using
+Turbo-C or MSC, the code is based on the authors' remarks except that the `"
+#Q"` string was not changed as that showed worse looking output instead of
+improved output though admittedly we have no way to test the compilers in
+question. YMMV.
 
-To compile:
+#### To build:
 
 ```sh
 make alt
 ```
+
+#### To use:
 
 Use `baruch.alt` as you would `baruch`.
 

--- a/bugs.md
+++ b/bugs.md
@@ -537,12 +537,16 @@ or any others.
 # 1987
 
 ## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
-## STATUS: INABIAF - please **DO NOT** fix
+## STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
 
-Two issues to be aware of: if you input invalid input (as in invalid characters
-like `.`) it might enter an infinite loop printing the same thing over and over.
-Also if you don't enter a valid number it will prompt you again.
+Cody fixed this to not enter an infinite loop (it was documented to detect this
+but it no longer worked). However this will forfeit the game for the user and
+it's not clear at this time if it was supposed to just act like you input `99`
+(see the README.md for details here) but that seems probable.
 
+Another issue might be that certain input when prompted for input will just
+prompt you again for input but it might be that I (Cody) do not remember how to
+play the game and it's expected this way.
 
 # 1988
 

--- a/faq.md
+++ b/faq.md
@@ -128,42 +128,88 @@ can look almost identical.
 ## Q: How can I easily see what was changed in order to get an entry to work in modern systems?
 
 Although the [thanks-for-fixes.md](/thanks-for-fixes.md) file sometimes gives
-commands to tell you how to do this, in general you can do:
+commands to tell you how to do this, we have set up make rules to easily do
+this. For these you should be in the directory of the entry you wish to see the
+diff output.
+
+If you want to see the difference from the _original_ source try:
 
 ```sh
-diff entry.c entry.orig.c
-diff prog.c prog.orig.c
+make orig_prog_diff
 ```
 
-to see it as if you wanted to make it go back to the original and, to see the
-difference to fix it, you can do:
+
+```
+make: [Makefile:158: orig_prog_diff] Error 1 (ignored)
+```
+
+but this is perfectly fine and expected.
+
+
+If however you wish to see the difference between the alt code and the entry
+itself, try:
 
 ```sh
-diff entry.orig.c entry.c
-diff prog.orig.c prog.c
+make alt_prog_diff
 ```
 
-For instance to see how [2001/anonymous](2001/anonymous/README.md) was fixed you
-can do:
+NOTE: this might show at the end something like:
+
+```
+make: [Makefile:163: alt_prog_diff] Error 1 (ignored)
+```
+
+The `alt_prog_diff` rule will do nothing if no alt file exists.
+
+If the alt code is the same as the original, say
+[1984/anonymous](1984/anonymous/README.md), there is no point in using this
+rule.
+
+As some examples we'll first look at one, that has really long lines which
+will make it harder to see what is different,
+[2001/anonymous](2001/anonymous/README.md). What you would do is `cd
+2001/anonymous` and then do:
 
 ```sh
-diff 2001/anonymous/anonymous.orig.c 2001/anonymous/anonymous.c
+make orig_prog_diff
 ```
+
+and then be really confused! :-)
+
+But for an entry like [1991/dds](1991/dds/README.md), you can see the
+differences much more easily. `1991/dds` is a good example where it's very
+simple to see what is different as it's just a couple lines.
 
 You might be quite surprised how little some entries had to be changed and at
 the same time how much other entries had to be changed, often with quite complex
 differences! In some cases if the line is rather long, like the above mentioned
 one, it will be harder to see what changed but in other cases like
-[1984/decot](1984/decot/README.md) it's a lot easier:
-
-```sh
-diff 1984/decot/decot.orig.c 1984/decot/decot.c
-```
+[1984/decot](1984/decot/README.md) or [1986/wall](1986/wall/README.md) it's a
+lot easier.
 
 Well, at least it's easier see the differences on a line-by-line basis but maybe
 not what actually changed, especially since it's easier to know what was fixed
-when you have compiler errors :-)
+when you have compiler errors :-) (though there are, as noted, some examples
+where it's quite easy to see the differences).
 
+[1991/dds](1991/dds/README.md) is also a good example to see the alt difference
+very easily. To do that `cd 1991/dds` and then do:
+
+```sh
+make alt_prog_diff
+```
+
+and you'll see a single line changed and very simply.
+
+### Tip: if you have `colordiff` installed it's a lot easier to see the differences
+
+To use these rules but provide a different `diff`, for instance `colordiff`,
+just do:
+
+```sh
+make DIFF=colordiff orig_prog_diff # for original diff
+make DIFF=colordiff alt_prog_diff # for alt diff
+```
 
 ## Q: I cannot get entry XYZZY from year 19xx to compile!
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -494,8 +494,16 @@ you know how?
 
 ## [1989/ovdluhe](1989/ovdluhe/ovdluhe.c) ([README.md](1989/ovdluhe/README.md]))
 
-Cody provided an [alternate version](1989/ovdluhe/ovdluhe.alt.c) based on the
-author's remarks. See the README.md for details.
+Cody fixed an infinite loop where the program would print the same thing over
+and over again, flooding the screen. The problem is that there was a `for` loop
+that by necessity had to not have an increment stage but only in the `if` path
+(in the loop itself) did the pointer get updated. Looking at the code it might
+be that it can work just as well by adding the increment in the loop itself but
+this was not done.
+
+Cody also provided an [alternate version](1989/ovdluhe/ovdluhe.alt.c) based on the
+author's remarks. See the README.md for details. The fix described above was
+fixed in this version too, after it was discovered and fixed.
 
 
 ## [1989/paul](1989/paul/paul.c) ([README.md](1989/paul/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -560,8 +560,17 @@ details in that file and further details are in the [bugs.md](bugs.md) file.
 
 ## [1990/baruch](1990/baruch/baruch.c) ([README.md](1990/baruch/README.md]))
 
-Cody added an [alternate version](1990/baruch/baruch.alt.c) which allows certain
-compilers to compile the code, based on the author's remarks.
+Cody added an [alternate version](1990/baruch/baruch.alt.c) which allows Turbo-C
+and MSC to compile this code, based on the authors' remarks, except that Cody
+did not change the `" #Q"` string as that showed worse looking output
+instead of improved output though he has no way to test the compilers in
+question. YMMV.
+
+Although this is appreciated we agree with him that <strike>no one</strike>
+[very few](https://en.wikipedia.org/wiki/0)
+[users](https://en.wikipedia.org/wiki/Microsoft_Windows)
+[here](https://www.ioccc.org) will need it! :-)
+
 
 
 ## [1990/cmills](1990/cmills/cmills.c) ([README.md](1990/cmills/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -290,7 +290,10 @@ that for System V we had to do this) Cody added to the Makefile
 
 ## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
 
-Cody made this ever so slightly like the original code by adding back the
+Cody fixed two infinite loops showing just `You:` by detecting invalid input
+which the program was documented to do. But see [bugs.md](/bugs.md).
+
+Cody also made this ever so slightly like the original code by adding back the
 `#define D define` even though it's unused. This was done for both versions as
 well (the one with the board and the one without, the entry itself with the
 limitations of the contest).


### PR DESCRIPTION

This was the last remaining missed case of me being in another README.md
which happened before the (I am a broken record, perhaps, but it's true)
vastly superior thanks-for-fixes.md file was thought of.

There are other entries not mine that refer to me but these come from 
the authors themselves, not fixes, so they should stay the same.

I still have to check if there are any README.md files that have 
references to Yusuke Endoh (for fixes) as well but that will be done in
another commit another time.

I updated the alternate code section and subsections here (the 
formatting and text) as well as added at the top that there is an alt 
version.