### PR TITLE
Format check and test 1990/dds/README.md

### DIFF
--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -38,10 +38,10 @@ Why is there no output?
 
 This alternate code is for the [very few](https://en.wikipedia.org/wiki/0)
 [users](https://en.wikipedia.org/wiki/Microsoft_Windows)
-[here](https://www.ioccc.org) who will need it but nonetheless if you're using
-Turbo-C or MSC, the code is based on the authors' remarks except that the `"
-#Q"` string was not changed as that showed worse looking output instead of
-improved output though admittedly we have no way to test the compilers in
+[here](https://www.ioccc.org) who will need it. Nonetheless if you're using
+Turbo-C or MSC, the code is available, based on the authors' remarks except that
+the `" #Q"` string was not changed as that showed worse looking output instead
+of improved output though admittedly we have no way to test the compilers in
 question. YMMV.
 
 
@@ -71,7 +71,7 @@ The goal of this work was to write a program that solves the classic [n-queens
 problem](https://en.wikipedia.org/wiki/Eight_queens_puzzle), with a board size
 of up to 99x99, while keeping the program as short as possible.
 
-The program finds all possibilities to place N chess queens on a NxN
+The program finds all possibilities to place N chess queens on an NxN
 [chessboard](https://en.wikipedia.org/wiki/Chessboard) so that no queen is in
 range of any other queen (not in the same column row or diagonal).  For each
 solution the chess board and the place of the queens is printed to stdout.
@@ -90,9 +90,8 @@ even more simple we used a very limited subset of C:
 
 In short, it contains no C language that might confuse the innocent reader. :-)
 
-This program demonstrates the claim that in C, any program
-can be written using a single 'for' statement, as long as it is
-long enough..
+This program demonstrates the claim that in C, any program can be written using
+a single 'for' statement, as long as it is long enough.
 
 ### For PC users:
 

--- a/1990/dds/README.md
+++ b/1990/dds/README.md
@@ -121,7 +121,7 @@ The Speed of DDS-BASIC Interpreter (Version 1.00) relative to Microsoft Advanced
 BASIC 3.31 is approximately 60%.
 
 The code size could be further reduced by doing ugly things like not declaring
-the return type of functions, not freeing memory, `#defin`ing define, and joining
+the return type of functions, not freeing memory, defining define, and joining
 lines.  In its present 1536 character form the program is reasonably portable
 (it may fail to run in a tagged object architecture) and nicely formatted (it
 fits in an `80*25` screen).

--- a/1998/schweikh3/.gitignore
+++ b/1998/schweikh3/.gitignore
@@ -4,4 +4,5 @@ file2
 file3
 file4
 schweikh3.orig
+samefile
 prog.orig

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -131,6 +131,7 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${LN} -sf $@ samefile
 
 # alternative executable
 #

--- a/1998/schweikh3/README.md
+++ b/1998/schweikh3/README.md
@@ -1,11 +1,8 @@
 # Most Space Efficient
 
-Jens Schweikhardt\
-DFN Network Operation Center\
-Schlartaeckerweg 3 (Home address)\
-D-71384 Weinstadt\
-Germany\
-<http://www.schweikhardt.net>
+Jens Schweikhardt <schweikh@schweikhardt.net>\
+<http://www.schweikhardt.net>\
+Germany
 
 
 ## To build:
@@ -22,7 +19,7 @@ all your favorite pictures off the Internet or from
 `alt.binaries.pictures.*`, do
 
 ```sh
-find dir -type f -print | ./schweikh3
+find dir -type f -print | ./samefile
 ```
 
 Maybe you will not need to buy another 10 Gb disk to store them.  :-)
@@ -33,7 +30,7 @@ Maybe you will not need to buy another 10 Gb disk to store them.  :-)
 If you're in this winning entry's directory:
 
 ```sh
-find . -type f -print | ./schweikh3
+find . -type f -print | ./samefile
 ```
 
 Notice that the tool finds a duplicate file, that of the man page.
@@ -44,21 +41,17 @@ Notice that the tool finds a duplicate file, that of the man page.
 Try this:
 
 ```sh
-cp schweikh3 file1
-cp schweikh3 file2
-cp schweikh3.c file3
-ln file3 file4
-
-find . -type f -name 'file?' | ./schweikh3
+./try.sh
 ```
 
 This program is not as smart as to detect identity of JPEG files with the same
 picture but with different compression levels. On the other hand compression can
-make it thing look/sound/feel different so these probably aren't duplicates
+make a thing look/sound/feel different so these probably aren't duplicates
 anyway. :-)
 
-NOTE: Some non-gcc compilers that are not fully ANSI standard do not compile
-this entry correctly.
+Some time after this entry won, the Internet Systems Consortium (ISC) added the
+samefile utility to its treasure of software gems! See the author's page about
+the tool as well at <http://www.schweikhardt.net/samefile>.
 
 
 ## Author's remarks:
@@ -66,11 +59,17 @@ this entry correctly.
 The source is expected to conform to IEEE Std 1003.1-1990 ("POSIX").
 Thank God the IEEE does not standardize a coding style...
 
+
 ###    What this program does
 
 This is best explained in the man page. The troff source for this
-man page can be found in the file samefile.1. To render try: `man
-./samefile.1`. Otherwise:
+man page can be found in the file samefile.1. To render try:
+
+```sh
+`man ./samefile.1
+```
+
+Otherwise:
 
 
 **SAMEFILE(1)                User Manuals               SAMEFILE(1)**
@@ -80,21 +79,23 @@ man page can be found in the file samefile.1. To render try: `man
 
    **samefile** - find identical files
 
+
 **SYNOPSIS**
 
-   **./samefile**
+   ./samefile
+   
 
 **DESCRIPTION**
 
-**samefile**  reads  a  list  of file names (one file name per
-line) from stdin.  For each file name pair with  identical
+`samefile`  reads  a  list  of file names (one file name per
+line) from `stdin`.  For each file name pair with  identical
 contents, a line consisting of six tab separated fields is
 output: The size in bytes, two file names,  the  character
 `=`  if the two files are on the same device, `X` otherwise,
 and the link counts of the two files.  The  output
 is sorted in reverse order by size.
 
-samefile uses two stages to give optimum performance.
+`samefile` uses two stages to give optimum performance.
 
 In  the  first  stage,  all  non-plain  files are silently
 ignored (directories, devices,  FIFOs,  sockets,  symbolic
@@ -186,7 +187,7 @@ otherwise.
 
 `find(1)`, `ln(1)`, `rm(1)`
 
-\
+
 ### Why I think it is obfuscated
 
 - The code is commented but this gives only an *extremely* faint clue.

--- a/1998/schweikh3/try.sh
+++ b/1998/schweikh3/try.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+make all || exit 1
+
+echo "$ cp -f schweikh3 file1"
+cp -f schweikh3 file1
+echo "$ cp -f schweikh3 file2"
+cp -f schweikh3 file2
+echo "$ cp -f schweikh3.c file3"
+cp -f schweikh3.c file3
+echo "$ ln -f file3 file4"
+ln -f file3 file4
+echo "$ find . -type f -name 'file?' | ./samefile"
+find . -type f -name 'file?' | ./samefile

--- a/bugs.md
+++ b/bugs.md
@@ -474,7 +474,7 @@ emulator to test it) but running the code on the binary itself produces a
 
 # 1985
 
-There was no known bugs and (Mis)features for 1985.
+There are no known bugs and (Mis)features for entries in 1985.
 
 
 # 1986
@@ -493,7 +493,7 @@ the judges and shouldn't be fixed.
 
 # 1987
 
-There was no known bugs and (Mis)features for 1987.
+There are no known bugs and (Mis)features for entries in 1987.
 
 
 # 1988
@@ -1942,7 +1942,7 @@ If you want to try and fix this (mis)feature, you are welcome to try.
 
 # 2015
 
-There was no known bugs and (Mis)features for 2015.
+There are no known bugs and (Mis)features for entries in 2015.
 
 
 # 2016

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1669,6 +1669,19 @@ interesting historical explanation and further details and fun, see the
 README.md.
 
 
+## [1998/schweikh3](1998/schweikh3/schweikh3.c) ([README.md](1998/schweikh3/README.md]))
+
+Cody added the [try.sh](1998/schweikh3/try.sh) script to make it easier to try
+the commands that we suggested. One command was not added, that of the to use
+command.
+
+Cody also made the Makefile rule `all` symlink the entry to `samefile` as that
+is the name of the program.
+
+There actually is a web page for the tool and this was added to the author
+information for the entry. It has not been added to any JSON file.
+
+
 ## [2000/anderson](2000/anderson/anderson.c) ([README.md](2000/anderson/README.md]))
 
 Cody changed this entry to use `fgets()` instead of `gets()` to make it safer

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1541,6 +1541,8 @@ Cody fixed this to not segfault under macOS. The problem was that the function
 pointer `w`, which points to `XCreateWindow()`, did not specify the parameters of
 the function in the pointer assignment.
 
+NOTE: if there is no X server running this program will still crash.
+
 
 ## [1996/westley](1996/westley/westley.c) ([README.md](1996/westley/README.md]))
 
@@ -1589,7 +1591,7 @@ doing:
 ```
 
 Cody also added the [try.sh](1998/schnitzi/try.sh) script to help users try the
-commands (as well as some added by him) we recommended.
+commands that we recommended as well as some added by him.
 
 
 ## [1998/schweikh1](1998/schweikh1/schweikh1.c) ([README.md](1998/schweikh1/README.md]))
@@ -1609,7 +1611,7 @@ So what was wrong with the original?
 
 The call to `freopen()` was incorrect with the second arg (the mode) being
 `5+__FILE__`; it is now `"r"`. (Observe that the mode to the `fopen()`
-call is: `44+__FILE__`. This might seem incorrect and indeed it can be changed
+call is: `43+__FILE__`. This might seem incorrect and indeed it can be changed
 to `"r"` as well but this was not actually necessary so once this was noticed it
 was changed back to the original.)
 

--- a/tmp/format-headers.sh
+++ b/tmp/format-headers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# format-headers.sh - script that formats headers in README.md files so that
+# before a line that starts with '##' (as in '^##') that have specific names
+# there are two blank lines (\n\n).
+#
+# Script written by Landon with minor improvements by Cody Boone Ferguson where
+# now it only acts on files under git control rather than any README.md file in
+# the [0-9]{4} directories.
+#
+
+for i in "$(git ls-files '[0-9][0-9][0-9][0-9]/*README.md')"; do
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(To build):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Bugs and \(Mis\)features):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(To use):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Try):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Original code):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Original build):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Original try):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Original use):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Alternate code):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Alternate build):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Alternate try):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Alternate use):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Judges. remarks):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Author.s remarks):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Authors. remarks):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+    perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Copyright and CC BY-SA 4.0 License):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
+done


### PR DESCRIPTION
In order to try and speed things along some of the things that might be
good to have in code blocks (as in '`` ` ``' ) have not been done so it can be
seen if this can be omitted. If it works out it's almost certain that
this can be done with other README.md files which also have places where
'`` ` ``'s might be useful. An example here where it's not used but might be
is in the section 'Program commands' with variables NOT enclosed in '`'s
and other things that might look a little better with them.
