### PR TITLE
Format/typo check 1990/cmills

### DIFF
--- a/1990/cmills/README.md
+++ b/1990/cmills/README.md
@@ -1,9 +1,6 @@
 # Best Game
 
 Chris Mills\
-Wyse Technology\
-3471 N. 1st St.\
-San Jose CA 95134\
 US
 
 ## To build:
@@ -38,6 +35,10 @@ that may be changed:
 
 The macro `V` should remain `void`.
 
+The author noted that a compiler being used assumed that `x=*p++` means `x*=p++`
+but do you know why? This is not so strange as it might seem if you look at [C's
+history](https://www.bell-labs.com/usr/dmr/www/chist.html). Example code where
+this occurs is in John Lions' Commentary on the Sixth Edition UNIX Operating System.
 
 ## Author's remarks:
 
@@ -47,7 +48,7 @@ As best I can figure, it should be ANSI-compliant, as well as portable to BSD &
 SysV (as well as the irritating compiler I was using which assumes `x=*p++`
 means `x*=p++`!).  It is reasonably robust in its error handling---it won't let
 you split, double, etc. unless you actually have the cash, etc.  To terminate
-the program, hit EOF or type 0 or a negative number for you wager.
+the program, hit `EOF` or type `0` or a negative number for you wager.
 
 The way it deals with splits is particularly cool (IMHO).  You can split many
 times, and it will show all hands as they are played.


### PR DESCRIPTION
I included a link in the judges' remarks written by Dennis Ritchie about C history in order to explain something the author noted, that I felt some might find interesting. It was stated:

    ... as well as the irritating compiler I was using which assumes
    x=*p++ means x*=p++ !

but the explanation is quite simple. In early C and also B the compound assignments had the = first so that:

    x += 5

used to be written as:

    x =+ 5

This is also shown in Lions' Commentary on the Sixth Edition UNIX Operating System but not linked, only referenced. Both the document and the book are quite fascinating.