### PR TITLE
Fix both original and alt code for 1992/westley

### DIFF
--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -10,17 +10,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1984 laman in bugs.md](/bugs.md#1984-laman).
-
-
 ## To use:
 
 ```sh

--- a/1984/laman/laman.c
+++ b/1984/laman/laman.c
@@ -1,5 +1,5 @@
 a[900];		b;c;d=1		;e=1;f;		g;h;O;		main(k,
-l)char*		*l;{g=		atoi(*		++l);		for(k=
+l)char*		*l;{if(k>1)	{g=atoi(*	++l);		for(k=
 0;k*k<		g;b=k		++>>1)		;for(h=		0;h*h<=
 g;++h);		--h;c=(		(h+=g>h		*(h+1))		-1)>>1;
 while(d		<=g){		++O;for		(f=0;f<		O&&d<=g
@@ -9,4 +9,4 @@ while(d		<=g){		++O;for		(f=0;f<		O&&d<=g
 b){if(b		<k/2)a[		b<<5|c]		^=a[(k		-(b+1))
 <<5|c]^=	a[b<<5		|c]^=a[		(k-(b+1		))<<5|c]
 ;printf(	a[b<<5|c	]?"%-4d"	:"    "		,a[b<<5
-|c]);}		putchar(	'\n');}}	/*Mike		Laman*/
+|c]);}		putchar(	'\n');}}}	/*Mike		Laman*/

--- a/1992/westley/westley.alt.c
+++ b/1992/westley/westley.alt.c
@@ -1,4 +1,5 @@
-main(l,a,n,d)char**a,**n,**d;{int N=n,D=d;for(D=atoi(a[1])/2*80-atoi(a[2])-2043;
+pain(l,a,n,d)char**a,**n,**d;{int N=n,D=d;for(D=atoi(a[1])/2*80-atoi(a[2])-2043;
 N="bnaBCOCXdBBHGYdAP[A M E R I C A].AqandkmavX|ELC}BOCd"
 [l++-3];)for(;N-->64;)putchar(!D+++33^l&1);}
+main(l,a)char**a;{pain(l,a,0,0);}
 

--- a/1992/westley/westley.c
+++ b/1992/westley/westley.c
@@ -1,7 +1,7 @@
            main(l
-   ,a)char**a;{int n;int
- d;for(d=atoi(a[1])/10*80-
- atoi(a[2])/5-596;n="@NKA\
+  ,a)char**a;{int n;int d;
+if (l>2)for(d=atoi(a[1])/10
+*80-atoi(a[2])/5-596;n="@NKA\
 CLCCGZAAQBEAADAFaISADJABBA^\
 SNLGAQABDAXIMBAACTBATAHDBAN\
 ZcEMMCCCCAAhEIJFAEAAABAfHJE\

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -13,17 +13,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1993 plummer in bugs.md](/bugs.md#1993-plummer).
-
-
 ## To use:
 
 ```sh
@@ -68,11 +57,6 @@ make clobber CDEFINE="-DZ=50" alt
 ```sh
 ./plummer.alt xyzzyzzyx 5555
 ```
-
-### INABIAF - it's not a bug it's a feature :-)
-
-This entry will very likely crash or do something else if you run it without
-enough args.
 
 
 ## Judges' remarks:

--- a/1993/plummer/plummer.alt.c
+++ b/1993/plummer/plummer.alt.c
@@ -1,1 +1,1 @@
-char*_,*O;main(S,l)char**l;{*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1,usleep(Z);_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}
+char*_,*O;main(S,l)char**l;{if(S<3)exit(1);*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1,usleep(Z);_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}

--- a/1993/plummer/plummer.c
+++ b/1993/plummer/plummer.c
@@ -1,1 +1,1 @@
-char*_,*O;main(S,l)char**l;{*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1;_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}
+char*_,*O;main(S,l)char**l;{if(S<3)exit(1);*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1;_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -59,11 +59,11 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DE='exit(1)' -DA=argc
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdlib.h
 
 # Optimization
 #

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -11,17 +11,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1994 horton in bugs.md](/bugs.md#1994-horton).
-
-
 ## To use:
 
 ```sh
@@ -30,12 +19,6 @@ For more detailed information see [1994 horton in bugs.md](/bugs.md#1994-horton)
 
 `A`, `B`, `C` and `D` are numeric arguments.
 
-### INABIAF - it's not a bug it's a feature! :-)
-
-Running this program without enough args will very likely crash or do something
-else.
-
-## Try:
 
 ```sh
 ./horton 3 2 1 0

--- a/1994/horton/horton.c
+++ b/1994/horton/horton.c
@@ -1,6 +1,6 @@
 #define S(r, c) f[r][c] = 1;
 
-char f[96][160]; main(argc, argv) char **argv; { double x, y, atof(); int
+char f[96][160]; main(argc, argv) char **argv; {if(A<5)E;double x, y; int
 r									,
 c									,
 bi									,

--- a/2001/cheong/README.md
+++ b/2001/cheong/README.md
@@ -11,27 +11,11 @@ US\
 make
 ```
 
-
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [2001 cheong in bugs.md](/bugs.md#2001-cheong).
-
-
 ## To use:
 
 ```sh
 ./cheong digits
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-This program will very likely crash or do something different without an arg.
 
 
 ## Try:

--- a/2001/cheong/cheong.c
+++ b/2001/cheong/cheong.c
@@ -11,4 +11,4 @@ c=o+     (D[I]+82)%10-(I>l/2)*
 :!(o=pain(c/10,O,I-1))*((c+999
 )%10-(D[I]+92)%10);}return o;}
 int main(int o,char **O)     {
-return pain(o, O, l);	     }
+return o>1?pain(o, O, l):1;  }

--- a/2001/ollinger/ollinger.c
+++ b/2001/ollinger/ollinger.c
@@ -11,6 +11,7 @@ char e[]="**3<HRZcir+3@OXakt;=GOXds*\?HRZcir*7HNZ`i19JS\\p*H[m1:CJSz*>H[`mr25\
 int main(int j,char *k[]) {
   int a,b,c,d,g,h,i=19;
 
+  if (j<2)exit(1);
   printf("       ");
   for(g=0[f=(char *)calloc(80+(h=atoi(1[k])),1)]=1; g<=h; g++) {
     if ((g>30)&&(f[i-2]+f[i-1]!=0)) i++;

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -16,7 +16,7 @@ make
 The current status of this entry is:
 
 ```
-STATUS: known bug - please help us fix
+STATUS: INABIAF - please **DO NOT** fix
 ```
 
 For more detailed information see [2001 schweikh in bugs.md](/bugs.md#2001-schweikh).

--- a/2001/schweikh/schweikh.c
+++ b/2001/schweikh/schweikh.c
@@ -1,1 +1,1 @@
-main(int c,char**v){return!m(v[1],v[2]);}m(char*s,char*t){return*t-42?*s?63==*t|*s==*t&&m(s+1,t+1):!*t:m(s,t+1)||*s&&m(s+1,t);}
+main(int c,char**v){return c<3?1:!m(v[1],v[2]);}m(char*s,char*t){return*t-42?*s?63==*t|*s==*t&&m(s+1,t+1):!*t:m(s,t+1)||*s&&m(s+1,t);}

--- a/2006/stewart/README.md
+++ b/2006/stewart/README.md
@@ -10,17 +10,6 @@ make
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [2006 stewart in bugs.md](/bugs.md#2006-stewart).
-
-
 ## To use:
 
 ```sh
@@ -47,11 +36,6 @@ where `FILE` is one of:
         pentagon pentagons rings rings2 spirals spirals2 spirals3
         spirals4 squares stars stars2 tree tree2 tree3 tree4 triangle
 
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-This program will very likely crash or do something funny if the file does not
-exist or cannot be opened.
 
 ## Judges' remarks:
 

--- a/2006/stewart/stewart.c
+++ b/2006/stewart/stewart.c
@@ -20,6 +20,7 @@ int main(int c,char**o)
    Z(v,6)=(long)malloc(Z(v,0));
    memset((void*)Z(v,6),0,Z(v,0));
    Z(v,13)=(long)fopen(o[3],"r");
+   if(F(v,13)==NULL)P("file doesn't exist\n"), exit(1);
    fscanf(F(v,13),"%ld",(long*)Y(v,3));
    Z(v,8)=(long)malloc(050+Z(v,3)*070);
    Z(Z(v,8),0)=Z(v,3);

--- a/bugs.md
+++ b/bugs.md
@@ -805,18 +805,6 @@ encourage you to test it. This should not be fixed.
 # 1993
 
 
-## 1993 plummber
-
-### STATUS: known bug - please help us fix
-### Source code: [1993/plummer/plummer.c](1993/plummer/plummer.c)
-### Information: [1993/plummer/README.md](1993/plummer/README.md)
-
-If not enough args are specified this program will likely crash or do something
-else.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 1993 lmfjyh
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -788,19 +788,6 @@ As you might see the part under the `warning:` line is different.
 Can you help us?
 
 
-## 1992 westley
-
-### STATUS: INABIAF - please **DO NOT** fix
-### Source code: [1992/westley/westley.c](1992/westley/westley.c)
-### Information: [1992/westley/README.md](1992/westley/README.md)
-
-This program and the alternate version will very likely crash or
-[nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
-world](https://en.wikipedia.org/wiki/Earth) or just the
-[USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
-args. And not that we need any help with this or anything :-) but we do
-encourage you to test it. This should not be fixed.
-
 
 # 1993
 

--- a/bugs.md
+++ b/bugs.md
@@ -1333,14 +1333,6 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.
 
 ## 2001 ollinger
 
-### STATUS: known bug - please help us fix
-### Source code: [2001/ollinger/ollinger.c](2001/ollinger/ollinger.c)
-### Information: [2001/ollinger/README.md](2001/ollinger/README.md0
-
-This program will very likely crash or do something else without an arg.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/schweikh/schweikh.c](2001/schweikh/schweikh.c)

--- a/bugs.md
+++ b/bugs.md
@@ -1342,21 +1342,14 @@ This program will very likely crash or do something else without an arg.
 If you want to try and fix this (mis)feature, you are welcome to try.
 
 
-## 2001 schweikh
-
-### STATUS: known bug - please help us fix
+### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/schweikh/schweikh.c](2001/schweikh/schweikh.c)
 ### Information: [2001/schweikh/README.md](2001/schweikh/README.md)
 
-This program will very likely crash or do something else if you do not give it
-two args.
-
-Note also that the glob pattern must match the whole string. See the author's
-comments for details and a workaround.
+The glob pattern must match the whole string. See the author's comments for
+details and a workaround.
 
 There's also no way to escape meta characters.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
 
 
 # 2002
@@ -1567,18 +1560,6 @@ Incorrect formulas will ungracefully crash the program.
 
 Fixing the (Mis)feature is likely to be a difficult challenge.
 You are welcome to try and fix it if you can!
-
-
-## 2006 stewart
-
-### STATUS: known bug - please help us fix
-### Source code: [2006/stewart/stewart.c](2006/stewart/stewart.c)
-### Information: [2006/stewart/README.md](2006/stewart/README.md)
-
-This program will very likely crash or do something funny if the file does not
-exist or cannot be opened.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
 
 
 ## 2006 toledo2

--- a/bugs.md
+++ b/bugs.md
@@ -832,18 +832,6 @@ An alternate version, however, does exist. See the README.md file for details.
 # 1994
 
 
-## 1994 horton
-
-### STATUS: known bug - please help us fix
-### Source code: [1994/horton/horton.c](1994/horton/horton.c)
-### Information: [1994/horton/README.md](1994/horton/README.md)
-
-If not enough args are specified this program will likely crash or do something
-else.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 1994 ldb
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -394,19 +394,15 @@ An example where a crash is not a bug: [2019/endoh](2019/endoh/endoh.c) is
 supposed to crash. There are others that are also supposed to crash or that are
 known to segfault but are considered features.
 
-As of 10 April 2023 the definition changed for a second time (the first time was
-07 April 2023). If something is noted by the author as a known bug or limitation
-it need not be fixed **unless it impacts the usability** of the program or **it removes
-instructional value**. An example where a crash undocumented needn't be fixed is
-[1984/laman](1984/laman/laman.c).  On the other hand the fixes made by [Cody
-Boone Ferguson](/winners.html#Cody_Boone_Ferguson) in
-[1990/theorem](1990/theorem/theorem.c) were useful.
+An important note is that if the README.md of the entry has a bug status that
+says it can be fixed it can be. Otherwise it should not be.
 
 Nonetheless we challenge you to fix these entries for educational/instructional
 value and/or enjoyment but we kindly request that you **DO NOT** submit a pull
-request! If you can't figure it out you're invited to look at the git diffs,
-where there are some (some were fixed earlier on but rolled back as both Cody
-and Landon individually felt that the fix was tampering with the entry).
+request unless it's a bug or (mis)feature we would like you to fix! If you can't
+figure it out you're invited to look at the git diffs, where there are some
+(some were fixed earlier on but rolled back as both Cody and Landon individually
+felt that the fix was tampering with the entry).
 
 NOTE: in the case of `gets()` we've fixed some to avoid the warning of the
 compiler, linker or even during runtime, depending on the system. In [some cases
@@ -466,24 +462,15 @@ $ ./decot
 without a newline after the `\`. This is not a bug.
 
 
-## 1984 laman
-
-### STATUS: INABIAF - please **DO NOT** fix
-### Source code: [1984/laman/laman.c](1984/laman/laman.c)
-### Information: [1984/laman/README.md](1984/laman/README.md)
-
-This entry will very likely crash or do something else if you run it without an
-arg. It likely won't do anything at all if the arg is not a positive number.
-
-
 ## 1984 mullender
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1984/mullender/mullender.c](1984/mullender/mullender.c)
 ### Information: [1984/mullender/README.md](1984/mullender/README.md)
 
-Although there are two alt versions added by Cody that will work in modern
-systems, if you do not have a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
+Although there is an alt version and supplementary program added by Cody that
+will work in modern systems, if you do not have a
+[VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
 [PDP-11](https://en.wikipedia.org/wiki/PDP-11) to run the original entry on it
 will not work. See the README.md for details on the alternate versions.
 

--- a/bugs.md
+++ b/bugs.md
@@ -1262,17 +1262,6 @@ and it can be run by itself for fun in modern systems, which was not possible
 before the fixes there.
 
 
-## 2001 cheong
-
-### STATUS: known bug - please help us fix
-### Source code: [2001/cheong/cheong.c](2001/cheong/cheong.c)
-### Information: [2001/cheong/README.md](2001/cheong/README.md)
-
-This program will very likely crash or do something different without an arg.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 2001 dgbeards
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1830,6 +1830,10 @@ the paddles move even when holding down the movement keys.
 Cody also provided an alternate version which lets you use the arrow keys on
 your keyboard instead of the more awkward '`,`' and '`.`'.
 
+## [2001/ollinger](2001/ollinger/ollinger.c) ([README.md](2001/ollinger/README.md))
+
+Cody fixed to not crash if not enough args, exiting 1 instead.
+
 ## [2001/schweikh](2001/schweikh/schweikh.c) ([README.md](2001/schweikh/README.md]))
 
 Cody fixed this to not crash if not enough args as this was not documented by

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1751,6 +1751,7 @@ letter word that would match the format and because it's pain that clang forces
 this. :-) This fix makes a point of the author's notes on portability no longer
 valid, btw.
 
+He also fixed it to check the number of args.
 
 ## [2001/coupard](2001/coupard/coupard.c) ([README.md](2001/coupard/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1289,6 +1289,12 @@ arg (as it was 0 at file scope already this is perfectly fine and it means
 there's no need to cast it to an int in the function call though that would also
 work).
 
+## [1994/horton](1994/horton/horton.c) ([README.md](1994/horton/README.md))
+
+Cody fixed this to check that four args were specified. With the use of the C
+pre-processor macro and inclusion of stdlib.h in the Makefile the layout of the
+source is exactly the same column width and no additional lines were added.
+
 
 ## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1251,9 +1251,11 @@ this was made the alternate version, not the actual entry.
 
 ## [1993/plummer](1993/plummer/plummer.c) ([README.md](1993/plummer/README.md]))
 
-Cody added an [alternate version](1993/plummer/plummer.alt.c) which uses
-`usleep()` so you can see what is happening with faster systems. See the
-README.md files for details.
+Cody added check for two args.
+
+Cody also added an [alternate version](1993/plummer/plummer.alt.c) which uses
+`usleep()` so you can see what is happening with faster systems. This version
+also checks for two args. See the README.md files for details.
 
 
 ## [1993/rince](1993/rince/rince.c) ([README.md](1993/rince/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1209,15 +1209,18 @@ Cody fixed this to work for clang by changing the third and fourth arg of
 **` and some versions do not even allow a fourth arg.
 
 He also added the alternate version that the author gave in the remarks that is
-specifically for the USA rather than the world.
+specifically for the USA rather than the world. This had to be fixed for clang
+as well to make the args of `main()` be the correct type and by moving the body
+of main() to another function, `pain()`, which does the work since not all
+versions of clang support four args to `main()`.
 
-NOTE: as noted in the README.md file and the [bugs.md](/bugs.md), this program and the
-[alternate version](1992/westley/westley.alt.c) will very likely crash or
-[nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
+Cody also added an arg check because the program and the
+[alternate version](1992/westley/westley.alt.c) might have crashed or
+[nuked](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
-args (2). And not that we need the help or anything for this :-) but we do
-encourage you to test this :-) This should NOT be fixed.
+args (2). And not that we need the help or anything for this :-) but we
+encourage you to try the original :-)
 
 
 ## [1993/jonth](1993/jonth/jonth.c) ([README.md](1993/jonth/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -21,9 +21,9 @@ CHALLENGING bug fixes** like
 (all **EXTREMELY CHALLENGING**), fixing entries to work with clang (some being
 **EXTREMELY CHALLENGING** like
 [1991/dds](/thanks-for-fixes.md#1991dds-readmemd)) or as much as possible (like
-[1989/westley](/thanks-for-fixes.md#1989westley-readmemd) which is **INCREDIBLY
-HARD, _MUCH, MUCH MORE SO_ than any other fix!**), porting entries to macOS (some being
-**EXTREMELY CHALLENGING** like
+[1989/westley](/thanks-for-fixes.md#1989westley-readmemd), a true masterpiece
+that is **INCREDIBLY HARD, _MUCH, MUCH MORE SO_ than any other fix!**), porting
+entries to macOS (some being **EXTREMELY CHALLENGING** like
 [1998/schweikh1](/thanks-for-fixes.md#1998schweikh1-readmemd)), fixing code like
 [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd) to work in both
 32-bit/64-bit which *can be* **EXTREMELY CHALLENGING**, providing alternate code
@@ -179,6 +179,15 @@ To see the difference from start to fixed:
 ```sh
 cd 1984/decot ; make diff_orig_prog
 ```
+
+## [1984/laman](1984/laman/laman.c) ([README.md](1984/laman/README.md]))
+
+Cody fixed this to not crash when no arg is specified. Note that if the arg is
+not a positive number it will not do anything useful or anything at all.
+
+This was fixed on 30 October 2023 after the bug status was changed from INABIAF
+(it's not a bug it's a feature) to bug.
+
 
 ## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md]))
 
@@ -1131,7 +1140,7 @@ from stdin after starting the program). Ideally `fgets()` would be used but this
 is a more problematic.  Previously it had a buffer size of 256 which could
 easily overflow. In this entry `gets()` is used in a more complicated way:
 first `m` is set to `*++p` in a for loop where `p` is argv. Later `m` is set to
-point to `h` which was of size \256. `gets()` is called as `m = gets(m)`) but
+point to `h` which was of size 256. `gets()` is called as `m = gets(m)`) but
 trying to change it to use `fgets()` proved more a problem. Since the input must
 come from the command line Cody changed the buffer size to `ARG_MAX+1` which
 should be enough (again theoretically) especially since the command expects
@@ -1139,6 +1148,9 @@ redirecting a dictionary file as part of the command line. This also makes it
 possible for longer strings to be read (in case the `gets()` was not used in a
 loop).
 
+Cody also added the [mkdict.sh](1992/gson/mkdict.sh) script that the author
+included in their remarks. See the README.md for its purpose. It was NOT fixed
+for ShellCheck because the author deliberately obfuscated it.
 
 ## [1992/kivinen](1992/kivinen/kivinen.c) ([README.md](1992/kivinen/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2154,6 +2154,11 @@ Since the author suggested that the lack of certain `#include`s might break the
 program in some systems he added `-include ...` to the Makefile as well.
 
 
+## [2006/stewart](2006/stewart/stewart.c) ([README.md](2006/stewart/README.md]))
+
+Cody fixed it so that if the file cannot be opened it exits rather than trying
+to read from the file.
+
 ## [2006/toledo2](2006/toledo2/toledo2.c) ([README.md](2006/toledo2/README.md]))
 
 Cody fixed a segfault in this program which was making it fail to work under

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1830,6 +1830,12 @@ the paddles move even when holding down the movement keys.
 Cody also provided an alternate version which lets you use the arrow keys on
 your keyboard instead of the more awkward '`,`' and '`.`'.
 
+## [2001/schweikh](2001/schweikh/schweikh.c) ([README.md](2001/schweikh/README.md]))
+
+Cody fixed this to not crash if not enough args as this was not documented by
+the author. The other problems are documented so were not fixed. See
+README.md for details.
+
 
 ## [2001/westley](2001/westley/westley.c) ([README.md](2001/westley/README.md]))
 


### PR DESCRIPTION

For both check args.

For alt move main()'s code to new function as some versions of clang do
not allow four args. Instead main() has two args now, the traditional
argc and argv, and the other two are passed 0.
