### PR TITLE
Make 1985/sicherman even more like original

### DIFF
--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -8,6 +8,10 @@ Dave Decot
 make all
 ```
 
+NOTE: there is an [alternate version](#alternate-code) which will only work if
+you have an old enough compiler or a compiler that supports `-traditional-cpp`.
+The original code was fixed in 2023 to not require this.
+
 ## To use:
 
 ```sh
@@ -18,7 +22,7 @@ make all
 
 This alternate code, the original, requires a compiler that supports
 `-traditional-cpp` or an old enough compiler. If you have such a compiler you
-can use this entry.
+can use this version.
 
 ### Alternate build:
 
@@ -55,7 +59,12 @@ for(signal=0;*k *x * __FILE__ *i;) do {
 ```
 
 To see what we mean look at the [original source file](decot.orig.c). The
-[alternate code](decot.alt.c) is the version that we modified.
+[alternate code](decot.alt.c) is the version that has this modification. The
+fixed version has instead:
+
+```c
+for(signal=0;*k *= * __FILE__ *i;) do {
+```
 
 
 ## Author's remarks:

--- a/1984/mullender/.gitignore
+++ b/1984/mullender/.gitignore
@@ -1,5 +1,7 @@
 mullender
 mullender.alt
+mullender.alt2
 gentab
+g.c
 mullender.orig
 prog.orig

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o ${PROG}.alt2.o
+ALT_TARGET= ${PROG}.alt ${PROG}.alt2
 
 
 #################
@@ -142,8 +142,11 @@ gentab: gentab.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-${ALT_TARGET}: ${PROG}.alt.c
-	${CC} -include stdio.h -include unistd.h -include stdlib.h ${CFLAGS} $< -o $@ ${LDFLAGS}
+${PROG}.alt: ${PROG}.alt.c
+	${CC} -include stdio.h -include unistd.h -include stdlib.h ${CFLAGS} -Wno-implicit-int $< -o $@ ${LDFLAGS}
+
+${PROG}.alt2: ${PROG}.alt2.c
+	${CC} -include stdio.h -include unistd.h -include stdlib.h ${CFLAGS} -Wno-implicit-int $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -9,56 +9,37 @@ Robbert van Renesse
 ## To build:
 
 ```sh
-make all
+make alt
 ```
 
+NOTE: the original code will not work on any system other than
+[VAX-11](https://en.wikipedia.org/wiki/VAX-11) and
+[PDP-11](https://en.wikipedia.org/wiki/PDP-11) and this is why we encourage you
+to use the alt version instead. See [original code](#original-code) below for
+the original version.
 
 ## To use:
 
 ```sh
-./mullender
-```
-
-NOTE: if your machine is not a [VAX-11](https://en.wikipedia.org/wiki/VAX-11)
-or [PDP-11](https://en.wikipedia.org/wiki/PDP-11), this program will not execute
-correctly.  In later years, machine dependent code was discouraged. An alternate
-version that will work with other systems is provided as alternate code below.
-
-
-## Alternate code:
-
-An alternate version exists which allows one to enjoy this entry on systems
-other than a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
-[PDP-11](https://en.wikipedia.org/wiki/PDP-11). This version has a delay feature
-as it goes so fast in modern systems. The author suggested that there was a
-delay in the original code as well.
-
-
-### Alternate build:
-
-
-```sh
-make alt
-```
-
-
-### Alternate use:
-
-```sh
 ./mullender.alt [microseconds]
+
+./mullender.alt2 [microseconds] # starts over after it times out
 ```
 
-The default microseconds is 10000. This feature is so you can experiment with
+The default microseconds is 10000 and it is also the lowest it can be as any
+lower doesn't work very well. This feature is so you can experiment with
 different speeds in between writes. It can be useful if your CPU is too slow or
-too fast.
+too fast (:-) ).
 
-Note that it is an `int` (argc) and it uses `atoi()` which does NOT check for
+The author stated that the original version also had a delay.
+
+Note that the microseconds is argc and it uses `atoi()` which does NOT check for
 overflow!
 
 BTW: is there such a thing as too fast a CPU ? :-) Actually yes for certain code
 which is probably not as uncommon as you think :-).
 
-### Alternate try:
+### Try:
 
 
 ```sh
@@ -71,6 +52,44 @@ which is probably not as uncommon as you think :-).
 ./mullender.alt 20000
 
 ./mullender.alt 100000
+
+./mullender.alt2 500
+# wait for 500 microseconds and see what happens
+```
+
+What happens if you hit enter after it reaches the end of the line? Why?
+
+
+## Original code:
+
+This original code will only execute correctly if your machine is a
+[VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
+[PDP-11](https://en.wikipedia.org/wiki/PDP-11). In the following years, 1985 on,
+machine dependent code was discouraged.
+
+
+### Original build:
+
+
+```sh
+make all
+```
+
+### Bugs and (Mis)features:
+
+This entry a listed in [bugs.md](/bugs.md) as:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [bugs.md](/bugs.md#1984mullender-readmemd).
+
+
+### Original use:
+
+```sh
+./mullender
 ```
 
 
@@ -122,7 +141,7 @@ close to as the original as possible we used a copy of
 in the *fabulous* [Unix History
 Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
-### Alternate build:
+### gentab build:
 
 `gentab.c` can be built like:
 
@@ -131,17 +150,20 @@ Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 make gentab
 ```
 
-### Alternate use:
+### gentab use:
 
 ```sh
 ./gentab file
 ```
 
-### Alternate try:
+### gentab try:
 
 ```sh
-./gentab gentab
+./gentab gentab > g.c
 ```
+
+NOTE: it is highly unlikely that you will be able to compile and run the output
+of `gentab` but it should at least compile.
 
 ## Author's remarks:
 

--- a/1984/mullender/gentab.c
+++ b/1984/mullender/gentab.c
@@ -40,7 +40,8 @@ main(argc, argv) char **argv;
 		fmt = "0x%x"; break;
 	}
 
-	if (32 <= n && n < 127 && (rand() % 4)) fmt = "'%c'";
+	if (n == '\\' || n == '\'') fmt = "'\\%c'";
+	else if (32 <= n && n < 127 && (rand() % 4)) fmt = "'%c'";
 	printf(n < 8 ? "%d" : fmt, n);
 	printf(",");
 	if (pos++ == 8) {

--- a/1984/mullender/mullender.alt.c
+++ b/1984/mullender/mullender.alt.c
@@ -1,1 +1,1 @@
-main(i,v)char**v;{i=v[1]?atoi(v[1]):10000;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);}
+main(i,v)char**v;{i=v[1]?atoi(v[1]):10000;i=i<500?500:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);}

--- a/1984/mullender/mullender.alt2.c
+++ b/1984/mullender/mullender.alt2.c
@@ -1,0 +1,1 @@
+main(i,v)char**v;{j:i=v[1]?atoi(v[1]):10000;i=i<500?500:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);goto j;}

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -9,14 +9,6 @@ Ed Lycklama
 make alt
 ```
 
-
-If you have an old enough compiler you can try:
-
-```sh
-make lycklama.orig
-```
-
-
 ## To use:
 
 ```sh
@@ -63,20 +55,20 @@ appreciate what it does, we encourage you to first try the alternate version.
 After this, however, you might wish to try the original version, fixed for
 modern systems.
 
-### Alternate build:
+### Original build:
 
 ```sh
 make all
 ```
 
-### Alternate use:
+### Original use:
 
 
 ```sh
 ./lycklama < some_file
 ```
 
-### Alternate try:
+### Original try:
 
 ```sh
 ./lycklama < lycklama.c

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-comment -Wno-deprecated-non-prototype -Wno-main -Wno-pedantic \
-	-Wno-return-type -Wno-strict-prototypes -Wno-unused-parameter -Wno-implicit-int
+	-Wno-return-type -Wno-strict-prototypes -Wno-unused-parameter -Wno-implicit-int \
+	-Wno-implicit-function-declaration -Wno-unused-value -Wno-multichar
 
 # Common C compiler warning flags
 #
@@ -62,7 +63,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE= -include unistd.h
+CINCLUDE=
 
 # Optimization
 #

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -8,6 +8,9 @@ Col. G. L. Sicherman
 make all
 ```
 
+NOTE: there is an [alternate version](#alternate-code) for those who have an old
+enough compiler or have a compiler that supports the option `-traditional-cpp`.
+
 ## To use:
 
 ```sh

--- a/1985/sicherman/sicherman.c
+++ b/1985/sicherman/sicherman.c
@@ -2,28 +2,25 @@
 #define _C_C(_)('\b'b'\b'>=C_C>'\t'b'\n')
 #define C_C _|_
 #define b *
-#define C /b b/
+#define C /**/
 #define V _C_C(
+char _,__;
 main(/*C,V)
 char **V;*/
 /*	C program. (If you don't
  *	understand it look it
- *	up.) (In the C */manual)
+ *	up.) (In the C manual*/)
 {
-	char _,__; 
+	char _,__;
 	while (read(0,&__,1) & write((_=(_=~' '&__,/*/)),
 	_C_,1)) _=/*/-('\b'*'\b'>=_|_>'\t'*'\n'))?__:__-_+
-
-
-	'\b'*'\b'|((_-52)%('\b'*'\b'+~' '&'\t'*'\n')+1),1),&_,1));
+	'\b'*'\b'|((_-52)%('\b'*'\b'+~' '&'\t'*'\n')+1),1),
+	&_,1))/*_=C-V+subr(&V)*/;
 }
 
-#if 0
 subr(C)
-char *C;
 {
-	C="Lint says "argument Manual isn't used."  What's that
-	mean?"; while (write((read(C_C('"'-'/*"'/*"*/))?__:__-_+
+	"Lint says argument Manual isn't used."  "What's that\
+	mean?"; while (write((read(('"'-'/*"'/*"*/))?__:__-_+
 	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1));
 }
-#endif

--- a/2020/endoh3/run_clock.sh
+++ b/2020/endoh3/run_clock.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/end bash
+#!/usr/bin/env bash
+
 while true; do
-cc -std=c11 -Wall -Wextra -pedantic -O3 clock.c -o clock
-clear
-./clock | tee clock.c
-sleep 5
+    cc -std=c11 -Wall -Wextra -pedantic -O3 clock.c -o clock
+    clear
+    ./clock | tee clock.c
+    sleep 5
 done

--- a/bugs.md
+++ b/bugs.md
@@ -449,6 +449,21 @@ without a newline after the `\`. This is not a bug.
 This entry will very likely crash or do something else if you run it without an
 arg. It likely won't do anything at all if the arg is not a positive number.
 
+## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md)
+### STATUS: INABIAF - please **DO NOT** fix
+
+Although there are two alt versions added by Cody that will work in modern
+systems, if you do not have a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
+[PDP-11](https://en.wikipedia.org/wiki/PDP-11) to run the original entry on it
+will not work. See the README.md for details on the alternate versions.
+
+Cody added and fixed the [gentab.c](1984/mullender/gentab.c) which is from the
+author's (or one of them, Mullender) remarks found by Cody. Cody fixed this to
+compile and work (as best as he can determine: he has no VAX-11 or PDP-11 or
+emulator to test it) but running the code on the binary itself produces a
+`short[]` that can compile in modern systems.
+
+
 # 1985
 
 

--- a/faq.md
+++ b/faq.md
@@ -241,9 +241,12 @@ can enjoy this entry. Try:
 ```sh
 make alt
 ./mullender.alt [microseconds]
+./mullender.alt2 [microseconds]
 ```
 
-The microseconds defaults to 10000.
+The microseconds defaults to 10000 but has a minimum value of 1000. The
+`mullender.alt2` is like the first alt except that it will start over once the
+program times out.
 
 Thank you Cody!
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2351,6 +2351,39 @@ debugging it since it works with `-O0`.
 He also added the script [demo.sh](2019/karns/demo.sh) to showcase the entry a
 bit more easily.
 
+## [2020/endoh3](2020/endoh3/prog.c) ([README.md](2020/endoh3/README.md))
+
+Cody fixed the script [run_clock.sh](2020/endoh3/run_clock.sh) which gave a
+funny error when running it:
+
+```sh
+$ ./run_clock.sh 
+-bash: ./run_clock.sh: cannot execute: required file not found
+```
+
+If run from within vim a different error message occurred:
+
+```
+/bin/bash: ./run_clock.sh: /usr/bin/end: bad interpreter: No such file or directory
+```
+
+though this was only noticed later on after it was fixed.
+
+What was wrong? A typo in the shebang which had `/usr/bin/end` instead of
+`/usr/bin/env`. Anyone who knows Cody would know that he'd zoom in on that quite
+quick.
+
+Cody also reported (during the preview period of 2020) for some systems (at some
+point?) like macOS the use of `make clock` would not work due possibly to a
+timing issue so Yusuke changed it to compile the [clock.c](2020/endoh3/clock.c)
+file directly (this might have been fixed in the Makefile later on but it
+doesn't hurt to keep it in and this way it isn't a problem in any system). How
+Cody remembers this minor detail more than three years ago is something that
+many people might wonder but he also once told us that if someone moves
+something of his even a millimetre from where it was he knows it so he might be
+called unusual (and he argues, with pride, eccentric :-) ) :-)
+
+
 ## [2020/ferguson2](2020/ferguson1/prog.c) ([README.md](2020/ferguson1/README.md))
 
 Cody, with intentional irony here :-), fixed formatting, links and typos in

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -166,17 +166,23 @@ cd 1984/decot ; make diff_orig_prog
 
 ## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md]))
 
-Cody provided an alternate version, an improved version of the judges, so that
-everyone can enjoy it with systems that are not VAX/PDP. We also refer you to
-the [FAQ](faq.md) as there are some winning entries that also let one enjoy it -
-with more to them of course!
+Cody provided an [alternate version](1984/mullender/mullender.alt.c), an
+improved version of the judges, so that everyone can enjoy it with systems that
+are not VAX/PDP. We also refer you to the [FAQ](faq.md) as there are some
+winning entries that also let one enjoy it - with more to them of course!
+
+Cody further added the second alt version,
+[mullender.alt2.c](1984/mullender/mullender.alt2.c) which is like the
+[1984/mullender/mullender.alt.c](1984/mullender/mullender.alt.c) except that it
+starts over after it times out.
 
 Cody also added the [gentab.c](1984/mullender/gentab.c) file, fixed to compile
-and work with modern systems and so that it would create the proper array (it
-had unbalanced '}'s), which the author noted in their remarks (which Cody also
-found). As this file uses the old header file `a.out.h` that is not available in
-all modern systems, Cody found a copy of it as to what it should have been at
-the time, in the fabulous [Unix History
+(and work!, though see [bugs.md](#1984mullender-readmemd) with modern systems
+and so that it would create the proper array (it had unbalanced '}'s), which the
+author noted in their remarks (which Cody also found). As this file uses the old
+header file `a.out.h` that is not available in all modern systems, Cody found a
+copy of it as to what it should have been at the time, in the fabulous [Unix
+History
 Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -11,15 +11,17 @@ contributed thousands, that we wish to thank.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
-responsible for most of the improvements and fixes including many **very
+responsible for most of the improvements and fixes including many **extremely
 complicated bug fixes** like
 [1988/phillipps](/thanks-for-fixes.md#1988phillipps-readmemd),
 [2001/anonymous](/thanks-for-fixes.md#2001anonymous-readmemd) and
 [2004/burley](/thanks-for-fixes.md#2004burley-readmemd), making entries like
+[1985/sicherman](/thanks-for-fixes.md#1985sicherman-readmemd) and
 [1986/wall](/thanks-for-fixes.md#1986wall-readmemd) not need `-traditional-cpp`
-(all **very complicated fixes**), fixing entries to work with clang (some being
-**very complicated** like [1991/dds](/thanks-for-fixes.md#1991dds-readmemd)),
-porting entries to macOS (some being **very complicated** like
+(all **extremely complicated fixes**), fixing entries to work with clang (some
+being **extremely complicated** like
+[1991/dds](/thanks-for-fixes.md#1991dds-readmemd)), porting entries to macOS
+(some being **very complicated** like
 [1998/schweikh1](/thanks-for-fixes.md#1998schweikh1-readmemd)), fixing code like
 [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd) to work in both
 32-bit/64-bit which *can be* **very complicated**, providing alternate code
@@ -237,7 +239,8 @@ then compare it to [sicherman.c](1985/sicherman/sicherman.c) for some good old
 C-fashioned fun!
 
 Later on Cody improved the fix so that it looks much more like the [original
-entry](1985/sicherman/sicherman.c).
+entry](1985/sicherman/sicherman.c). He did this one more time and it's about as
+close to the original as one can get without causing a compilation error.
 
 
 ## [1986/hague](1986/hague/hague.c) ([README.md](1986/hague/README.md]))

--- a/tmp/awards_check.sh
+++ b/tmp/awards_check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# check_awards - check the award lines in README.md files
+# awards_check - check the award lines in README.md files
 #
 # XXX - This is a temporary utility that will be replaced when
 #	the .winner.json files are built
@@ -10,19 +10,20 @@
 # generate as it was not worth getting everything correct. It was initially
 # generated like:
 #
-#	echo '#!/bin/bash' > bin/check_awards.sh ; ( while read -r g ; do
+#	echo '#!/bin/bash' > bin/awards_check.sh ; ( while read -r g ; do
 #	    echo grep "$g";
 #	done < <(sed -e 's,_,/,g' -e 's/"/\\"/g' tmp/year-auth-prize.csv |
 #	    awk -F, '{print grep "\x22" $2 "\x22" " " $1 "/" "README.md"}' ); )
-#	    >> bin/check_awards.sh
+#	    >> bin/awards_check.sh
 #
 # To determine how many entries have a mismatch in award compared to the CSV
 # file do:
 #
-#	sh bin/check_awards.sh | grep :0
+#	sh tmp/awards_check.sh | grep :0
 #
-# It must be run in the top level directory. It shouldn't be necessary in future
-# IOCCC contests as the problem should not occur again.
+# It must be run in the tmp/ subdirectory. It shouldn't be necessary in future
+# IOCCC contests as the problem should not occur again (hence it's a temporary
+# file :-) )
 #
 # This was a hack and not the prettiest hack made by Cody Boone Ferguson
 # (@xexyl) to quickly check all entries from 1984 through 2020. It probably could

--- a/tmp/check_path_list.sh
+++ b/tmp/check_path_list.sh
@@ -56,7 +56,7 @@ trap 'rm -f $TMP_FILE; exit' 0 1 2 3 15
 comm -23 "$REQUIRED_PATH_LIST" "$FOUND_LIST" | sort -t/ > "$TMP_FILE"
 if [[ -s $TMP_FILE ]]; then
     COUNT=$(wc -l < "$TMP_FILE" | sed -e 's/^ *//')
-    echo "# $0: Waning: missing required file count: $COUNT"
+    echo "# $0: Warning: missing required file count: $COUNT"
     EXIT_CODE=18	# exit 18
     echo "#"
     echo "# $0: missing required file list starts below"
@@ -72,7 +72,7 @@ trap 'rm -f $TMP_FILE; exit' 0 1 2 3 15
 comm -13 "$MANIFEST_LIST" "$FOUND_LIST" | sort -t/ > "$TMP_FILE"
 if [[ -s $TMP_FILE ]]; then
     COUNT=$(wc -l < "$TMP_FILE" | sed -e 's/^ *//')
-    echo "# $0: Waning: found files not in the manifest count: $COUNT"
+    echo "# $0: Warning: found files not in the manifest count: $COUNT"
     EXIT_CODE=19	# exit 19
     echo "#"
     echo "# $0: found files not in the manifest list starts below"

--- a/tmp/fix_manifest_csv.sh
+++ b/tmp/fix_manifest_csv.sh
@@ -16,8 +16,6 @@
 export MANIFEST_CSV="manifest.csv"
 export TMP_CSV
 
-# fix manifest CSV
-#
 if [[ ! -f $MANIFEST_CSV ]]; then
     echo "$0: ERROR: MANIFEST_CSV is missing: $MANIFEST_CSV" 1>&2
     exit 10
@@ -46,9 +44,12 @@ if [[ $status -ne 0 ]]; then
     exit 13
 fi
 if [[ ! -s $TMP_CSV ]]; then
-    printf "$0: ERROR: TMP_CSV: tr -d '\\\015' < %s > %s produced a empty file" "$MANIFEST_CSV" "$TMP_CSV" 1>&2
+    printf "$0: ERROR: TMP_CSV: tr -d '\\\015' < %s > %s produced an empty file" "$MANIFEST_CSV" "$TMP_CSV" 1>&2
     exit 14
 fi
+
+# fix manifest CSV
+#
 
 # sort manifest CSV file
 #

--- a/tmp/gen_path_list.found.sh
+++ b/tmp/gen_path_list.found.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# gen_path_list.found.sh - generate tmp/path_list.found.txt for entry directories under a year
+# gen_path_list.found.sh - generate tmp/path_list.found.txt for entry
+# directories under a year
 #
 # XXX - This is a temporary utility that will be replaced when
 #	the .winner.json files are built


### PR DESCRIPTION

By changing some macros to what they used to expand to more of the code
can be used / not commented out. For instance now subr() no longer is
commented out. It cannot be used but it now is uncommented to make it
more like the original, even using the C macro as the arg (albeit
without a type specified as it actually just translates to /**/). The
macro that C used to use, 'b' (which is '*'), is still used just not in
C as doing so will cause compilation problems.

The single arg of main() was commented out because some versions of
clang do not only allow one arg to main().

There might have been other things to make it more like the original as
well.
