### PR TITLE
Make 1991/dds C generated code use fgets()

### DIFF
--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -10,17 +10,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1984 laman in bugs.md](/bugs.md#1984-laman).
-
-
 ## To use:
 
 ```sh

--- a/1984/laman/laman.c
+++ b/1984/laman/laman.c
@@ -1,5 +1,5 @@
 a[900];		b;c;d=1		;e=1;f;		g;h;O;		main(k,
-l)char*		*l;{g=		atoi(*		++l);		for(k=
+l)char*		*l;{if(k>1)	{g=atoi(*	++l);		for(k=
 0;k*k<		g;b=k		++>>1)		;for(h=		0;h*h<=
 g;++h);		--h;c=(		(h+=g>h		*(h+1))		-1)>>1;
 while(d		<=g){		++O;for		(f=0;f<		O&&d<=g
@@ -9,4 +9,4 @@ while(d		<=g){		++O;for		(f=0;f<		O&&d<=g
 b){if(b		<k/2)a[		b<<5|c]		^=a[(k		-(b+1))
 <<5|c]^=	a[b<<5		|c]^=a[		(k-(b+1		))<<5|c]
 ;printf(	a[b<<5|c	]?"%-4d"	:"    "		,a[b<<5
-|c]);}		putchar(	'\n');}}	/*Mike		Laman*/
+|c]);}		putchar(	'\n');}}}	/*Mike		Laman*/

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -67,7 +67,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT= -O3
+OPT=
 
 # Default flags for ANSI C compilation
 #

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -67,7 +67,7 @@ shark.sh, contains a 'jaw.c' embedded within it!
 The sender must have `compress` and `btoa`. To send, try:
 
 ```sh
-sh shark.sh jaw.* README.md > receive
+./shark.sh jaw.* README.md > receive
 ```
 
 The resulting file, `receive`, unpacks the input files
@@ -86,7 +86,7 @@ cmp ../README.md README.md
 ### ABSTRACT
 
 #### Minimal, Universal File Bundling (or, Functional Obfuscation in a Self-Decoding Unix Shell Archive)
-\
+
 James A. Woods\
 Universities Space Research Association\
 NASA Ames Research Center
@@ -94,7 +94,7 @@ NASA Ames Research Center
 ---
 
 > "Use an algorithm, go to jail."
->\
+>
 > -- anon., circa 1988, pre-Morris worm era
 
 ----
@@ -134,7 +134,7 @@ environment.
 >   And he shows them pearly white
 >   Just a jackknife has Macheath, dear--
 >   And he keeps it out of sight.
->\
+>
 >   -- Bertolt Brecht, Threepenny Opera
 
 ----------------------------------------------

--- a/1990/jaw/jaw.c
+++ b/1990/jaw/jaw.c
@@ -1,5 +1,5 @@
 #define C char
-#define F X,perror("oops"),1
+#define F X,fprintf(stderr,"oops\n"),1
 #define G getchar()
 #define I ;if(
 #define P putchar

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -11,16 +11,16 @@ for i in "${@?${usage?$0 file...}}";do<"$i"||exit;done
 #
 PATH=$PATH:. a=atob m=unshark z=zcat
 r="rm -f $a $m* $z" v="cc -Wno-implicit-function-declaration -o $z $m.c"
-trap "$r;exit 1" 1 2 13 15
+trap '$r;exit 1' 1 2 13 15
 echo decoding...
-(:|compress|./btoa|$a|$z)2>$m>&2||(sed '1,9s/./#define & /
+(:|compress|./btoa|./$a|./$z)2>$m>&2||(sed '1,9s/./#define & /
 s/@/[w]/g
 s/C/char /g
 s/I/;if(/g
 s/W/;while(/g
 s/Y/%lx /g
 s/}/;}/g'>$m.c<<_&&
-FX,perror("$m bite: resend"),1;
+FX,fprintf(stderr,"$m bite: resend\n"),1;
 GgetC()
 H(w=g())
 K[69001]
@@ -43,5 +43,5 @@ Z,h@=w;n=8;f=Q+e;i=o=HIo<0)X,1;P(i)WH+1){Iw==Q&e){Z;m=n=8;f=QIH<0)X}
 c=wIw>=f)U++=i,w=oWw>=Q)U++=h@,w=t@;P(i=h@)Wp>D+Q)P(*--p)
 I(w=f)<1l<<k)t@=o,h[f++]=i;o=c}X}
 _
-($v)&&ln $z $a)&&$a<<\w>$m-&&$z<$m->$m&&tar xvf $m&&$r
+($v)&&ln -f $z $a)&&./$a<<\w>./$m-&&./$z<./$m->./$m&&tar xvf ./$m&&$r
 Z

--- a/1990/jaw/try.sh
+++ b/1990/jaw/try.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo "Running shark.sh:"
+sh shark.sh README.md jaw.c README.md > receive || exit 1
+echo "Done."
+
+echo "Attempting to extract files:"
+
+mkdir -p test
+cd test
+sh ../receive

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -15,30 +15,13 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1990 westley in bugs.md](/bugs.md#1990-westley).
-
-
 ## To use:
 
 ```sh
-./westley number
+./westley <number
 ```
 
-
-### INABIAF - it's not a bug it's a feature :-)
-
-This entry will very likely crash or do something else without an arg.
-
-This program will enter an infinite loop if input is not a number > 0.
-
+The number should be greater than 0.
 
 ## Try:
 

--- a/1990/westley/westley.c
+++ b/1990/westley/westley.c
@@ -11,6 +11,7 @@ char*lie;
 
 dear; (char)lotte--;
 
+	if (ly < 2 || atoi(die[1])<1) exit(1);
 	for(get= !me;; not){
 
 	1 -  out & out ;lie;{

--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -13,17 +13,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: INABIAF - please **DO NOT** fix
-STATUS: uses gets() - change to fgets() if possible
-```
-
-For more detailed information see [1991 dds in bugs.md](/bugs.md#1991-dds).
-
 
 ## To use:
 

--- a/1991/dds/dds.c
+++ b/1991/dds/dds.c
@@ -11,8 +11,8 @@ aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)hfut)c**aHb%JD12JON1!Qjg)a%LN1UP1D12JIQUa\
 P1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssps!.Xop.sfu\
 vso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!b/d";int k;char R[4][99]
 ;main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*q)--;{FILE*i=fopen(v
-[1],"r"),*o=fopen(q-3,"w");for(p=s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF
-&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return system(q-69);}*r=0
-B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0'
-)(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(
-*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}
+[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p++)switch(*p++){B'M':
+Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return
+system(q-69);}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--
+B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G'
+:k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}

--- a/1991/dds/dds.c
+++ b/1991/dds/dds.c
@@ -7,12 +7,13 @@ o)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<aN2!Q\
 Qs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQUaP1H\
 R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
 \\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
-aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)hfut)c**aHb%JD12JON1!Qjg)a%LN1UP1D12JIQUa\
-P1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssps!.Xop.sfu\
-vso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!b/d";int k;char R[4][99]
-;main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*q)--;{FILE*i=fopen(v
-[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p++)switch(*p++){B'M':
-Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n",o);fclose(o);return
-system(q-69);}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--
-B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G'
-:k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'][0]++;}}}
+aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
+P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
+s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.jodmvef!tuejp/i!b/d";
+int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*
+q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p
+++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n"
+,o);fclose(o);return system(q-86);}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':
+Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;
+if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'
+][0]++;}}}

--- a/1992/buzzard.1/README.md
+++ b/1992/buzzard.1/README.md
@@ -1,9 +1,6 @@
 # Most Obfuscated Algorithm
 
 Sean Barrett\
-Software Construction Company\
-430 Southwest Parkway, #1906\
-College Station, TX 77840\
 US
 
 
@@ -12,17 +9,6 @@ US
 ```sh
 make all
 ```
-
-
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1992 buzzard.1 in bugs.md](/bugs.md#1992-buzzard.1).
 
 
 ## To use:

--- a/1992/buzzard.1/buzzard.1.c
+++ b/1992/buzzard.1/buzzard.1.c
@@ -1,7 +1,7 @@
 #define A(c,a,b) t=b;t+=a;_(c)
 #define	B(b,a) P(u,a)t=0;t-=a;R t+=u;t+=1;t/=2;_(b)
 #define b(x) x(g)
-#define C ;main(argc,argv)char**argv;{for(;!w;){q=0;l
+#define C ;main(argc,argv)char**argv;{if(argc<3)exit(1);for(;!w;){q=0;l
 #define c(y) x
 #define D(c,a,b) t=a;t/=b;_(c)
 #define d(x) S(x,x,1)

--- a/1992/gson/README.md
+++ b/1992/gson/README.md
@@ -1,9 +1,6 @@
 # Most Humorous Output
 
 Andreas Gustafsson\
-Helsinki University of Technology\
-Arentikuja 1 D 305\
-00410 Helsinki\
 Finland
 
 
@@ -69,16 +66,16 @@ The name of the game:
 AG is short for either Anagram Generator or simply AnaGram.  It might also be
 construed to mean Alphabet Game, and by pure coincidence it happens to be the
 author's initials.
-\
-\
+
+
 ### What it does
-\
+
 AG takes one or more words as arguments, and tries to find anagrams of those
 words, i.e. words or sentences containing exactly the same letters.
 
 
 ### How to use it
-\
+
 To run AG, you need a dictionary file consisting of distinct words in the
 natural language of your choice, one word on each line.  If your machine doesn't
 have one already, you can make your own dictionary by concatenating a few
@@ -102,7 +99,7 @@ limit can be changed using a numeric command line option, as in
 `./ag -4 international obfuscated c code contest </usr/dict/words`.
 
 ### Bugs
-\
+
 - There is no error checking.
 - Standard input must be seekable, so you can't pipe the dictionary into AG.
 - The input sentence and each line in the dictionary may contain at most 32
@@ -115,8 +112,8 @@ less.
 
 
 ### Obfuscatory notes
-\
-As you can see, AG takes advantage of the new '92 whitespace rules to
+
+As you can see, AG takes advantage of the new '92 whitespace rules' to
 achieve a clear, readable, self-documenting layout.  The identifiers
 have been chosen in a way appropriate for an alphabet game, and common
 sources of bugs such as goto statements and malloc/free have been
@@ -124,135 +121,139 @@ eliminated.  As AG also refrains from abusing the preprocessor, it
 doesn't really have much to offer in terms of "surface obfuscation".
 Instead, it tries to achieve both its speed and its obscurity through a
 careful choice of algorithms.  Some of the finer points of those
-algorithms are outlined in the rot-13 encoded spoiler below.
+algorithms are outlined in the spoiler below.
 
 ### How it works:  (ROT13 to read)
 
+Here follows a description of some of the data structures and
+algorithms used by AG.  It is by no means complete, but it may help
+you get an idea about the general principles.
 
-	Urer sbyybjf n qrfpevcgvba bs fbzr bs gur qngn fgehpgherf naq
-	nytbevguzf hfrq ol NT.  Vg vf ol ab zrnaf pbzcyrgr, ohg vg znl uryc
-	lbh trg na vqrn nobhg gur trareny cevapvcyrf.
-\
-	--
-\
-	Vagreanyyl, NT ercerfragf jbeqf naq fragraprf nf neenlf bs 32
-	4-ovg vagrtre ryrzragf.  Rnpu ryrzrag ercerfragf gur ahzore bs
-	gvzrf n yrggre bpphef va gur jbeq/fragrapr.  Gurer ner 32 ryrzragf
-	orpnhfr 32 vf n pbairavrag cbjre bs gjb ynetre guna gur ahzore bs
-	yrggref va zbfg jrfgrea nycunorgf, naq gur ryrzragf ner 4 ovgf
-	rnpu orpnhfr gur fnzr yrggre vf hayvxryl gb bpphe zber guna 15
-	gvzrf va n cenpgvpny nantenz trarengvba ceboyrz.
-\
-	Gurfr 32*4-ovg neenlf ner npghnyyl fgberq va zrzbel va n
-	"ovg-genafcbfrq" sbezng, nf neenlf bs sbhe "ybat" inyhrf.  Vg vf
-	nffhzrq gung n "ybat" vf ng yrnfg 32 ovgf.  Gur svefg 4-ovg yrggre
-	pbhag vf sbezrq ol gur yrnfg fvtavsvpnag (2^0) ovg va rnpu bs gur
-	sbhe ybatf, gur arkg bar vf sbezrq ol gur 2^1 ovgf, rgp.
-\
-	Guvf fgbentr sbezng znxrf vg cbffvoyr gb nqq be fhogenpg gjb fhpu
-	irpgbef bs 32 4-ovg inyhrf va cnenyyry ol fvzhyngvat n frg bs 32
-	ovanel shyy nqqref va fbsgjner hfvat ovgjvfr ybtvpny bcrengvbaf.
-	R.t., nyy gur YFO:f bs gur erfhyg ner sbezrq va cnenyyry ol gnxvat
-	gur rkpyhfvir BE bs gur YFO:f va rnpu fhzznaq, naq 32 pneel ovgf
-	ner sbezrq va cnenyyry va n fvzvyne jnl hfvat n ybtvpny NAQ.
-	Guhf, 32 vaqrcraqrag 4-ovg nqqvgvbaf pna or cresbezrq ol whfg sbhe
-	vgrengvbaf bs n ybbc pbagnvavat fbzr 32-ovg ovgjvfr ybtvpny
-	bcrengvbaf, ohg ab nevguzrgvp bcrengvbaf bgure guna gubfr vzcyvrq
-	ol neenl vaqrkvat.
-\
-	Fhogenpgvba jbexf fvzvyneyl, naq va snpg NT bayl vzcyrzragf
-	fhogenpgvba qverpgyl, unaqyvat nqqvgvba ol zrnaf bs gur vqragvgl
-	n+o = n-(0-o).
-\
-	Va nqqvgvba gb guvf 32*4-ovg ercerfragngvba, NT nyfb sbezf n fb-pnyyrq
-	"fvtangher" gung vf gur ovgjvfr BE bs gur sbhe ybatf, juvpu vf
-	rdhvinyrag gb fnlvat gung gur fvtangher bs n jbeq pbagnvaf n ybtvpny 1
-	va gur ovg cbfvgvbaf pbeerfcbaqvat gb yrggref bppheevat ng yrnfg bapr
-	va gung jbeq.
-\
-	Gur svefg guvat NT qbrf vf gb pbafgehpg n ybbxhc gnoyr bs 256
-	ybatf, bar sbe rnpu 8-ovg punenpgre inyhr.  Gur ragel sbe n
-	punenpgre jvyy or mreb vs gung punenpgre qbrfa'g nccrne va gur
-	fragrapr tvira ba gur pbzznaq yvar, be vg jvyy unir n fvatyr ovg
-	frg vs gur punenpgre qbrf nccrne va gur fragrapr.  Ol nqqvat
-	gbtrgure gur ovg znfxf sbe nyy gur yrggref va gur vachg fragrapr
-	hfvat gur genafcbfr nqqvgvba zrgubq qrfpevorq nobir, NT sbezf gur
-	32*4 ovg neenl ercerfragngvba bs gur vachg fragrapr.
-\
-	Gur arkg npgvba cresbezrq vf ernqvat gur qvpgvbanel.  Gubfr jbeqf gung
-	pbagnva yrggref abg va gur vachg fragrapr ner vzzrqvngryl qvfpneqrq.
-	Jbeqf pbagnvavat gur evtug yrggref ohg va rkprffvir ahzoref ner
-	ryvzvangrq va n frcnengr purpx vaibyivat gur 32*4 ovg neenl.
-\
-	Gur erznvavat jbeqf, juvpu jvyy or ersreerq gb nf "pnaqvqngr jbeqf",
-	ner fgberq va 32*4-ovg ercerfragngvba, gbtrgure jvgu gurve fvtangherf\
-	naq bssfrgf vagb gur qvpgvbanel svyr fb gung gur cynva-grkg irefvba bs
-	n jbeq pna yngre or sbhaq sbe cevagvat.  Guvf vasbezngvba vf xrcg va n
-	ybpny "fgehpg" va gur qvpgvbanel-ernqvat shapgvba, naq zrzbel vf
-	nyybpngrq sbe rnpu pnaqvqngr jbeq fvzcyl ol znxvat nabgure erphefvir
-	pnyy gb gung shapgvba.
-\
-	Rnpu fgehpg fb nyybpngrq vf yvaxrq vagb n svkrq-fvmr unfu gnoyr bs
-	4096 ragevrf vaqrkrq ol gur 12 ybj ovgf bs gur jbeq'f fvtangher.\
-	Jura gur qvpgvbanel-ernqvat shapgvba rapbhagref raq-bs-svyr, nyy gur
-	pnaqvqngr jbeqf unir orra fgberq va arfgrq npgvingvba erpbeqf ba gur
-	fgnpx, npprffvoyr guebhtu gur unfu gnoyr.
-\
-	Trarengvat gur nantenzf vf gura qbar ol genirefvat gur unfu gnoyr naq
-	fhogenpgvat gur yrggref bs rnpu jbeq va gur unfu gnoyr sebz gur
-	"pheerag fragrapr", juvpu vavgvnyyl vf gur fragrapr tvira ba gur
-	pbzznaq yvar.
-\
-	Gur fhogenpgvba vf cresbezrq va cnenyyry ba gur 4-ovg yrggre pbhagf
-	nf qrfpevorq nobir, naq vs nyy 32 erfhygf ner mreb, na nantenz unf
-	orra sbhaq.  Vs gur erfhyg vf artngvir sbe bar be zber bs gur yrggref
-	(nf vaqvpngrq ol bar be zber "1" va n irpgbe bs 32 obeebj ovgf
-	erghearq ol gur fhogenpgvba ebhgvar), gur jbeq qvq abg zngpu gur
-	pheerag fragrapr naq vf vtaberq.  Svanyyl, vs gur erfhyg pbagnvarq
-	bayl abaartngvir yrggre pbhagf, jr unir sbhaq n cnegvny nantenz:\
-	n jbeq pbagnvavat fbzr, ohg abg nyy, bs gur yrggref va gur pheerag
-	fragrapr.  Va guvf pnfr jr erphefviryl gel gb svaq na nantenz bs gur
-	erznvavat yrggref.  Gur qrcgu bs gur erphefvba vf yvzvgrq gb gur
-	znkvzhz ahzore bs jbeqf va gur nantenz, nf fcrpvsvrq ol gur hfre.
-\
-	Jura gur qrrcrfg erphefvba yriry unf orra ernpurq, na bcgvzvmngvba pna
-	or nccyvrq: orpnhfr ab shegure erphefvba jvyy or qbar, gurer vf ab
-	arrq gb ybbx sbe cnegvny nantenzf, naq gurersber NT bayl arrqf gb
-	purpx sbe jbeqf gung pbagnva rknpgyl gur fnzr yrggref nf gur pheerag
-	fragrapr.  Gubfr jbeqf pna or sbhaq fvzcyl ol vaqrkvat gur unfu gnoyr
-	jvgu gur fvtangher bs gur pheerag fragrapr.
-\
-	Rira jura abg ba gur qrrcrfg erphefvba yriry, NT trarenyyl nibvqf
-	rknzvavat nyy gur ragevrf bs gur unfu gnoyr.  Gur vqrn vf gung jr ner
-	abg vagrerfgrq va unfu ohpxrgf jubfr jbeqf pbagnva nal yrggref abg
-	va gur pheerag fragrapr; gurfr ohpxrgf ner rknpgyl gubfr jubfr vaqrk
-	unf n ybtvpny bar va n ovg cbfvgvba jurer gur fvtangher bs gur pheerag
-	fragrapr unf n mreb.  Chg nabgure jnl, jr jnag gb ybbc guebhtu bayl
-	gubfr unfu ohpxrg vaqvprf "v" gung pbagnva mrebrf va nyy gur ovg
-	cbfvgvbaf jurer gur fvtangher "f" bs gur pheerag fragrapr pbagnvaf
-	n mreb; guvf pna or rkcerffrq va P nf (v & ~f == 0).
-\
-	Vg vf cbffvoyr gb ybbc guebhtu nyy fhpu ahzoref va na rssvpvrag jnl ol
-	gnxvat nqinagntr bs pregnva cebcregvrf bs ovanel nevguzrgvp: ol
-	sbepvat gur ovgf pbeerfcbaqvat gb mrebrf va "f" gb barf, jr pna znxr
-	gur pneevrf trarengrq va vaperzragvat "v" cebcntngr fgenvtug npebff
-	gubfr ovgf gung fubhyq erznva mreb.  Sbe rknzcyr, gur sbyybjvat
-	cebtenz cevagf nyy gubfr 16-ovg vagrtref gung pbagnva mrebrf va nyy
-	rira ovg cbfvgvbaf:
-\
-	    znva(){vag v=0,f=0kNNNN;qb{cevags("%04k\g",v);}juvyr(v=((v|~f)+1)&f);}
-\
-	NT hfrf n fvzvyne zrgubq ohg jbexf va gur bccbfvgr qverpgvba, svaqvat
-	gur arkg ybjre inyhr jvgu mrebrf va tvira ovg cbfvgvbaf ol cebcntngvat
-	obeebjf npebff gubfr ovgf.  Fbzr nqqvgvbany nqwhfgzragf ner znqr
-	gb gur unfu gnoyr vaqrk jura vavgvngvat n erphefvir frnepu, hfvat
-	fvzvyne ovg-gjvqqyvat grpuavdhrf.
-\
-	Jurarire na nantenz unf orra sbhaq, vg vf cevagrq ol genirefvat n
-	yvaxrq yvfg sbezrq ol fgehpgf va gur npgvingvba erpbeqf bs gur
-	erphefvir vaibpngvbaf bs gur frnepu shapgvba, frrxvat gb gur ortvaavat
-	bs gur jbeq zngpurq ol gung vaibpngvba, naq pbclvat gur punenpgref bs
-	gur jbeq qverpgyl sebz fgnaqneq vachg gb fgnaqneq bhgchg.
+--
+
+Internally, AG represents words and sentences as arrays of 32
+4-bit integer elements.  Each element represents the number of
+times a letter occurs in the word/sentence.  There are 32 elements
+because 32 is a convenient power of two larger than the number of
+letters in most western alphabets, and the elements are 4 bits
+each because the same letter is unlikely to occur more than 15
+times in a practical anagram generation problem.
+
+These `32*4`-bit arrays are actually stored in memory in a
+"bit-transposed" format, as arrays of four "long" values.  It is
+assumed that a "long" is at least 32 bits.  The first 4-bit letter
+count is formed by the least significant (2^0) bit in each of the
+four longs, the next one is formed by the 2^1 bits, etc.
+
+This storage format makes it possible to add or subtract two such
+vectors of 32 4-bit values in parallel by simulating a set of 32
+binary full adders in software using bitwise logical operations.
+E.g., all the LSB:s of the result are formed in parallel by taking
+the exclusive OR of the LSB:s in each summand, and 32 carry bits
+are formed in parallel in a similar way using a logical AND.
+Thus, 32 independent 4-bit additions can be performed by just four
+iterations of a loop containing some 32-bit bitwise logical
+operations, but no arithmetic operations other than those implied
+by array indexing.
+
+Subtraction works similarly, and in fact AG only implements
+subtraction directly, handling addition by means of the identity
+`a+b = a-(0-b)`.
+
+In addition to this `32*4`-bit representation, AG also forms a so-called
+"signature" that is the bitwise OR of the four longs, which is
+equivalent to saying that the signature of a word contains a logical 1
+in the bit positions corresponding to letters occurring at least once
+in that word.
+
+The first thing AG does is to construct a lookup table of 256
+longs, one for each 8-bit character value.  The entry for a
+character will be zero if that character doesn't appear in the
+sentence given on the command line, or it will have a single bit
+set if the character does appear in the sentence.  By adding
+together the bit masks for all the letters in the input sentence
+using the transpose addition method described above, AG forms the
+`32*4` bit array representation of the input sentence.
+
+The next action performed is reading the dictionary.  Those words that
+contain letters not in the input sentence are immediately discarded.
+Words containing the right letters but in excessive numbers are
+eliminated in a separate check involving the `32*4` bit array.
+
+The remaining words, which will be referred to as "candidate words",
+are stored in `32*4`-bit representation, together with their signatures\
+and offsets into the dictionary file so that the plain-text version of
+a word can later be found for printing.  This information is kept in a
+local "struct" in the dictionary-reading function, and memory is
+allocated for each candidate word simply by making another recursive
+call to that function.
+
+Each struct so allocated is linked into a fixed-size hash table of
+4096 entries indexed by the 12 low bits of the word's signature.\
+When the dictionary-reading function encounters end-of-file, all the
+candidate words have been stored in nested activation records on the
+stack, accessible through the hash table.
+
+Generating the anagrams is then done by traversing the hash table and
+subtracting the letters of each word in the hash table from the
+"current sentence", which initially is the sentence given on the
+command line.
+
+The subtraction is performed in parallel on the 4-bit letter counts
+as described above, and if all 32 results are zero, an anagram has
+been found.  If the result is negative for one or more of the letters
+(as indicated by one or more "1" in a vector of 32 borrow bits
+returned by the subtraction routine), the word did not match the
+current sentence and is ignored.  Finally, if the result contained
+only non-negative letter counts, we have found a partial anagram:\
+a word containing some, but not all, of the letters in the current
+sentence.  In this case we recursively try to find an anagram of the
+remaining letters.  The depth of the recursion is limited to the
+maximum number of words in the anagram, as specified by the user.
+
+When the deepest recursion level has been reached, an optimization can
+be applied: because no further recursion will be done, there is no
+need to look for partial anagrams, and therefore AG only needs to
+check for words that contain exactly the same letters as the current
+sentence.  Those words can be found simply by indexing the hash table
+with the signature of the current sentence.
+
+Even when not on the deepest recursion level, AG generally avoids
+examining all the entries of the hash table.  The idea is that we are
+not interested in hash buckets whose words contain any letters not
+in the current sentence; these buckets are exactly those whose index
+has a logical one in a bit position where the signature of the current
+sentence has a zero.  Put another way, we want to loop through only
+those hash bucket indices "i" that contain zeroes in all the bit
+positions where the signature "s" of the current sentence contains
+a zero; this can be expressed in C as (i & ~s == 0).
+
+It is possible to loop through all such numbers in an efficient way by
+taking advantage of certain properties of binary arithmetic: by
+forcing the bits corresponding to zeroes in "s" to ones, we can make
+the carries generated in incrementing "i" propagate straight across
+those bits that should remain zero.  For example, the following
+program prints all those 16-bit integers that contain zeroes in all
+even bit positions:
+
+
+```c
+main(){int i=0,s=0xAAAA;do{printf("%04x\t",i);}while(i=((i|~s)+1)&s);}
+```
+
+
+AG uses a similar method but works in the opposite direction, finding
+the next lower value with zeroes in given bit positions by propagating
+borrows across those bits.  Some additional adjustments are made
+to the hash table index when initiating a recursive search, using
+similar bit-twiddling techniques.
+
+Whenever an anagram has been found, it is printed by traversing a
+linked list formed by structs in the activation records of the
+recursive invocations of the search function, seeking to the beginning
+of the word matched by that invocation, and copying the characters of
+the word directly from standard input to standard output.
+
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1992/westley/westley.alt.c
+++ b/1992/westley/westley.alt.c
@@ -1,4 +1,5 @@
-main(l,a,n,d)char**a,**n,**d;{int N=n,D=d;for(D=atoi(a[1])/2*80-atoi(a[2])-2043;
+pain(l,a,n,d)char**a,**n,**d;{int N=n,D=d;for(D=atoi(a[1])/2*80-atoi(a[2])-2043;
 N="bnaBCOCXdBBHGYdAP[A M E R I C A].AqandkmavX|ELC}BOCd"
 [l++-3];)for(;N-->64;)putchar(!D+++33^l&1);}
+main(l,a)char**a;{pain(l,a,0,0);}
 

--- a/1992/westley/westley.c
+++ b/1992/westley/westley.c
@@ -1,7 +1,7 @@
            main(l
-   ,a)char**a;{int n;int
- d;for(d=atoi(a[1])/10*80-
- atoi(a[2])/5-596;n="@NKA\
+  ,a)char**a;{int n;int d;
+if (l>2)for(d=atoi(a[1])/10
+*80-atoi(a[2])/5-596;n="@NKA\
 CLCCGZAAQBEAADAFaISADJABBA^\
 SNLGAQABDAXIMBAACTBATAHDBAN\
 ZcEMMCCCCAAhEIJFAEAAABAfHJE\

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -13,17 +13,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1993 plummer in bugs.md](/bugs.md#1993-plummer).
-
-
 ## To use:
 
 ```sh
@@ -68,11 +57,6 @@ make clobber CDEFINE="-DZ=50" alt
 ```sh
 ./plummer.alt xyzzyzzyx 5555
 ```
-
-### INABIAF - it's not a bug it's a feature :-)
-
-This entry will very likely crash or do something else if you run it without
-enough args.
 
 
 ## Judges' remarks:

--- a/1993/plummer/plummer.alt.c
+++ b/1993/plummer/plummer.alt.c
@@ -1,1 +1,1 @@
-char*_,*O;main(S,l)char**l;{*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1,usleep(Z);_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}
+char*_,*O;main(S,l)char**l;{if(S<3)exit(1);*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1,usleep(Z);_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}

--- a/1993/plummer/plummer.c
+++ b/1993/plummer/plummer.c
@@ -1,1 +1,1 @@
-char*_,*O;main(S,l)char**l;{*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1;_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}
+char*_,*O;main(S,l)char**l;{if(S<3)exit(1);*(O=*(l+++S-1)-1)=13,*l[1]=0;for(;;)for(printf(*l),_=O-1;_>=*l&&++*_>(S+*O+S)*S;*_--=(S+*O)*S);}

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -59,11 +59,11 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DE='exit(1)' -DA=argc
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdlib.h
 
 # Optimization
 #

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -11,17 +11,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1994 horton in bugs.md](/bugs.md#1994-horton).
-
-
 ## To use:
 
 ```sh
@@ -30,12 +19,6 @@ For more detailed information see [1994 horton in bugs.md](/bugs.md#1994-horton)
 
 `A`, `B`, `C` and `D` are numeric arguments.
 
-### INABIAF - it's not a bug it's a feature! :-)
-
-Running this program without enough args will very likely crash or do something
-else.
-
-## Try:
 
 ```sh
 ./horton 3 2 1 0

--- a/1994/horton/horton.c
+++ b/1994/horton/horton.c
@@ -1,6 +1,6 @@
 #define S(r, c) f[r][c] = 1;
 
-char f[96][160]; main(argc, argv) char **argv; { double x, y, atof(); int
+char f[96][160]; main(argc, argv) char **argv; {if(A<5)E;double x, y; int
 r									,
 c									,
 bi									,

--- a/2001/cheong/README.md
+++ b/2001/cheong/README.md
@@ -11,27 +11,11 @@ US\
 make
 ```
 
-
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [2001 cheong in bugs.md](/bugs.md#2001-cheong).
-
-
 ## To use:
 
 ```sh
 ./cheong digits
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-This program will very likely crash or do something different without an arg.
 
 
 ## Try:

--- a/2001/cheong/cheong.c
+++ b/2001/cheong/cheong.c
@@ -11,4 +11,4 @@ c=o+     (D[I]+82)%10-(I>l/2)*
 :!(o=pain(c/10,O,I-1))*((c+999
 )%10-(D[I]+92)%10);}return o;}
 int main(int o,char **O)     {
-return pain(o, O, l);	     }
+return o>1?pain(o, O, l):1;  }

--- a/2001/ollinger/ollinger.c
+++ b/2001/ollinger/ollinger.c
@@ -11,6 +11,7 @@ char e[]="**3<HRZcir+3@OXakt;=GOXds*\?HRZcir*7HNZ`i19JS\\p*H[m1:CJSz*>H[`mr25\
 int main(int j,char *k[]) {
   int a,b,c,d,g,h,i=19;
 
+  if (j<2)exit(1);
   printf("       ");
   for(g=0[f=(char *)calloc(80+(h=atoi(1[k])),1)]=1; g<=h; g++) {
     if ((g>30)&&(f[i-2]+f[i-1]!=0)) i++;

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -16,7 +16,7 @@ make
 The current status of this entry is:
 
 ```
-STATUS: known bug - please help us fix
+STATUS: INABIAF - please **DO NOT** fix
 ```
 
 For more detailed information see [2001 schweikh in bugs.md](/bugs.md#2001-schweikh).

--- a/2001/schweikh/schweikh.c
+++ b/2001/schweikh/schweikh.c
@@ -1,1 +1,1 @@
-main(int c,char**v){return!m(v[1],v[2]);}m(char*s,char*t){return*t-42?*s?63==*t|*s==*t&&m(s+1,t+1):!*t:m(s,t+1)||*s&&m(s+1,t);}
+main(int c,char**v){return c<3?1:!m(v[1],v[2]);}m(char*s,char*t){return*t-42?*s?63==*t|*s==*t&&m(s+1,t+1):!*t:m(s,t+1)||*s&&m(s+1,t);}

--- a/2006/stewart/README.md
+++ b/2006/stewart/README.md
@@ -10,17 +10,6 @@ make
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [2006 stewart in bugs.md](/bugs.md#2006-stewart).
-
-
 ## To use:
 
 ```sh
@@ -47,11 +36,6 @@ where `FILE` is one of:
         pentagon pentagons rings rings2 spirals spirals2 spirals3
         spirals4 squares stars stars2 tree tree2 tree3 tree4 triangle
 
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-This program will very likely crash or do something funny if the file does not
-exist or cannot be opened.
 
 ## Judges' remarks:
 

--- a/2006/stewart/stewart.c
+++ b/2006/stewart/stewart.c
@@ -20,6 +20,7 @@ int main(int c,char**o)
    Z(v,6)=(long)malloc(Z(v,0));
    memset((void*)Z(v,6),0,Z(v,0));
    Z(v,13)=(long)fopen(o[3],"r");
+   if(F(v,13)==NULL)P("file doesn't exist\n"), exit(1);
    fscanf(F(v,13),"%ld",(long*)Y(v,3));
    Z(v,8)=(long)malloc(050+Z(v,3)*070);
    Z(Z(v,8),0)=Z(v,3);

--- a/bugs.md
+++ b/bugs.md
@@ -805,18 +805,6 @@ encourage you to test it. This should not be fixed.
 # 1993
 
 
-## 1993 plummber
-
-### STATUS: known bug - please help us fix
-### Source code: [1993/plummer/plummer.c](1993/plummer/plummer.c)
-### Information: [1993/plummer/README.md](1993/plummer/README.md)
-
-If not enough args are specified this program will likely crash or do something
-else.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 1993 lmfjyh
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -634,19 +634,6 @@ will enter an infinite loop, printing 0 over and over again; another condition
 where this occurred was fixed but this one should not be fixed. Thank you.
 
 
-## 1990 westley
-
-### STATUS: known bug - please help us fix
-### Source code: [1990/westley/westley.c](1990/westley/westley.c)
-### Information: [1990/westley/README.md](1990/westley/README.md)
-
-This entry will very likely crash or do something strange without an arg.
-
-This entry will also enter an infinite loop if input is not a number > 0.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 # 1991
 
 

--- a/bugs.md
+++ b/bugs.md
@@ -788,19 +788,6 @@ As you might see the part under the `warning:` line is different.
 Can you help us?
 
 
-## 1992 westley
-
-### STATUS: INABIAF - please **DO NOT** fix
-### Source code: [1992/westley/westley.c](1992/westley/westley.c)
-### Information: [1992/westley/README.md](1992/westley/README.md)
-
-This program and the alternate version will very likely crash or
-[nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
-world](https://en.wikipedia.org/wiki/Earth) or just the
-[USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
-args. And not that we need any help with this or anything :-) but we do
-encourage you to test it. This should not be fixed.
-
 
 # 1993
 

--- a/bugs.md
+++ b/bugs.md
@@ -688,16 +688,6 @@ possibility. Can you find out how?
 
 # 1992
 
-## 1992 buzzard.1
-
-### STATUS: known bug - please help us fix
-### Source code: [1992/buzzard.1/buzzard.1.c](1992/buzzard.1/buzzard.1.c)
-### Information: [1992/buzzard.1/README.md](1992/buzzard.1/README.md)
-
-This entry will crash without enough args (2).
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
 
 ## 1992 kivinen
 

--- a/bugs.md
+++ b/bugs.md
@@ -579,46 +579,11 @@ You are welcome to try and fix it if you can!
 ### Source code: [1990/jaw/jaw.c](1990/jaw/jaw.c)
 ### Information: [1990/jaw/README.md](1990/jaw/README.md)
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed the scripts to
-work in modern systems. He notes however that the command in the try section,
-the one to test the official C entry, **appears** (the keyword!) to not work
-with macOS, giving:
-
-
-```sh
-$ echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
-oops: Undefined error: 0
-oops: Undefined error: 0
-```
-
-However this is because the entry uses `perror()` and it just so happens that
-the default `errno` of 0 gives that result. For instance if you run the
-following C program under macOS you will get undefined error but if you do it
-under Linux you'll likely get success.
-
-
-```c
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-int main()
-{
-    errno = 0;
-    printf("%d, %s\n", errno, strerror(errno));
-}
-```
-
-In fact the condition which is in the `a()` function on line 18 of the entry
-namely:
-
-	I k>16)
-
-is true on both linux and macOS, with `k` being equal to 22!
-
-Should the entry use `perror()`? Perhaps not but we're not sure of its purpose
-so it should stay with this note.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
+It seems like the scripts do not work correctly, where not all files are
+extracted. Some work was done to get them to work some but it does not appear
+that all files can be extracted. For instance in the [try.sh](1990/jaw/try.sh)
+script which Cody added it is supposed to add the README.md file to the archive
+and it did at one point (or so he recalls) but now it doesn't seem to happen.
 
 
 ## 1990 theorem

--- a/bugs.md
+++ b/bugs.md
@@ -1333,14 +1333,6 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.
 
 ## 2001 ollinger
 
-### STATUS: known bug - please help us fix
-### Source code: [2001/ollinger/ollinger.c](2001/ollinger/ollinger.c)
-### Information: [2001/ollinger/README.md](2001/ollinger/README.md0
-
-This program will very likely crash or do something else without an arg.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/schweikh/schweikh.c](2001/schweikh/schweikh.c)

--- a/bugs.md
+++ b/bugs.md
@@ -1342,21 +1342,14 @@ This program will very likely crash or do something else without an arg.
 If you want to try and fix this (mis)feature, you are welcome to try.
 
 
-## 2001 schweikh
-
-### STATUS: known bug - please help us fix
+### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/schweikh/schweikh.c](2001/schweikh/schweikh.c)
 ### Information: [2001/schweikh/README.md](2001/schweikh/README.md)
 
-This program will very likely crash or do something else if you do not give it
-two args.
-
-Note also that the glob pattern must match the whole string. See the author's
-comments for details and a workaround.
+The glob pattern must match the whole string. See the author's comments for
+details and a workaround.
 
 There's also no way to escape meta characters.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
 
 
 # 2002
@@ -1567,18 +1560,6 @@ Incorrect formulas will ungracefully crash the program.
 
 Fixing the (Mis)feature is likely to be a difficult challenge.
 You are welcome to try and fix it if you can!
-
-
-## 2006 stewart
-
-### STATUS: known bug - please help us fix
-### Source code: [2006/stewart/stewart.c](2006/stewart/stewart.c)
-### Information: [2006/stewart/README.md](2006/stewart/README.md)
-
-This program will very likely crash or do something funny if the file does not
-exist or cannot be opened.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
 
 
 ## 2006 toledo2

--- a/bugs.md
+++ b/bugs.md
@@ -652,23 +652,16 @@ If you want to try and fix this (mis)feature, you are welcome to try.
 
 ## 1991 dds
 
-### STATUS: INABIAF - please **DO NOT** fix
+### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [1991/dds/dds.c](1991/dds/dds.c)
 ### Information: [1991/dds/README.md](1991/dds/README.md)
 
-If the BASIC file cannot be opened for reading or the output file cannot be
-opened for writing the program will very likely crash or do something funny.
-This is not a bug but a feature.  Please do not fix this except for the
-challenge to yourself.
-
-### STATUS: uses gets() - change to fgets() if possible
-
-That being said the compiled code uses `gets()` not `fgets()`. Can you fix this?
-It's quite complicated to do: the `s` array is certainly relevant and you can
-see a bit of the magic in the [thanks](/thanks-for-fixes.md) and the README.md
-file for how it works. It's easy enough to get the code to refer to `fgets()`
-and call it correctly but it might take more work to get the generated code
-sorted. This will be looked at later.
+The compiled code uses `gets()` not `fgets()`. Can you fix this?  It's quite
+complicated to do: the `s` array is certainly relevant and you can see a bit of
+the magic in the [thanks](/thanks-for-fixes.md) and the README.md file for how
+it works. It's easy enough to get the code to refer to `fgets()` and call it
+correctly but it might take more work to get the generated code sorted. This
+will be looked at later.
 
 
 ## 1991 westley

--- a/bugs.md
+++ b/bugs.md
@@ -832,18 +832,6 @@ An alternate version, however, does exist. See the README.md file for details.
 # 1994
 
 
-## 1994 horton
-
-### STATUS: known bug - please help us fix
-### Source code: [1994/horton/horton.c](1994/horton/horton.c)
-### Information: [1994/horton/README.md](1994/horton/README.md)
-
-If not enough args are specified this program will likely crash or do something
-else.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 1994 ldb
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -394,19 +394,15 @@ An example where a crash is not a bug: [2019/endoh](2019/endoh/endoh.c) is
 supposed to crash. There are others that are also supposed to crash or that are
 known to segfault but are considered features.
 
-As of 10 April 2023 the definition changed for a second time (the first time was
-07 April 2023). If something is noted by the author as a known bug or limitation
-it need not be fixed **unless it impacts the usability** of the program or **it removes
-instructional value**. An example where a crash undocumented needn't be fixed is
-[1984/laman](1984/laman/laman.c).  On the other hand the fixes made by [Cody
-Boone Ferguson](/winners.html#Cody_Boone_Ferguson) in
-[1990/theorem](1990/theorem/theorem.c) were useful.
+An important note is that if the README.md of the entry has a bug status that
+says it can be fixed it can be. Otherwise it should not be.
 
 Nonetheless we challenge you to fix these entries for educational/instructional
 value and/or enjoyment but we kindly request that you **DO NOT** submit a pull
-request! If you can't figure it out you're invited to look at the git diffs,
-where there are some (some were fixed earlier on but rolled back as both Cody
-and Landon individually felt that the fix was tampering with the entry).
+request unless it's a bug or (mis)feature we would like you to fix! If you can't
+figure it out you're invited to look at the git diffs, where there are some
+(some were fixed earlier on but rolled back as both Cody and Landon individually
+felt that the fix was tampering with the entry).
 
 NOTE: in the case of `gets()` we've fixed some to avoid the warning of the
 compiler, linker or even during runtime, depending on the system. In [some cases
@@ -466,24 +462,15 @@ $ ./decot
 without a newline after the `\`. This is not a bug.
 
 
-## 1984 laman
-
-### STATUS: INABIAF - please **DO NOT** fix
-### Source code: [1984/laman/laman.c](1984/laman/laman.c)
-### Information: [1984/laman/README.md](1984/laman/README.md)
-
-This entry will very likely crash or do something else if you run it without an
-arg. It likely won't do anything at all if the arg is not a positive number.
-
-
 ## 1984 mullender
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1984/mullender/mullender.c](1984/mullender/mullender.c)
 ### Information: [1984/mullender/README.md](1984/mullender/README.md)
 
-Although there are two alt versions added by Cody that will work in modern
-systems, if you do not have a [VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
+Although there is an alt version and supplementary program added by Cody that
+will work in modern systems, if you do not have a
+[VAX-11](https://en.wikipedia.org/wiki/VAX-11) or
 [PDP-11](https://en.wikipedia.org/wiki/PDP-11) to run the original entry on it
 will not work. See the README.md for details on the alternate versions.
 

--- a/bugs.md
+++ b/bugs.md
@@ -1262,17 +1262,6 @@ and it can be run by itself for fun in modern systems, which was not possible
 before the fixes there.
 
 
-## 2001 cheong
-
-### STATUS: known bug - please help us fix
-### Source code: [2001/cheong/cheong.c](2001/cheong/cheong.c)
-### Information: [2001/cheong/README.md](2001/cheong/README.md)
-
-This program will very likely crash or do something different without an arg.
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 2001 dgbeards
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -682,8 +682,8 @@ someone called Cody's late grandmother said to him: 'it's not cheating unless
 you're caught'. :-)
 
 Please don't try and fix it as it's not a bug and was actually documented as a
-possibility. Can you find out how?
-
+possibility. Can you find out how? There's also a way to make it so that even
+when you're cheating it ends up winning! Can you figure that out as well?
 
 
 # 1992

--- a/bugs.md
+++ b/bugs.md
@@ -604,18 +604,6 @@ where this occurred was fixed but this one should not be fixed. Thank you.
 
 ## 1991 dds
 
-### STATUS: uses gets() - change to fgets() if possible
-### Source code: [1991/dds/dds.c](1991/dds/dds.c)
-### Information: [1991/dds/README.md](1991/dds/README.md)
-
-The compiled code uses `gets()` not `fgets()`. Can you fix this?  It's quite
-complicated to do: the `s` array is certainly relevant and you can see a bit of
-the magic in the [thanks](/thanks-for-fixes.md) and the README.md file for how
-it works. It's easy enough to get the code to refer to `fgets()` and call it
-correctly but it might take more work to get the generated code sorted. This
-will be looked at later.
-
-
 ## 1991 westley
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -785,6 +785,12 @@ lush.c:40:9: note: previous definition is here
 
 As you might see the part under the `warning:` line is different.
 
+The entry is supposed to show warnings and then print:
+
+```
+Hello World.
+```
+
 Can you help us?
 
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1032,10 +1032,12 @@ slightly more like the original, even though it's unused.
 ## [1991/dds](1991/dds/dds.c) ([README.md](1991/dds/README.md]))
 
 Cody fixed a segfault that prevented this entry from working in any condition
-and he also made it work for clang. Clang (at least in some systems?) defaults
-to having `-Werror` and the code that the entry generates had some warnings
-that were causing compilation to fail as it just ran `cc a.c`. It ran it by what
-was once `system(q-6);` but with clang this was not enough..
+and he also made it work for clang. He also added checks for NULL `FILE *`s.
+
+Clang (at least in some systems?) defaults to having `-Werror` and the code that
+the entry generates had some warnings that were causing compilation to fail as
+it just ran `cc a.c`. It ran it by what was once `system(q-6);` but with clang
+this was not enough.
 
 The following had to be added to the string `s` (which to fix the segfault was
 changed from `char*s` to `char s[]`):

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -933,9 +933,15 @@ With these improvements the entry looks much more like the original!
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))
 
 Cody fixed the script to work properly in modern environments (to do with `$PATH`
-not having `.` in it). He notes that with an invocation in the try section will
-with macOS show what appears to be an error message but is actually okay. He
-gives more information in the [bugs.md](/bugs.md) file.
+not having `.` in it). Other adjustments were made as well.
+
+He also changed the `perror(3)` call to `fprintf(3)` because in macOS when errno
+is 0 it shows what looks like an error.
+
+He added the [try.sh](1990/jaw/try.sh) to run the commands that we suggested at
+the time. However, there is a known bug still, see [bugs.md](bugs.md) for
+details.
+
 
 NOTE: as `btoa` is not common we used a ruby script from Yusuke.
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1015,6 +1015,11 @@ was changed to just `1`.  Since it's instructional to see the differences he has
 provided an alternate version, [westley.alt.c](1990/westley/westley.alt.c), which
 is the original code.
 
+He also fixed the code to not enter an infinite loop if arg is a number not > 0
+and to not crash if no arg is specified.
+
+The alt code did NOT have arg checks added as it is actually a copy of the
+original code.
 
 ## [1991/brnstnd](1991/brnstnd/brnstnd.c) ([README.md](1991/brnstnd/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1830,6 +1830,10 @@ the paddles move even when holding down the movement keys.
 Cody also provided an alternate version which lets you use the arrow keys on
 your keyboard instead of the more awkward '`,`' and '`.`'.
 
+## [2001/ollinger](2001/ollinger/ollinger.c) ([README.md](2001/ollinger/README.md))
+
+Cody fixed to not crash if not enough args, exiting 1 instead.
+
 ## [2001/schweikh](2001/schweikh/schweikh.c) ([README.md](2001/schweikh/README.md]))
 
 Cody fixed this to not crash if not enough args as this was not documented by

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1751,6 +1751,7 @@ letter word that would match the format and because it's pain that clang forces
 this. :-) This fix makes a point of the author's notes on portability no longer
 valid, btw.
 
+He also fixed it to check the number of args.
 
 ## [2001/coupard](2001/coupard/coupard.c) ([README.md](2001/coupard/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1289,6 +1289,12 @@ arg (as it was 0 at file scope already this is perfectly fine and it means
 there's no need to cast it to an int in the function call though that would also
 work).
 
+## [1994/horton](1994/horton/horton.c) ([README.md](1994/horton/README.md))
+
+Cody fixed this to check that four args were specified. With the use of the C
+pre-processor macro and inclusion of stdlib.h in the Makefile the layout of the
+source is exactly the same column width and no additional lines were added.
+
 
 ## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1251,9 +1251,11 @@ this was made the alternate version, not the actual entry.
 
 ## [1993/plummer](1993/plummer/plummer.c) ([README.md](1993/plummer/README.md]))
 
-Cody added an [alternate version](1993/plummer/plummer.alt.c) which uses
-`usleep()` so you can see what is happening with faster systems. See the
-README.md files for details.
+Cody added check for two args.
+
+Cody also added an [alternate version](1993/plummer/plummer.alt.c) which uses
+`usleep()` so you can see what is happening with faster systems. This version
+also checks for two args. See the README.md files for details.
 
 
 ## [1993/rince](1993/rince/rince.c) ([README.md](1993/rince/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1209,15 +1209,18 @@ Cody fixed this to work for clang by changing the third and fourth arg of
 **` and some versions do not even allow a fourth arg.
 
 He also added the alternate version that the author gave in the remarks that is
-specifically for the USA rather than the world.
+specifically for the USA rather than the world. This had to be fixed for clang
+as well to make the args of `main()` be the correct type and by moving the body
+of main() to another function, `pain()`, which does the work since not all
+versions of clang support four args to `main()`.
 
-NOTE: as noted in the README.md file and the [bugs.md](/bugs.md), this program and the
-[alternate version](1992/westley/westley.alt.c) will very likely crash or
-[nuke](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
+Cody also added an arg check because the program and the
+[alternate version](1992/westley/westley.alt.c) might have crashed or
+[nuked](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire
 world](https://en.wikipedia.org/wiki/Earth) or just the
 [USA](https://en.wikipedia.org/wiki/United_States), respectively, without enough
-args (2). And not that we need the help or anything for this :-) but we do
-encourage you to test this :-) This should NOT be fixed.
+args (2). And not that we need the help or anything for this :-) but we
+encourage you to try the original :-)
 
 
 ## [1993/jonth](1993/jonth/jonth.c) ([README.md](1993/jonth/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -21,9 +21,9 @@ CHALLENGING bug fixes** like
 (all **EXTREMELY CHALLENGING**), fixing entries to work with clang (some being
 **EXTREMELY CHALLENGING** like
 [1991/dds](/thanks-for-fixes.md#1991dds-readmemd)) or as much as possible (like
-[1989/westley](/thanks-for-fixes.md#1989westley-readmemd) which is **INCREDIBLY
-HARD, _MUCH, MUCH MORE SO_ than any other fix!**), porting entries to macOS (some being
-**EXTREMELY CHALLENGING** like
+[1989/westley](/thanks-for-fixes.md#1989westley-readmemd), a true masterpiece
+that is **INCREDIBLY HARD, _MUCH, MUCH MORE SO_ than any other fix!**), porting
+entries to macOS (some being **EXTREMELY CHALLENGING** like
 [1998/schweikh1](/thanks-for-fixes.md#1998schweikh1-readmemd)), fixing code like
 [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd) to work in both
 32-bit/64-bit which *can be* **EXTREMELY CHALLENGING**, providing alternate code
@@ -179,6 +179,15 @@ To see the difference from start to fixed:
 ```sh
 cd 1984/decot ; make diff_orig_prog
 ```
+
+## [1984/laman](1984/laman/laman.c) ([README.md](1984/laman/README.md]))
+
+Cody fixed this to not crash when no arg is specified. Note that if the arg is
+not a positive number it will not do anything useful or anything at all.
+
+This was fixed on 30 October 2023 after the bug status was changed from INABIAF
+(it's not a bug it's a feature) to bug.
+
 
 ## [1984/mullender](1984/mullender/mullender.c) ([README.md](1984/mullender/README.md]))
 
@@ -1131,7 +1140,7 @@ from stdin after starting the program). Ideally `fgets()` would be used but this
 is a more problematic.  Previously it had a buffer size of 256 which could
 easily overflow. In this entry `gets()` is used in a more complicated way:
 first `m` is set to `*++p` in a for loop where `p` is argv. Later `m` is set to
-point to `h` which was of size \256. `gets()` is called as `m = gets(m)`) but
+point to `h` which was of size 256. `gets()` is called as `m = gets(m)`) but
 trying to change it to use `fgets()` proved more a problem. Since the input must
 come from the command line Cody changed the buffer size to `ARG_MAX+1` which
 should be enough (again theoretically) especially since the command expects
@@ -1139,6 +1148,9 @@ redirecting a dictionary file as part of the command line. This also makes it
 possible for longer strings to be read (in case the `gets()` was not used in a
 loop).
 
+Cody also added the [mkdict.sh](1992/gson/mkdict.sh) script that the author
+included in their remarks. See the README.md for its purpose. It was NOT fixed
+for ShellCheck because the author deliberately obfuscated it.
 
 ## [1992/kivinen](1992/kivinen/kivinen.c) ([README.md](1992/kivinen/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2154,6 +2154,11 @@ Since the author suggested that the lack of certain `#include`s might break the
 program in some systems he added `-include ...` to the Makefile as well.
 
 
+## [2006/stewart](2006/stewart/stewart.c) ([README.md](2006/stewart/README.md]))
+
+Cody fixed it so that if the file cannot be opened it exits rather than trying
+to read from the file.
+
 ## [2006/toledo2](2006/toledo2/toledo2.c) ([README.md](2006/toledo2/README.md]))
 
 Cody fixed a segfault in this program which was making it fail to work under

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1131,6 +1131,10 @@ one must keep the `Y[strlen(Y)-1]='\0';` part and keep it there.
 This is a complex change due to the way the program and Makefile generate
 additional tools.
 
+## [1992/buzzard.1](1992/buzzard.1/buzzard.1.c) ([README.md](1992/buzzard.1/README.md))
+
+Cody added a check for the right number of args, exiting 1 if not enough (2)
+used.
 
 ## [1992/gson](1992/gson/gson.c) ([README.md](1992/gson/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1830,6 +1830,12 @@ the paddles move even when holding down the movement keys.
 Cody also provided an alternate version which lets you use the arrow keys on
 your keyboard instead of the more awkward '`,`' and '`.`'.
 
+## [2001/schweikh](2001/schweikh/schweikh.c) ([README.md](2001/schweikh/README.md]))
+
+Cody fixed this to not crash if not enough args as this was not documented by
+the author. The other problems are documented so were not fixed. See
+README.md for details.
+
 
 ## [2001/westley](2001/westley/westley.c) ([README.md](2001/westley/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1044,11 +1044,16 @@ slightly more like the original, even though it's unused.
 
 Cody fixed a segfault that prevented this entry from working in any condition
 and he also made it work for clang. He also added checks for NULL `FILE *`s.
+Furthermore he changed it so that the C from the BASIC uses `fgets()`, not
+`gets()`. For the magic of clang and `fgets()` see below.
 
 Clang (at least in some systems?) defaults to having `-Werror` and the code that
 the entry generates had some warnings that were causing compilation to fail as
 it just ran `cc a.c`. It ran it by what was once `system(q-6);` but with clang
 this was not enough.
+
+(Cody stupidly did the below manually until he thought to write a simple program
+to do the conversions which he used for `gets()` to `fgets()`.)
 
 The following had to be added to the string `s` (which to fix the segfault was
 changed from `char*s` to `char s[]`):
@@ -1076,10 +1081,58 @@ string. Thus the end of the string actually looks like:
 !.Xop.fssps!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!b/d
 ```
 
-With these changes in place it will compile and work with both gcc and clang.
+But then there is the matter of getting the C to use `fgets()`. As can be seen
+above it's not as simple as changing `gets()` to `fgets()`. This was more magic
+characters that had to be updated and some added. The C code:
+
+```c
+atoi(gets(b))
+```
+
+is in the string:
+
+```
+bupj)hfut)c**
+```
+
+which was changed to be (in C):
+
+```c
+atoi(fgets(b,99,stdin))
+```
+
+which in the program is:
+
+```
+bupj)ghfut)c-::-tuejo**
+```
+
+That's fine and well but since the code does not include `stdio.h` there
+obviously would be a compilation error. Thus the compiler line had to updated to
+have `-include stdio.h` which in this rotated string is:
+
+```
+.jodmvef!tuejp/i
+```
+
+which had to be added after:
+
+```
+efdmbsbujpo!
+```
+
+which is the end of the warning disabled for clang as described above.
+
+But now the `system(q-69);` had to be changed to `system(q-86);`.
+
+With these changes in place it will compile and work with both gcc and clang and
+the C code generated will use `fgets()`, not `gets()`, therefore removing the
+annoying warnings. Note that the array passed to `fgets()` is an int but that
+was the same for `gets()` and is not necessary to update to a `char[]`.
+
 The key to the string is that it rotates the character by `+1`. This was not
 immediately clear until reading the author's remarks so there was an alt version
-that was something of a kludge, running `make a` instead.
+that was something of a kludge, running `make a` instead but that was removed.
 
 Cody also fixed a typo in LANDER.BAS.
 


### PR DESCRIPTION

This took less time than the previous fix (to let it work with clang) 
because after stupidly doing the decryption/encryption manually I had 
decided to write a simple program that does it instead.

Now systems won't whine about gets() being unsafe.

The thanks file further documents how this was done and the bugs.md file
no longer has this entry.