### PR TITLE
Improve fixes to 1998/schnitzi

### DIFF
--- a/1994/schnitzi/.gitignore
+++ b/1994/schnitzi/.gitignore
@@ -1,4 +1,7 @@
 schnitzi
+schnitzi2
+schnitzi2.c
 schnitzi.alt
+schnitzi.alt2
 schnitzi.orig
 prog.orig

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -130,13 +130,25 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: the buffer size of this entry is very small at 100."
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+${PROG}2: ${PROG}2.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	@echo "NOTE: this version has fgets() but will not generate code that can be compiled."
+	@echo "Other functionality is not affected."
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+${PROG}.alt2: ${PROG}.alt2.c
+	@echo "NOTE: this version has an increased buffer size and will generate code that can"
+	@echo "compile but the buffer size is not increased. Other functionality is unaffected."
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -1,9 +1,6 @@
 # Best Layout
 
 Mark Schnitzius\
-ISX Corporation\
-1165 Northchase Pkwy, Suite 120\
-Marietta, GA 30067\
 US\
 <http://computronium.org/ioccc.html>
 
@@ -13,6 +10,11 @@ US\
 ```sh
 make all
 ```
+
+There are two alternate versions, one that has an increased buffer size and one
+that uses `fgets()`; neither are completely functional.
+See below section bugs and (mis)features for details and the [alternate
+code](#alternate-code) section for how to use.
 
 
 ### Bugs and (Mis)features
@@ -36,20 +38,37 @@ For more detailed information see [1994 schnitzi in bugs.md](/bugs.md#1994-schni
 ## Try:
 
 ```sh
-./schnitzi < /etc/motd
-./schnitzi < /etc/passwd
+./schnitzi < /etc/motd 2>/dev/null
+./schnitzi < /etc/passwd 2>/dev/null
+
+./schnitzi < schnitzi.c > schnitzi2.c 2>/dev/null
+make schnitzi2
+./schnitzi2 < README.md
 ```
 
 
 ## Alternate code:
 
-To build the alternative code try:
+The first version, `schnitzi.alt.c`, uses `fgets(3)` but when fed its own code
+it will generate code that still uses `gets(3)`. What's more is it will not
+compile. Other functionality works fine.
+
+The second version, `schnitzi.alt2.c`, has an increased buffer size but when fed
+its own source code it will generate code that can compile but with the original
+buffer size. This is due to a comment which is explained in more detail in
+[1994/schnitzi in bugs.md](/bugs.md#1994-schnitzi).
+
+
+### Alternate build:
 
 ```sh
 make alt
 ```
 
-Use `schnitzi.alt` as you would `schnitzi`.
+### Alternate use:
+
+Use `schnitzi.alt` and `schnitzi.alt2` as you would `schnitzi` above except that
+feeding the source code to it will not work right.
 
 
 ## Judges' remarks:
@@ -65,6 +84,7 @@ find out why?
 
 
 ## Author's remarks:
+
 
 ### SPOILER:
 
@@ -83,7 +103,7 @@ schnitzi < info
 
 The program generates interesting results when its source file is
 used as input:
-\
+
 ```sh
     	schnitzi < schnitzi.c
 ```
@@ -94,11 +114,11 @@ version of itself work identically (you'll need to redirect the
 output of the above command into a separate file and compile it).
 You might notice some differences in the flipped version, though.
 First off, a secret message becomes visible that was not visible
-in the original program.  Also, much of the code shows up in\
+in the original program.  Also, much of the code shows up in
 different places in the flipped program than it appeared in the
-first program.  My first version of this program was perfectly\
+first program.  My first version of this program was perfectly
 symmetrical along the diagonal, but later found out there were
-interesting ways to break the symmetry.  The best way to see this\
+interesting ways to break the symmetry.  The best way to see this
 is to load both the original and flipped versions of the program
 into an editor and switch back and forth between them rapidly.
 

--- a/1994/schnitzi/schnitzi.alt2.c
+++ b/1994/schnitzi/schnitzi.alt2.c
@@ -20,12 +20,12 @@ h                   mh111 de{l)   +di (+'( d+%  c n+
  */                 n         =             0     ;
                main        (       )   {
                 char       v   [
-                1000   ]                   ,  s;
-          int t[100    ]                    ,
-              u[100              ]     ;  u
+              10000    ]                   ,  s;
+          int t[100     ]                    ,
+              u[100               ]     ;  u
                   [                   0
       ]=ftell(stdin        )       ;
-         while(fgets(v,100,stdin )&&((v[strlen(v)-1]='\0',1))                )
+         while(gets (v    )                 )
                  {t  [         r ]=
              strlen                 (
                v);y=

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-security \
 	-Wno-int-to-pointer-cast -Wno-int-conversion -Wno-unused-parameter \
-	-Wno-incompatible-pointer-types
+	-Wno-incompatible-pointer-types -Wno-implicit-int -Wno-unused-value
 
 # Common C compiler warning flags
 #

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -1,9 +1,6 @@
 # Best Flow Control
 
 Mark Schnitzius
-ISX Corporation
-1280 West Peachtree St. Apt. 1507
-Atlanta, GA 30309
 US
 <http://computronium.org/ioccc.html>
 
@@ -29,29 +26,35 @@ For more detailed information see [1998 schnitzi in bugs.md](/bugs.md#1998-schni
 ## To use:
 
 ```sh
-./schnitzi 5 > sort.c
+./schnitzi n > sort.c
 make sort
+./sort
+# enter three numbers, space separated
+
+echo x y z | ./sort
 ```
+
+where `n` and `x`, `y` and `z` are numbers.
 
 
 ## Try:
 
 ```sh
-./schnitzi 3 > sort.c
-make sort
-echo 123 > data
-echo 234 >> data
-echo 413 >> data
-echo 134 >> data
-echo 324 >> data
-./sort < data
+./try.sh
 ```
 
-### INABIAF - it's not a bug it's a feature :-)
+What happens if at the command line you don't specify `n` numbers that the
+program expects? For instance try:
 
-NOTE: the larger the number given to the program the longer the output becomes
-and quite substantially so.  Doing `./schnitzi 9` will actually print 771999
-lines!
+```sh
+./schnitzi 5 > sort.c
+make sort
+
+# try running the next command four or five times:
+echo 2 5 3 1 | ./sort
+```
+
+Why does this happen?
 
 
 ## Judges' remarks:
@@ -81,9 +84,9 @@ the letter 'e'.
 
 The IOCCC has been no stranger to this concept.  Several winning entries from
 years past have accomplished interesting feats while completely avoiding the use
-of certain C constructs thought to be essential (e.g. 1988's
-[robison.c](//1988/robison/robison.c)).  If you have to ask why they would do it
-this way, then this contest just isn't for you.
+of certain C constructs thought to be essential (e.g.
+[1988/robison.c](/1988/robison/robison.c)).  If you have to ask why they would
+do it this way, then this contest just isn't for you.
 
 In continuing with this fine tradition, this program suggests to the ANSI
 committee some new practical simplifications for the C language.  For instance,

--- a/1998/schnitzi/schnitzi.c
+++ b/1998/schnitzi/schnitzi.c
@@ -52,6 +52,8 @@ void x_(){ O=g; *r=y[k-2]; _=r; j=o_; }
 void d (){ O=g; *r=y[k]; _=r; k=k+1; m=k<z; w=_t; l=p_; j=p; }
 void y_(){ O=g; *r=x[17][1]+k; _=r; j=q_; }
 void r_(){ O=_b; _=x[17]; s=(char**)_d; s=s+1; i=*s; q=0; }
-main(int v,char **V){ if (V[1]) {if(atoi(V[1])!=0) {
+main(int v,char **V){
+((V[1]&&((atoi(V[1])>0&&atoi(V[1])<27)||(exit(1),1))));
  q=0; O=r_; _d=V;
-  x: (O)(); goto x; }}}
+  x: (O)(); goto x; }
+

--- a/1998/schnitzi/try.sh
+++ b/1998/schnitzi/try.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+make all || exit 1
+
+echo "$ ./schnitzi 3 > sort.c" 1>&2
+./schnitzi 3 > sort.c
+
+echo "Compiling sort.c:" 1>&2
+make sort >/dev/null || exit 1
+
+echo "...built sort." 1>&2
+
+echo "Creating data:" 1>&2
+
+echo "$ echo 234 > data" 1>&2
+echo 234 > data
+
+echo "$ echo 413 >> data" 1>&2
+echo 413 >> data
+
+echo "$ echo 123 >> data" 1>&2
+echo 123 >> data
+
+echo "Sorting data:" 1>&2
+echo "$ ./sort < data" 1>&2
+./sort < data
+
+echo 1>&2
+
+echo "Using stdin/stdout:" 1>&2
+echo "$ echo 10 7 9 | ./sort" 1>&2
+echo "10 7 9" | ./sort
+
+echo "$ ./schnitzi 5 > sort.c" 1>&2
+./schnitzi 5 > sort.c
+
+echo "Compiling sort.c:" 1>&2
+make sort >/dev/null || exit 1
+
+echo "...built sort." 1>&2
+
+echo "Creating data:" 1>&2
+
+echo "$ echo 124 > data" 1>&2
+echo 124 > data
+
+echo "$ echo 422 >> data" 1>&2
+echo 422 >> data
+
+echo "$ echo 120 >> data" 1>&2
+echo 120 >> data
+
+echo "$ echo 100 >> data" 1>&2
+echo 100 >> data
+
+echo "$ echo 777 >> data" 1>&2
+echo 777 >> data
+
+echo "Sorting data:" 1>&2
+echo "$ ./sort < data" 1>&2
+./sort < data
+
+echo 1>&2
+
+echo "Using stdin/stdout:" 1>&2
+echo "$ echo 5 10 7 9 1 | ./sort" 1>&2
+echo "5 10 7 9 1" | ./sort

--- a/bugs.md
+++ b/bugs.md
@@ -875,21 +875,60 @@ one liner it's already quite long.
 ### Source code: [1994/schnitzi/schnitzi.c](1994/schnitzi/schnitzi.c)
 ### Information: [1994/schnitzi/README.md](1994/schnitzi/README.md)
 
-The buffer size of this entry is 100 which is very easily overflowed
-with `gets()` which it uses. Changing it to use `fgets()` is difficult. Even
-changing the buffer size can cause compilation errors and even when that is
-fixed it will not translate to the generated file. The buffer size was changed
-but to make it the same functionality it was changed back.
+NOTE: the generated code of all versions, when fed its own source, will differ
+even when it works. See the author's remarks in the README.md for details.
+Increasing the buffer size and having it, when fed its own source code,
+generate code that will compile with the same buffer size is difficult: it just
+uses the original size. Cody explains this further down.
+
+Getting it to use `fgets()` is even harder as when fed its own code it will
+generate code that cannot even compile let alone use `fgets(3)`.
+
+In both cases, changing the buffer size and changing it to use `fgets(3)`, will
+cause compilation errors without other adjustments.
+
+See the below magic for details. Along with the author's remarks in the
+README.md file it might prove possible to get it to use `fgets(3)`. Cody,
+writing this on 02 November 2023, only just noticed the author's remarks and
+will later on look at this if nobody takes up the challenge. More important work
+like getting to a place that the next contest can run must be done first.
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) explains the magic of
-how this entry works which will be necessary if this entry is to be fixed, below.
+how this entry works, which will be necessary if this entry is to be fixed,
+below.
+
+You might wish to run the command:
+
+```sh
+make diff_orig_prog
+```
+
+to see what had to change for the buffer size, when looking at the below.
+Furthermore you will want to look at:
+
+
+```sh
+diff schnitzi.alt.c schnitzi.alt2.c
+```
+
+as the `fgets()` version can compile it just can't generate compilable code (let
+alone using `fgets()`) when fed itself (to reiterate, just changing the call to
+`fgets(3)` does not mean it can compile and there's a further problem in that
+`fgets(3)` retains the newline whereas `gets(3)` does not). Nevertheless looking
+at these commands will be of help to understand how it works.
+
+For the alternate versions the other functionality is unaffected.
 
 ### The magic of [1994/schnitzi](1994/schnitzi/schnitzi.c) and how it flips text
 
 The problem is getting the generated code to use `fgets()` (once it even
-compiles which is easy to do) and also have the updated buffer size be the same.
-The generated output, when changed to `fgets()` failed to compile. The buffer
-size, when using `gets()` is still the same.
+compiles which was easy to do) and also have the updated buffer size be the
+same (which was easy to do too at least in the original version). The generated
+output, when changed to `fgets()` failed to compile and it also used `gets(3)`
+and these are the bugs here.
+
+The buffer size, when using `gets()` is still the same but as noted above the
+original code has had a buffer size increase.
 
 The real problem is with formatting the code. Take a look at the interesting
 comment as well as the `int r=0,x,y=0` at the top of the file. If you look at

--- a/bugs.md
+++ b/bugs.md
@@ -1138,37 +1138,21 @@ See above entry [1998/dlowe](1998/dlowe/dlowe.c).
 ### Source code: [1998/schnitzi/schnitzi.c](1998/schnitzi/schnitzi.c)
 ### Information: [1998/schnitzi/README.md](1998/schnitzi/README.md)
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) fixed this to work for
-modern systems but he notes a couple compile warnings to ignore.
-
-First if you get the warning:
-
-	warning: incompatible implicit declaration of built-in function 'printf' [-Wbuiltin-declaration-mismatch]
-	   11 | void  g(){ O=j; printf(_); }
-	      |                 ^~~~~~
-
-
-please do NOT change it! Doing so will break the generated output.
-
-Another warning that was introduced but should be ignored (it's required) is:
-
-
-	warning: assignment to 'char *' from incompatible pointer type 'char **' [-Wincompatible-pointer-types]
-	   55 | main(int v,char **c){ O=r_; _d=c;
-	      |                               ^
-
-Please DO NOT change this either.
-
-If there are any other warnings triggered by your compiler please DO NOT fix
-those either!
-
-Another important note is that as the number passed into the program gets bigger
-the number of lines of output gets substantially larger. For instance:
+A point worth considering is that as the number passed into the program gets
+bigger the number of lines of output gets substantially larger. For instance:
 
 ```sh
 $ ./schnitzi 9|wc -l
   771999
 ```
+
+The larger the number the bigger the file can become too, even becoming
+gigabytes in size. The range is checked for `>0 && <27` as not having this can
+be a problem including a segfault.
+
+If you use the generated program and do not give enough numbers in input
+something funny will happen, very possibly with different results per run. This
+is in the README.md file as something to try and ponder.
 
 
 # 1999

--- a/faq.md
+++ b/faq.md
@@ -1,8 +1,8 @@
 <HTML>
 <BODY TEXT="#000000">
 
-<center><img alt="IOCCC" SRC="png/ioccc.png"></center><br>
-<center><font size="6"><I>The International Obfuscated C Code Contest </I></font></center><br>
+<center><img alt="IOCCC" SRC="png/ioccc.png"></center>\
+<center><font size="6"><I>The International Obfuscated C Code Contest </I></font></center>\
 
 <P>
 <CENTER>
@@ -17,22 +17,26 @@
 <A HREF="years.html">Winning entries</A>
 <BR><BR>
 <A HREF="bugs.md">Known Bugs &amp; (Mis)features</A> |
-<A HREF="how-to-bugfix.md">How to fix an IOCCC winner</A> |
+<A HREF="how-to-help.md">How to help</A> |
 <A HREF="thanks-for-fixes.md">Thanks for the fixes</A> |
 <A HREF="www-history.md">A bit of web site history</A>
 </CENTER>
 
 <HR>
 
+
 # The IOCCC FAQ
+
 
 ## Q: How many entries do you receive each year?
 
 By tradition, we do not say.
 
+
 ## Q: How many judging rounds do you have?
 
 Are you trying to trick us? We will not say that either.
+
 
 ## Q: What are the general Makefile rules used in order to clean and build entries for use?
 
@@ -80,6 +84,13 @@ clobber` depends on `clean` so running `make clobber` will invoke `make clean`.
 
 Are there any other rules? You tell us!
 
+NOTE about the above rules: the Makefile default assumes `cc` which might be a
+gcc-based compiler, or a clang-based compiler, or some other compiler. Only by
+forcing `CC=clang` or `CC=gcc` will one invoke a specific compiler to, say,
+enable or disable additional warnings or flags. Even so different versions or
+compilers might do different things, have different defects or other issues.
+
+
 ## Q: How come some entries have code that is incongruent with what the author(s) wrote about the entry?
 
 It is very likely in this case that the code was fixed to work for modern
@@ -87,6 +98,7 @@ systems as part of the reworking of the website. If you have this problem in
 some entries you should look at the original code as in `winner.orig.c` or
 `prog.orig.c`. Sometimes the original is in an alt version like `winner.alt.c`
 or `prog.alt.c`.
+
 
 ## Q: Why have some entries that originally used `gets()` been modified to use `fgets()`? Doesn't this tamper with the entry too much?
 
@@ -124,6 +136,7 @@ NOTE: due to 'compatibility reasons' `fgets()` stores the newline and `gets()`
 does not. We're not sure how this is compatibility but either way it can cause a
 problem and it is this that has complicated most of the fixes though again some
 can look almost identical.
+
 
 ## Q: How can I easily see what was changed in order to get an entry to work in modern systems?
 
@@ -210,6 +223,7 @@ make diff_alt_prog
 
 and you'll see a single line changed and very simply.
 
+
 ### Tip: if you have `colordiff` installed it's a lot easier to see the differences
 
 To use these rules but provide a different `diff`, for instance `colordiff`,
@@ -222,6 +236,7 @@ make DIFF=colordiff diff_alt_prog # for alt to prog diff
 
 Obviously if you want to view the alt code or the orig code you can just open
 the files as described above.
+
 
 ## Q: Sometimes the author's or authors' remarks do not match the source! Why and what can I do about it?
 
@@ -276,6 +291,7 @@ that works for modern systems but one can view the original code in the
 
 Some entries should not have modern system versions replaced. See below.
 
+
 ## Q: I can't get some entries to work in 64-bit systems that don't support 32-bit!
 
 Unfortunately some older entries are non-portable and require 32-bit support of
@@ -289,6 +305,7 @@ possible that some were missed. These entries are very likely in the
 for 64-bit systems. Many were fixed to work with modern systems but some are
 supposed to only work with 32-bit systems so any updated version of these
 entries should be an alternate version.
+
 
 ## Q: Under macOS I can't compile some entries and/or they don't work right. Why?
 
@@ -318,6 +335,7 @@ At the same time some entries are not designed to work with clang. There might
 be alternate code added at some point but as above this depends on free time and
 other things that have to be done plus remembering to do it.
 
+
 ## Q: What is `cb` that is mentioned in some of the older entries?
 
 This was a C beautifier for Unix, both AT&T and Berkeley, but it seems to no
@@ -340,11 +358,13 @@ In macOS Mountain Lion and beyond to run X11 applications one needs to install
 [XQuartz](https://www.xquartz.org). This will let you compile, link and run X11
 applications.
 
+
 ## Q: How do I compile and run entries that use SDL1/SDL2 ?
 
 This depends on your operating system but below are instructions for linux and
 macOS with alternative methods for macOS and different package managers with
 linux.
+
 
 ### Red Hat based linux
 
@@ -369,6 +389,7 @@ export SDL2_INCLUDE_ROOT=/usr
 
 but this might not be necessary in more modern days especially as we use
 `sdl-config` and `sdl2-config` which should find the proper paths.
+
 
 ### Debian based linux
 
@@ -403,11 +424,13 @@ feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
+
 ### macOS
 
 If you're using macOS there are at least three ways to obtain it. You can
 download it from the SDL website and install the package. That will not
 work well for the IOCCC but these will:
+
 
 #### MacPorts
 
@@ -418,6 +441,7 @@ If you haven't already, install
 ```sh
 sudo port install libsdl libsdl2
 ```
+
 
 #### Homebrew
 
@@ -430,12 +454,13 @@ brew install sdl2 sdl12-compat
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
-##### NOTE: there might be extra SDL packages required
+### NOTE: there might be extra SDL packages required
 
 In the case that some entries do not work even with SDL1/SDL2 installed it might
 be that you need additional SDL libraries. See the entry's README.md for
 details. If something is not noted you're welcome to report it as an issue or
 fix it and make a new pull request.
+
 
 ## Q: How do I compile and run entries that use sound in macOS?
 
@@ -448,6 +473,7 @@ you can use either MacPorts or Homebrew. See below for instructions for each.
 Usually the README.md file will explain how to use it in linux so we do not
 include this here, at least for now.
 
+
 ### MacPorts
 
 If you haven't already, install
@@ -457,6 +483,7 @@ If you haven't already, install
 ```sh
 sudo port install sox
 ```
+
 
 ### Homebrew
 
@@ -469,6 +496,7 @@ brew install sox
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
+
 ## Q: How did entry XYZZY win? It breaks rule 2!
 
 As entries have been fixed it is entirely possible that some of the entries no
@@ -478,6 +506,7 @@ and/or number of rows have also changed.
 For the original version see the [/archive](/archive) directory where you can
 find all the original winning entries. In some cases the `winner.alt.c` is the
 original source code.
+
 
 ## Q: I found a bug in a previous winner, what should I do?
 
@@ -498,6 +527,7 @@ More generally please see the file [how-to-bugfix.md](/how-to-bugfix.md). Note
 that this file is not a tutorial on how to fix X, Y and Z problems but rather
 what to do to get the fix in.
 
+
 ## Q: Do you have a list of entries with known problems and/or features that might appear to be bugs but are not?
 
 Yes! Please see [bugs.md](/bugs.md) for a list of known bugs and/or issues of a
@@ -506,6 +536,7 @@ variety of kinds.
 Note that just because an entry is not in the bugs file does not mean there is
 not an issue and note that some issues are simply missing files, dead URL(s) or
 something like that.
+
 
 ## Q: Are there types of entries that are submitted so frequently that the judges get tired of them?
 
@@ -518,6 +549,7 @@ The [guidelines](guidelines.html) say:
 We like variety. However too often we see (please look at the winning examples
 given to be aware of the level of the competition):
 
+
 ### maze generator
 - [1985/shapiro](years.html#1985_shapiro)
 
@@ -529,13 +561,15 @@ given to be aware of the level of the competition):
 
 - [1998/bas1](years.html#1998_bas1)
 
-### tic-tac-toe game
+
+### tic-tac-toe/noughts and crosses/Xs and Os game
 
 - [1991/westley](years.html#1991_westley)
 
 - [1996/jonth](years.html#1996_jonth)
 
 - [2020/carlini](years.html#2020_carlini)
+
 
 ### solitaire/Othello game
 
@@ -561,6 +595,7 @@ given to be aware of the level of the competition):
 _As you can see, just a list of primes (let alone small primes) does not cut it
 anymore._
 
+
 ### self reproducing program
 
 - [1990/scjones](years.html#1990_scjones)
@@ -568,6 +603,7 @@ anymore._
 - [1994/smr](years.html#1994_smr) - _do not claim your program is the smallest one without seeing this!
 
 - [2000/dhyang](years.html#2000_dhyang) - _unless you beat this one, your chances are slim_
+
 
 ### entries that just print "Hello, world!"
 
@@ -587,6 +623,7 @@ anymore._
 
 _**...it's so 20th century...**_
 
+
 ### entries that use some complex state machine/table to print something
 
 - [1988/isaak](years.html#1988_isaak)
@@ -596,6 +633,7 @@ _**...it's so 20th century...**_
 - [2018/ciura](years.html#2018_ciura)
 
 - [2018/giles](years.html#2018_giles)
+
 
 ### rot13
 
@@ -607,6 +645,7 @@ _**...it's so 20th century...**_
 
 - [1991/fine](years.html#1991_fine)
 
+
 ### **pi** or **e** computation
 
 - [1986/august](years.html#1986_august)
@@ -616,6 +655,7 @@ _**...it's so 20th century...**_
 - [1988/westley](years.html#1988_westley)
 
 - [1989/roemer](years.html#1989_roemer)
+
 
 #### Hints on overused themes
 
@@ -631,9 +671,11 @@ explain near the beginning of your remarks why you are submitting a entry based
 on an 'overused theme' and why the judges should not simply toss it out as being
 boring.
 
+
 ## Q: What should I write in the 'remarks' (remarks.md) section of my entry, if anything at all?
 
 As much or as little as you wish.
+
 
 ### What helps:
 
@@ -646,6 +688,7 @@ As much or as little as you wish.
 - what are the limitations of your entry in respect of portability and/or input data
 
 - how it works (if you are really condescending)
+
 
 ### What does not help:
 
@@ -695,17 +738,20 @@ which you should update and submit, using the instructions above if necessary.
 
 There are none. There was no IOCCC in those years.
 
+
 ## Q: What are the .orig.c files in the directories in winning entries ?
 
 Due to the fact that the original code has sometimes had to change these files
 are the original winning entry or as close to as possible to the original that
 we can find.
 
+
 ## Q: Why don't you publish non-winners?
 
 Because the publication on the IOCCC site **_IS_**
 the award! Anyone is free to put their IOCCC hopefuls, lookalikes and/or
 non-winners on their web page for everyone to see.
+
 
 ## Q: How much time does it take to judge the contest?
 
@@ -734,14 +780,17 @@ If it can compile and run on Windows and/or Mac  (see
 even better. Being able to compile with other compilers like clang is also a
 good thing.
 
+
 ## Q: I would like to mirror the IOCCC web site. May I do so?
 
 We are not accepting mirror requests at this time, sorry.
+
 
 ## Q: I want to publish some parts of the IOCCC in an article, or book, or newsletter, or use then in class/instructional notes, or quote from the IOCCC. May I do so?
 
 Please ask the [IOCCC judges](/judges.html) first. Please send your request using the
 instructions on the [contacting the IOCCC Judges](/contact.html) page.
+
 
 ## Q: What are the grand prize / Best of Show winners?
 
@@ -790,6 +839,7 @@ from the judges, they used the following awards:
 These could be considered the 'best entry' for those years with 1 or
 more other entries that came in close behind.
 
+
 ## Q: I managed to get entry XYZZY from year 19xx to compile; now it fails to run!
 
 switch(19xx/XYZZY) {
@@ -833,6 +883,7 @@ break;
 compilers.
 
 }
+
 
 ## Q: How did the IOCCC get started?
 
@@ -922,10 +973,11 @@ for more details.
 <TD><a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="/png/by-sa-3.0-88x31.png" /></a></TD>
 <TD><P>&copy; Copyright 1984-2020,
 [Leo Broukhis, Landon Curt Noll](/judges.html)
-- All rights reserved<br>
+- All rights reserved\
 This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.</P></TD>
 <TD>&nbsp;<!--<a href="https://validator.w3.org/check?uri=referer"><img src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01 Transitional" height="31" width="88"></a>--></TD>
 </TR></TABLE>
+
 
 ## Q: Why do you sometimes use the first person plural?
 
@@ -962,6 +1014,7 @@ exaggeration](https://books.google.com/books?id=ms3tce7BgJsC&lpg=PA134&vq=%22the
 p.s. Here is an image of F. D. C. Willard:
 
 [F D C Willard](png/F.D.C.Willard.png)
+
 
 ## Q: Why do Makefiles use `-Weverything` with `clang`? Don't you know that its use is not recommended by clang developers?
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1409,6 +1409,24 @@ program chooses that line it might print the first 231 characters or it might
 print (up to) the next 231 characters and so on.
 
 
+## [1994/schnitzi](1994/schnitzi/schnitzi.c) ([README.md](1994/schnitzi/README.md]))
+
+Cody added two alt versions, [one which uses
+`fgets()`](1994/schnitzi/schnitzi.alt.c) but when fed its own source code cannot
+generate code that compile and another [one with a bigger buffer
+size](1994/schnitzi/schnitzi.alt2.c) which, when fed its own source code, will
+generate compilable code but not with the same buffer size but rather the
+original buffer size. Cody explains this in the at [1994/schnitzi in
+bugs.md](/bugs.md#1994-schnitzi).
+
+The purpose for these versions it both demonstrate how the magic works behind it
+and to help others, should they wish to, get the code to work with `fgets(3)`, with
+or without an increase in buffer size. See [1994/schnitzi in
+bugs.md](/bugs.md#1994-schnitzi) where Cody also explains the magic for more
+details. Later on, if nobody takes up the task, Cody might resume it, but for
+now there is more important work to do so that the next contest can run.
+
+
 ## [1994/shapiro](1994/shapiro/shapiro.c) ([README.md](1994/shapiro/README.md]))
 
 Cody fixed a bug on systems where `EOF != -1`. The problem is that `getc()` and

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1571,6 +1571,22 @@ linux and further changes for macOS. He also fixed a segfault (after printing
 garbage) when the arg specified evaluated to 0. It was decided that these
 segfault fixes should be made because the program is so beautiful.
 
+Later on Cody improved the fixes by checking that the arg is a number `>0 &&
+<27` as that was noted by the author as a requirement and again since it's such
+a beautiful program it is worth it, especially as the larger the number the
+larger the resulting program becomes. It can be gigabytes in length if it
+doesn't crash. At this point since the author stated it has no `while`,
+`do...while`, `for`, `if/else`, `switch`, `?:` Cody removed the if statement by
+doing:
+
+```c
+((V[1]&&((atoi(V[1])>0&&atoi(V[1])<27)||(exit(1),1))));
+```
+
+Cody also added the [try.sh](1998/schnitzi/try.sh) script to help users try the
+commands (as well as some added by him) we recommended.
+
+
 ## [1998/schweikh1](1998/schweikh1/schweikh1.c) ([README.md](1998/schweikh1/README.md]))
 
 Cody fixed this for modern systems (it did not work at all) and added an

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Sat 21 Oct 2023 11:04:58 UTC*
+*Last updated: Thu 02 Nov 2023 12:32:15 UTC*
 
 This document is primarily for [Cody Boone
 Ferguson](/winners.html#Cody_Boone_Ferguson) as he (that is I :-) ) wanted a way
@@ -38,18 +38,9 @@ years through 2013 and up through 2014/endoh1 have been checked. As for the
 things have to be done in those years. These things, such as dealing with old
 email addresses and such, can likely be done with the typo pass (see below).
 
-- *AFTER* the README.md files have been format fixed: check for typos in
-README.md files. Although I did up through I believe 2011 I have to do another
-pass through all except that as of 12 July 2023 I went through 1984 and 1985. At
-the same time the formatting has to be / is being checked.
-    * UPDATE on 06 July 2023: some while back I noticed that _ALL_ years will
-    have to be checked again but most of the years checked through 2011 (I think
-    it is but I have this vague memory I did a couple more years - that will be
-    checked when I return to this item) can be checked more quickly.
-    * UPDATE on 06 July 2023: see below list under the item _Verify which
-    README.md files have not been checked for correct formatting_ as well.
-    * UPDATE on 06 July 2023: note that this does NOT include the
-    `YYYY/README.md` files! See the below item for that.
+- Typo fix ALL markdown files. For the README.md files years 1984-1989 have been
+done (along with the format fixes) except that YYYY/README.md files have not
+been completed. See below item for details on that.
 
 - Go through all year README.md files: that is 1984/README.md, 1985/README.md and
 so on. As of **Mon 16 Oct 11:22:52 UTC 2023** the following years have had a
@@ -59,12 +50,15 @@ determined if this will be done with the typo pass (what should be the final
 pass) or not but it's very possible that it can be just to speed things along.
 
 - Verify which README.md files have not been checked for correct formatting and
-fix any issues.
+fix any issues found.
     * This includes author information: not only at first column but making sure
-    that the lines end with `<br>` so that the rendered output does not end up
+    that the lines end with `\` so that the rendered output does not end up
     on one line only. Note that earlier spaces were being added to the end of
     the line but after discussion on GitHub it was decided it is preferable to
-    have `<br>` instead.
+    have `\` instead.
+	NOTE that this has been done already BUT it was not done manually so
+	there are some lines that should not end in `\` including some in code
+	blocks.
     * [Cody Boone
     Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) has done
     many and has some kind of record of what he's done but these can be added
@@ -73,15 +67,18 @@ fix any issues.
     except that the years not checked / fixed should only need one pass (but
     probably will have a second pass anyway just to make sure things are good as
     seeing things a second time is a good way to find additional errors).
+    * NOTE that as of some days ago (today being 02 November 2023) the years
+    1984-1989 have been checked for formatting and other issues including typos.
+    Whether a quick final pass will be made is not determined yet.
 
-- Remove addresses from older winning entries but (if known) keep country code +
-add country code and name to the respective JSON file in the [author](/author)
-subdirectory. As of half past 4 Pacific time on 22 April 2023 only the years
-through 1986 have been done entirely. This should not take much time but I
-(Cody) am bored with it for now and would rather do other more important things.
-This will likely not be updated until after it's done (and when I remember to
-remove it - I expect that when I go for it I'll do it in one sitting or maybe a
-few sittings with a few brief breaks).
+- Remove addresses from older winning entries but (if known) keep country code
+and if known add it and the name to the respective JSON file in the
+[author](/author) subdirectory. As of half past 4 Pacific time on 22 April 2023
+only the years through 1986 have been done entirely. This should not take much
+time but I (Cody) am bored with it for now and would rather do other more
+important things.  This will likely not be updated until after it's done (and
+when I remember to remove it - I expect that when I go for it I'll do it in one
+sitting or maybe a few sittings with a few brief breaks).
 
 - NOTE: do this AFTER everything else is done! Verify that
 [2004/gavin](2004/gavin/)'s [img/fs.tar](2004/gavin/img/fs.tar) contains the
@@ -137,18 +134,13 @@ entries in the respective README.md files. This cannot be done without examining
 each because some names are mentioned by the author. For instance I (Cody) can
 think of at least three where I have been mentioned explicitly by the author:
 one in 2018, one in 2019 and one in 2020.
+    * NOTE: this _appears_ to be done as of some time back from this writing (02
+    November 2023). This is being verified as each README.md file is checked.
 
 - For the YYYY/README.md files where it refers to emailing the judges fixes
 instead change it to make pull requests. See the
 [1995/README.md](1995/README.md) file for example.
 
 - Check the YYYY/README.md files for other things besides the GitHub pull
-requests rather thane mailing judges. This can be done on the final pass of the
+requests rather than emailing judges. This can be done on the final pass of the
 files.
-
-- When adding to the FAQ about `make` rules `make sure` :-) that this text is
-added:
->    The Makefile default assumes `cc` which might be a gcc-based compiler, or a
-    clang-based compiler, or some other compiler. Only by forcing `CC=clang` or
-    `CC=gcc` will one invoke a specific compiler. Even so different versions or
-    compilers might do different things, have different defects or other issues.


### PR DESCRIPTION

The author stated that there was no 'if's and I have made it that way
now.

The author stated that the number should be > 0 && < 27 so I added the
range check (was previously != 0). Too high value could segfault and < 0
was problematic too. 27 itself was code that could not compile. Since
the program is so beautiful it had been decided to fix the problems
which is why these changes were added too.

The above was done like:

    ((V[1]&&((atoi(V[1])>0&&atoi(V[1])<27)||(exit(1),1))));

The try.sh script has been added to the entry to try out a lot of
commands instead of copy pasting it from the judges' remarks.

Removed duplicate INABIAF information from README.md (which is why the
other updates).

Updated bugs.md with more information to the features like how output
can end up being gigabytes in length depending on the number specified
to the program. Removed from the bugs.md details about warnings to
ignore as the compiler -Wno- options take care of that now. Extra
parentheses were added to the above to prevent another warning (I was
not sure if all compilers and versions had the -Wno- so I decided to fix
it in the code itself).

The try section has a question to ponder as well. The detail is also in
the bugs.md file.