### PR TITLE
Remove outdated INABIAF in 1987/lievaart

### DIFF
--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -22,8 +22,7 @@ This entry a listed in [bugs.md](/bugs.md) as:
 STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [bugs.md](/bugs.md#1984-laman-laman.c).
-
+For more detailed information see [bugs.md](/bugs.md#1984laman-readmemd).
 
 ## Try:
 

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -20,6 +20,16 @@ make all
 This entry will very likely crash or do something else if you run it without an
 arg. It likely won't do anything at all if the arg is not a positive number.
 
+### Bugs and (Mis)features
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md)(1984-laman-laman.c).
+
 
 ## Try:
 

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -14,12 +14,6 @@ make all
 ./laman <positive number>
 ```
 
-
-### INABIAF - it's not a bug it's a feature :-)
-
-This entry will very likely crash or do something else if you run it without an
-arg. It likely won't do anything at all if the arg is not a positive number.
-
 ### Bugs and (Mis)features
 
 This entry a listed in [bugs.md](/bugs.md) as:
@@ -28,7 +22,7 @@ This entry a listed in [bugs.md](/bugs.md) as:
 STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [bugs.md](/bugs.md)(1984-laman-laman.c).
+For more detailed information see [bugs.md](/bugs.md#1984-laman-laman.c).
 
 
 ## Try:

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -38,11 +38,6 @@ make alt
 
 Use `./lievaart.alt` as you would `./lievaart` above.
 
-### INABIAF - it's not a bug it's a feature! :-)
-
-If you enter invalid input the program will enter an infinite loop displaying a
-string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
-incorrect value it will prompt you again until you input a proper value.
 
 ## Judges' remarks:
 

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -65,7 +65,7 @@ enough args.
 
 
 ## Judges' remarks:
-\
+
 For extra credit: What happens when 'number' contains non-numeric
 characters, and why?
 

--- a/bugs.md
+++ b/bugs.md
@@ -443,12 +443,11 @@ without a newline after the `\`. This is not a bug.
 
 
 
-## STATUS: INABIAF - please **DO NOT** fix
-## [1984/laman](1984/laman/laman.c) ([README.md](1984/laman/README.md)
+## [1984/laman](1984/laman/laman.c) ([README.md](1984/laman/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
 This entry will very likely crash or do something else if you run it without an
-arg.
+arg. It likely won't do anything at all if the arg is not a positive number.
 
 # 1985
 


### PR DESCRIPTION

It was actually declared it was a bug (the entry no longer did the 
invalid input check that it once did) and I fixed it so it no longer
needs to be documented at all.