### PR TITLE
Don't hard code paths in 1990/jaw/shark.sh

### DIFF
--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -142,7 +142,7 @@ atob: zcat
 ${PROG}:
 	${RM} -f $@
 	echo 'PATH=;export PATH;./atob|./zcat' > $@
-	${CHMOD} 0555 $@
+	${CHMOD} 0755 $@
 
 # alternative executable
 #

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -17,17 +17,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features:
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1990 jaw in bugs.md](/bugs.md#1990-jaw).
-
-
 ### Try:
 
 To test the official C entry, one might try:
@@ -40,7 +29,7 @@ which should apply the identity transformation to a minimal holoalphabetic
 sentence.
 
 
-Also try:
+#### Also try:
 
 ```sh
 ./try.sh

--- a/1990/jaw/btoa
+++ b/1990/jaw/btoa
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-puts "xbtoa Begin"
+
+puts "btoa Begin"
 data = $<.read
 n, e, s, r = data.bytesize, 0, 0, 0
 (-n % 4).times { data << 0 }
@@ -9,4 +10,4 @@ end
 data.unpack("N*").flat_map do |v|
   v == 0 ? [?z.ord] : (0..4).map {|i| v / 85**(4 - i) % 85 + 33 }
 end.pack("C*").scan(/.{1,78}/) { puts $& }
-puts "xbtoa End N %d %x E %x S %x R %x" % [n, n, e, s, r]
+puts "btoa End N %d %x E %x S %x R %x" % [n, n, e, s, r]

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -43,5 +43,5 @@ Z,h@=w;n=8;f=Q+e;i=o=HIo<0)X,1;P(i)WH+1){Iw==Q&e){Z;m=n=8;f=QIH<0)X}
 c=wIw>=f)U++=i,w=oWw>=Q)U++=h@,w=t@;P(i=h@)Wp>D+Q)P(*--p)
 I(w=f)<1l<<k)t@=o,h[f++]=i;o=c}X}
 _
-($v);echo 1>&2;ln -f $z $a);./$a<<\w>./$m-&&./$z<./$m->./$m;tar xvf ../$m.tar&&$r
+($v);echo 1>&2;ln -f $z $a);./$a<<\w>$m-&&./$z<$m->$m;tar xvf ../$m.tar&&$r
 Z

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -9,11 +9,11 @@ for i in "${@?${usage?$0 file...}}";do<"$i"||exit;done
 #
 # "Cleverly he dialed from within." -- D. Van Vliet, "Trout Mask Replica"
 #
-PATH=$PATH:.:.. a=atob m=unshark z=zcat
+a=atob m=unshark z=zcat
 r="rm -f $a $m* ../$m.tar $z" v="cc -Wno-implicit-function-declaration -Wno-implicit-int -o $z $m.c"
 trap '$r;exit 1' 1 2 13 15
 echo decoding...
-(:|compress|btoa|./$a|./$z)2>$m>&2||(sed '1,9s/./#define & /
+(:|compress|btoa|$a|$z)2>$m>&2||(sed '1,9s/./#define & /
 s/@/[w]/g
 s/C/char /g
 s/I/;if(/g

--- a/bugs.md
+++ b/bugs.md
@@ -658,31 +658,8 @@ errors.
 That's about all I can say for how it works as other things have to be done too.
 Enjoy! :-)
 
+
 # 1990
-
-
-## 1990 jaw
-
-### STATUS: known bug - please help us fix
-### Source code: [1990/jaw/jaw.c](1990/jaw/jaw.c)
-### Information: [1990/jaw/README.md](1990/jaw/README.md)
-
-The command:
-
-```sh
-echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
-```
-
-just prints:
-
-```
-$ echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
-oops
-oops
-```
-
-Do you have a fix? We welcome it (Cody does have an idea and will look at it
-later but we also don't know what it's supposed to do now)!
 
 
 ## 1990 theorem
@@ -700,8 +677,6 @@ where this occurred was fixed but this one should not be fixed. Thank you.
 
 # 1991
 
-
-## 1991 dds
 
 ## 1991 westley
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -959,10 +959,9 @@ is 0 it shows what looks like an error.
 He added the [try.sh](1990/jaw/try.sh) to run the commands that we suggested at
 the time.
 
-However, there is a known bug still, see [1990 jaw in
-bugs.md](/bugs.md#1990-jaw) for details.
-
-NOTE: as `btoa` is not common we used a ruby script from Yusuke.
+NOTE: as `btoa` is not common we used a ruby script from Yusuke but with a minor
+fix applied by Cody that made the program just show `oops` twice from invalid
+input.
 
 
 ## [1990/pjr](1990/pjr/pjr.c) ([README.md](1990/pjr/README.md]))
@@ -1020,14 +1019,24 @@ again (since it did not work anyway a segfault prevention was added here). He
 also fixed some array addressing (some of which might not be strictly necessary
 but as he was testing the `fibonacci.c` bug he ended up changing it anyway).
 
-Finally he changed this program to use `fgets()` not `gets()` to make it safer
+BTW: why can't the fix:
+
+```c
+if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;
+```
+
+be changed to just test the value of `A` when `a` is argv and `A` is argc?
+
+
+Finally Cody changed this program to use `fgets()` not `gets()` to make it safer
 and to prevent a warning about `gets()` at linking or runtime. Since this
 program is so incredible the extra fixes were deemed worth having and this is why
 it was done.
 
-Cody disabled a warning in the Makefile that proved to be a problem only with
-clang in linux but which was defaulting to an error. This way was the simplest
-way to deal with the problem in question due to the way the entry works.
+Cody later disabled a warning in the Makefile that proved to be a problem only
+with clang in linux but which was defaulting to an error. This way was the
+simplest way to deal with the problem in question due to the way the entry
+works.
 
 Yusuke pointed out that `atof` nowadays needs `#include <stdlib.h>` which was
 used in order to get this to work initially (prior to this output was there but

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -948,10 +948,9 @@ with if the C preprocessor botches single quotes in cpp expansion.
 
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))
 
-Cody fixed the script to work properly in modern environments including paths,
-writing to and extracting from stdout, (to do with `$PATH`
-not having `.` in it) and relying on the exit code in the commands to allow for
-`&& ...`.
+Cody fixed the script to work properly in modern environments including writing
+to and extracting from `stdout` and relying on the exit code in the commands to
+allow for `&& ...`.
 
 He also changed the `perror(3)` call to `fprintf(3)` because in macOS when errno
 is 0 it shows what looks like an error.
@@ -961,7 +960,7 @@ the time.
 
 NOTE: as `btoa` is not common we used a ruby script from Yusuke but with a minor
 fix applied by Cody that made the program just show `oops` twice from invalid
-input.
+input but which now works.
 
 
 ## [1990/pjr](1990/pjr/pjr.c) ([README.md](1990/pjr/README.md]))


### PR DESCRIPTION

It is not actually necessary to mess with the path and in fact the $PATH variable is no longer modified or even referred to. The purpose of the program was that even without btoa and uncompress the script should be able to extract the tarball.

Now only the tarball path is hard coded as reading a tarball from stdin is problematic though I'm pretty sure it used to work.