### PR TITLE
Many fixes and additions to 1984/mullender

### DIFF
--- a/1984/mullender/.gitignore
+++ b/1984/mullender/.gitignore
@@ -1,5 +1,7 @@
 mullender
 mullender.alt
+mullender.alt2
 gentab
+g.c
 mullender.orig
 prog.orig

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o ${PROG}.alt2.o
+ALT_TARGET= ${PROG}.alt ${PROG}.alt2
 
 
 #################
@@ -142,8 +142,11 @@ gentab: gentab.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-${ALT_TARGET}: ${PROG}.alt.c
-	${CC} -include stdio.h -include unistd.h -include stdlib.h ${CFLAGS} $< -o $@ ${LDFLAGS}
+${PROG}.alt: ${PROG}.alt.c
+	${CC} -include stdio.h -include unistd.h -include stdlib.h ${CFLAGS} -Wno-implicit-int $< -o $@ ${LDFLAGS}
+
+${PROG}.alt2: ${PROG}.alt2.c
+	${CC} -include stdio.h -include unistd.h -include stdlib.h ${CFLAGS} -Wno-implicit-int $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -9,56 +9,37 @@ Robbert van Renesse
 ## To build:
 
 ```sh
-make all
+make alt
 ```
 
+NOTE: the original code will not work on any system other than
+[VAX-11](https://en.wikipedia.org/wiki/VAX-11) and
+[PDP-11](https://en.wikipedia.org/wiki/PDP-11) and this is why we encourage you
+to use the alt version instead. See [original code](#original-code) below for
+the original version.
 
 ## To use:
 
 ```sh
-./mullender
-```
-
-NOTE: if your machine is not a [VAX-11](https://en.wikipedia.org/wiki/VAX-11)
-or [PDP-11](https://en.wikipedia.org/wiki/PDP-11), this program will not execute
-correctly.  In later years, machine dependent code was discouraged. An alternate
-version that will work with other systems is provided as alternate code below.
-
-
-## Alternate code:
-
-An alternate version exists which allows one to enjoy this entry on systems
-other than a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
-[PDP-11](https://en.wikipedia.org/wiki/PDP-11). This version has a delay feature
-as it goes so fast in modern systems. The author suggested that there was a
-delay in the original code as well.
-
-
-### Alternate build:
-
-
-```sh
-make alt
-```
-
-
-### Alternate use:
-
-```sh
 ./mullender.alt [microseconds]
+
+./mullender.alt2 [microseconds] # starts over after it times out
 ```
 
-The default microseconds is 10000. This feature is so you can experiment with
+The default microseconds is 10000 and it is also the lowest it can be as any
+lower doesn't work very well. This feature is so you can experiment with
 different speeds in between writes. It can be useful if your CPU is too slow or
-too fast.
+too fast (:-) ).
 
-Note that it is an `int` (argc) and it uses `atoi()` which does NOT check for
+The author stated that the original version also had a delay.
+
+Note that the microseconds is argc and it uses `atoi()` which does NOT check for
 overflow!
 
 BTW: is there such a thing as too fast a CPU ? :-) Actually yes for certain code
 which is probably not as uncommon as you think :-).
 
-### Alternate try:
+### Try:
 
 
 ```sh
@@ -71,6 +52,44 @@ which is probably not as uncommon as you think :-).
 ./mullender.alt 20000
 
 ./mullender.alt 100000
+
+./mullender.alt2 500
+# wait for 500 microseconds and see what happens
+```
+
+What happens if you hit enter after it reaches the end of the line? Why?
+
+
+## Original code:
+
+This original code will only execute correctly if your machine is a
+[VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
+[PDP-11](https://en.wikipedia.org/wiki/PDP-11). In the following years, 1985 on,
+machine dependent code was discouraged.
+
+
+### Original build:
+
+
+```sh
+make all
+```
+
+### Bugs and (Mis)features:
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md#1984mullender-readmemd).
+
+
+### Original use:
+
+```sh
+./mullender
 ```
 
 
@@ -122,7 +141,7 @@ close to as the original as possible we used a copy of
 in the *fabulous* [Unix History
 Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
-### Alternate build:
+### gentab build:
 
 `gentab.c` can be built like:
 
@@ -131,17 +150,20 @@ Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 make gentab
 ```
 
-### Alternate use:
+### gentab use:
 
 ```sh
 ./gentab file
 ```
 
-### Alternate try:
+### gentab try:
 
 ```sh
-./gentab gentab
+./gentab gentab > g.c
 ```
+
+NOTE: it is highly unlikely that you will be able to compile and run the output
+of `gentab` but it should at least compile.
 
 ## Author's remarks:
 

--- a/1984/mullender/gentab.c
+++ b/1984/mullender/gentab.c
@@ -40,7 +40,8 @@ main(argc, argv) char **argv;
 		fmt = "0x%x"; break;
 	}
 
-	if (32 <= n && n < 127 && (rand() % 4)) fmt = "'%c'";
+	if (n == '\\' || n == '\'') fmt = "'\\%c'";
+	else if (32 <= n && n < 127 && (rand() % 4)) fmt = "'%c'";
 	printf(n < 8 ? "%d" : fmt, n);
 	printf(",");
 	if (pos++ == 8) {

--- a/1984/mullender/mullender.alt.c
+++ b/1984/mullender/mullender.alt.c
@@ -1,1 +1,1 @@
-main(i,v)char**v;{i=v[1]?atoi(v[1]):10000;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);}
+main(i,v)char**v;{i=v[1]?atoi(v[1]):10000;i=i<500?500:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);}

--- a/1984/mullender/mullender.alt2.c
+++ b/1984/mullender/mullender.alt2.c
@@ -1,0 +1,1 @@
+main(i,v)char**v;{j:i=v[1]?atoi(v[1]):10000;i=i<500?500:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);goto j;}

--- a/2020/endoh3/run_clock.sh
+++ b/2020/endoh3/run_clock.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/end bash
+#!/usr/bin/env bash
+
 while true; do
-cc -std=c11 -Wall -Wextra -pedantic -O3 clock.c -o clock
-clear
-./clock | tee clock.c
-sleep 5
+    cc -std=c11 -Wall -Wextra -pedantic -O3 clock.c -o clock
+    clear
+    ./clock | tee clock.c
+    sleep 5
 done

--- a/bugs.md
+++ b/bugs.md
@@ -449,6 +449,21 @@ without a newline after the `\`. This is not a bug.
 This entry will very likely crash or do something else if you run it without an
 arg. It likely won't do anything at all if the arg is not a positive number.
 
+## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md)
+### STATUS: INABIAF - please **DO NOT** fix
+
+Although there are two alt versions added by Cody that will work in modern
+systems, if you do not have a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
+[PDP-11](https://en.wikipedia.org/wiki/PDP-11) to run the original entry on it
+will not work. See the README.md for details on the alternate versions.
+
+Cody added and fixed the [gentab.c](1984/mullender/gentab.c) which is from the
+author's (or one of them, Mullender) remarks found by Cody. Cody fixed this to
+compile and work (as best as he can determine: he has no VAX-11 or PDP-11 or
+emulator to test it) but running the code on the binary itself produces a
+`short[]` that can compile in modern systems.
+
+
 # 1985
 
 

--- a/faq.md
+++ b/faq.md
@@ -241,9 +241,12 @@ can enjoy this entry. Try:
 ```sh
 make alt
 ./mullender.alt [microseconds]
+./mullender.alt2 [microseconds]
 ```
 
-The microseconds defaults to 10000.
+The microseconds defaults to 10000 but has a minimum value of 1000. The
+`mullender.alt2` is like the first alt except that it will start over once the
+program times out.
 
 Thank you Cody!
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2351,6 +2351,39 @@ debugging it since it works with `-O0`.
 He also added the script [demo.sh](2019/karns/demo.sh) to showcase the entry a
 bit more easily.
 
+## [2020/endoh3](2020/endoh3/prog.c) ([README.md](2020/endoh3/README.md))
+
+Cody fixed the script [run_clock.sh](2020/endoh3/run_clock.sh) which gave a
+funny error when running it:
+
+```sh
+$ ./run_clock.sh 
+-bash: ./run_clock.sh: cannot execute: required file not found
+```
+
+If run from within vim a different error message occurred:
+
+```
+/bin/bash: ./run_clock.sh: /usr/bin/end: bad interpreter: No such file or directory
+```
+
+though this was only noticed later on after it was fixed.
+
+What was wrong? A typo in the shebang which had `/usr/bin/end` instead of
+`/usr/bin/env`. Anyone who knows Cody would know that he'd zoom in on that quite
+quick.
+
+Cody also reported (during the preview period of 2020) for some systems (at some
+point?) like macOS the use of `make clock` would not work due possibly to a
+timing issue so Yusuke changed it to compile the [clock.c](2020/endoh3/clock.c)
+file directly (this might have been fixed in the Makefile later on but it
+doesn't hurt to keep it in and this way it isn't a problem in any system). How
+Cody remembers this minor detail more than three years ago is something that
+many people might wonder but he also once told us that if someone moves
+something of his even a millimetre from where it was he knows it so he might be
+called unusual (and he argues, with pride, eccentric :-) ) :-)
+
+
 ## [2020/ferguson2](2020/ferguson1/prog.c) ([README.md](2020/ferguson1/README.md))
 
 Cody, with intentional irony here :-), fixed formatting, links and typos in

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -166,17 +166,23 @@ cd 1984/decot ; make diff_orig_prog
 
 ## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md]))
 
-Cody provided an alternate version, an improved version of the judges, so that
-everyone can enjoy it with systems that are not VAX/PDP. We also refer you to
-the [FAQ](faq.md) as there are some winning entries that also let one enjoy it -
-with more to them of course!
+Cody provided an [alternate version](1984/mullender/mullender.alt.c), an
+improved version of the judges, so that everyone can enjoy it with systems that
+are not VAX/PDP. We also refer you to the [FAQ](faq.md) as there are some
+winning entries that also let one enjoy it - with more to them of course!
+
+Cody further added the second alt version,
+[mullender.alt2.c](1984/mullender/mullender.alt2.c) which is like the
+[1984/mullender/mullender.alt.c](1984/mullender/mullender.alt.c) except that it
+starts over after it times out.
 
 Cody also added the [gentab.c](1984/mullender/gentab.c) file, fixed to compile
-and work with modern systems and so that it would create the proper array (it
-had unbalanced '}'s), which the author noted in their remarks (which Cody also
-found). As this file uses the old header file `a.out.h` that is not available in
-all modern systems, Cody found a copy of it as to what it should have been at
-the time, in the fabulous [Unix History
+(and work!, though see [bugs.md](#1984mullender-readmemd) with modern systems
+and so that it would create the proper array (it had unbalanced '}'s), which the
+author noted in their remarks (which Cody also found). As this file uses the old
+header file `a.out.h` that is not available in all modern systems, Cody found a
+copy of it as to what it should have been at the time, in the fabulous [Unix
+History
 Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
 

--- a/tmp/awards_check.sh
+++ b/tmp/awards_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# check_awards - check the award lines in README.md files
+# awards_check - check the award lines in README.md files
 #
 # XXX - This is a temporary utility that will be replaced when
 #	the .winner.json files are built
@@ -10,19 +10,20 @@
 # generate as it was not worth getting everything correct. It was initially
 # generated like:
 #
-#	echo '#!/bin/bash' > bin/check_awards.sh ; ( while read -r g ; do
+#	echo '#!/bin/bash' > bin/awards_check.sh ; ( while read -r g ; do
 #	    echo grep "$g";
 #	done < <(sed -e 's,_,/,g' -e 's/"/\\"/g' tmp/year-auth-prize.csv |
 #	    awk -F, '{print grep "\x22" $2 "\x22" " " $1 "/" "README.md"}' ); )
-#	    >> bin/check_awards.sh
+#	    >> bin/awards_check.sh
 #
 # To determine how many entries have a mismatch in award compared to the CSV
 # file do:
 #
-#	sh bin/check_awards.sh | grep :0
+#	sh tmp/awards_check.sh | grep :0
 #
-# It must be run in the top level directory. It shouldn't be necessary in future
-# IOCCC contests as the problem should not occur again.
+# It must be run in the tmp/ subdirectory. It shouldn't be necessary in future
+# IOCCC contests as the problem should not occur again (hence it's a temporary
+# file :-) )
 #
 # This was a hack and not the prettiest hack made by Cody Boone Ferguson
 # (@xexyl) to quickly check all entries from 1984 through 2020. It probably could

--- a/tmp/check_path_list.sh
+++ b/tmp/check_path_list.sh
@@ -56,7 +56,7 @@ trap 'rm -f $TMP_FILE; exit' 0 1 2 3 15
 comm -23 "$REQUIRED_PATH_LIST" "$FOUND_LIST" | sort -t/ > "$TMP_FILE"
 if [[ -s $TMP_FILE ]]; then
     COUNT=$(wc -l < "$TMP_FILE" | sed -e 's/^ *//')
-    echo "# $0: Waning: missing required file count: $COUNT"
+    echo "# $0: Warning: missing required file count: $COUNT"
     EXIT_CODE=18	# exit 18
     echo "#"
     echo "# $0: missing required file list starts below"
@@ -72,7 +72,7 @@ trap 'rm -f $TMP_FILE; exit' 0 1 2 3 15
 comm -13 "$MANIFEST_LIST" "$FOUND_LIST" | sort -t/ > "$TMP_FILE"
 if [[ -s $TMP_FILE ]]; then
     COUNT=$(wc -l < "$TMP_FILE" | sed -e 's/^ *//')
-    echo "# $0: Waning: found files not in the manifest count: $COUNT"
+    echo "# $0: Warning: found files not in the manifest count: $COUNT"
     EXIT_CODE=19	# exit 19
     echo "#"
     echo "# $0: found files not in the manifest list starts below"

--- a/tmp/fix_manifest_csv.sh
+++ b/tmp/fix_manifest_csv.sh
@@ -16,8 +16,6 @@
 export MANIFEST_CSV="manifest.csv"
 export TMP_CSV
 
-# fix manifest CSV
-#
 if [[ ! -f $MANIFEST_CSV ]]; then
     echo "$0: ERROR: MANIFEST_CSV is missing: $MANIFEST_CSV" 1>&2
     exit 10
@@ -46,9 +44,12 @@ if [[ $status -ne 0 ]]; then
     exit 13
 fi
 if [[ ! -s $TMP_CSV ]]; then
-    printf "$0: ERROR: TMP_CSV: tr -d '\\\015' < %s > %s produced a empty file" "$MANIFEST_CSV" "$TMP_CSV" 1>&2
+    printf "$0: ERROR: TMP_CSV: tr -d '\\\015' < %s > %s produced an empty file" "$MANIFEST_CSV" "$TMP_CSV" 1>&2
     exit 14
 fi
+
+# fix manifest CSV
+#
 
 # sort manifest CSV file
 #

--- a/tmp/gen_path_list.found.sh
+++ b/tmp/gen_path_list.found.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# gen_path_list.found.sh - generate tmp/path_list.found.txt for entry directories under a year
+# gen_path_list.found.sh - generate tmp/path_list.found.txt for entry
+# directories under a year
 #
 # XXX - This is a temporary utility that will be replaced when
 #	the .winner.json files are built


### PR DESCRIPTION
                
Swap order of alt and original code in build/try sections so that the 
original code is suggested second, after alt code, with the bugs and 
(mis)features added to the README.md file, pointing out that it'll only
work on VAX-11 / PDP-11 machines. This is added in the bugs.md (it was 
actually missing from the bugs.md file).

The alt code (both versions, see below) now have a lower limit on the
microseconds at 500 (still defaults at 10000). This is because anything
much lower and it's nigh impossible to see and in some cases it won't
work at all (at least in the MacBook Pro with the M1 chip).

Added second alt code which is like the first except that once it times
out it starts over.

Running make alt will compile both alt versions.

The gentab.c file that I added (found from the author) and fixed to
compile could not always create code that would compile due to some
characters needing to be escaped like ' and \. These are now escaped if
they are encountered but there certainly could be more that I did not
think of that would have to be escaped.
