### PR TITLE
Make current 2012/kang properly alt code

### DIFF
--- a/2012/kang/.gitignore
+++ b/2012/kang/.gitignore
@@ -1,3 +1,4 @@
 kang
+kang.alt
 kang.orig
 prog.orig

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -114,8 +114,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/2012/kang/README.md
+++ b/2012/kang/README.md
@@ -11,6 +11,8 @@ Seonghoon Kang\
 make
 ```
 
+There is alternate code which fixes some German at the expense of other German.
+See [Alternate code](#alternate-code) below.
 
 ## To run:
 
@@ -25,28 +27,49 @@ echo "full spelling of an English cardinal numeral less than a quadrillion" | ./
 echo Nineteen hundred and eighty-four | ./kang
 echo uno | ./kang
 echo trois | ./kang
-echo vier | ./kang
+echo fier | ./kang # notice the issue here, see alternate code instead
 echo "shest'" | ./kang
 
+./en.sh # English 0 through 13
+
+./de.sh # German 0 through 13 with both umlauts and without (additional 'e')
 ```
 
 How does it have no `u` or `o` in a string in the source code and yet it gets
 `uno` right?
 
-### Also try:
+### Alternate code:
 
-For those who speak Germans:
+This alternate code fixes the program that would throw off those who know German
+where the sound of 'V' is 'F' and so the program had the letter be 'F'. A
+problem, however, with changing it is that it breaks other words. Thus there is
+the alternate version instead which fixes the problem.
+
+#### To build:
 
 ```sh
-for i in eins zwei drei vier fuenf sechs sieben acht neun zehn elf zwoelf dreizehn ; \
-do
-    echo "$i"|./kang;
-done
-
+make alt
 ```
 
-What does it get right? What does it get wrong? Finally why does it get what it
-gets wrong wrong?
+#### To use:
+
+```sh
+echo vier | ./kang.alt
+echo uno | ./kang.alt
+```
+
+#### Also try:
+
+
+```sh
+KANG=kang.alt ./de.sh # German 0 through 13 both with and without umlaut
+KANG=kang.alt ./en.sh # English 0 through 13
+```
+
+What does it get right? What does it get wrong? How does it compare to the
+original entry without the change of `f` to `v`?
+
+Finally why does it get what it gets wrong wrong? 
 
 
 ## Judges' remarks:

--- a/2012/kang/de.sh
+++ b/2012/kang/de.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# 
+# run 2012/kang with German words for 0 through 13
+#
+# For five, fünf, it uses both ue and umlaut (ü) form, and for twelve, zwölf, it
+# uses both oe and ö.
+#
+# What does it get right and what does it get wrong? Why does it get what it
+# gets wrong wrong?
+
+make everything || exit 1
+
+# set up path to program if not set
+if [[ -z "$KANG" ]]; then
+    KANG="kang"
+fi
+
+# first set up translation (for those who don't know German):
+declare -a NUMBERS
+j=0
+for i in 0 1 2 3 4 5 5 6 7 8 9 10 11 12 12 13; do
+    NUMBERS["$j"]="$i";
+    ((j++))
+done
+
+
+j=0
+for i in Null eins zwei drei vier fünf fuenf sechs sieben acht neun zehn elf zwoelf zwölf dreizehn ; \
+do
+    echo -n "$i (${NUMBERS[$j]}): "
+	echo "$i"|"./$KANG"
+	((j++))
+done

--- a/2012/kang/en.sh
+++ b/2012/kang/en.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# 
+# run 2012/kang with English words for 1 through 13
+#
+# What does it get right and what does it get wrong? Why does it get what it
+# gets wrong wrong?
+
+make everything || exit 1
+
+# set up path to program if not set
+if [[ -z "$KANG" ]]; then
+    KANG="kang"
+fi
+
+declare -a NUMBERS
+j=0
+for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13; do
+    NUMBERS["$j"]="$i";
+    ((j++))
+done
+
+j=0
+for i in zero one two three four five six seven eight nine ten eleven twelve thirteen ; \
+do
+    echo -n "$i (${NUMBERS[$j]}): "
+    echo "$i"|"./$KANG"
+    ((j++))
+done

--- a/2012/kang/kang.alt.c
+++ b/2012/kang/kang.alt.c
@@ -1,5 +1,5 @@
 long long n,u,m,b;main(e,r)char **r;{f\
-or(;n++||(e=getchar()|32)>=0;b="ynwtsflrabg"[n%=11]-e?b:b*8+
+or(;n++||(e=getchar()|32)>=0;b="ynwtsvlrabg"[n%=11]-e?b:b*8+
 n)for(r=b%64-25;e<47&&b;b/=8)for(n=19;n;n["1+DIY/.K430x9\
 G(kC["]-42&255^b||(m+=n>15?n:n>9?m%u*~-u:~(int)r?n+
 !(int)r*16:n*16,b=0))u=1ll<<6177%n--*4;printf("%llx\n",m);}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1921,11 +1921,20 @@ implicitly (linux doesn't seem to but macOS does).
 
 ## [2012/kang](2012/kang/kang.c) ([README.md](2012/kang/README.md]))
 
-Cody changed the code to accept the proper German for four 'vier' where before
-it was spelt with the sound of V (fier not vier). But was this a bug or a
-feature? He's on the fence here but he went ahead and did it anyway as it seems
-useful and not having it fixed somewhat lessens the usability, especially for
-those who know German and expect it to be 'vier' :-)
+Cody added alt code that fixes the problem where in German 'v' sounds like 'f'
+which the program has as 'f'. Thus with the original version it would translate
+'fier' to '4' when the word is 'vier'. Originally this was updated in the
+original code but it was noticed that this caused _other_ words to be incorrect
+so it was set as an alt version since the code was already there. It might also
+be considered a feature and not a bug so an alt version is the better way to go
+about it. Using both allows one to experience different capabilities and also
+enjoy or appreciate the entry more.
+
+Cody also added two scripts, [en.sh](2012/kang/en.sh) and
+[de.sh](2012/kang/de.sh) which counts from 0 through 13 in English and German.
+In the German script it uses the umlaut and also does it without the umlaut (add
+an 'e'). Both scripts can use either version to see the differences. See the
+README.md file for details.
 
 
 ## [2012/vik](2012/vik/vik.c) ([README.md](2012/vik/README.md]))


### PR DESCRIPTION
I was on the fence of whether it's a feature or bug that the program deciphers 'fier' as '4' instead of proper 'vier' but to help with preventing confusion to those who know German I ended up changing it. This was thought okay but after more thought and also playing with it a bit I have made that fix the alt version instead. It so happens that (and I wondered about this at the time but did not have examples then) by changing it to 'vier' it caused other number words to be wrong. Thus the version that I'll call vier (even though it's zwei or if alternatively if zero based eins :-) ) is now the alt version.

Added en.sh and de.sh scripts to count from 0 through 13 (reason below), showing the word and number and then the result. One can choose whether to use the alt version or not by passing in KANG=... to the script like:

    KANG=kang.alt ./de.sh

would run the vier version of kang (kang.alt).

As for why 13 it's to demonstrate two of the German umlauts, ö and ü (in German you can add an 'e' or 'E' if you don't have the umlaut so it does both to demonstrate how the program deals with it).

Makefile updated so one can run make alt.

.gitignore updated.

Now the program is how it was and how it should be and yet at the same time one play with the vier versus fier.