### PR TITLE
Disable -Wno-macro-redefined in 1986/wall/Makefile

### DIFF
--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -39,9 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
-	-Wno-macro-redefined -Wno-parentheses -Wno-c99-extensions \
-	-Wno-declaration-after-statement -Wno-deprecated-non-prototype \
-        -Wno-strict-prototypes -Wno-string-plus-char
+	-Wno-parentheses -Wno-c99-extensions -Wno-declaration-after-statement \
+	-Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-string-plus-char
 
 # Common C compiler warning flags
 #


### PR DESCRIPTION
This is because of what the entry is, the author's remarks and the fact that the warning produces fun output for the entry itself. The author had stated other warnings were fun but what these warnings were are no longer known and the messages almost certainly would be different now.