### PR TITLE
Update 1996/gandalf/Makefile about modern systems

### DIFF
--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -131,7 +131,6 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry might not compile when using modern compilers."
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 hatcat: ${PROG}


### PR DESCRIPTION
Remove outdated message about compilation not working in modern systems as I fixed this quite some time ago but failed to remove the message.