### PR TITLE
Alternate code heading level 2

### DIFF
--- a/1984/anonymous/README.md
+++ b/1984/anonymous/README.md
@@ -14,7 +14,7 @@ make all
 ./anonymous
 ```
 
-### Alternate code:
+## Alternate code:
 
 The original version of this entry was added, by request,
 in order to show the code that was turned into the

--- a/1984/anonymous/README.md
+++ b/1984/anonymous/README.md
@@ -8,7 +8,7 @@ Anonymous
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./anonymous
@@ -27,7 +27,7 @@ as the alternate code. See below in the tattoo side-by-side with the code.
 make alt
 ```
 
-#### To run:
+#### To use:
 
 NOTE: this version might not work on some systems like macOS.
 

--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -14,7 +14,7 @@ make all
 ./decot
 ```
 
-### Alternate code:
+## Alternate code:
 
 This alternate code, the original, requires a compiler that supports
 `-traditional-cpp` or an old enough compiler. If you have such a compiler you

--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -8,7 +8,7 @@ Dave Decot
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./decot
@@ -26,7 +26,7 @@ can use this entry.
 make alt
 ```
 
-#### To run:
+#### To use:
 
 ```sh
 ./decot.alt

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -19,7 +19,7 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [bugs.md](/bugs.md#1984laman-readmemd).
 
 
-## To run:
+## To use:
 
 ```sh
 ./laman <positive number>

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -13,7 +13,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./mullender
@@ -42,7 +42,7 @@ make alt
 ```
 
 
-#### To run:
+#### To use:
 
 ```sh
 ./mullender.alt [microseconds]

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -25,7 +25,7 @@ correctly.  In later years, machine dependent code was discouraged. An alternate
 version that will work with other systems is provided as alternate code below.
 
 
-### Alternate code:
+## Alternate code:
 
 An alternate version exists which allows one to enjoy this entry on systems
 other than a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or

--- a/1985/august/README.md
+++ b/1985/august/README.md
@@ -9,7 +9,7 @@ Lennart Augustsson\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./august

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -17,7 +17,7 @@ make lycklama.orig
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./lycklama.alt < some_file

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -26,7 +26,7 @@ echo IOCCC | ./sicherman
 ./sicherman < sicherman.c | ./sicherman
 ```
 
-### Alternate code:
+## Alternate code:
 
 This alternate version, which is the original entry, requires either an old
 enough compiler or a compiler that supports `-traditional-cpp`. If you have such

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -39,7 +39,7 @@ a compiler you can try this version.
 make alt
 ```
 
-#### To run:
+#### To use:
 
 ```sh
 ./sicherman.alt < file

--- a/1986/applin/README.md
+++ b/1986/applin/README.md
@@ -10,7 +10,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./applin

--- a/1986/bright/README.md
+++ b/1986/bright/README.md
@@ -8,7 +8,7 @@ Walter Bright
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./bright some_file

--- a/1986/hague/README.md
+++ b/1986/hague/README.md
@@ -13,7 +13,7 @@ There is an alternate version which uses `fgets()`. See the Alternate code
 section below as well as the [bugs.md](/bugs.md) file for more details as to why
 it is worth having as an alternate version.
 
-## To run:
+## To use:
 
 ```sh
 ./hague 2>/dev/null

--- a/1986/hague/README.md
+++ b/1986/hague/README.md
@@ -35,7 +35,7 @@ Also try:
 echo IOCCC | ./hague 2>/dev/null
 ```
 
-### Alternate code:
+## Alternate code:
 
 Whereas with some entries the change to `fgets()` (see the [FAQ](/faq.md) for
 details on why this has been done) can be done in the original code this entry

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -23,7 +23,7 @@ to read it for entertainment if nothing else.
 ./marshall
 ```
 
-### Alternate code:
+## Alternate code:
 
 As some changes had to be made due to the problem of conflicting compiler
 options briefly noted above we provide the code that demonstrates the problem so

--- a/1986/stein/README.md
+++ b/1986/stein/README.md
@@ -8,7 +8,7 @@ Jan Stein
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./stein $(printf "\015\015"); echo

--- a/1987/biggar/README.md
+++ b/1987/biggar/README.md
@@ -10,7 +10,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 some_command | ./biggar | od -c

--- a/1987/heckbert/README.md
+++ b/1987/heckbert/README.md
@@ -11,7 +11,7 @@ make all
 On System V systems, we had to compile with `-Dindex=strchr`.
 To compile on a 16 bit machine, change 300000 to 30000.
 
-## To run:
+## To use:
 
 ```sh
 ./heckbert col < file

--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -9,7 +9,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hines file.c

--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -21,7 +21,7 @@ make all
 ./hines hines.c
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry is in [hines.alt.c](hines.alt.c). With older
 compilers you can try the alt version:

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -12,7 +12,7 @@ make all
 There is [Alternate code](#alternate-code) available for if you have an old
 enough compiler.
 
-## To run:
+## To use:
 
 ```sh
 ./lievaart

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -10,7 +10,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./wall

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -10,7 +10,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./westley

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -16,7 +16,7 @@ make all
 ./westley
 ```
 
-### Alternate code:
+## Alternate code:
 
 If you have an older compiler you can try compiling the original source code
 which is true symmetry:

--- a/1988/applin/README.md
+++ b/1988/applin/README.md
@@ -21,7 +21,7 @@ program.  See the [Alternate code](#alternate-code) section below for details.
 ./applin
 ```
 
-### Alternate code:
+## Alternate code:
 
 As noted above a smaller version can be used in case your `cpp` has a hard time
 with this entry.

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -38,7 +38,7 @@ behaviour?
 ./dale "$(printf "the following files exist in this directory:\n%s\n" *)"
 ```
 
-### Alternate code:
+## Alternate code:
 
 If you have an old enough compiler you can try the original version in
 [dale.alt.c](dale.alt.c). To use:

--- a/1988/isaak/README.md
+++ b/1988/isaak/README.md
@@ -19,7 +19,7 @@ code](#alternate-code) below.
 ./isaak
 ```
 
-### Alternate code:
+## Alternate code:
 
 The original version of this code is in [isaak.alt.c](isaak.alt.c).
 The original entry starts with the line:

--- a/1988/isaak/README.md
+++ b/1988/isaak/README.md
@@ -13,7 +13,7 @@ There is an alternate version, the original, that can't be compiled in modern
 systems but can be if you have an old enough compiler. See [Alternate
 code](#alternate-code) below.
 
-## To run:
+## To use:
 
 ```sh
 ./isaak

--- a/1988/litmaath/README.md
+++ b/1988/litmaath/README.md
@@ -9,7 +9,7 @@ The Netherlands
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./litmaath some text

--- a/1988/litmaath/README.md
+++ b/1988/litmaath/README.md
@@ -24,7 +24,7 @@ code](#alternate-code) section below.
 ./litmaath eschew obfuscation
 ```
 
-### Alternate code:
+## Alternate code:
 
 
 This alternate code, added to help understand the entry and for fun, is code

--- a/1988/westley/README.md
+++ b/1988/westley/README.md
@@ -55,7 +55,7 @@ You might enjoy looking at the output of:
 cc -E westley.alt.c
 ```
 
-### Alternate code:
+## Alternate code:
 
 To see if your compiler has the problem described above try:
 

--- a/1989/fubar/README.md
+++ b/1989/fubar/README.md
@@ -21,7 +21,7 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [bugs.md](/bugs.md#1989fubar-readmemd).
 
 
-## To run:
+## To use:
 
 ```sh
 ./fubar <number>

--- a/1989/jar.1/README.md
+++ b/1989/jar.1/README.md
@@ -26,7 +26,7 @@ NOTE: this will run the program itself:
 make clobber all
 ```
 
-### Alternate code:
+## Alternate code:
 
 This code, which prints something slightly different, is provided as well.
 

--- a/1989/jar.1/README.md
+++ b/1989/jar.1/README.md
@@ -18,7 +18,7 @@ make clobber all
 There is an alternate version with a slight difference that you may wish to try.
 See [Alternate code](#alternate-code) below.
 
-## To run:
+## To use:
 
 NOTE: this will run the program itself:
 
@@ -38,7 +38,7 @@ NOTE: this will run the program itself.
 make clobber alt
 ```
 
-#### To run:
+#### To use:
 
 Alternatively, you can run it directly:
 

--- a/1989/jar.2/README.md
+++ b/1989/jar.2/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./jar.2

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -35,7 +35,7 @@ by chance or is killed.
 ./ovdluhe < README.md
 ```
 
-### Alternate code:
+## Alternate code:
 
 The author suggested that one varies the definition of `P` from 2 through 10. As
 it's a `#define` it's easy to set up. To use try:

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -14,7 +14,7 @@ make all
 
 To get this to compile with a modern CPP, we had to replace `#D` with `#define`.
 
-## To run:
+## To use:
 
 Run the program this way:
 

--- a/1989/paul/README.md
+++ b/1989/paul/README.md
@@ -18,7 +18,7 @@ out. See [alternate code](#alternate-code) below for more details.
 ./paul
 ```
 
-### Alternate code:
+## Alternate code:
 
 This version was described by the author like:
 

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -20,7 +20,7 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [bugs.md](/bugs.md#1989robison-readmemd).
 
 
-## To run:
+## To use:
 
 ```sh
 ./robison

--- a/1989/tromp/README.md
+++ b/1989/tromp/README.md
@@ -9,7 +9,7 @@ Netherlands
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./tromp [drops_per_sec  [cmd_string]]

--- a/1989/tromp/README.md
+++ b/1989/tromp/README.md
@@ -48,7 +48,7 @@ place and the winner is the
 loser](https://web.archive.org/web/20181023221954/https://www.chicagotribune.com/news/ct-xpm-2002-07-31-0207310310-story.html) :-)
 
 
-### Alternate code:
+## Alternate code:
 
 The author provided an alternate version of the code with some improvements. See
 the judges' additional remarks in the author's remarks, for more details.

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -14,7 +14,7 @@ make all
 
 There is [alternate code](#alternate-code) for those using Turbo-C or MSC.
 
-## To run:
+## To use:
 
 ```sh
 echo 4 | ./baruch

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -30,7 +30,7 @@ echo 3 | ./baruch
 
 Why is there no output?
 
-### Alternate code:
+## Alternate code:
 
 This alternate code is for the [very few](https://en.wikipedia.org/wiki/0)
 [users](https://en.wikipedia.org/wiki/Microsoft_Windows)

--- a/1990/cmills/README.md
+++ b/1990/cmills/README.md
@@ -9,7 +9,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./cmills [starting_cash]

--- a/1990/dds/README.md
+++ b/1990/dds/README.md
@@ -12,7 +12,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./dds

--- a/1990/dg/README.md
+++ b/1990/dg/README.md
@@ -13,7 +13,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 echo foo bar | ./dg

--- a/1990/pjr/README.md
+++ b/1990/pjr/README.md
@@ -14,7 +14,7 @@ England, U.K.
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./pjr

--- a/1990/scjones/README.md
+++ b/1990/scjones/README.md
@@ -11,7 +11,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./scjones

--- a/1990/stig/README.md
+++ b/1990/stig/README.md
@@ -11,7 +11,7 @@ Norway
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 make all

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -13,7 +13,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./tbr

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./theorem expression x1 x2 h y1

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -38,7 +38,7 @@ This program will enter an infinite loop if input is not a number > 0.
 ./westley 5
 ```
 
-### Alternate code:
+## Alternate code:
 
 If you have an old enough compiler try and to see how C has changed over the years:
 

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -15,7 +15,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./westley number

--- a/1991/ant/README.md
+++ b/1991/ant/README.md
@@ -12,7 +12,7 @@ Canada, N2J 2W9			Canada, N2L 6G9
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./ant some_file

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./buzzard

--- a/1991/cdupont/README.md
+++ b/1991/cdupont/README.md
@@ -13,7 +13,7 @@ France
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./cdupont

--- a/1991/davidguy/README.md
+++ b/1991/davidguy/README.md
@@ -20,7 +20,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./davidguy ip_address:server.screen

--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -12,7 +12,7 @@ Mastodon: <https://mstdn.social/@DSpinellis>
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dds basic_program 2>/dev/null

--- a/1991/fine/README.md
+++ b/1991/fine/README.md
@@ -10,7 +10,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 echo text | ./fine

--- a/1991/rince/README.md
+++ b/1991/rince/README.md
@@ -14,7 +14,7 @@ England
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./rince

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -14,7 +14,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 Make and run as follows:
 

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -12,7 +12,7 @@ The Netherlands
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./albert number

--- a/1992/ant/README.md
+++ b/1992/ant/README.md
@@ -13,7 +13,7 @@ Canada
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./am Makefile

--- a/1992/buzzard.1/README.md
+++ b/1992/buzzard.1/README.md
@@ -13,7 +13,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./buzzard.1 num num

--- a/1992/buzzard.2/README.md
+++ b/1992/buzzard.2/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 First:
 

--- a/1992/gson/README.md
+++ b/1992/gson/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./ag word word2 word3 < /path/to/dictionary

--- a/1992/imc/README.md
+++ b/1992/imc/README.md
@@ -14,7 +14,7 @@ England
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 # text mode

--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -11,7 +11,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./runme.sh

--- a/1992/marangon/README.md
+++ b/1992/marangon/README.md
@@ -12,7 +12,7 @@ Italy
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./marangon

--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -13,7 +13,7 @@ UK BS12 4SQ
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./nathan

--- a/1992/vern/README.md
+++ b/1992/vern/README.md
@@ -14,7 +14,7 @@ Berkeley, CA 94720  US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./vern 3		# <-- default is 2

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -12,7 +12,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 If lost:
 

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -39,7 +39,7 @@ show correctly!
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 The author provided a version for the US which we added. To build:
 

--- a/1993/ant/README.md
+++ b/1993/ant/README.md
@@ -12,7 +12,7 @@ Canada
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./ant 'ERE' [file ...]

--- a/1993/cmills/README.md
+++ b/1993/cmills/README.md
@@ -17,7 +17,7 @@ compile. macOS users running Mountain Lion and later will need to download and
 install [XQuartz](https://www.xquartz.org) in order to compile and run this
 entry.
 
-## To run:
+## To use:
 
 ```sh
 DISPLAY="your_X_server_display"\

--- a/1993/dgibson/README.md
+++ b/1993/dgibson/README.md
@@ -13,7 +13,7 @@ South Africa
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dgibson.sh [datafile]

--- a/1993/ejb/README.md
+++ b/1993/ejb/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./ejb level

--- a/1993/jonth/README.md
+++ b/1993/jonth/README.md
@@ -19,7 +19,7 @@ install [XQuartz](https://www.xquartz.org) in order to compile and run this
 entry.
 
 
-## To run:
+## To use:
 
 ```sh
 ./jonth			# must be run on an X11 server

--- a/1993/leo/README.md
+++ b/1993/leo/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 To have the computer guess:
 

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -30,7 +30,7 @@ There is an alternate version which simply does what the program did with gcc <
 2.3.3.
 
 
-## To run:
+## To use:
 
 If you have gcc < 2.3.3 (i.e. the entry can compile):
 

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -39,7 +39,7 @@ If you have gcc < 2.3.3 (i.e. the entry can compile):
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 To use:
 

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -13,7 +13,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./plummer number arg

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -34,7 +34,7 @@ NOTE: an alternate version exists. See Alternate code section below.
 
 ```
 
-### Alternate code:
+## Alternate code:
 
 To use:
 

--- a/1993/rince/README.md
+++ b/1993/rince/README.md
@@ -23,7 +23,7 @@ where:
 
 `[cabbage]` is a CABBAGE description file  (default: `rince.c`)
 
-### Alternate code: slowing down the game
+## Alternate code: slowing down the game
 
 Some people may want to slow down the game by increasing the
 value 17 in the lines:

--- a/1993/rince/README.md
+++ b/1993/rince/README.md
@@ -13,7 +13,7 @@ make all
 NOTE: there is an alternate version of this program that allows one to slow down
 the game. See the Alternate code section below.
 
-## To run:
+## To use:
 
 ```sh
 ./rince [cabbage]

--- a/1993/schnitzi/README.md
+++ b/1993/schnitzi/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./schnitzi file

--- a/1993/vanb/README.md
+++ b/1993/vanb/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./vanb 'exp'

--- a/1994/dodsond1/README.md
+++ b/1994/dodsond1/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dodsond1

--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dodsond2

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -10,7 +10,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./horton A B C D

--- a/1994/imc/README.md
+++ b/1994/imc/README.md
@@ -13,7 +13,7 @@ England
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./imc [NUMBER]

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -12,7 +12,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./ldb < file

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -30,7 +30,7 @@ make all
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 To build the alternative code try:
 

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -15,7 +15,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./schnitzi < textfile

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./shapiro &

--- a/1994/smr/README.md
+++ b/1994/smr/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./smr

--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -12,7 +12,7 @@ Finland
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./tvr mode screensize/2 < colormapfile

--- a/1994/weisberg/README.md
+++ b/1994/weisberg/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./weisberg

--- a/1994/westley/README.md
+++ b/1994/westley/README.md
@@ -20,7 +20,7 @@ will get different error messages and one compiler line will make you win the
 game!
 
 
-## To run:
+## To use:
 
 There is no running as such. See below.
 

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -19,7 +19,7 @@ how fast your computer is :-) (and you can also use both to see the difference).
 For this alternate, slower version, please see below.
 
 
-## To run:
+## To use:
 
 ```sh
 ./cdua

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -33,7 +33,7 @@ solving the maze. This is a feature, not a bug. See [bugs.md](/bugs.md) for more
 details.
 
 
-### Alternate code:
+## Alternate code:
 
 This version uses `usleep(3)` with the `Z` (defined in the Makefile, default
 `3000`) microseconds to make it easier to see the maze being solved in real

--- a/1995/dodsond1/README.md
+++ b/1995/dodsond1/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dodsond1 < text_file

--- a/1995/dodsond2/README.md
+++ b/1995/dodsond2/README.md
@@ -9,7 +9,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dodsond2

--- a/1995/esde/README.md
+++ b/1995/esde/README.md
@@ -11,7 +11,7 @@ Poland
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./esde data-file word

--- a/1995/garry/README.md
+++ b/1995/garry/README.md
@@ -28,7 +28,7 @@ make all
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 While it may not have been the intention of the author, the
 judges noted that the C pre-processed version (with the `#include`s

--- a/1995/garry/README.md
+++ b/1995/garry/README.md
@@ -12,7 +12,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./garry <input_file >output_file

--- a/1995/heathbar/README.md
+++ b/1995/heathbar/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./heathbar num num

--- a/1995/leo/README.md
+++ b/1995/leo/README.md
@@ -11,7 +11,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./leo [ deep ] [ right ] [ Variable ] [ cycle [ freq ] ]

--- a/1995/makarios/README.md
+++ b/1995/makarios/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./makarios

--- a/1995/savastio/README.md
+++ b/1995/savastio/README.md
@@ -12,7 +12,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./savastio

--- a/1995/schnitzi/README.md
+++ b/1995/schnitzi/README.md
@@ -14,7 +14,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./schnitzi num

--- a/1995/spinellis/README.md
+++ b/1995/spinellis/README.md
@@ -11,7 +11,7 @@ Mastodon: <https://mstdn.social/@DSpinellis>
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./spinellis < spinellis.c

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -26,7 +26,7 @@ make clobber all LEVEL=6
 ./vanschnitz
 ```
 
-### Alternate code:
+## Alternate code:
 
 The authors provided a spoiler version of the program. Originally uuencoded we
 have decoded it for the wider audience in [spoiler.c](spoiler.c). The

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -13,7 +13,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./vanschnitz

--- a/1996/august/README.md
+++ b/1996/august/README.md
@@ -11,7 +11,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 cat august.c test.oc | ./august > test.oo

--- a/1996/dalbec/README.md
+++ b/1996/dalbec/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./dalbec

--- a/1996/eldby/README.md
+++ b/1996/eldby/README.md
@@ -11,7 +11,7 @@ make alt
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./eldby.alt

--- a/1996/gandalf/README.md
+++ b/1996/gandalf/README.md
@@ -16,7 +16,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./gandalf

--- a/1996/huffman/README.md
+++ b/1996/huffman/README.md
@@ -14,7 +14,7 @@ huffmancoding@gmail.com
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 echo 'Huffman Decoding' | ./huffman

--- a/1996/jonth/README.md
+++ b/1996/jonth/README.md
@@ -19,7 +19,7 @@ install [XQuartz](https://www.xquartz.org) in order to compile and run this
 entry.
 
 
-## To run:
+## To use:
 
 ```sh
 ./jonth :0 :0

--- a/1996/rcm/README.md
+++ b/1996/rcm/README.md
@@ -11,7 +11,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./rcm < rfc1951.gz

--- a/1996/schweikh1/README.md
+++ b/1996/schweikh1/README.md
@@ -13,7 +13,7 @@ Germany\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./schweikh1

--- a/1996/schweikh2/README.md
+++ b/1996/schweikh2/README.md
@@ -14,7 +14,7 @@ Germany\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./schweikh2

--- a/1996/schweikh3/README.md
+++ b/1996/schweikh3/README.md
@@ -13,7 +13,7 @@ Germany\
 make all
 ```
 
-## To run:
+## To use:
 
 **WARNING: DO NOT RUN this program without reading this text down to the end!**
 It may render your system unusable for a limited amount of time

--- a/1996/westley/README.md
+++ b/1996/westley/README.md
@@ -14,7 +14,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 sh ./clock1

--- a/1996/westley/README.md
+++ b/1996/westley/README.md
@@ -39,7 +39,7 @@ And for a good time, try:
 sh ./clock3
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [westley.alt.c](westley.alt.c), is provided.
 This version is the original code and does not contain the above mentioned

--- a/1998/banks/README.md
+++ b/1998/banks/README.md
@@ -13,7 +13,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 cat horizon.sc pittsburgh.sc | ./banks

--- a/1998/bas1/README.md
+++ b/1998/bas1/README.md
@@ -12,7 +12,7 @@ The Netherlands
 make all
 ```
 
-## To run:
+## To use:
 
 If `lpr` on your system can print PostScript:
 

--- a/1998/bas2/README.md
+++ b/1998/bas2/README.md
@@ -12,7 +12,7 @@ The Netherlands
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./bas2 < bas2.c

--- a/1998/chaos/README.md
+++ b/1998/chaos/README.md
@@ -23,7 +23,7 @@ make chaos_nohalf
 ```
 
 
-## To run:
+## To use:
 
 
 ```sh

--- a/1998/df/README.md
+++ b/1998/df/README.md
@@ -12,7 +12,7 @@ German Federal Republic
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./df

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -27,7 +27,7 @@ make all
 
 Why is there different output?
 
-### Alternate code:
+## Alternate code:
 
 NOTE: The original entry was just a text based pootifier.  To build
 that version try:

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -11,7 +11,7 @@ US\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dlowe < anyfile > pootfile

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -13,7 +13,7 @@ US
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 

--- a/1998/dorssel/README.md
+++ b/1998/dorssel/README.md
@@ -12,7 +12,7 @@ The Netherlands
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dorssel

--- a/1998/fanf/README.md
+++ b/1998/fanf/README.md
@@ -13,7 +13,7 @@ make all
 NOTE: This may take a while.  Some systems may have problems building\
 this entry because of the system resources it requires.
 
-## To run:
+## To use:
 
 ```sh
 ./fanf

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -15,7 +15,7 @@ make all
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./schnitzi 5 > sort.c

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -28,7 +28,7 @@ how to use it.
 NOTE: a limitation with the entry was that it required `gcc` but this limitation
 has been removed to make it more portable, requiring only `cc`.
 
-### Alternate code:
+## Alternate code:
 
 As noted above this entry will not work as it stands for macOS and there are
 some important notes as well as a description of how the fixed version works

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -19,7 +19,7 @@ There is an alternate version of this entry that will work with macOS. See the
 how to use it.
 
 
-## To run:
+## To use:
 
 ```sh
 ./schweikh1

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -11,7 +11,7 @@ Germany\
 make all
 ```
 
-## To run:
+## To use:
 
 
 ```sh

--- a/1998/schweikh3/README.md
+++ b/1998/schweikh3/README.md
@@ -13,7 +13,7 @@ Germany\
 make all
 ```
 
-## To run:
+## To use:
 
 If "dir" is the directory (or a directory tree) where you keep
 all your favorite pictures off the Internet or from

--- a/1998/tomtorfs/README.md
+++ b/1998/tomtorfs/README.md
@@ -13,7 +13,7 @@ Belgium\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./tomtorfs tomtorfs.c 32 04C11DB7 1 FFFFFFFF FFFFFFFF

--- a/2000/anderson/README.md
+++ b/2000/anderson/README.md
@@ -14,7 +14,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 echo something | ./anderson

--- a/2000/bellard/README.md
+++ b/2000/bellard/README.md
@@ -12,7 +12,7 @@ France\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./bellard

--- a/2000/bmeyer/README.md
+++ b/2000/bmeyer/README.md
@@ -13,7 +13,7 @@ Australia\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./bmeyer

--- a/2000/briddlebane/README.md
+++ b/2000/briddlebane/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./briddlebane

--- a/2000/dhyang/README.md
+++ b/2000/dhyang/README.md
@@ -13,7 +13,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dhyang

--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -18,7 +18,7 @@ perl -MConfig -e 'print "$Config{archlibexp}/CORE\n"'
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./dlowe [file ...]

--- a/2000/jarijyrki/README.md
+++ b/2000/jarijyrki/README.md
@@ -22,7 +22,7 @@ make
 You will need X11 header files and libraries installed to build this program.
 
 
-## To run:
+## To use:
 
 ```sh
 ./jarijyrki < infile.info > outfile.info

--- a/2000/natori/README.md
+++ b/2000/natori/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./natori

--- a/2000/natori/README.md
+++ b/2000/natori/README.md
@@ -27,7 +27,7 @@ Try modifying the code so that it will show another Moon phase based on input
 or else just by the code itself. Bonus points if you can make it show all!
 
 
-### Alternate code:
+## Alternate code:
 
 The author noted that those in the southern hemisphere might want to change
 `acos(l/2)` into `acos(-l/2)` which we have done in the alternate version.

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -9,7 +9,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 echo n | ./primenum n

--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -13,7 +13,7 @@ England
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./rince number number2

--- a/2000/robison/README.md
+++ b/2000/robison/README.md
@@ -11,7 +11,7 @@ US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./robison

--- a/2000/schneiderwent/README.md
+++ b/2000/schneiderwent/README.md
@@ -9,7 +9,7 @@ WI, US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./schneiderwent datafile

--- a/2000/thadgavin/README.md
+++ b/2000/thadgavin/README.md
@@ -25,7 +25,7 @@ make thadgavin_sdl
 Use `thadgavin_sdl` as you would `thadgavin` below.
 
 
-## To run:
+## To use:
 
 ```sh
 ./thadgavin
@@ -88,7 +88,7 @@ less than dazzling. We could not test this entry in DOS mode.
 
 ## Authors' remarks:
 
-### To run under DOS:
+### To use under DOS:
 
 Compile using DJGPP as follows:
 
@@ -96,7 +96,7 @@ Compile using DJGPP as follows:
 gcc thadgavin.c -o thadgavin.exe -Wall -lm -O6 -mpentium -fomit-frame-pointer -ffast-math
 ```
 
-### To run under Windows, X-Windows or MacOS using the Simple DirectMedia Layer:
+### To use under Windows, X-Windows or MacOS using the Simple DirectMedia Layer:
 
 ```sh
 gcc -O6 -lpthread -g -o thadgavin thadgavin.c -lSDL -DSDL -lm

--- a/2000/tomx/README.md
+++ b/2000/tomx/README.md
@@ -13,7 +13,7 @@ India\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./tomx

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./anonymous x86_program

--- a/2001/bellard/README.md
+++ b/2001/bellard/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./bellard file

--- a/2001/cheong/README.md
+++ b/2001/cheong/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./cheong digits

--- a/2001/coupard/README.md
+++ b/2001/coupard/README.md
@@ -15,7 +15,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./coupard

--- a/2001/ctk/README.md
+++ b/2001/ctk/README.md
@@ -13,7 +13,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./ctk

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./dgbeards

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -18,7 +18,7 @@ make
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 The author provided a way to speed it up a bit and also how to make it so it
 doesn't crash on losing.  The idea that it crashes on losing was too good to

--- a/2001/herrmann1/README.md
+++ b/2001/herrmann1/README.md
@@ -10,7 +10,7 @@ Germany\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
     ./herrmann1.sh 'prg=file'

--- a/2001/herrmann2/README.md
+++ b/2001/herrmann2/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./herrmann2

--- a/2001/herrmann2/README.md
+++ b/2001/herrmann2/README.md
@@ -73,7 +73,7 @@ diff herrmann2.alt.c herrmann2.orig.c && echo "output matches with original code
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 If you wish to use the original version that does not work for all platforms,
 you can make use of the [herrmann2.alt.c](herrmann2.alt.c) by running:

--- a/2001/jason/README.md
+++ b/2001/jason/README.md
@@ -12,7 +12,7 @@ US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./jason

--- a/2001/kev/README.md
+++ b/2001/kev/README.md
@@ -13,7 +13,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./kev # in one terminal

--- a/2001/kev/README.md
+++ b/2001/kev/README.md
@@ -42,7 +42,7 @@ paddle. See below Alternate code.
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 To use:
 

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -10,7 +10,7 @@ France
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./ollinger integer

--- a/2001/rosten/README.md
+++ b/2001/rosten/README.md
@@ -10,7 +10,7 @@ UK\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./rosten [number]

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -10,7 +10,7 @@ Germany\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./schweikh string string2

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./westley

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -26,7 +26,7 @@ make
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [westley.alt.c](westley.alt.c), is provided.
 This alternate code might be less portable.

--- a/2001/williams/README.md
+++ b/2001/williams/README.md
@@ -9,7 +9,7 @@ US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./williams

--- a/2004/anonymous/README.md
+++ b/2004/anonymous/README.md
@@ -10,7 +10,7 @@ Singapore\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./anonymous

--- a/2004/arachnid/README.md
+++ b/2004/arachnid/README.md
@@ -36,7 +36,7 @@ QWERTY keyboards.  Rogue players, vi users, and Dvorak typists are
 invited to get lost (or use the alt version)!
 
 
-### Alternate code:
+## Alternate code:
 
 To use:
 

--- a/2004/arachnid/README.md
+++ b/2004/arachnid/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./arachnid [mazefile]

--- a/2004/burley/README.md
+++ b/2004/burley/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./burley

--- a/2004/gavare/README.md
+++ b/2004/gavare/README.md
@@ -10,7 +10,7 @@ Sweden\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./gavare

--- a/2004/gavare/README.md
+++ b/2004/gavare/README.md
@@ -22,7 +22,7 @@ make
 ./gavare > ioccc_ray.ppm
 ```
 
-### Alternate code:
+## Alternate code:
 
 The author provided [on their web page for the
 entry](https://gavare.se/ioccc/ioccc_gavare.c.html) an unobfuscated version that was used

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./gavin

--- a/2004/hibachi/README.md
+++ b/2004/hibachi/README.md
@@ -10,7 +10,7 @@ Canada\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 cd build; ./hibachi-start.sh &

--- a/2004/hoyle/README.md
+++ b/2004/hoyle/README.md
@@ -10,7 +10,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hoyle point ...

--- a/2004/hoyle/README.md
+++ b/2004/hoyle/README.md
@@ -24,7 +24,7 @@ make
 ./hoyle 2 0 1 0 -0.001
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [hoyle.alt.c](hoyle.alt.c), is provided.
 This alternate code has a missing newline and used a non-standard tab stop size.

--- a/2004/jdalbec/README.md
+++ b/2004/jdalbec/README.md
@@ -10,7 +10,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./jdalbec number ...

--- a/2004/kopczynski/README.md
+++ b/2004/kopczynski/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./kopczynski < input_file

--- a/2004/kopczynski/README.md
+++ b/2004/kopczynski/README.md
@@ -42,7 +42,7 @@ What happens if you feed the program source to the program? Can you figure out
 why?
 
 
-### Alternate code:
+## Alternate code:
 
 The judges modified the program to print its result.  The original
 program returned the result as an exit code:

--- a/2004/newbern/README.md
+++ b/2004/newbern/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./newbern [file.dat arg]

--- a/2004/omoikane/README.md
+++ b/2004/omoikane/README.md
@@ -10,7 +10,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./omoikane infile layout outfile

--- a/2004/schnitzi/README.md
+++ b/2004/schnitzi/README.md
@@ -10,7 +10,7 @@ Australia\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./schnitzi

--- a/2004/sds/README.md
+++ b/2004/sds/README.md
@@ -10,7 +10,7 @@ Finland\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./sds

--- a/2004/vik1/README.md
+++ b/2004/vik1/README.md
@@ -12,7 +12,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./vik1 [arg]

--- a/2004/vik2/README.md
+++ b/2004/vik2/README.md
@@ -11,7 +11,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./vik2

--- a/2005/aidan/README.md
+++ b/2005/aidan/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./aidan < puzzle

--- a/2005/anon/README.md
+++ b/2005/anon/README.md
@@ -13,7 +13,7 @@ NOTE: if your shell does not support `stty` then see the alternate version
 described in the section below.
 
 
-## To run:
+## To use:
 
 ```sh
 ./anon x y [z]

--- a/2005/boutines/README.md
+++ b/2005/boutines/README.md
@@ -10,7 +10,7 @@ Toulouse, France\
 make
 ```
 
-## To run:
+## To use:
 
 You will need an [SVG](https://www.w3.org/TR/SVG11/expanded-toc.html) viewer.
 Look here to find some [SVG Viewer

--- a/2005/chia/README.md
+++ b/2005/chia/README.md
@@ -10,7 +10,7 @@ Singapore\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./chia

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -23,7 +23,7 @@ version but it's a complicated one. See also the [bugs.md](/bugs.md) file for
 more information.
 
 
-## To run:
+## To use:
 
 ```sh
 ./giljade

--- a/2005/jetro/README.md
+++ b/2005/jetro/README.md
@@ -18,7 +18,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./jetro

--- a/2005/klausler/README.md
+++ b/2005/klausler/README.md
@@ -10,7 +10,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./klausler arg1 arg2 | head

--- a/2005/mikeash/README.md
+++ b/2005/mikeash/README.md
@@ -11,7 +11,7 @@ mike@mikeash.com\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./mikeash

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -33,7 +33,7 @@ Some have pointed out that this will not work for https initially
 for two reasons. For a starting point see the alternate code section below.
 
 
-### Alternate code:
+## Alternate code:
 
 As noted this will not work for https. This is because it does not scan for
 https but also a secure connection needs to be set up before http commands can

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./mynx http://<domain>

--- a/2005/persano/README.md
+++ b/2005/persano/README.md
@@ -10,7 +10,7 @@ Brazil\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./persano p q [num frames]

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -10,7 +10,7 @@ Stephen Sykes\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./sykes binary_file

--- a/2005/timwi/README.md
+++ b/2005/timwi/README.md
@@ -10,7 +10,7 @@ Germany\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./timwi < bf_program

--- a/2005/toledo/README.md
+++ b/2005/toledo/README.md
@@ -11,7 +11,7 @@ Mexico\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./toledo [a ...]

--- a/2005/vik/README.md
+++ b/2005/vik/README.md
@@ -11,7 +11,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./vik [file.map]

--- a/2005/vince/README.md
+++ b/2005/vince/README.md
@@ -29,7 +29,7 @@ another) while the X11 server is running.
 echo "Do or do not. There is no try."
 ```
 
-### Alternate code:
+## Alternate code:
 
 The [vince.alt.c](vince.alt.c) code of the submission will run on SGI IRIX and
 also has the recursive CPP macro (which sneaked in accidentally) removed.

--- a/2005/vince/README.md
+++ b/2005/vince/README.md
@@ -14,7 +14,7 @@ installed.
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./vince

--- a/2006/birken/README.md
+++ b/2006/birken/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./birken < file.tofu

--- a/2006/borsanyi/README.md
+++ b/2006/borsanyi/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./borsanyi string > file.gif

--- a/2006/grothe/README.md
+++ b/2006/grothe/README.md
@@ -9,7 +9,7 @@ US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./grothe carrier_freq pixelclock horizontal_total < some_input.txt

--- a/2006/hamre/README.md
+++ b/2006/hamre/README.md
@@ -9,7 +9,7 @@ Norway
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hamre math_expression_string

--- a/2006/meyer/README.md
+++ b/2006/meyer/README.md
@@ -9,7 +9,7 @@ US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./meyer

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -14,7 +14,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./monge expression ...

--- a/2006/night/README.md
+++ b/2006/night/README.md
@@ -29,7 +29,7 @@ echo "Do or do not. There is no try."
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 To compile:
 

--- a/2006/night/README.md
+++ b/2006/night/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./night

--- a/2006/sloane/README.md
+++ b/2006/sloane/README.md
@@ -11,7 +11,7 @@ make alt
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./slone.alt

--- a/2006/stewart/README.md
+++ b/2006/stewart/README.md
@@ -9,7 +9,7 @@ US
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./stewart width_and_height iterations file > file.xbm

--- a/2006/sykes1/README.md
+++ b/2006/sykes1/README.md
@@ -10,7 +10,7 @@ Finland\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./sykes1

--- a/2006/sykes2/README.md
+++ b/2006/sykes2/README.md
@@ -10,7 +10,7 @@ Finland\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./sykes2

--- a/2006/toledo1/README.md
+++ b/2006/toledo1/README.md
@@ -11,7 +11,7 @@ Mexico\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./toledo1 [0-9][0-9]

--- a/2006/toledo2/README.md
+++ b/2006/toledo2/README.md
@@ -13,7 +13,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./toledo2

--- a/2006/toledo3/README.md
+++ b/2006/toledo3/README.md
@@ -13,7 +13,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./toledo3 [1 | 2 | 3 [b]]

--- a/2011/akari/README.md
+++ b/2011/akari/README.md
@@ -10,7 +10,7 @@ Don Yang\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./akari [ input_file | - ] [ output_file | - ]  [even]

--- a/2011/blakely/README.md
+++ b/2011/blakely/README.md
@@ -10,7 +10,7 @@ Cambridge, UK\
 make
 ```
 
-## To run:
+## To use:
 
 Zoom out and make your terminal window 53 or more lines deep.
 

--- a/2011/borsanyi/README.md
+++ b/2011/borsanyi/README.md
@@ -10,7 +10,7 @@ Germany\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./borsanyi < some_data_file

--- a/2011/dlowe/README.md
+++ b/2011/dlowe/README.md
@@ -11,7 +11,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dlowe -<n_iterations> corpus1/ [...] corpus0/ < start.net > trained.net

--- a/2011/eastman/README.md
+++ b/2011/eastman/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./eastman

--- a/2011/fredriksson/README.md
+++ b/2011/fredriksson/README.md
@@ -9,7 +9,7 @@ Kimmo Fredriksson\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./fredriksson [-icvtnk#] regexp < file

--- a/2011/goren/README.md
+++ b/2011/goren/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 echo "some text" | ./goren

--- a/2011/hamaji/README.md
+++ b/2011/hamaji/README.md
@@ -9,7 +9,7 @@ Shinichiro Hamaji\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hamaji < a_nonogram_file

--- a/2011/hou/README.md
+++ b/2011/hou/README.md
@@ -9,7 +9,7 @@ Hou Qiming\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hou 'expression'

--- a/2011/konno/README.md
+++ b/2011/konno/README.md
@@ -10,7 +10,7 @@ Japan\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./konno lower_case_word

--- a/2011/richards/README.md
+++ b/2011/richards/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./richards

--- a/2011/toledo/README.md
+++ b/2011/toledo/README.md
@@ -11,7 +11,7 @@ Mexico\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./toledo

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -45,7 +45,7 @@ It is possible to download a number of Mod files from [The Mod
 Archive](http://modarchive.org).
 
 
-### Alternate code:
+## Alternate code:
 
 Assuming that `make` is similar enough try:
 

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./vik file.mod > audio_file.raw

--- a/2011/zucker/README.md
+++ b/2011/zucker/README.md
@@ -10,7 +10,7 @@ Matt Zucker\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./zucker > image.ppm

--- a/2012/blakely/README.md
+++ b/2012/blakely/README.md
@@ -10,7 +10,7 @@ UK\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./blakely "RPN formula" resolution > output.gif

--- a/2012/deckmyn/README.md
+++ b/2012/deckmyn/README.md
@@ -9,7 +9,7 @@ Alex Deckmyn\
 make
 ```
 
-## To run:
+## To use:
 
 A shell interpreter with proper backtick interpolation is required.
 

--- a/2012/dlowe/README.md
+++ b/2012/dlowe/README.md
@@ -16,7 +16,7 @@ compile. macOS users running Mountain Lion and later will need to download and
 install [XQuartz](https://www.xquartz.org) in order to compile and run this
 entry.
 
-## To run:
+## To use:
 
 ```sh
 ./dlowe

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./endoh1 < configuration.txt

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -32,7 +32,7 @@ this by default.
 
 
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, `endoh1.alt.c`, is provided.
 This alternate code is a de-obfuscated version of `endoh1.c`.

--- a/2012/endoh2/README.md
+++ b/2012/endoh2/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./endoh2 > pi.c

--- a/2012/grothe/README.md
+++ b/2012/grothe/README.md
@@ -13,7 +13,7 @@ David Madore\
 make
 ```
 
-## To run:
+## To use:
 
 To create a shared secret shared among `M` people with `N+1` needed to reconstruct:
 

--- a/2012/hamano/README.md
+++ b/2012/hamano/README.md
@@ -9,7 +9,7 @@ Tsukasa Hamano\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hamano < textfile > output.pdf

--- a/2012/hou/README.md
+++ b/2012/hou/README.md
@@ -10,7 +10,7 @@ Qiming Hou\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hou syntax-file file-to-process

--- a/2012/kang/README.md
+++ b/2012/kang/README.md
@@ -34,7 +34,7 @@ echo "full spelling of an English cardinal numeral less than a quadrillion" | ./
 How does it have no `u` or `o` in a string in the source code and yet it gets
 `uno` right?
 
-### Alternate code:
+## Alternate code:
 
 This alternate code fixes the program that would throw off those who know German
 where the sound of 'V' is 'F' and so the program had the letter be 'F'. A

--- a/2012/kang/README.md
+++ b/2012/kang/README.md
@@ -14,7 +14,7 @@ make
 There is alternate code which fixes some German at the expense of other German.
 See [Alternate code](#alternate-code) below.
 
-## To run:
+## To use:
 
 ```sh
 echo "full spelling of an English cardinal numeral less than a quadrillion" | ./kang

--- a/2012/konno/README.md
+++ b/2012/konno/README.md
@@ -10,7 +10,7 @@ Japan\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./konno N

--- a/2012/konno/README.md
+++ b/2012/konno/README.md
@@ -24,7 +24,7 @@ NOTE: N is an integer from 0 to 255.
 ./konno 30
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [konno.alt.c](konno.alt.c), is provided.
 This alternate code is an unobfuscated version of the winning code.

--- a/2012/omoikane/README.md
+++ b/2012/omoikane/README.md
@@ -10,7 +10,7 @@ Don Yang\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./nyaruko [seed.txt] < original.bin > output.c

--- a/2012/tromp/README.md
+++ b/2012/tromp/README.md
@@ -14,7 +14,7 @@ make tromp32		# On a 32-bit machine
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./tromp [-b]
@@ -23,7 +23,7 @@ make tromp32		# On a 32-bit machine
 Use `./tromp32` as you would `./tromp` if on a 32-bit machine.
 
 
-## To run:
+## To use:
 
 ```sh
 cat ascii-prog.blc data | ./tromp -b

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -67,7 +67,7 @@ fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)) :-)
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 For those few who might use Windows, To compile:
 

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -14,7 +14,7 @@ make
 This entry requires [Zlib](https://www.zlib.net).
 
 
-## To run:
+## To use:
 
 To embed text (from file or command line):
 

--- a/2012/zeitak/README.md
+++ b/2012/zeitak/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./zeitak < file.c

--- a/2012/zeitak/README.md
+++ b/2012/zeitak/README.md
@@ -28,7 +28,7 @@ try [incorrect.c](incorrect.c) and the program itself.
 NOTE: it prints an error and exits on the first nesting error so it will not
 detect multiple issues!
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [zeitak.alt.c](zeitak.alt.c), is provided.
 The file [zeitak.alt.c](zeitak.alt.c) provides a version that has been slightly

--- a/2013/birken/README.md
+++ b/2013/birken/README.md
@@ -11,7 +11,7 @@ Michael Birken\
 make alt
 ```
 
-## To run:
+## To use:
 
 To see why we recommend the alternate version instead of the original version,
 see the [original code](#original-code) section.

--- a/2013/cable1/README.md
+++ b/2013/cable1/README.md
@@ -9,7 +9,7 @@ Adrian Cable\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./cable1 name group1 group2

--- a/2013/cable2/README.md
+++ b/2013/cable2/README.md
@@ -9,7 +9,7 @@ Adrian Cable\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./cable2 file.bmp [color]

--- a/2013/cable3/README.md
+++ b/2013/cable3/README.md
@@ -28,7 +28,7 @@ available. See the [Alternate code](#alternate-code) section below.
 
 NOTE: to quit the program type `QUITEMU`.
 
-### Alternate code:
+## Alternate code:
 
 An alternate version, which should compile in Windows, is provided. To use try:
 

--- a/2013/cable3/README.md
+++ b/2013/cable3/README.md
@@ -13,7 +13,7 @@ make
 An alternate version that should compile in Windows/MS Visual Studio is
 available. See the [Alternate code](#alternate-code) section below.
 
-## To run:
+## To use:
 
 ```sh
 ./cable3 bios-image-file floppy-image-file [harddisk-image-file]
@@ -194,7 +194,7 @@ stty cooked echo
 
 See the [runme](runme) script.
 
-## To run the emulator - floppy mode only
+## To use the emulator - floppy mode only
 
 The simplest use of the emulator is with a single floppy boot disk image, like
 the fd.img provided, which is a FreeDOS boot disk.
@@ -210,7 +210,7 @@ stty cbreak raw -echo min 0
 stty cooked echo
 ```
 
-## To run the emulator - floppy + HD mode
+## To use the emulator - floppy + HD mode
 
 Easiest to start with is to try a ready-made 40MB hard disk image containing a
 whole bunch of software: <http://bitly.com/1bU8URK>

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -11,7 +11,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./dlowe [numbers...]

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./endoh1 [file.lazy]

--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 make check

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./endoh3

--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./endoh4 < file

--- a/2013/hou/README.md
+++ b/2013/hou/README.md
@@ -10,7 +10,7 @@ Qiming Hou\
 make all
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./hou [scene-file-name] [options]

--- a/2013/mills/README.md
+++ b/2013/mills/README.md
@@ -9,7 +9,7 @@ Christopher Mills\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./mills

--- a/2013/misaka/README.md
+++ b/2013/misaka/README.md
@@ -13,7 +13,7 @@ make
 This will build a bunch of versions of the code. See the author's details for
 information on all of these builds.
 
-## To run:
+## To use:
 
 ```sh
 ./horizontal_cat [files...] > [output]

--- a/2013/morgan1/README.md
+++ b/2013/morgan1/README.md
@@ -9,7 +9,7 @@ Yves-Marie Morgan\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 echo "2013/10/03" | ./morgan1

--- a/2013/morgan2/README.md
+++ b/2013/morgan2/README.md
@@ -9,7 +9,7 @@ Yves-Marie Morgan\
 make
 ```
 
-## To run:
+## To use:
 
 For the console version (ncurses):
 

--- a/2013/robison/README.md
+++ b/2013/robison/README.md
@@ -9,7 +9,7 @@ Arch D. Robison\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./robison

--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -14,7 +14,7 @@ Alexander Prishchepov\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < some_secret_or_something
@@ -71,7 +71,7 @@ a client-side downloader.  The hidden transmitted data cannot be reconstructed
 or even detected from the binary content of the traffic between the client and
 the server.
 
-## To run web server
+## To use web server
 
 ```sh
 ./prog < secret_file_to_be_downloaded
@@ -83,7 +83,7 @@ Try using the program's source code as the secret file:
 ./prog < prog.c
 ```
 
-## To run client-side downloader
+## To use client-side downloader
 
 ```sh
 ./prog http://host[:port]

--- a/2014/deak/README.md
+++ b/2014/deak/README.md
@@ -27,7 +27,7 @@ compile. See [alternate code](#alternate-code) below.
 Try changing bounding box coordinates in the source to explore
 various regions of the fractal.
 
-### Alternate code:
+## Alternate code:
 
 The alternate code is included as [prog.alt.c](prog.alt.c) so you can more
 easily see the difference in what it might look like if the C was more

--- a/2014/deak/README.md
+++ b/2014/deak/README.md
@@ -12,7 +12,7 @@ make
 There is an alternate version that the author provided but fixed in 2023 to
 compile. See [alternate code](#alternate-code) below.
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2014/endoh1/README.md
+++ b/2014/endoh1/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog > foo.c

--- a/2014/endoh2/README.md
+++ b/2014/endoh2/README.md
@@ -11,7 +11,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < input > output

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -15,7 +15,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679

--- a/2014/maffiodo2/README.md
+++ b/2014/maffiodo2/README.md
@@ -10,7 +10,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog arg

--- a/2014/morgan/README.md
+++ b/2014/morgan/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog [arg ..]

--- a/2014/sinon/README.md
+++ b/2014/sinon/README.md
@@ -10,7 +10,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 cp -f sinon.c run.c; ./hecate.sh

--- a/2014/skeggs/README.md
+++ b/2014/skeggs/README.md
@@ -10,7 +10,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -13,7 +13,7 @@ US\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog > foo.c

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -31,7 +31,7 @@ echo 'Want to hear me beep?' | ./prog > audio_file.raw
 echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
 ```
 
-### Alternate code:
+## Alternate code:
 
 The alternate code, [prog.alt.c](prog.alt.c), is based on the author's
 instructions on how to get it to work with Windows. This has not been tested but

--- a/2014/wiedijk/README.md
+++ b/2014/wiedijk/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2015/burton/README.md
+++ b/2015/burton/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog "expression"

--- a/2015/dogon/README.md
+++ b/2015/dogon/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2015/duble/README.md
+++ b/2015/duble/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 echo Some text | ./prog

--- a/2015/endoh1/README.md
+++ b/2015/endoh1/README.md
@@ -12,7 +12,7 @@ Someone Anonymous
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2015/endoh2/README.md
+++ b/2015/endoh2/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2015/endoh3/README.md
+++ b/2015/endoh3/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2015/endoh4/README.md
+++ b/2015/endoh4/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog <a number of arguments>

--- a/2015/hou/README.md
+++ b/2015/hou/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 echo IOCCC | ./prog

--- a/2015/howe/README.md
+++ b/2015/howe/README.md
@@ -44,7 +44,7 @@ cp war-and-peace.txt nuked.tmp
 ./avgtime.sh 100 ./prog war-and-peace.txt nuked.tmp
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, `prog.alt.c`, is provided.
 This alternate code does not use a 64 bit FNV hash.

--- a/2015/howe/README.md
+++ b/2015/howe/README.md
@@ -10,7 +10,7 @@ Montreal, Quebec, Canada\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog file1 file2

--- a/2015/mills1/README.md
+++ b/2015/mills1/README.md
@@ -8,7 +8,7 @@ Chris Mills
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2015/mills2/README.md
+++ b/2015/mills2/README.md
@@ -8,7 +8,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog compressed_file.Z

--- a/2015/muth/README.md
+++ b/2015/muth/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 make -B [MACHINE=your_machine.h] [TAPE=your_tape.h] [X=[0|1|2|3|4|5|6|7|8|9]] [V=[0|1|2]] run

--- a/2015/schweikhardt/README.md
+++ b/2015/schweikhardt/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog n

--- a/2015/yang/README.md
+++ b/2015/yang/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 echo Some text | ./prog\

--- a/2018/algmyr/README.md
+++ b/2018/algmyr/README.md
@@ -8,7 +8,7 @@ Anton Älgmyr
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 cat prog.c | ./prog           # Printing garbage might break your font

--- a/2018/anderson/README.md
+++ b/2018/anderson/README.md
@@ -8,7 +8,7 @@ Derek Anderson
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < textfile

--- a/2018/bellard/README.md
+++ b/2018/bellard/README.md
@@ -9,7 +9,7 @@ Fabrice Bellard\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog > lena.ppm

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -22,7 +22,7 @@ make
 ./prog < prog.c
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided
 This alternate code was supposed to compile without warnings, however

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < any-file

--- a/2018/burton2/README.md
+++ b/2018/burton2/README.md
@@ -9,7 +9,7 @@ Dave Burton\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog [-tcksri] < file.c

--- a/2018/ciura/README.md
+++ b/2018/ciura/README.md
@@ -21,7 +21,7 @@ make
 ./prog < README.md
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, `prog.alt.c`, is provided.  As mentioned in
 the Author's remarks, the alternate version lacks a useful bug fix.

--- a/2018/ciura/README.md
+++ b/2018/ciura/README.md
@@ -8,7 +8,7 @@ Marcin Ciura <mciura@gmail.com>
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < text

--- a/2018/endoh1/README.md
+++ b/2018/endoh1/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < textfile > output.gif

--- a/2018/endoh2/README.md
+++ b/2018/endoh2/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -28,7 +28,7 @@ make
 make test
 ```
 
-### Alternate code:
+## Alternate code:
 
 The author provided an alternate version which has a simpler keyboard for the
 monkey Eric. See his comments under the 'keyboards' section, briefly referred to

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -11,7 +11,7 @@ Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./weasel

--- a/2018/giles/README.md
+++ b/2018/giles/README.md
@@ -82,7 +82,7 @@ Makefiles.
 See also the judges' remarks below.
 
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2018/hou/README.md
+++ b/2018/hou/README.md
@@ -8,7 +8,7 @@ Qiming Hou
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < input.json > output.html

--- a/2018/mills/README.md
+++ b/2018/mills/README.md
@@ -8,7 +8,7 @@ Christopher Mills <mrxo@sonic.net>
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2018/poikola/README.md
+++ b/2018/poikola/README.md
@@ -12,7 +12,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -8,7 +8,7 @@ Scott Vokes
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < example-1.txt

--- a/2018/yang/README.md
+++ b/2018/yang/README.md
@@ -9,7 +9,7 @@
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 more generated1.c

--- a/2019/adamovsky/README.md
+++ b/2019/adamovsky/README.md
@@ -8,7 +8,7 @@ Ondřej Adamovský <oa@cmail.cz>
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog file.unl

--- a/2019/burton/README.md
+++ b/2019/burton/README.md
@@ -8,7 +8,7 @@ Dave Burton
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < prog.c

--- a/2019/ciura/README.md
+++ b/2019/ciura/README.md
@@ -34,7 +34,7 @@ make
 ```
 
 
-### Alternate code:
+## Alternate code:
 
 There is an alternate version of this code that flushes stdout after writing a newline.
 See the Author's remarks for more information.

--- a/2019/ciura/README.md
+++ b/2019/ciura/README.md
@@ -10,7 +10,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./getwords.sh en | grep .. | ./prog string

--- a/2019/diels-grabsch1/README.md
+++ b/2019/diels-grabsch1/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./prog < file > file.Z

--- a/2019/diels-grabsch2/README.md
+++ b/2019/diels-grabsch2/README.md
@@ -11,7 +11,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2019/dogon/README.md
+++ b/2019/dogon/README.md
@@ -8,7 +8,7 @@ Gil Dogon
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog < pattern.mc

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -9,7 +9,7 @@ Etienne Duble\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog file

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -61,7 +61,7 @@ find . -name '.[A-Z]*' -delete
 
 though one might want to check that the program is not currently running. :-)
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.  This alternate
 code might not work as well on macOS.

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2019/giles/README.md
+++ b/2019/giles/README.md
@@ -8,7 +8,7 @@ Edward Giles
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog infile.wav outfile.wav

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -10,7 +10,7 @@ make
 ```
 
 
-## To run:
+## To use:
 
 ```sh
 ./prog < textfile_that_fits_on_the_screen

--- a/2019/lynn/README.md
+++ b/2019/lynn/README.md
@@ -9,7 +9,7 @@ Ben Lynn
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -8,7 +8,7 @@ Christopher Mills
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 make cpclean

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -9,7 +9,7 @@ Timo Poikola\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog 512 ./prog

--- a/2019/yang/README.md
+++ b/2019/yang/README.md
@@ -9,7 +9,7 @@ Don Yang\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog sample_input.txt a b c d

--- a/2020/burton/README.md
+++ b/2020/burton/README.md
@@ -37,7 +37,7 @@ arg. It might also print strange output with more than one arg.
 ./prog 128 128 128 128
 ```
 
-### Alternate code:
+## Alternate code:
 
 By default, this code compiles for Little Endian machines.
 An alternate version is also compiled for Big Endian machines.

--- a/2020/burton/README.md
+++ b/2020/burton/README.md
@@ -9,7 +9,7 @@ Dave Burton
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog arg ...

--- a/2020/carlini/README.md
+++ b/2020/carlini/README.md
@@ -9,7 +9,7 @@ Nicholas Carlini <nicholas@carlini.com>\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/endoh1/README.md
+++ b/2020/endoh1/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/endoh1/README.md
+++ b/2020/endoh1/README.md
@@ -29,7 +29,7 @@ make
 ./prog unwinnable.txt
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.  This
 alternate code lacks the additional rule to flag all unprobed cells.  See the

--- a/2020/endoh2/README.md
+++ b/2020/endoh2/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/endoh3/README.md
+++ b/2020/endoh3/README.md
@@ -10,7 +10,7 @@ Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/endoh3/README.md
+++ b/2020/endoh3/README.md
@@ -23,7 +23,7 @@ make
 # And watch closely for 15-20 seconds
 ```
 
-### Alternate code:
+## Alternate code:
 
 An alternate version of this entry, `prog.alt.c`, is provided.  This alternate code uses Unicode letters.
 

--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -11,7 +11,7 @@ Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 WAIT=N WALLS=[01] EVADE=N SIZE=N MAXSIZE=N GROW=N SHEDS=N SHED=N CANNIBAL=[01] ./prog

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -12,7 +12,7 @@ Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/giles/README.md
+++ b/2020/giles/README.md
@@ -9,7 +9,7 @@ Edward Giles\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/kurdyukov1/README.md
+++ b/2020/kurdyukov1/README.md
@@ -25,7 +25,7 @@ echo IOCCC | ./prog
 ./prog < prog.x86_64.asm
 ```
 
-### Alternate code:
+## Alternate code:
 
 An even smaller alternate version of this entry, prog.alt.c, is provided.  This code does not contain any headers, nor any workaround for WIN32 based platforms.
 

--- a/2020/kurdyukov1/README.md
+++ b/2020/kurdyukov1/README.md
@@ -9,7 +9,7 @@ Ilya Kurdyukov\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/kurdyukov2/README.md
+++ b/2020/kurdyukov2/README.md
@@ -9,7 +9,7 @@ Ilya Kurdyukov\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/kurdyukov3/README.md
+++ b/2020/kurdyukov3/README.md
@@ -28,7 +28,7 @@ echo International Obfuscated C Code Contest | ./prog
 ./prog < input.txt
 ```
 
-### Alternate code:
+## Alternate code:
 
 There is an alternate version of this code in `prog.alt.c` where the main code is a macro.
 

--- a/2020/kurdyukov3/README.md
+++ b/2020/kurdyukov3/README.md
@@ -9,7 +9,7 @@ Ilya Kurdyukov\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/kurdyukov4/README.md
+++ b/2020/kurdyukov4/README.md
@@ -9,7 +9,7 @@ Ilya Kurdyukov\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog text_file output_length context_length random_seed

--- a/2020/otterness/README.md
+++ b/2020/otterness/README.md
@@ -9,7 +9,7 @@ Nathan Otterness\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/tsoj/README.md
+++ b/2020/tsoj/README.md
@@ -9,7 +9,7 @@ tsoj <tsoj.tsoj@gmx.de>\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog

--- a/2020/yang/README.md
+++ b/2020/yang/README.md
@@ -9,7 +9,7 @@ Don Yang\
 make
 ```
 
-## To run:
+## To use:
 
 ```sh
 ./prog [PIN] < input.txt > output.c


### PR DESCRIPTION

Change level 3 (###) to level 2 (##):

    sgit -e 's/^### \(Alternate code\)/## \1/g' '*README.md'

which is the same as:

    sgit -e 's/^### Alternate code/## Alternate code/g' '*README.md'

This is per discussion in GitHub.