### PR TITLE
Fix 1989/jar.2

### DIFF
--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -62,11 +62,11 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 
 # Optimization
 #
-OPT= -O3
+OPT=
 
 # Default flags for ANSI C compilation
 #

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -6,15 +6,17 @@
 #define l int
 #define C y=v+111;H(x,v)*y++= *x
 #define H(a,b)R(a=b+11;a<b+89;a++)
-#define s(a)t=scanf("%d",&a)
+#define s(a)t=scanf("%2s",a)
+char A[100];
 l V[1100],u,r[]={-1,-11,-10,-9,1,11,10,9},h[]={11,18,81,88},ih[]={22,27,72,77},
 bz,lv=60,*x,*y,m,t;S(d,v,f,a,b)l*v;{l c=0,*n=v+100,bw=d<u-1?a:-9000,w,z,i,zb,q=
 3-f;if(d>u){R(w=i=0;i<4;i++)w+=(m=v[h[i]])==f?300:m==q?-300:(t=v[ih[i]])==f?-50
 :t==q?50:0;return w;}H(z,0){if(GZ(v,z,f,100)){c++;w= -S(d+1,n,q,-b,-bw);if(w>bw
 ){zb=z;bw=w;if(w>=b||w>=8003)Y w;}}}if(!c){bz=0;C;Y-S(d+1,n,q,-b,-bw);}bz=zb;Y
 d>=u-1?bw+(c<<3):bw;}main(){R(;t<1100;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88
-||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;I("Level:");s(u);e(lv>0){do{I("Yo\
-u:");s(m);if(t<1)break;}e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
+||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((u
+=atoi(A))>10||u<0||!isdigit(*A))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
+}e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
 ;I("Value:%d\n",S(0,V,1,-9000,9000));I("move: %d\n",(lv-=GZ(V,bz,1,0),bz));}}GZ
 (v,z,f,o)l*v;{l*j,q=3-f,g=0,i,h,*k=v+z;if(*k==0)R(i=7;i>=0;i--){j=k+(h=r[i]);e(
 *j==q)j+=h;if(*j==f&&j-h!=k){if(!g){g=1;C;}e(j!=k)*((j-=h)+o)=f;}}Y g;}

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -7,8 +7,9 @@
 #define W if
 #define C y=v+111;H(x,v)*y++= *x
 #define H(a,b)R(a=b+11;a<b+89;a++)
-#define s(a)t=scanf("%d",&a)
+#define s(a)t=scanf("%2s",&a)
 #define U Z I
+char A[100];
 #define Z I("123\
 45678\n");H(x,V){putchar(".XO"[*x]);W((x-V)%10==8){x+=2;I("%d\n",(x-V)/10-1);}}
 l V[1600],u,r[]={-1,-11,-10,-9,1,11,10,9},h[]={11,18,81,88},ih[]={22,27,72,77},
@@ -17,8 +18,9 @@ bz,lv=60,*x,*y,m,t;S(d,v,f,_,a,b)l*v;{l c=0,*n=v+100,j=d<u-1?a:-9000,w,z,i,g,q=
 t==q?50:0;Y w;}H(z,0){W(E(v,z,f,100)){c++;w= -S(d+1,n,q,0,-b,-j);W(w>j){g=bz=z;
 j=w;W(w>=b||w>=8003)Y w;}}}W(!c){g=0;W(_){H(x,v)c+= *x==f?1:*x==3-f?-1:0;Y c>0?
 8000+c:c-8000;}C;j= -S(d+1,n,q,1,-b,-j);}bz=g;Y d>=u-1?j+(c<<3):j;}main(){R(;t<
-1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;I("Level:");V[44]
-=V[55]=1;V[45]=V[54]=2;s(u);e(lv>0){Z do{I("You:");s(m);if(t<1)break;}e(!E(V,m,2,0)&&m!=99);
+1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;x:I("Level:");V[44]
+=V[55]=1;V[45]=V[54]=2;s(A);if(((u=atoi(A))>10)||u<0||!isdigit(*A))goto x;e(lv>0){Z
+do{I("You:");s(A);m=atoi(A);*A='\0';}e(!E(V,m,2,0)&&m!=99);
 W(m!=99)lv--;W(lv<15&&u<10)u+=2;U("Wait\n");I("Value:%d\n",S(0,V,1,0,-9000,9000
 ));I("move: %d\n",(lv-=E(V,bz,1,0),bz));}}E(v,z,f,o)l*v;{l*j,q=3-f,g=0,i,w,*k=v
 +z;W(*k==0)R(i=7;i>=0;i--){j=k+(w=r[i]);e(*j==q)j+=w;W(*j==f&&j-w!=k){W(!g){g=1

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -140,10 +140,12 @@ alt: data ${ALT_TARGET}
 	@${TRUE}
 
 ${PROG}.alt: ${PROG}.alt.c
-	@echo "NOTE: The original source might not compile using modern compilers."
+	@echo NOTE: this compilation results in running the program itself.
 	${RM} -f $@
 	${CP} jar.1.alt.sh $@
 	${CHMOD} +x $@
+	@echo NOTE: We will now simulate: ${CC} -c -o /dev/tty jar.1.alt.c
+	${CC} -c -o /dev/stdout jar.1.alt.c 2>/dev/null | ${STRINGS}
 
 # data files
 #

--- a/1989/jar.1/README.md
+++ b/1989/jar.1/README.md
@@ -9,11 +9,18 @@ Finland
 
 ## To build:
 
+NOTE: this will run the program itself.
+
 ```sh
 make clobber all
 ```
 
+There is an alternate version with a slight difference. See [Alternate
+code](#alternate-code) below.
+
 ## To run:
+
+NOTE: this will run the program itself:
 
 ```sh
 make clobber all
@@ -21,23 +28,25 @@ make clobber all
 
 ### Alternate code:
 
-One may try:
+This code, which prints something slightly different, is provided as well.
 
-```
-./jar.1.sh
-```
+#### To build:
 
-Or for the original $xurce might not compile using modern compilers, try:
+NOTE: this will run the program itself.
 
 ```sh
 make clobber alt
 ```
 
-or even:
+#### To run:
+
+Alternatively, you can run it directly:
+
 
 ```sh
 ./jar.1.alt.sh
 ```
+
 
 ## Judges' remarks:
 

--- a/1989/jar.1/jar.1.alt.sh
+++ b/1989/jar.1/jar.1.alt.sh
@@ -4,5 +4,12 @@
 # run/compile it
 rm -f jar.1.alt.o
 cc jar.1.alt.c -c
-cat jar.1.alt.o | strings
+# we do it this way to prevent ShellCheck from whining about useless use of cat,
+# a most ill-famed warning. Why is it ill-famed? Because there is no such thing
+# as a useless cat! In fact, the fact cats exist is proof that the Earth is NOT
+# flat: if it was flat they would have pushed everything off it by now! :-) And
+# besides that, they provide hours and hours, years and years even, of joy and
+# companionship to ailurophiles and, contrary to popular belief, they most
+# certainly do have personalities and they can be very sociable too!
+strings < jar.1.alt.o
 rm -f jar.1.alt.o

--- a/1989/jar.1/jar.1.sh
+++ b/1989/jar.1/jar.1.sh
@@ -4,5 +4,12 @@
 # run/compile it
 rm -f jar.1.o
 cc jar.1.c -c
-cat jar.1.o | strings
+# we do it this way to prevent ShellCheck from whining about useless use of cat,
+# a most ill-famed warning. Why is it ill-famed? Because there is no such thing
+# as a useless cat! In fact, the fact cats exist is proof that the Earth is NOT
+# flat: if it was flat they would have pushed everything off it by now! :-) And
+# besides that, they provide hours and hours, years and years even, of joy and
+# companionship to ailurophiles and, contrary to popular belief, they most
+# certainly do have personalities and they can be very sociable too!
+strings < jar.1.o
 rm -f jar.1.o

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -290,8 +290,40 @@ that for System V we had to do this) Cody added to the Makefile
 
 ## [1987/lievaart](1987/lievaart/lievaart.c) ([README.md](1987/lievaart/README.md))
 
-Cody fixed two infinite loops showing just `You:` by detecting invalid input
-which the program was documented to do. But see [bugs.md](/bugs.md).
+Cody added back the documented checks for invalid input which no longer worked
+and instead resulted in either accepting the level, whether or not it was a
+number or out of range (see below on range). For the move it entered an infinite
+loop, prompting the player with `"You:"` but not letting the player input
+anything so that the screen was flooded and the game could not play.
+
+For both the level and move it did a `scanf()` with a `%d` specifier but this
+resulted in, if invalid input, either proceeding (for the level), presumably
+incorrectly done as it might not even be a number (see below) or printing
+`"You:"` in an infinite loop, expecting input again but not letting the player
+input anything, both as noted above.
+
+The fix is that now the specifier is a `%2s` for a `char A[100]`. For the level
+if `atoi(A)>10||<0` (see next part) or `!isdigit(*A)` it goes back and prompts
+again. The level is checked for >=0||<=10, perhaps incorrectly or perhaps not, because
+in the code that variable is checked for `<10` and if that is the case it is
+incremented by 2. I do not know the rules of the game and neither do I know what
+the author had in mind so I chosen 10 as the maximum.
+
+As for the move the `do..while` loop works properly now that it does it in two
+steps (`scanf("%2s", A); m=atoi(A);`) so there's no need to check the value
+explicitly, again. Thus it will prompt until valid input is entered, but only
+showing `"You:"` once per prompting.
+
+In the case of the level prior to prompting for the level it does a `*A='\0';`
+and in the case of the move it does it after the `m=atoi(A);`. This is done this
+way because the check for the value of the level (`atoi(A)`) is done in the
+`if()` that also checks for a digit (though it does `(u=atoi(A))>10||u<0` first,
+thus checking the level, and `|| !isdigit(*A)`). Of course since `-` is not a
+digit the `<0` is superfluous but it's done anyway. If that `if` is 1 then it
+immediately goes back to the prompting of the level.
+
+But for the move it can happen after due to the fact the condition of the
+`do..while` loop will take care of things.
 
 Cody also made this ever so slightly like the original code by adding back the
 `#define D define` even though it's unused. This was done for both versions as

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -502,10 +502,25 @@ entry as seeing the code with the result at once is far more beautiful.
 
 ## [1989/fubar](1989/fubar/fubar.c) ([README.md](1989/fubar/README.md]))
 
-Cody got this to work with modern systems. The `main()` issues were an
+Cody got this to work with modern systems. The main issues were that an
 `#include` had to be added along with fixing the path (due to `.` not being in
 `$PATH`) to files referred to in the code.
 
+
+## [1989/jar.1](1989/jar.1/jar.1.c) ([README.md](1989/jar.1/README.md]))
+
+To prevent annoying output to `/dev/tty` we changed the code to simulate the
+output via `strings(1)` but Cody removed the ill-famed `useless use of cat` to
+shut ShellCheck up. Why is it ill-famed? Because there is no such thing as a
+useless cat, that's why! For instance, the fact they even exist is proof that
+the Earth is **NOT** flat: because if it was they would have pushed everything
+off it by now! :-) They're also a great joy to all ailurophiles and yes they
+most certainly do have a personality and they can be very sociable.
+
+Whilst he was at it, Cody made it so that one need not run the alt script or alt
+code directly, to match that of the main entry. As we simulate the functionality
+anyway, and since one may still run the code or the script (for the original
+entry and the alt code) anyway, it works out well.
 
 ## [1989/jar.2](1989/jar.2/jar.2.c) ([README.md](1989/jar.2/README.md]))
 

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Mon 16 Oct 11:22:52 UTC 2023*
+*Last updated: Thu 19 Oct 18:57:35 UTC 2023*
 
 This document is primarily for [Cody Boone
 Ferguson](/winners.html#Cody_Boone_Ferguson) as he (that is I :-) ) wanted a way
@@ -145,3 +145,6 @@ instead change it to make pull requests. See the
 - Check the YYYY/README.md files for other things besides the GitHub pull
 requests rather thane mailing judges. This can be done on the final pass of the
 files.
+
+- Consider adding a `1987/lievaart/lievaart3.alt.c` that doesn't forfeit the
+game if you input invalid input.

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Thu 19 Oct 18:57:35 UTC 2023*
+*Last updated: Fri 20 Oct 11:59:47 UTC 2023*
 
 This document is primarily for [Cody Boone
 Ferguson](/winners.html#Cody_Boone_Ferguson) as he (that is I :-) ) wanted a way
@@ -145,6 +145,3 @@ instead change it to make pull requests. See the
 - Check the YYYY/README.md files for other things besides the GitHub pull
 requests rather thane mailing judges. This can be done on the final pass of the
 files.
-
-- Consider adding a `1987/lievaart/lievaart3.alt.c` that doesn't forfeit the
-game if you input invalid input.


### PR DESCRIPTION

There were some things unclear in the README.md file that have now been corrected.

Clarified in the README.md that running make clobber all will run the program itself.

The make alt target now runs the alt code just like the entry itself.  This is fine because it is a simulation (to avoid annoyance of writing binary data to /dev/tty) and since one may still run the program or script directly it's fine.

The alternate code section in the README.md was cleaned up and formatted as well.
