### PR TITLE
Typo fixes in bugs.md

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -474,7 +474,7 @@ emulator to test it) but running the code on the binary itself produces a
 
 # 1985
 
-There was no known bugs and (Mis)features for 1985.
+There are no known bugs and (Mis)features for entries in 1985.
 
 
 # 1986
@@ -493,7 +493,7 @@ the judges and shouldn't be fixed.
 
 # 1987
 
-There was no known bugs and (Mis)features for 1987.
+There are no known bugs and (Mis)features for entries in 1987.
 
 
 # 1988
@@ -1942,7 +1942,7 @@ If you want to try and fix this (mis)feature, you are welcome to try.
 
 # 2015
 
-There was no known bugs and (Mis)features for 2015.
+There are no known bugs and (Mis)features for entries in 2015.
 
 
 # 2016


### PR DESCRIPTION
The new text saying that there are no known bugs or (mis)features in a year is great but rather than say:

    There was no known bugs and (Mis)features for [0-9]{4}.

(which has a typo: was -> were)

it now says:

    There are no known bugs and (Mis)features for entries in [0-9]{4}.

as this is clearer and it's possible that bugs or (mis)features might be discovered yet.