### PR TITLE
Add alt code to 2006/toledo2

### DIFF
--- a/1984/anonymous/Makefile
+++ b/1984/anonymous/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= anonymous

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -108,7 +108,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= decot

--- a/1984/laman/Makefile
+++ b/1984/laman/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= laman

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mullender

--- a/1985/applin/Makefile
+++ b/1985/applin/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= applin

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= august

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= lycklama

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= shapiro

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sicherman

--- a/1986/applin/Makefile
+++ b/1986/applin/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= applin

--- a/1986/august/Makefile
+++ b/1986/august/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= august

--- a/1986/bright/Makefile
+++ b/1986/bright/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= bright

--- a/1986/hague/Makefile
+++ b/1986/hague/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hague

--- a/1986/holloway/Makefile
+++ b/1986/holloway/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= holloway

--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= marshall

--- a/1986/pawka/Makefile
+++ b/1986/pawka/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= pawka

--- a/1986/stein/Makefile
+++ b/1986/stein/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= stein

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= wall

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -39,9 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
-	-Wno-macro-redefined -Wno-parentheses -Wno-c99-extensions \
-	-Wno-declaration-after-statement -Wno-deprecated-non-prototype \
-        -Wno-strict-prototypes -Wno-string-plus-char
+	-Wno-parentheses -Wno-c99-extensions -Wno-declaration-after-statement \
+	-Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-string-plus-char
 
 # Common C compiler warning flags
 #

--- a/1987/biggar/Makefile
+++ b/1987/biggar/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= biggar

--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= heckbert

--- a/1987/hines/Makefile
+++ b/1987/hines/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hines

--- a/1987/korn/Makefile
+++ b/1987/korn/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= korn

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= lievaart

--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -117,7 +117,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= wall

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= applin

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dale

--- a/1988/isaak/Makefile
+++ b/1988/isaak/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= isaak

--- a/1988/litmaath/Makefile
+++ b/1988/litmaath/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= litmaath

--- a/1988/phillipps/Makefile
+++ b/1988/phillipps/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= phillipps

--- a/1988/reddy/Makefile
+++ b/1988/reddy/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= reddy

--- a/1988/robison/Makefile
+++ b/1988/robison/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= robison

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= spinellis

--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1989/fubar/Makefile
+++ b/1989/fubar/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= fubar

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jar.1

--- a/1989/jar.2/Makefile
+++ b/1989/jar.2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jar.2

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ovdluhe

--- a/1989/paul/Makefile
+++ b/1989/paul/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= paul

--- a/1989/robison/Makefile
+++ b/1989/robison/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= robison

--- a/1989/roemer/Makefile
+++ b/1989/roemer/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= roemer

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tromp

--- a/1989/vanb/Makefile
+++ b/1989/vanb/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vanb

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= baruch

--- a/1990/cmills/Makefile
+++ b/1990/cmills/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cmills

--- a/1990/dds/Makefile
+++ b/1990/dds/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dds

--- a/1990/dg/Makefile
+++ b/1990/dg/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dg

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jaw

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -1,22 +1,12 @@
 # Best Entropy-reducer
 
 James A. Woods\
-Research Institute for Advanced Computer Science\
-MS 230-5\
-NASA Ames Research Center\
-Moffett Field, CA 94131\
 US
 
 Karl F. Fox\
-Morning Star Technologies, Inc.\
-1760 Zollinger Road\
-Columbus, OH 43221\
 US
 
 Paul Eggert\
-Twin Sun Inc.\
-360 N. Sepulveda Blvd. #2055\
-El Segundo, CA 90245\
 US
 
 ## To build:
@@ -24,9 +14,6 @@ US
 ```sh
 make all
 ```
-
-NOTE: see the [bugs.md](/bugs.md) file for information on what appears to be a
-bug in macOS but is actually not.
 
 
 ### Bugs and (Mis)features

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -38,6 +38,13 @@ echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
 which should apply the identity transformation to a minimal holoalphabetic
 sentence.
 
+
+Also try:
+
+```sh
+./try.sh
+```
+
 ## Judges' remarks:
 
 

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -1,5 +1,5 @@
 for i in "${@?${usage?$0 file...}}";do<"$i"||exit;done
-(cat&&tar cbf 1 - "$@"|compress|./btoa&&echo w)<<\Z
+(cat&&tar cbf 1 unshark.tar "$@"|compress|./btoa&&echo w)<<\Z
 #!/bin/sh
 #
 # GENTLE READER -- write this message to file [no headers!]; run "sh file".
@@ -9,11 +9,11 @@ for i in "${@?${usage?$0 file...}}";do<"$i"||exit;done
 #
 # "Cleverly he dialed from within." -- D. Van Vliet, "Trout Mask Replica"
 #
-PATH=$PATH:. a=atob m=unshark z=zcat
+PATH=$PATH:.:.. a=atob m=unshark z=zcat
 r="rm -f $a $m* $z" v="cc -Wno-implicit-function-declaration -o $z $m.c"
 trap '$r;exit 1' 1 2 13 15
 echo decoding...
-(:|compress|./btoa|./$a|./$z)2>$m>&2||(sed '1,9s/./#define & /
+(:|compress|btoa|./$a|./$z)2>$m>&2||(sed '1,9s/./#define & /
 s/@/[w]/g
 s/C/char /g
 s/I/;if(/g
@@ -43,5 +43,5 @@ Z,h@=w;n=8;f=Q+e;i=o=HIo<0)X,1;P(i)WH+1){Iw==Q&e){Z;m=n=8;f=QIH<0)X}
 c=wIw>=f)U++=i,w=oWw>=Q)U++=h@,w=t@;P(i=h@)Wp>D+Q)P(*--p)
 I(w=f)<1l<<k)t@=o,h[f++]=i;o=c}X}
 _
-($v)&&ln -f $z $a)&&./$a<<\w>./$m-&&./$z<./$m->./$m&&tar xvf ./$m&&$r
+($v);ln -f $z $a);./$a<<\w>./$m-&&./$z<./$m->./$m;tar xvf ../$m.tar&&$r
 Z

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -10,7 +10,7 @@ for i in "${@?${usage?$0 file...}}";do<"$i"||exit;done
 # "Cleverly he dialed from within." -- D. Van Vliet, "Trout Mask Replica"
 #
 PATH=$PATH:.:.. a=atob m=unshark z=zcat
-r="rm -f $a $m* $z" v="cc -Wno-implicit-function-declaration -o $z $m.c"
+r="rm -f $a $m* ../$m.tar $z" v="cc -Wno-implicit-function-declaration -Wno-implicit-int -o $z $m.c"
 trap '$r;exit 1' 1 2 13 15
 echo decoding...
 (:|compress|btoa|./$a|./$z)2>$m>&2||(sed '1,9s/./#define & /
@@ -43,5 +43,5 @@ Z,h@=w;n=8;f=Q+e;i=o=HIo<0)X,1;P(i)WH+1){Iw==Q&e){Z;m=n=8;f=QIH<0)X}
 c=wIw>=f)U++=i,w=oWw>=Q)U++=h@,w=t@;P(i=h@)Wp>D+Q)P(*--p)
 I(w=f)<1l<<k)t@=o,h[f++]=i;o=c}X}
 _
-($v);ln -f $z $a);./$a<<\w>./$m-&&./$z<./$m->./$m;tar xvf ../$m.tar&&$r
+($v);echo 1>&2;ln -f $z $a);./$a<<\w>./$m-&&./$z<./$m->./$m;tar xvf ../$m.tar&&$r
 Z

--- a/1990/jaw/try.sh
+++ b/1990/jaw/try.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Running shark.sh:"
-sh shark.sh shark.sh README.md jaw.c > receive || exit 1
+sh shark.sh shark.sh README.md jaw.c try.sh > receive || exit 1
 echo "Done."
 
 

--- a/1990/jaw/try.sh
+++ b/1990/jaw/try.sh
@@ -4,8 +4,26 @@ echo "Running shark.sh:"
 sh shark.sh shark.sh README.md jaw.c > receive || exit 1
 echo "Done."
 
-echo "Attempting to extract files:"
 
-mkdir -p test
-cd test
+# delete directory for clean state
+rm -fr test
+
+# make sure we can make the new directory
+mkdir -p test || exit 0
+
+# make sure we can cd to the new directory
+cd test || exit
+# run the script
+echo "Attempting to extract files:"
 sh ../receive
+
+echo 1>&2
+echo "$ ls -al" 1>&2
+ls -al
+
+echo 1>&2
+echo "Comparing the files from the parent directory:" 1>&2
+echo 1>&2
+for i in *; do
+    echo -n "   " 1>&2; diff -s "$i" ../"$i"
+done

--- a/1990/jaw/try.sh
+++ b/1990/jaw/try.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Running shark.sh:"
-sh shark.sh README.md jaw.c README.md > receive || exit 1
+sh shark.sh shark.sh README.md jaw.c > receive || exit 1
 echo "Done."
 
 echo "Attempting to extract files:"

--- a/1990/pjr/Makefile
+++ b/1990/pjr/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= pjr

--- a/1990/scjones/Makefile
+++ b/1990/scjones/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= scjones

--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= stig

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tbr

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -108,7 +108,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= theorem

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ant

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= brnstnd

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= buzzard

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cdupont

--- a/1991/davidguy/Makefile
+++ b/1991/davidguy/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= davidguy

--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dds

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= fine

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= rince

--- a/1991/westley/Makefile
+++ b/1991/westley/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -110,7 +110,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= adrian

--- a/1992/albert/Makefile
+++ b/1992/albert/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= albert

--- a/1992/ant/Makefile
+++ b/1992/ant/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ant

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= buzzard.1

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= buzzard.2

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= gson

--- a/1992/imc/Makefile
+++ b/1992/imc/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= imc

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kivinen

--- a/1992/lush/Makefile
+++ b/1992/lush/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= lush

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= marangon

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= nathan

--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vern

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1993/ant/Makefile
+++ b/1993/ant/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ant

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cmills

--- a/1993/dgibson/Makefile
+++ b/1993/dgibson/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dgibson

--- a/1993/ejb/Makefile
+++ b/1993/ejb/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ejb

--- a/1993/jonth/Makefile
+++ b/1993/jonth/Makefile
@@ -109,7 +109,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jonth

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= leo

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= lmfjyh

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= plummer

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= rince

--- a/1993/schnitzi/Makefile
+++ b/1993/schnitzi/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schnitzi

--- a/1993/vanb/Makefile
+++ b/1993/vanb/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vanb

--- a/1994/dodsond1/Makefile
+++ b/1994/dodsond1/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dodsond1

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dodsond2

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= horton

--- a/1994/imc/Makefile
+++ b/1994/imc/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= imc

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ldb

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schnitzi

--- a/1994/shapiro/Makefile
+++ b/1994/shapiro/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= shapiro

--- a/1994/smr/Makefile
+++ b/1994/smr/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= smr

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tvr

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= weisberg

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cdua

--- a/1995/dodsond1/Makefile
+++ b/1995/dodsond1/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dodsond1

--- a/1995/dodsond2/Makefile
+++ b/1995/dodsond2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dodsond2

--- a/1995/esde/Makefile
+++ b/1995/esde/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= esde

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= garry

--- a/1995/heathbar/Makefile
+++ b/1995/heathbar/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= heathbar

--- a/1995/leo/Makefile
+++ b/1995/leo/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= leo

--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= makarios

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= savastio

--- a/1995/schnitzi/Makefile
+++ b/1995/schnitzi/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schnitzi

--- a/1995/spinellis/Makefile
+++ b/1995/spinellis/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= spinellis

--- a/1995/vanschnitz/Makefile
+++ b/1995/vanschnitz/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vanschnitz

--- a/1996/august/Makefile
+++ b/1996/august/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= august

--- a/1996/dalbec/Makefile
+++ b/1996/dalbec/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dalbec

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= eldby

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= gandalf

--- a/1996/huffman/Makefile
+++ b/1996/huffman/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= huffman

--- a/1996/jonth/Makefile
+++ b/1996/jonth/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jonth

--- a/1996/rcm/Makefile
+++ b/1996/rcm/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= rcm

--- a/1996/schweikh1/Makefile
+++ b/1996/schweikh1/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh1

--- a/1996/schweikh2/Makefile
+++ b/1996/schweikh2/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh2

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh3

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= banks

--- a/1998/bas1/Makefile
+++ b/1998/bas1/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= bas1

--- a/1998/bas2/Makefile
+++ b/1998/bas2/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= bas2

--- a/1998/chaos/Makefile
+++ b/1998/chaos/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= chaos

--- a/1998/df/Makefile
+++ b/1998/df/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= df

--- a/1998/dlowe/Makefile
+++ b/1998/dlowe/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dlowe

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dloweneil

--- a/1998/dorssel/Makefile
+++ b/1998/dorssel/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dorssel

--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= fanf

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schnitzi

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh1

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh2

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh3

--- a/1998/tomtorfs/Makefile
+++ b/1998/tomtorfs/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tomtorfs

--- a/2000/anderson/Makefile
+++ b/2000/anderson/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= anderson

--- a/2000/bellard/Makefile
+++ b/2000/bellard/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= bellard

--- a/2000/bmeyer/Makefile
+++ b/2000/bmeyer/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= bmeyer

--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= briddlebane

--- a/2000/dhyang/Makefile
+++ b/2000/dhyang/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dhyang

--- a/2000/dlowe/Makefile
+++ b/2000/dlowe/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dlowe

--- a/2000/jarijyrki/Makefile
+++ b/2000/jarijyrki/Makefile
@@ -109,7 +109,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jarijyrki

--- a/2000/natori/Makefile
+++ b/2000/natori/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= natori

--- a/2000/primenum/Makefile
+++ b/2000/primenum/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= primenum

--- a/2000/primenum/primenum.c
+++ b/2000/primenum/primenum.c
@@ -1,8 +1,8 @@
-#define BeginProgram void main(int argc, char *argv[])
+#define BeginProgram int main(int argc, char *argv[])
 #define CloseBrace }
 #define CommandLineArgument -1
 #define Declare int i,j,n,Flag=1;
-#define EndOfProgram return;
+#define EndOfProgram return 0;
 #define False 0;
 #define ForLoop ;for
 #define GetCommandLineArgument n=atoi(argv[1]);

--- a/2000/rince/Makefile
+++ b/2000/rince/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= rince

--- a/2000/robison/Makefile
+++ b/2000/robison/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= robison

--- a/2000/schneiderwent/Makefile
+++ b/2000/schneiderwent/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schneiderwent

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= thadgavin

--- a/2000/tomx/Makefile
+++ b/2000/tomx/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tomx

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -110,7 +110,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= anonymous

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= bellard

--- a/2001/cheong/Makefile
+++ b/2001/cheong/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cheong

--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= coupard

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ctk

--- a/2001/dgbeards/Makefile
+++ b/2001/dgbeards/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dgbeards

--- a/2001/herrmann1/Makefile
+++ b/2001/herrmann1/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= herrmann1

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= herrmann2

--- a/2001/jason/Makefile
+++ b/2001/jason/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jason

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kev

--- a/2001/ollinger/Makefile
+++ b/2001/ollinger/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ollinger

--- a/2001/rosten/Makefile
+++ b/2001/rosten/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= rosten

--- a/2001/schweikh/Makefile
+++ b/2001/schweikh/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikh

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= westley

--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= williams

--- a/2004/anonymous/Makefile
+++ b/2004/anonymous/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= anonymous

--- a/2004/arachnid/Makefile
+++ b/2004/arachnid/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= arachnid

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= burley

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= gavare

--- a/2004/gavin/Makefile
+++ b/2004/gavin/Makefile
@@ -112,7 +112,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= gavin

--- a/2004/hibachi/Makefile
+++ b/2004/hibachi/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hibachi

--- a/2004/hoyle/Makefile
+++ b/2004/hoyle/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hoyle

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jdalbec

--- a/2004/kopczynski/Makefile
+++ b/2004/kopczynski/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kopczynski

--- a/2004/newbern/Makefile
+++ b/2004/newbern/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= newbern

--- a/2004/omoikane/Makefile
+++ b/2004/omoikane/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= omoikane

--- a/2004/schnitzi/Makefile
+++ b/2004/schnitzi/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schnitzi

--- a/2004/sds/Makefile
+++ b/2004/sds/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sds

--- a/2004/vik1/Makefile
+++ b/2004/vik1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vik1

--- a/2004/vik2/Makefile
+++ b/2004/vik2/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vik2

--- a/2005/aidan/Makefile
+++ b/2005/aidan/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= aidan

--- a/2005/anon/Makefile
+++ b/2005/anon/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= anon

--- a/2005/boutines/Makefile
+++ b/2005/boutines/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= boutines

--- a/2005/chia/Makefile
+++ b/2005/chia/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= chia

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -109,7 +109,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= giljade

--- a/2005/jetro/Makefile
+++ b/2005/jetro/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= jetro

--- a/2005/klausler/Makefile
+++ b/2005/klausler/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= klausler

--- a/2005/mikeash/Makefile
+++ b/2005/mikeash/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mikeash

--- a/2005/mynx/Makefile
+++ b/2005/mynx/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mynx

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= persano

--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sykes

--- a/2005/timwi/Makefile
+++ b/2005/timwi/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= timwi

--- a/2005/toledo/Makefile
+++ b/2005/toledo/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= toledo

--- a/2005/vik/Makefile
+++ b/2005/vik/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vik

--- a/2005/vince/Makefile
+++ b/2005/vince/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vince

--- a/2006/birken/Makefile
+++ b/2006/birken/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= birken

--- a/2006/borsanyi/Makefile
+++ b/2006/borsanyi/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= borsanyi

--- a/2006/grothe/Makefile
+++ b/2006/grothe/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= grothe

--- a/2006/hamre/Makefile
+++ b/2006/hamre/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hamre

--- a/2006/meyer/Makefile
+++ b/2006/meyer/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= meyer

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -109,7 +109,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= monge

--- a/2006/night/Makefile
+++ b/2006/night/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= night

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sloane

--- a/2006/stewart/Makefile
+++ b/2006/stewart/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= stewart

--- a/2006/sykes1/Makefile
+++ b/2006/sykes1/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sykes1

--- a/2006/sykes2/Makefile
+++ b/2006/sykes2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sykes2

--- a/2006/toledo1/Makefile
+++ b/2006/toledo1/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= toledo1

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= toledo2

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -116,8 +116,8 @@ OBJ= ${PROG}.o
 DATA= C.BASIC C.BIOS
 TARGET= ${PROG} C
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -143,6 +143,9 @@ C: C.BASIC
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/2006/toledo2/README.md
+++ b/2006/toledo2/README.md
@@ -12,6 +12,10 @@ Mexico\
 make
 ```
 
+There is [alternate code](#alternate-code) that is based on the author's notes
+for DOS/Windows. This cannot be tested by us, not even to compile, but it appears
+that it should be fine, after the proper header files were added.
+
 
 ### Bugs and (Mis)features
 
@@ -19,7 +23,7 @@ The current status of this entry is:
 
 ```
 STATUS: INABIAF - please **DO NOT** fix
-STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
+STATUS: missing files - please provide them
 ```
 
 For more detailed information see [2006 toledo2 in bugs.md](/bugs.md#2006-toledo2).
@@ -35,13 +39,6 @@ To end execution press `ctrl-z`. As mentioned in the author's remarks and in the
 below section, it is supposed to crash on termination though some noted this
 does not seem to happen in macOS. He asks ironically: 'if it's supposed to crash
 and it does not crash is it actually a bug or is it a feature? :-)'
-
-### INABIAF - it's not a bug it's a feature! :-)
-
-By design this program is supposed to crash on termination.
-
-You must type in caps (except in strings) and this program is indeed
-case-sensitive.
 
 
 ## Try:
@@ -61,14 +58,23 @@ RUN
 
 To end the program hit ctrl-z.
 
-### IABINAF - it's a bug it's not a feature! :-)
+## Alternate code:
 
-Although the program does not crash when reading in `C.BIOS` it appears that the
-CP/M emulator does not work as expected at least according to the author's
-remarks.
+This version, as noted, should work for DOS/Windows. It uses non-standard
+functions in place of `read(2)` and `write(2)`.
 
-See also [bugs.md](/bugs.md) for more details.
+### Alternate build:
 
+```sh
+make alt
+```
+
+### Alternate use:
+
+The author noted that for PC/DOS you will have to add `ANSI.SYS` to your
+`CONFIG.SYS` but this is also not something we can test.
+
+Use `toledeo2.alt` as you would `toledo2` above.
 
 ## Judges' remarks:
 
@@ -166,7 +172,7 @@ When the `>` prompt appears, do:
 IMPORT DDT.COM
 ```
 
-When it ends, do `HALT`, so the file is saved, and you can start
+When it ends, do `HALT`, so the file is closed, and you can start
 the same process with another file.
 
 At this time I have tested successfully the following software
@@ -199,10 +205,14 @@ ANSI terminal:
         write   -->  putchar(7[o])
         system  -->  nothing
 
+Notice that you'll have to do `#include <conio.h>` as well.
+
 Also add the following to trap Ctrl-C:
 
         #include <signal.h>
         signal(SIGINT, SIG_IGN);
+
+NOTE: this is what the [alternate code](#alternate-code) is for!
 
 NOTE from the judges: in Unix like systems `getch()` is part of curses but this
 is not what is needed.

--- a/2006/toledo3/Makefile
+++ b/2006/toledo3/Makefile
@@ -108,7 +108,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= toledo3

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -108,7 +108,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= akari

--- a/2011/blakely/Makefile
+++ b/2011/blakely/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= blakely

--- a/2011/borsanyi/Makefile
+++ b/2011/borsanyi/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= borsanyi

--- a/2011/dlowe/Makefile
+++ b/2011/dlowe/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dlowe

--- a/2011/eastman/Makefile
+++ b/2011/eastman/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= eastman

--- a/2011/fredriksson/Makefile
+++ b/2011/fredriksson/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= fredriksson

--- a/2011/goren/Makefile
+++ b/2011/goren/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= goren

--- a/2011/hamaji/Makefile
+++ b/2011/hamaji/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hamaji

--- a/2011/hou/Makefile
+++ b/2011/hou/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hou

--- a/2011/konno/Makefile
+++ b/2011/konno/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= konno

--- a/2011/richards/Makefile
+++ b/2011/richards/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= richards

--- a/2011/toledo/Makefile
+++ b/2011/toledo/Makefile
@@ -110,7 +110,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= toledo

--- a/2011/vik/Makefile
+++ b/2011/vik/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vik

--- a/2011/zucker/Makefile
+++ b/2011/zucker/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= zucker

--- a/2012/blakely/Makefile
+++ b/2012/blakely/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= blakely

--- a/2012/deckmyn/Makefile
+++ b/2012/deckmyn/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= deckmyn

--- a/2012/dlowe/Makefile
+++ b/2012/dlowe/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dlowe

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2012/endoh2/Makefile
+++ b/2012/endoh2/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh2

--- a/2012/grothe/Makefile
+++ b/2012/grothe/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= grothe

--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hamano

--- a/2012/hou/Makefile
+++ b/2012/hou/Makefile
@@ -108,7 +108,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hou

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kang

--- a/2012/konno/Makefile
+++ b/2012/konno/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= konno

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= omoikane

--- a/2012/tromp/Makefile
+++ b/2012/tromp/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tromp

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vik

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= zeitak

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= birken

--- a/2013/cable1/Makefile
+++ b/2013/cable1/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cable1

--- a/2013/cable2/Makefile
+++ b/2013/cable2/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cable2

--- a/2013/cable3/Makefile
+++ b/2013/cable3/Makefile
@@ -111,7 +111,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= cable3

--- a/2013/dlowe/Makefile
+++ b/2013/dlowe/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dlowe

--- a/2013/endoh1/Makefile
+++ b/2013/endoh1/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh2

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh3

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh4

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hou

--- a/2013/mills/Makefile
+++ b/2013/mills/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mills

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= misaka

--- a/2013/morgan1/Makefile
+++ b/2013/morgan1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= morgan1

--- a/2013/morgan2/Makefile
+++ b/2013/morgan2/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= morgan2

--- a/2013/robison/Makefile
+++ b/2013/robison/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= robison

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= birken

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= deak

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh2

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -109,7 +109,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= maffiodo1

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= maffiodo2

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= morgan

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= sinon

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= skeggs

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vik

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= wiedijk

--- a/2015/burton/Makefile
+++ b/2015/burton/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= burton

--- a/2015/dogon/Makefile
+++ b/2015/dogon/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dogon

--- a/2015/duble/Makefile
+++ b/2015/duble/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= duble

--- a/2015/endoh1/Makefile
+++ b/2015/endoh1/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2015/endoh2/Makefile
+++ b/2015/endoh2/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh2

--- a/2015/endoh3/Makefile
+++ b/2015/endoh3/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh3

--- a/2015/endoh4/Makefile
+++ b/2015/endoh4/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh4

--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hou

--- a/2015/howe/Makefile
+++ b/2015/howe/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= howe

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mills1

--- a/2015/mills2/Makefile
+++ b/2015/mills2/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mills2

--- a/2015/muth/Makefile
+++ b/2015/muth/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= muth

--- a/2015/schweikhardt/Makefile
+++ b/2015/schweikhardt/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= schweikhardt

--- a/2015/yang/Makefile
+++ b/2015/yang/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= yang

--- a/2018/algmyr/Makefile
+++ b/2018/algmyr/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= algmyr

--- a/2018/anderson/Makefile
+++ b/2018/anderson/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= anderson

--- a/2018/bellard/Makefile
+++ b/2018/bellard/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2018/burton1/Makefile
+++ b/2018/burton1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= burton1

--- a/2018/burton2/Makefile
+++ b/2018/burton2/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= burton2

--- a/2018/ciura/Makefile
+++ b/2018/ciura/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ciura

--- a/2018/endoh1/Makefile
+++ b/2018/endoh1/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh2

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ferguson

--- a/2018/giles/Makefile
+++ b/2018/giles/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= giles

--- a/2018/hou/Makefile
+++ b/2018/hou/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= hou

--- a/2018/mills/Makefile
+++ b/2018/mills/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mills

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= poikola

--- a/2018/vokes/Makefile
+++ b/2018/vokes/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= vokes

--- a/2018/yang/Makefile
+++ b/2018/yang/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= yang

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= adamovsky

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= burton

--- a/2019/ciura/Makefile
+++ b/2019/ciura/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ciura

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= diels-grabsch1

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= diels-grabsch2

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -108,7 +108,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= dogon

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= duble

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= giles

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= karns

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= lynn

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -106,7 +106,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= mills

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -105,7 +105,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= poikola

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= yang

--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -101,7 +101,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= burton

--- a/2020/carlini/Makefile
+++ b/2020/carlini/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= carlini

--- a/2020/endoh1/Makefile
+++ b/2020/endoh1/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh1

--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh2

--- a/2020/endoh3/Makefile
+++ b/2020/endoh3/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= endoh3

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -107,7 +107,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ferguson1

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= ferguson2

--- a/2020/giles/Makefile
+++ b/2020/giles/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= giles

--- a/2020/kurdyukov1/Makefile
+++ b/2020/kurdyukov1/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kurdyukov1

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kurdyukov2

--- a/2020/kurdyukov3/Makefile
+++ b/2020/kurdyukov3/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kurdyukov3

--- a/2020/kurdyukov4/Makefile
+++ b/2020/kurdyukov4/Makefile
@@ -102,7 +102,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= kurdyukov4

--- a/2020/otterness/Makefile
+++ b/2020/otterness/Makefile
@@ -103,7 +103,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= otterness

--- a/2020/tsoj/Makefile
+++ b/2020/tsoj/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= tsoj

--- a/2020/yang/Makefile
+++ b/2020/yang/Makefile
@@ -104,7 +104,7 @@ endif
 
 
 ##############################
-# Special flags for this entry
+# Special Makefile variables for this entry
 ##############################
 #
 ENTRY= yang

--- a/bugs.md
+++ b/bugs.md
@@ -667,11 +667,22 @@ Enjoy! :-)
 ### Source code: [1990/jaw/jaw.c](1990/jaw/jaw.c)
 ### Information: [1990/jaw/README.md](1990/jaw/README.md)
 
-It seems like the scripts do not work correctly, where not all files are
-extracted. Some work was done to get them to work some but it does not appear
-that all files can be extracted. For instance in the [try.sh](1990/jaw/try.sh)
-script which Cody added it is supposed to add the README.md file to the archive
-and it did at one point (or so he recalls) but now it doesn't seem to happen.
+The command:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
+```
+
+just prints:
+
+```
+$ echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
+oops
+oops
+```
+
+Do you have a fix? We welcome it (Cody does have an idea and will look at it
+later but we also don't know what it's supposed to do now)!
 
 
 ## 1990 theorem

--- a/bugs.md
+++ b/bugs.md
@@ -1130,13 +1130,15 @@ This program does not do what you might think it does! Running it like:
 will seemingly wait for input exactly because it is waiting for input. See the
 README.md file or look at the source.
 
-Although the name of the program suggests it prints prime numbers
-this is not the case. This is by design. See the author's comments
-for more details or better yet look at the code and if necessary
-try it out.  Please do not try and fix this.
+Although the name of the program suggests it prints prime numbers this is not
+the case. This is by design. See the author's comments for more details or
+better yet look at the code and if necessary try it out.  Please do not try and
+fix this.
 
-A crash in the program is known as well. This is also a feature.
-Please do not try to fix the crashing of this code.
+A crash in the program is known as well. This is also a feature.  Please do not
+try to fix the crashing of this code except to challenge yourself (if you think
+that it'll be worth your two second fix :-) ).  If you do fix it please do not
+make a pull request.
 
 
 ## 2000 rince

--- a/bugs.md
+++ b/bugs.md
@@ -1534,28 +1534,20 @@ not crash in macOS (it appeared to work fine in fedora linux on an `x86_64`
 architecture but he does not know if it crashed in macOS Ventura due to the fact
 it is an `arm64` CPU - the Apple silicon chip). This fix, BTW, is a mix of a fix
 by [Yusuke Endoh](/winners.html#Yusuke_Endoh) and Cody's. Nevertheless there are
-two features that are not bugs and one bug (see below).
+two features that are not bugs.
 
 By design this program is supposed to crash on termination.
 
 You must type in caps (except in strings) and this program is indeed
 case-sensitive.
 
-### STATUS: possible bug (possibly depending on system) - please help test and if necessary fix
+### STATUS: missing files - please provide them
 
-The author showed something like this in their remarks:
-
-```sh
-./toledo2 DDT.COM
-A> IMPORT DDT.COM
-```
-
-but the `A>` prompt never appears; instead it's just the same as if you
-specified no arg which is `>`. It seems like the `A>` might be a typo. That
-being said from the description by the author, if the required files exist in
-the directory, it seems you can do `HALT` 'so the file is saved, and you can
-start the same process with another file'. This does not seem to work but it
-might be not enough information or a misunderstanding.
+A file is missing from the archive linked to by the author so we have not been
+able to add it. Cody tried a few of the other zip files at the website linked to
+but no luck. Do you have the proper file? The file is `IMPORT.COM`. If you do
+please provide a link or make a pull request, adding it to the repo, after
+testing it to make sure it works in the program.
 
 
 # 2007

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2274,6 +2274,10 @@ macOS - it did not seem to be a problem under linux, at least not fedora. The
 problem was wrong variable types - implicit `int`s instead of `FILE *`s. It now
 works with both macOS and linux.
 
+Cody also added the (untested) alt code that is based on the author's remarks to
+port this to systems that have the non-standard `kbhit()` and `getch()` (not the
+one from curses) which is typically (always?) in `conio.h`.
+
 
 ## [2006/toledo3](2006/toledo3/toledo3.c) ([README.md](2006/toledo3/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1657,6 +1657,11 @@ itself a one-line like the code is in the original entry. Now it looks much more
 like the original entry but with the two fixes.
 
 
+## [2000/primenum](2000/primenum/primenum.c) ([README.md](2000/primenum/README.md]))
+
+Cody made this more portable by changing the `void main` to `int main`.
+
+
 ## [2000/thadgavin](2000/thadgavin/thadgavin.c) ([README.md](2000/thadgavin/README.md]))
 
 Cody fixed the code and added an appropriate make rule so that the SDL version

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -932,16 +932,19 @@ With these improvements the entry looks much more like the original!
 
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))
 
-Cody fixed the script to work properly in modern environments (to do with `$PATH`
-not having `.` in it). Other adjustments were made as well.
+Cody fixed the script to work properly in modern environments including paths,
+writing to and extracting from stdout, (to do with `$PATH`
+not having `.` in it) and relying on the exit code in the commands to allow for
+`&& ...`.
 
 He also changed the `perror(3)` call to `fprintf(3)` because in macOS when errno
 is 0 it shows what looks like an error.
 
 He added the [try.sh](1990/jaw/try.sh) to run the commands that we suggested at
-the time. However, there is a known bug still, see [bugs.md](bugs.md) for
-details.
+the time.
 
+However, there is a known bug still, see [1990 jaw in
+bugs.md](/bugs.md#1990-jaw) for details.
 
 NOTE: as `btoa` is not common we used a ruby script from Yusuke.
 

--- a/tmp/fake.gen_inventory.sh
+++ b/tmp/fake.gen_inventory.sh
@@ -59,7 +59,7 @@ Exit codes:
      0	    all OK
      2	    -h and help string printed or -V and version string printed
      3	    command line error
-     4	    cannot find writiable winner directory
+     4	    cannot find writable winner directory
  >= 10	    internal error
 
 $NAME version: $VERSION"


### PR DESCRIPTION

The alt code is based on the author's remarks that should allow users
with non-standard systems like DOS/Windows which have conio.h to use
this program, replacing read(2) and write(2) syscalls. It need hardly be
mentioned that I have no way of testing this so it's possible I did
something wrong but it seems not the case (whether anything has changed
since 2006 that might also break it is unknown).

The bug status has been updated both that one bug is not actually a bug
but appeared to be a typo and there also appears to be a missing file
(IMPORT.COM).