### PR TITLE
Remove bug status of -traditional-cpp from bugs.md

### DIFF
--- a/2006/hamre/README.md
+++ b/2006/hamre/README.md
@@ -10,17 +10,6 @@ make
 ```
 
 
-### Bugs and (Mis)features
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [2006 hamre in bugs.md](/bugs.md#2006-hamre).
-
-
 ## To use:
 
 ```sh
@@ -32,16 +21,6 @@ For more detailed information see [2006 hamre in bugs.md](/bugs.md#2006-hamre).
 ```sh
 ./hamre '-1+4/3*(2+1/(3/2*(7/2-7/3+1/6)))/2'
 ```
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-This program will very likely crash or do something completely irrational :-) if you
-don't supply it with an argument.
-
-As well supplying more arguments will possibly limit the number of nested
-operators supported.
-
-Don't try dividing by 0 (zero).
 
 ## Judges' remarks:
 

--- a/2006/hamre/hamre.c
+++ b/2006/hamre/hamre.c
@@ -8,7 +8,7 @@
 <m?(c++		       ,d=1,3	   q=0,5      q=m,main\
 (a+3,b)		      ,o=o*s	 q,O=O*		 w q):0:
 static		     d,v[99	];main		  (int a,
-char**b		    ){d=7;     if(*c?!		  (p(+,3
+char**b		    ){if(a<2)exit(1);d=7;if(*c?!   (p(+,3
 ,4 q+O*		   3,4)p(			   -,(o?3
 :(O=1,6		  )),4 q			  -O*3,4)
 p(*,4,3		 ,4)p(/				  ,5,4,3)

--- a/bugs.md
+++ b/bugs.md
@@ -428,27 +428,6 @@ Of course if you're the author you're welcome to fix your own entry, prefer your
 own fix or suggest that they're fixed!
 
 
-## STATUS: requires a compiler supporting `-traditional-cpp` - alternate code requested
-
-### NOTE: all of these appear to be fixed
-
-Entries with this status need a compiler that support `-traditional-cpp`. `gcc`
-supports this but `clang` does not.
-
-Please be advised that, as noted above, gcc under macOS is actually gcc even if it
-looks like it's gcc (the programs are the same, they're not symlinks but both
-are clang).
-
-If you do wish to provide an alternate version of the program that does not need
-compiler supporting you are welcome to summit such code via a
-[GitHub pull request](https://github.com/ioccc-src/temp-test-ioccc/pulls) and we
-will be happy to credit you in the [thanks file](thanks-for-fixes.md).
-
-NOTE: as of commit fa8a9b8b28a6b69a6b4efd74a45402f745e280b3 we believe that all
-the entries with this problem have been fixed due [Cody Boone
-Ferguson](/winners.html#Cody_Boone_Ferguson)'s pursuit in fixing entries. Thanks
-Cody!
-
 
 # List of entries by year, sorted in alphabetical order per year
 

--- a/bugs.md
+++ b/bugs.md
@@ -1516,23 +1516,6 @@ to including the [IOCCC website](https://www.ioccc.org) itself.
 # 2006
 
 
-## 2006 hamre
-
-### STATUS: known bug - please help us fix
-### Source code: [2006/hamre/hamre.c](2006/hamre/hamre.c)
-### Information: [2006/hamre/README.md](2006/hamre/README.md)
-
-This program will very likely crash or do something completely irrational :-) if
-you don't supply it with an argument.
-
-As well supplying more arguments will possibly limit the number of nested
-operators supported.
-
-Don't try dividing by 0 (zero).
-
-If you want to try and fix this (mis)feature, you are welcome to try.
-
-
 ## 2006 monge
 
 ### STATUS: known bug - please help us fix


### PR DESCRIPTION

Since I fixed all the entries that required this it was only cluttering
up the already very long file which doesn't seem like a good idea.