### PR TITLE
Retitle a bug status about some compilers

### DIFF
--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -16,7 +16,7 @@ make all
 The current status of this entry is:
 
 ```
-STATUS: doesn't work with some compilers - please provide alternative code
+STATUS: doesn't work with some compilers - please provide alternative code or fix for all compilers
 ```
 
 For more detailed information see [1992 lush in bugs.md](/bugs.md#1992-lush).

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -131,7 +131,6 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry might not compile when using modern compilers."
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 hatcat: ${PROG}

--- a/bugs.md
+++ b/bugs.md
@@ -231,7 +231,7 @@ Entries with this status do not work under some OSes and/or architectures (and/o
 something else?). Please help us to fix it!
 
 
-## STATUS: doesn't work with some compilers - please provide alternative code
+## STATUS: doesn't work with some compilers - please provide alternative code or fix for all compilers
 
 NOTE: we're still locating entries and working on fixes with this status so we're not yet
 ready for help. We will remove this when we are.
@@ -652,7 +652,7 @@ If you want to try and fix this (mis)feature, you are welcome to try.
 
 ## 1992 lush
 
-### STATUS: doesn't work with some compilers - please provide alternative code
+### STATUS: doesn't work with some compilers - please provide alternative code or fix for all compilers
 ### Source code: [1992/lush/lush.c](1992/lush/lush.c)
 ### Information: [1992/lush/README.md](1992/lush/README.md)
 
@@ -937,8 +937,7 @@ We would appreciate anyone who has it or even just knows the name! Thank you.
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed a segfault in
 this program that prevented it from working in gcc. It is known, however, that
-some compilers (like clang) will compile the code so that it enters an infinite
-loop. See the README.md file for an example command that this can happen with.
+some compilers will compile the code so that it enters an infinite loop.
 
 
 ## 1996 gandalf


### PR DESCRIPTION

Rather than have:

    STATUS: doesn't work with some compilers - please provide alternative cod

It might be better to have:

    STATUS: doesn't work with some compilers - please provide alternative code or fix for all compilers

which it now is.

Only one entry had it in so that entry and bugs.md were both updated.
Another entry in bugs.md was modified before and the README.md but the 
status was not changed. That will be in the next commit which will be 
this retitled one.