### PR TITLE
Move INABIAF to bugs.md in 1980s entries

### DIFF
--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -8,12 +8,6 @@ Mike Laman
 make all
 ```
 
-## To run:
-
-```sh
-./laman <positive number>
-```
-
 ### Bugs and (Mis)features
 
 This entry a listed in [bugs.md](/bugs.md) as:
@@ -23,6 +17,14 @@ STATUS: INABIAF - please **DO NOT** fix
 ```
 
 For more detailed information see [bugs.md](/bugs.md#1984laman-readmemd).
+
+
+## To run:
+
+```sh
+./laman <positive number>
+```
+
 
 ## Try:
 

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -22,8 +22,7 @@ This entry a listed in [bugs.md](/bugs.md) as:
 STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [bugs.md](/bugs.md#1984-laman-laman.c).
-
+For more detailed information see [bugs.md](/bugs.md#1984laman-readmemd).
 
 ## Try:
 

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -20,6 +20,16 @@ make all
 This entry will very likely crash or do something else if you run it without an
 arg. It likely won't do anything at all if the arg is not a positive number.
 
+### Bugs and (Mis)features
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md)(1984-laman-laman.c).
+
 
 ## Try:
 

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -14,12 +14,6 @@ make all
 ./laman <positive number>
 ```
 
-
-### INABIAF - it's not a bug it's a feature :-)
-
-This entry will very likely crash or do something else if you run it without an
-arg. It likely won't do anything at all if the arg is not a positive number.
-
 ### Bugs and (Mis)features
 
 This entry a listed in [bugs.md](/bugs.md) as:
@@ -28,7 +22,7 @@ This entry a listed in [bugs.md](/bugs.md) as:
 STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [bugs.md](/bugs.md)(1984-laman-laman.c).
+For more detailed information see [bugs.md](/bugs.md#1984-laman-laman.c).
 
 
 ## Try:

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -38,11 +38,6 @@ make alt
 
 Use `./lievaart.alt` as you would `./lievaart` above.
 
-### INABIAF - it's not a bug it's a feature! :-)
-
-If you enter invalid input the program will enter an infinite loop displaying a
-string like `"You:"` repeatedly (for instance if you input `.`). If you enter an
-incorrect value it will prompt you again until you input a proper value.
 
 ## Judges' remarks:
 

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -9,6 +9,19 @@ Australia
 make all
 ```
 
+### INABIAF - it's not a bug it's a feature! :-)
+
+### Bugs and (Mis)features
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md#1988dale-readmemd).
+
+
 ## Try:
 
 ```sh
@@ -25,11 +38,6 @@ behaviour?
 ./dale $(printf "the following files exist in this directory:\n%s\n" *)
 ./dale "$(printf "the following files exist in this directory:\n%s\n" *)"
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-In linux it might happen that core dumps are created when running this entry
-even though it works fine and you don't see any message about dumping core.
 
 ### Alternate code
 

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -9,7 +9,6 @@ Australia
 make all
 ```
 
-### INABIAF - it's not a bug it's a feature! :-)
 
 ### Bugs and (Mis)features
 

--- a/1989/fubar/README.md
+++ b/1989/fubar/README.md
@@ -1,10 +1,6 @@
 # Best self-modifying program
 
 Jay Vosburgh\
-Sequent Computer Systems, Inc\
-15450 SW Koll Parkway\
-Beaverton, OR\
-97006\
 US
 
 ## To build:
@@ -12,6 +8,18 @@ US
 ```sh
 make all
 ```
+
+
+### Bugs and (Mis)features
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md#1989fubar-readmemd).
+
 
 ## To run:
 
@@ -25,11 +33,6 @@ make all
 ./fubar 2
 ```
 
-### INABIAF - it's not a bug it's a feature! :-)
-
-If you use either `fubar` or `ouroboros.c` (it's executable, see below) with a
-number < 0 or larger than, say 20, it's very likely that the program will turn
-into an infinite loop trying to compile code with syntax errors.
 
 ## Judges' remarks:
 

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -1,10 +1,6 @@
 # Best minimal use of C
 
 Arch D. Robison\
-University of Illinois\
-1304 W. Springfield Ave.\
-Urbana, IL\
-61801\
 US
 
 ## To build:
@@ -12,6 +8,16 @@ US
 ```sh
 make all
 ```
+
+### Bugs and (Mis)features
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md#1989robison-readmemd).
 
 
 ## To run:

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -65,7 +65,7 @@ enough args.
 
 
 ## Judges' remarks:
-\
+
 For extra credit: What happens when 'number' contains non-numeric
 characters, and why?
 

--- a/bugs.md
+++ b/bugs.md
@@ -542,7 +542,8 @@ or any others.
 ## STATUS: INABIAF - please **DO NOT** fix
 
 In linux it might happen that despite no error message or message about doing
-so, the program drops a core file into the directory.
+so, the program drops a core file into the directory even though the entry works
+and does not crash.
 
 # 1989
 
@@ -550,10 +551,12 @@ so, the program drops a core file into the directory.
 ## [1989/fubar](1989/fubar/fubar.c) ([README.md](1989/fubar/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
-Specifying too large a number (or < 0) to either `fubar` or the source code file
-(it's executable) that it generates will cause the program to enter an infinite
-loop, trying to compile code with syntax errors. At least in one system any
-number larger than 20 did this.
+If you use either `fubar` or `ouroboros.c` (it's executable, see README.md for
+details) with a number < 0 or larger than, say 20, it's very likely that the
+program will turn into an infinite loop trying to compile code with syntax
+errors.
+
+
 
 ## [1989/robison](1989/robison/robison.c) ([README.md](1989/robison/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -443,12 +443,11 @@ without a newline after the `\`. This is not a bug.
 
 
 
-## STATUS: INABIAF - please **DO NOT** fix
-## [1984/laman](1984/laman/laman.c) ([README.md](1984/laman/README.md)
+## [1984/laman](1984/laman/laman.c) ([README.md](1984/laman/README.md))
 ## STATUS: INABIAF - please **DO NOT** fix
 
 This entry will very likely crash or do something else if you run it without an
-arg.
+arg. It likely won't do anything at all if the arg is not a positive number.
 
 # 1985
 


### PR DESCRIPTION

Having to click on the links in each README.md file will have to be done
to verify the links work but it appears to be in the form of:

    /bugs.md#YYYYauthor-readmemd
