### PR TITLE
Fixes in 2000/primenum - int main from void main

### DIFF
--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -39,9 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
-	-Wno-macro-redefined -Wno-parentheses -Wno-c99-extensions \
-	-Wno-declaration-after-statement -Wno-deprecated-non-prototype \
-        -Wno-strict-prototypes -Wno-string-plus-char
+	-Wno-parentheses -Wno-c99-extensions -Wno-declaration-after-statement \
+	-Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-string-plus-char
 
 # Common C compiler warning flags
 #

--- a/2000/primenum/primenum.c
+++ b/2000/primenum/primenum.c
@@ -1,8 +1,8 @@
-#define BeginProgram void main(int argc, char *argv[])
+#define BeginProgram int main(int argc, char *argv[])
 #define CloseBrace }
 #define CommandLineArgument -1
 #define Declare int i,j,n,Flag=1;
-#define EndOfProgram return;
+#define EndOfProgram return 0;
 #define False 0;
 #define ForLoop ;for
 #define GetCommandLineArgument n=atoi(argv[1]);

--- a/bugs.md
+++ b/bugs.md
@@ -1130,13 +1130,15 @@ This program does not do what you might think it does! Running it like:
 will seemingly wait for input exactly because it is waiting for input. See the
 README.md file or look at the source.
 
-Although the name of the program suggests it prints prime numbers
-this is not the case. This is by design. See the author's comments
-for more details or better yet look at the code and if necessary
-try it out.  Please do not try and fix this.
+Although the name of the program suggests it prints prime numbers this is not
+the case. This is by design. See the author's comments for more details or
+better yet look at the code and if necessary try it out.  Please do not try and
+fix this.
 
-A crash in the program is known as well. This is also a feature.
-Please do not try to fix the crashing of this code.
+A crash in the program is known as well. This is also a feature.  Please do not
+try to fix the crashing of this code except to challenge yourself (if you think
+that it'll be worth your two second fix :-) ).  If you do fix it please do not
+make a pull request.
 
 
 ## 2000 rince

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1657,6 +1657,11 @@ itself a one-line like the code is in the original entry. Now it looks much more
 like the original entry but with the two fixes.
 
 
+## [2000/primenum](2000/primenum/primenum.c) ([README.md](2000/primenum/README.md]))
+
+Cody made this more portable by changing the `void main` to `int main`.
+
+
 ## [2000/thadgavin](2000/thadgavin/thadgavin.c) ([README.md](2000/thadgavin/README.md]))
 
 Cody fixed the code and added an appropriate make rule so that the SDL version


### PR DESCRIPTION

To make the entry more portable the void main was changed to int main.

The no arg check was NOT fixed: this is a documented feature not a bug 
and should not be fixed. If one wants to fix it for personal enjoyment 
(if they can get pleasure from a couple seconds :-) ) they may do so but
it is not to be committed.
