### PR TITLE
Temporary (? :-) ) fixes in tmp/ scripts

### DIFF
--- a/tmp/awards_check.sh
+++ b/tmp/awards_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# check_awards - check the award lines in README.md files
+# awards_check - check the award lines in README.md files
 #
 # XXX - This is a temporary utility that will be replaced when
 #	the .winner.json files are built
@@ -10,19 +10,20 @@
 # generate as it was not worth getting everything correct. It was initially
 # generated like:
 #
-#	echo '#!/bin/bash' > bin/check_awards.sh ; ( while read -r g ; do
+#	echo '#!/bin/bash' > bin/awards_check.sh ; ( while read -r g ; do
 #	    echo grep "$g";
 #	done < <(sed -e 's,_,/,g' -e 's/"/\\"/g' tmp/year-auth-prize.csv |
 #	    awk -F, '{print grep "\x22" $2 "\x22" " " $1 "/" "README.md"}' ); )
-#	    >> bin/check_awards.sh
+#	    >> bin/awards_check.sh
 #
 # To determine how many entries have a mismatch in award compared to the CSV
 # file do:
 #
-#	sh bin/check_awards.sh | grep :0
+#	sh tmp/awards_check.sh | grep :0
 #
-# It must be run in the top level directory. It shouldn't be necessary in future
-# IOCCC contests as the problem should not occur again.
+# It must be run in the tmp/ subdirectory. It shouldn't be necessary in future
+# IOCCC contests as the problem should not occur again (hence it's a temporary
+# file :-) )
 #
 # This was a hack and not the prettiest hack made by Cody Boone Ferguson
 # (@xexyl) to quickly check all entries from 1984 through 2020. It probably could

--- a/tmp/check_path_list.sh
+++ b/tmp/check_path_list.sh
@@ -56,7 +56,7 @@ trap 'rm -f $TMP_FILE; exit' 0 1 2 3 15
 comm -23 "$REQUIRED_PATH_LIST" "$FOUND_LIST" | sort -t/ > "$TMP_FILE"
 if [[ -s $TMP_FILE ]]; then
     COUNT=$(wc -l < "$TMP_FILE" | sed -e 's/^ *//')
-    echo "# $0: Waning: missing required file count: $COUNT"
+    echo "# $0: Warning: missing required file count: $COUNT"
     EXIT_CODE=18	# exit 18
     echo "#"
     echo "# $0: missing required file list starts below"
@@ -72,7 +72,7 @@ trap 'rm -f $TMP_FILE; exit' 0 1 2 3 15
 comm -13 "$MANIFEST_LIST" "$FOUND_LIST" | sort -t/ > "$TMP_FILE"
 if [[ -s $TMP_FILE ]]; then
     COUNT=$(wc -l < "$TMP_FILE" | sed -e 's/^ *//')
-    echo "# $0: Waning: found files not in the manifest count: $COUNT"
+    echo "# $0: Warning: found files not in the manifest count: $COUNT"
     EXIT_CODE=19	# exit 19
     echo "#"
     echo "# $0: found files not in the manifest list starts below"

--- a/tmp/fix_manifest_csv.sh
+++ b/tmp/fix_manifest_csv.sh
@@ -16,8 +16,6 @@
 export MANIFEST_CSV="manifest.csv"
 export TMP_CSV
 
-# fix manifest CSV
-#
 if [[ ! -f $MANIFEST_CSV ]]; then
     echo "$0: ERROR: MANIFEST_CSV is missing: $MANIFEST_CSV" 1>&2
     exit 10
@@ -46,9 +44,12 @@ if [[ $status -ne 0 ]]; then
     exit 13
 fi
 if [[ ! -s $TMP_CSV ]]; then
-    printf "$0: ERROR: TMP_CSV: tr -d '\\\015' < %s > %s produced a empty file" "$MANIFEST_CSV" "$TMP_CSV" 1>&2
+    printf "$0: ERROR: TMP_CSV: tr -d '\\\015' < %s > %s produced an empty file" "$MANIFEST_CSV" "$TMP_CSV" 1>&2
     exit 14
 fi
+
+# fix manifest CSV
+#
 
 # sort manifest CSV file
 #

--- a/tmp/gen_path_list.found.sh
+++ b/tmp/gen_path_list.found.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# gen_path_list.found.sh - generate tmp/path_list.found.txt for entry directories under a year
+# gen_path_list.found.sh - generate tmp/path_list.found.txt for entry
+# directories under a year
 #
 # XXX - This is a temporary utility that will be replaced when
 #	the .winner.json files are built


### PR DESCRIPTION
Typos and make the renaming of check_awards.sh -> awards_check.sh consistent in the comments (as in change the name of the script in the comments to the new name).

None of these are super important as they're temporary files but they are still incorrect so have to be fixed in my mind.