### PR TITLE
Improve links in thanks-for-fixes.md

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -130,42 +130,51 @@ can look almost identical.
 Although the [thanks-for-fixes.md](/thanks-for-fixes.md) file sometimes gives
 commands to tell you how to do this, we have set up make rules to easily do
 this. For these you should be in the directory of the entry you wish to see the
-diff output.
+diff output of.
 
-If you want to see the difference from the _original_ source try:
+When we say `entry` below, in a file name, we mean either the winner name or
+`prog`. For instance one of Landon's all time favourite entries is
+[1984/mullender](1984/mullender/README.md) so the file names would be:
+`mullender.orig.c`, `mullender.alt.c` and `mullender.c`. For later years, it
+would be instead `prog.orig.c`, `prog.alt.c` and `prog.c`.
 
-```sh
-make diff_orig_prog
+The following `make` rules exist:
+
+* `make diff_orig_prog`:
+    - This rule will show the diff of the _original_ source to the
+    current source (that is `entry.orig.c` to `entry.c`).
+* `make make diff_alt_orig`:
+    - This rule will show the diff of the alt code to the original
+    code (that is `entry.alt.c` to `entry.orig.c`). If no alt code exists
+    nothing will be shown.
+* `make diff_alt_prog`:
+    - This rule will show the diff of the alt code to the entry as it
+    stands (that is `entry.alt.c` to `entry.c`).
+* `make diff_orig_alt`:
+    - This rule will show the diff of the original code to the alt code
+    (that is `entry.orig.c` to `entry.alt.c`).
+* `make diff_prog_alt`:
+    - This rule will show the diff of the entry to the alt code (that is
+    `entry.c` to `entry.alt.c`).
+* `make diff_prog_orig`:
+    - This rule will show the diff of the entry to the original code (that is
+    `entry.c` to `entry.orig.c`).
+
+
+Note that you might see something like:
+
+```
+make: [Makefile:170: diff_orig_prog] Error 1 (ignored)
 ```
 
+at the end of the output but this is completely normal if there are differences.
 
-```
-make: [Makefile:158: diff_orig_prog] Error 1 (ignored)
-```
+If the alt code is the same as the original, say with
+[1984/anonymous](1984/anonymous/README.md), then naturally there is no point in
+running the rule and the same applies for all the other rules but this system
+allows for easily seeing the diffs.
 
-but this is perfectly fine and expected.
-
-
-If however you wish to see the difference between the alt code and the entry
-itself, try:
-
-```sh
-make diff_alt_prog
-```
-
-NOTE: this might show at the end something like:
-
-```
-make: [Makefile:163: diff_alt_prog] Error 1 (ignored)
-```
-
-The `diff_alt_prog` rule will do nothing if no alt file exists.
-
-If the alt code is the same as the original, say
-[1984/anonymous](1984/anonymous/README.md), there is no point in using this
-rule.
-
-As some examples we'll first look at one, that has really long lines which
+As some examples we'll first look at one that has really long lines which
 will make it harder to see what is different,
 [2001/anonymous](2001/anonymous/README.md). What you would do is `cd
 2001/anonymous` and then do:
@@ -207,9 +216,13 @@ To use these rules but provide a different `diff`, for instance `colordiff`,
 just do:
 
 ```sh
-make DIFF=colordiff diff_orig_prog # for original diff
-make DIFF=colordiff diff_alt_prog # for alt diff
+make DIFF=colordiff diff_orig_prog # for orig to prog diff
+make DIFF=colordiff diff_alt_prog # for alt to prog diff
 ```
+
+Obviously if you want to view the alt code or the orig code you can just open
+the files as described above.
+
 
 ## Q: I cannot get entry XYZZY from year 19xx to compile!
 
@@ -246,9 +259,11 @@ alternative code and/or fixed them. Most entries do now work and the others we
 are working on (slowly as other things are also being done and this is on free
 time).
 
-In some cases we replaced the original code with code that works for modern
-systems but one can view the original code in the `.orig.c` files (sometimes the
-original code is also in the directory as a `winner.alt.c` or `prog.alt.c`).
+In some cases we replaced the original code (not the `.orig.c` file!) with code
+that works for modern systems but one can view the original code in the
+`.orig.c` files (sometimes the original code is also in the directory as a
+`winner.alt.c` or `prog.alt.c`).
+
 Some entries should not have modern system versions replaced. See below.
 
 ## Q: I can't get some entries to work in 64-bit systems that don't support 32-bit!
@@ -274,12 +289,7 @@ actually clang, even `/usr/bin/gcc`.
 That being said many (if not most) of these entries have been fixed and some
 others will be looked at, when found.
 
-## Q: What is `cb` that is mentioned in some of the older entries?
-
-This was a C beautifier for Unix, both AT&T and Berkeley, but it seems to no
-longer be available, code wise, except for Plan 9, but Plan 9 was never used for
-judging the IOCCC. A Unix man page for `cb`
-[still exists](https://www.ibm.com/docs/en/aix/7.3?topic=c-cb-command).
+See also below.
 
 
 ## Q: I can't get XYZZY entry to compile with clang. What can I do?
@@ -297,6 +307,14 @@ then what was main() became another function of the original main() type.
 At the same time some entries are not designed to work with clang. There might
 be alternate code added at some point but as above this depends on free time and
 other things that have to be done plus remembering to do it.
+
+## Q: What is `cb` that is mentioned in some of the older entries?
+
+This was a C beautifier for Unix, both AT&T and Berkeley, but it seems to no
+longer be available, code wise, except for Plan 9, but Plan 9 was never used for
+judging the IOCCC. A Unix man page for `cb`
+[still exists](https://www.ibm.com/docs/en/aix/7.3?topic=c-cb-command).
+
 
 ## Q: After running a program my terminal is all messed up! How do I restore my terminal?
 
@@ -402,6 +420,13 @@ brew install sdl2 sdl12-compat
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
+##### NOTE: there might be extra SDL packages required
+
+In the case that some entries do not work even with SDL1/SDL2 installed it might
+be that you need additional SDL libraries. See the entry's README.md for
+details. If something is not noted you're welcome to report it as an issue or
+fix it and make a new pull request.
+
 ## Q: How do I compile and run entries that use sound in macOS?
 
 This might depend on the entry but in some cases like
@@ -443,12 +468,6 @@ and/or number of rows have also changed.
 For the original version see the [/archive](/archive) directory where you can
 find all the original winning entries. In some cases the `winner.alt.c` is the
 original source code.
-
-## Q: Since some entries have been modified over time, how can I view the original entry?
-
-See either the `winner.orig.c` or `prog.orig.c`, depending on the year (earlier
-years we did not rename the code to `prog.c` but had it as the winner handle),
-in the winning directories.
 
 ## Q: I found a bug in a previous winner, what should I do?
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -11,30 +11,32 @@ contributed thousands, that we wish to thank.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
-responsible for many of the improvements including many **very complicated bug
-fixes** like [1988/phillipps](1988/phillipps/README.md),
-[2001/anonymous](2001/anonymous/README.md) and
-[2004/burley](2004/burley/README.md), making entries like
-[1986/wall](1986/wall/README.md) not need `-traditional-cpp` (all **very
-complicated fixes**), fixing entries to work with clang (some being **very
-complicated** like [1991/dds](1991/dds/README.md)), porting entries to
-macOS (some being **very complicated** like
-[1998/schweikh1](1998/schweikh1/README.md)), fixing code like
-[2001/herrmann2](2001/herrmann2/README.md) to work in both 32-bit/64-bit which
-*can be* **very complicated**, providing alternate code where useful/necessary,
-fixing where possible dead links or removing them, typo/consistency fixes,
-improving **ALL _Makefiles_** and writing [sgit](https://github.com/xexyl/sgit)
-that we installed locally to easily run `sed` on files in the repo to help build
-the website. **Thank you very much** for your extensive efforts in helping
-improve the IOCCC presentation of past IOCCC winners and fixing almost all past
-entries for modern systems!
+responsible for most of the improvements including many **very complicated bug
+fixes** like [1988/phillipps](/thanks-for-fixes.md#1988phillipps-readmemd),
+[2001/anonymous](/thanks-for-fixes.md#2001anonymous-readmemd) and
+[2004/burley](/thanks-for-fixes.md#2004burley-readmemd), making entries like
+[1986/wall](/thanks-for-fixes.md#1986wall-readmemd) not need `-traditional-cpp`
+(all **very complicated fixes**), fixing entries to work with clang (some being
+**very complicated** like [1991/dds](/thanks-for-fixes.md#1991dds-readmemd)),
+porting entries to macOS (some being **very complicated** like
+[1998/schweikh1](/thanks-for-fixes.md#1998schweikh1-readmemd)), fixing code like
+[2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd) to work in both
+32-bit/64-bit which *can be* **very complicated**, providing alternate code
+where useful/necessary, fixing where possible dead links or removing them,
+typo/consistency fixes, improving **ALL _Makefiles_** and writing
+[sgit](https://github.com/xexyl/sgit) that we installed locally to easily run
+`sed` on files in the repo to help build the website. **THANK YOU VERY MUCH**
+for your extensive efforts in helping improve the IOCCC presentation of past
+IOCCC winners and fixing almost all past entries for modern systems!
 
 [Yusuke Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) supplied a
 number of important bug fixes to a number of past IOCCC winners. Some of those
 fixes were **very technically challenging** such as
-[1989/robison](1989/robison/README.md), [1990/cmills](1990/cmills/README.md),
-[1992/lush](1992/lush/README.md) and [2001/ctk](2001/ctk/README.md). **Thank you very
-much** for your help!
+[1989/robison](/thanks-for-fixes.md#1989robison-readmemd),
+[1990/cmills](https://github.com/ioccc-src/temp-test-ioccc/blob/master/thanks-for-fixes.md#1990cmills-readmemd),
+[1992/lush](/thanks-for-fixes.md#1992lush-readmemd) and
+[2001/ctk](/thanks-for-fixes.md#2001ctk-readmemd). **THANK YOU VERY MUCH** for
+your help!
 
 A good number of the [past winners of the
 IOCCC](https://www.ioccc.org/winners.html) tested, identified and helped correct
@@ -75,6 +77,26 @@ Where useful he added some notes to the Makefiles during compilation to let one
 know of certain problems or features that matter.
 
 There were some other fixes as well including typos in the Makefiles.
+
+A lot of these fixes were done with his [sgit
+tool](https://github.com/xexyl/sgit).
+
+## Typo fixes and consistency improvements
+
+Cody made many, many typ0 (... :-) ) fixes throughout the README.md files,
+scripts, other data files, Makefiles (see above) etc.
+
+He also updated the formatting of the README.md files (after renaming the old
+files to README.md) to proper markdown.
+
+Where possible he made the presentation of the entries much more consistent
+across the entries of all the years as well as other files. This is not possible
+for everything (the remarks of authors, for instance, cannot be and should not
+be made consistent but adding markdown where necessary in the remarks is).
+
+A lot of these fixes were done with his [sgit
+tool](https://github.com/xexyl/sgit) but many were done manually as well.
+
 
 ## [1984/anonymous](1984/anonymous/anonymous.c) ([README.md](1984/anonymous/README.md))
 
@@ -138,7 +160,7 @@ but not clang - or at least some versions.
 To see the difference from start to fixed:
 
 ```sh
-diff 1984/decot/decot.orig.c 1984/decot/decot.c
+cd 1984/decot ; make diff_orig_prog
 ```
 
 ## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md]))
@@ -276,7 +298,7 @@ If you'd like to see the difference between the version that requires
 `-traditional-cpp` and the fixed version, try:
 
 ```sh
-diff 1986/wall/wall.alt.c 1986/wall/wall.c
+cd 1986/wall ; make diff_alt_prog
 ```
 
 ## [1987/heckbert](1987/heckbert/heckbert.c) ([README.md](1987/heckbert/README.md))
@@ -361,12 +383,14 @@ unlikely(?) but nevertheless suggested case that `putchar()` is not available.
 ## [1988/dale](1988/dale/dale.c) ([README.md](1988/dale/README.md]))
 
 Cody fixed this twisted entry (as we called it :-) ) for modern compilers,
-including making it no longer require `-traditional-cpp`. There were two
-problems here to fix, which Cody did.
+including making it no longer require `-traditional-cpp`. Fixing
+`-traditional-cpp` is, as noted earlier, very complicated, but we encourage you
+to compare the fix from the original entry. There was another problem to resolve
+as well, however.
 
-One, as noted above, was that the entry required `-traditional-cpp`
-(which <strike>not all compilers support</strike> `clang` does not support)
-It needed that option in modern systems because of two things it did:
+First of all, as noted above, the entry required `-traditional-cpp` (which
+<strike>not all compilers support</strike> `clang` does not support) It needed
+that option in modern systems because of two things it did:
 
 ```c
 #define a(x)get/***/x/***/id())
@@ -440,7 +464,7 @@ version in case you have an older compiler or wish to try `-traditional-cpp`.
 ## [1988/isaak](1988/isaak/isaak.c) ([README.md](1988/isaak/README.md]))
 
 Cody fixed this to work for modern systems. The problem was that the important
-function, a redefinition of `exit()`, was not being called in main(). The
+function, a redefinition of `exit()`, was not being called in `main()`. The
 original version is in [1988/isaak/isaak.alt.c](1988/isaak/isaak.alt.c). See the
 README.md file for more details.
 
@@ -453,11 +477,12 @@ publication, in the remarks, to help understand the entry, and for fun.
 
 Cody fixed this for modern systems. It did not compile with clang because it
 requires the second and third args of `main()` to be `char **` but even before
-that with gcc it printed random characters.
+that with gcc it printed garbage and then crashed.
 
-After fixing it for clang by changing `main()` to call the new function `pain()`
-(chosen because it's a pain that clang requires these args to be `char **` :-) )
-with the correct args it now works with gcc and clang.
+After fixing it for clang by changing the very `main()` (in fact it called
+itself up to 12 times!) to call the new function `pain()` (chosen because it's a
+pain that clang requires these args to be `char **` :-), which is just as
+recursive, with the correct args it now works with both gcc and clang.
 
 Later Cody improved the fix to make it look a bit more like the original, using
 K&R style functions, and trying to match the format as best as possible of what
@@ -1370,7 +1395,7 @@ These also had to be done:
 closed prior to executing the program. This is the `f` variable which is of type
 `l`, a `#define` for `int *`.
 - `munmap()` also had to be called prior to executing the program. This involved
-a new `off_t N` so which was added in the `mmap()` call which was then used in
+a new `off_t N` which was added in the `mmap()` call which was then used in
 the `munmap()` call.
 
 Without those changes the program was not executed after modification which it
@@ -1473,7 +1498,7 @@ by Yusuke.
 ## [2001/cheong](2001/cheong/cheong.c) ([README.md](2001/cheong/README.md]))
 
 Cody fixed this to work with clang by adding another function that is allowed to
-have a third arg as an int, not a `char **`. He chose pain() because it's a four
+have a third arg as an int, not a `char **`. He chose `pain()` because it's a four
 letter word that would match the format and because it's pain that clang forces
 this. :-) This fix makes a point of the author's notes on portability no longer
 valid, btw.
@@ -1525,7 +1550,7 @@ version that the author did not note. Do you know what these are?
 Cody fixed this so that the when compiling the code the program is not executed
 itself by itself which just showed the usage string and exited. The [script
 herrmann1.sh](2001/herrmann1/herrmann1.sh) is used to compile the program but
-it's also how you invoke the program. 
+it's also how you invoke the program.
 
 He also fixed the [script herrmann1.sh](2001/herrmann1/herrmann1.sh) for
 shellcheck. In particular there were quite a few:
@@ -1542,7 +1567,7 @@ errors/warnings.
 
 Cody fixed this to work with both 64-bit and 32-bit compilers by changing most of
 the `int`s (all but that in `main`) to `long`s. He also fixed it to compile with
-clang by changing the args of main to be `int` and `char **` respectively and
+clang by changing the args of main to be `int` and `char **`, respectively, and
 changing specific references to the `argv` arg, casting to `long` (was `int` but
 the 64-bit fix requires `long`) which was its old type. The original file, used
 for demonstration purposes, as well as if you want to see if your system works
@@ -1857,7 +1882,7 @@ back for arrow keys in the [alternate version](2006/night/night.alt.c).
 
 Cody fixed this entry to work with clang which has a defect with the args to
 `main()`: it requires specific types: `int` and `char **` for the first and
-latter args. 
+latter args.
 
 The [alternate version](2006/sloane/sloane.alt.c), which allows one to see what
 is going on in modern systems, and which we recommend one use _first_, was


### PR DESCRIPTION

Rather than have the specific entries noted at the top (for Yusuke and
me) link to the README.md file of the entries, it seems better to me to
link to the entry in the file as that explains what was done which is
what is being honoured/appreciated.

I also added another section or two (both short). One has a joke in it.

Some of the entries had improvements in text of what had to be done to
fix them to work / what was wrong.