### PR TITLE
Typo/format check 1990/westley/README.md

### DIFF
--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -142,7 +142,7 @@ atob: zcat
 ${PROG}:
 	${RM} -f $@
 	echo 'PATH=;export PATH;./atob|./zcat' > $@
-	${CHMOD} 0555 $@
+	${CHMOD} 0755 $@
 
 # alternative executable
 #

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -41,14 +41,15 @@ sentence.
 The program, in its base form, implements two useful utilities:
 
 
-- `atob` - ascii to binary conversion
+- `atob` - ASCII to binary conversion
 - `zcat` - decompression filter
 
 Included with this entry is a shell script (with comments edited down to reduce
 it to 1530 bytes) which implements the complete shark utility. The script,
-shark.sh, contains a 'jaw.c' embedded within it!
+[shark.sh](shark.sh), contains a `jaw.c` embedded within it!
 
 The sender must have `compress` and `btoa`. To send, try:
+
 
 ```sh
 ./shark.sh jaw.* README.md > receive
@@ -65,8 +66,12 @@ cmp ../jaw.c jaw.c
 cmp ../README.md README.md
 ```
 
+NOTE: a limitation is that the script should be in the parent directory of the
+directory it is run from.
+
 
 ## Authors' remarks:
+
 
 ### ABSTRACT
 
@@ -76,13 +81,15 @@ James A. Woods\
 Universities Space Research Association\
 NASA Ames Research Center
 
+
 ---
 
 > "Use an algorithm, go to jail."
 >
-> -- anon., circa 1988, pre-Morris worm era
+> -- anon., circa 1988, pre-[Morris worm](https://en.wikipedia.org/wiki/Morris_worm) era
 
 ----
+
 
 Myriad formats have been proposed for network-mailable data. A major difficulty
 undermining the popularity of most file/message bundlers is that the sender
@@ -90,11 +97,12 @@ assumes prior installation of the computational dual of such bundling software
 by the receiver. Command shell archives alleviate this problem somewhat, but
 still require standardization for the function of data compression and
 mail-transparency encoding. On Unix, these coding format quandaries are overcome
-by planting a novel Trojan Horse in the archive header to perform
-negotiation-less decoding.
+by planting a novel [Trojan
+Horse](https://en.wikipedia.org/wiki/Trojan_horse_(computing)) in the archive
+header to perform negotiation-less decoding.
 
 Specifically, we outline the development of an extraordinarily compact portable
-(un)bundler to (dis)assemble data-compressed, binary-to-ASCII-converted,
+bundler/extractor to (dis)assemble data-compressed, binary-to-ASCII-converted,
 length-split, and checksummed directory structures using standard Unix tools.
 Miniature versions of counterparts to a Lempel-Ziv coder (`compress` or
 `squeeze`) and an efficient bit packetizer (`btoa`) are compiled on-the-fly at
@@ -102,7 +110,7 @@ mail destination sites where they may not already exist. These are written in
 purposefully obfuscated-C to accompany similarly-shrunk shell command glue. This
 resulting shell archiver is dubbed `shark`.
 
-`shark` procedure overhead consumes as few as three dozen shell lines (or
+`shark` procedure overhead consumes as few as three dozen shell commands (or
 `~1100` bytes), commensurate with the size of many Internet mail headers; it
 amortizes favorably with message size. `shark` is portable across Unix
 variants, while the underlying technique is inherently generalizable to other
@@ -115,11 +123,11 @@ environment.
 
 ----------------------------------------------
 
->   Oh, the shark has pretty teeth, dear--
->   And he shows them pearly white
->   Just a jackknife has Macheath, dear--
->   And he keeps it out of sight.
->
+>   Oh, the shark has pretty teeth, dear--\
+>   And he shows them pearly white\
+>   Just a jackknife has Macheath, dear--\
+>   And he keeps it out of sight.\
+> \
 >   -- Bertolt Brecht, Threepenny Opera
 
 ----------------------------------------------
@@ -190,39 +198,39 @@ rm /tmp/shark$$*
 
 ### Shark history:
 
-- May 1987: Karl Fox introduces 1023-byte zcat.c to USENET.
+- May 1987: Karl Fox introduces 1023-byte `zcat.c` to USENET.
 	     It's too late for the 4th IOCCC.
 
 - May 21, 1987: James A. Woods extends idea to construct self
-	     decompressing shar Trojan horse, utilizing 'cc', 'shar',
-	     'zcat', & 'btoa'; size: 2303 bytes.
+	     decompressing `shar` Trojan horse, utilizing `cc`, `shar`,
+	     `zcat`, & `btoa`; size: 2303 bytes.
 
-- May 23, 1987: 'jaw' trims 250 bytes without much thought.
+- May 23, 1987: `jaw` trims 250 bytes without much thought.
 
-- June 2, 1987: 52 lines of shell, 1991 bytes, now made with 'tar',
+- June 2, 1987: 52 lines of shell, 1991 bytes, now made with `tar`,
 	     short-circuit C-compile at far end, dual-use main.c,
 	     portability mods. (jaw)
 
 - Mar-May 1988: abortive run at 5th IOCCC.
-	     jaw.c - 1529 bytes. compile line: 152 bytes.
-	     generated funny code with execvp() to invoke shell.
+	     `jaw.c` - 1529 bytes. compile line: 152 bytes.
+	     generated funny code with `execvp()` to invoke shell.
 
 - Aug 29, 1988: production version, now at 1830 bytes.
 
 - Jan 1990: Paul Eggert does tour-de-force shark re-engineering.
 
-- May 24, 1990: collaboration yields 999-byte jaw.c core (see above)
+- May 24, 1990: collaboration yields 999-byte `jaw.c` core (see above)
 	     and 1530-byte production shell code (w/comments).
 	     Eggert comes through with lion's share of improvements.
-	     7th IOCCC code now faster than the btoa/zcat it replaces.
+	     7th IOCCC code now faster than the `btoa`/`zcat` it replaces.
 
-- May 1990: 'jaw' develops experimental replacement using
+- May 1990: `jaw` develops experimental replacement using
 	     Dan Bernstein's high-compression 'squeeze'.
 
 
 To which we add:
 
-- June 1990: 'shark' wins the IOCCC, finally! :-)
+- June 1990: `shark` wins the IOCCC, finally! :-)
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -17,17 +17,6 @@ make all
 ```
 
 
-### Bugs and (Mis)features:
-
-The current status of this entry is:
-
-```
-STATUS: known bug - please help us fix
-```
-
-For more detailed information see [1990 jaw in bugs.md](/bugs.md#1990-jaw).
-
-
 ### Try:
 
 To test the official C entry, one might try:
@@ -40,7 +29,7 @@ which should apply the identity transformation to a minimal holoalphabetic
 sentence.
 
 
-Also try:
+#### Also try:
 
 ```sh
 ./try.sh

--- a/1990/jaw/btoa
+++ b/1990/jaw/btoa
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-puts "xbtoa Begin"
+
+puts "btoa Begin"
 data = $<.read
 n, e, s, r = data.bytesize, 0, 0, 0
 (-n % 4).times { data << 0 }
@@ -9,4 +10,4 @@ end
 data.unpack("N*").flat_map do |v|
   v == 0 ? [?z.ord] : (0..4).map {|i| v / 85**(4 - i) % 85 + 33 }
 end.pack("C*").scan(/.{1,78}/) { puts $& }
-puts "xbtoa End N %d %x E %x S %x R %x" % [n, n, e, s, r]
+puts "btoa End N %d %x E %x S %x R %x" % [n, n, e, s, r]

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -43,5 +43,5 @@ Z,h@=w;n=8;f=Q+e;i=o=HIo<0)X,1;P(i)WH+1){Iw==Q&e){Z;m=n=8;f=QIH<0)X}
 c=wIw>=f)U++=i,w=oWw>=Q)U++=h@,w=t@;P(i=h@)Wp>D+Q)P(*--p)
 I(w=f)<1l<<k)t@=o,h[f++]=i;o=c}X}
 _
-($v);echo 1>&2;ln -f $z $a);./$a<<\w>./$m-&&./$z<./$m->./$m;tar xvf ../$m.tar&&$r
+($v);echo 1>&2;ln -f $z $a);./$a<<\w>$m-&&./$z<$m->$m;tar xvf ../$m.tar&&$r
 Z

--- a/1990/jaw/shark.sh
+++ b/1990/jaw/shark.sh
@@ -9,11 +9,11 @@ for i in "${@?${usage?$0 file...}}";do<"$i"||exit;done
 #
 # "Cleverly he dialed from within." -- D. Van Vliet, "Trout Mask Replica"
 #
-PATH=$PATH:.:.. a=atob m=unshark z=zcat
+a=atob m=unshark z=zcat
 r="rm -f $a $m* ../$m.tar $z" v="cc -Wno-implicit-function-declaration -Wno-implicit-int -o $z $m.c"
 trap '$r;exit 1' 1 2 13 15
 echo decoding...
-(:|compress|btoa|./$a|./$z)2>$m>&2||(sed '1,9s/./#define & /
+(:|compress|btoa|$a|$z)2>$m>&2||(sed '1,9s/./#define & /
 s/@/[w]/g
 s/C/char /g
 s/I/;if(/g

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -132,7 +132,7 @@ and cd. It flags errors on failed `chdir()`, `open()`, `creat()`,
 
 This program is obfuscated in a few notable ways: apart from the layout (an
 unformatted (but crunched) version is included for people who want to put this
-through cb) it makes clever use of a write statement, so that the same statement
+through `cb`) it makes clever use of a `write()` statement, so that the same statement
 can be used to print errors and the prompt. By calling the error function with
 the value `-8`, the pointer offset in the expression `"?\n$ "-x/4` goes from 0
 to 2.  Presto!  A prompt. For errors with numbers smaller than `-4` (i.e., UNIX
@@ -158,6 +158,7 @@ eliminate more than a few characters (we can't see how to make it
 any smaller!).  550 characters is pretty lean for a shell that does
 this much.
 
+
 ### BUGS
 
 The syntax of the shell has not been fully explored, but if you try
@@ -172,20 +173,20 @@ example:
 cat > foo > bar
 ```
 
-cats to foo, since it was pushed last, but
+cats to `foo`, since it was pushed last, but
 
 ```sh
 cat > > foo bar
 ```
 
-cats to bar, since bar was pushed under foo (remember we're
+cats to `bar`, since `bar` was pushed under `foo` (remember we're
 parsing right-left).
 
-Depending on your flavor of Unix, cd without an argument will
+Depending on your flavor of Unix, `cd` without an argument will
 either produce an error or just do nothing.
 
 There is just one error message, the question mark, but hey, that's
-all ed does too.
+all `ed(1)` does too.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -1,9 +1,6 @@
 # Best Layout
 
 Brian Westley (Merlyn LeRoy on usenet)\
-DigiBoard, Inc.\
-1026 Blair Ave.\
-St. Paul, MN  55104\
 US\
 <http://www.westley.org>
 
@@ -18,7 +15,7 @@ make all
 ## To use:
 
 ```sh
-./westley <number
+./westley <number>
 ```
 
 The number should be greater than 0.
@@ -36,18 +33,28 @@ The number should be greater than 0.
 
 ## Alternate code:
 
+The alternate code is provided to show how C changed.
+
+
+### Alternate build:
+
 If you have an old enough compiler try and to see how C has changed over the years:
 
 ```sh
 make alt
 ```
 
-Use `westley.alt` as you would `westley`.
+### Alternate use:
+
+
+```sh
+./westley.alt <number>
+```
 
 
 ## Judges' remarks:
 
-If you would rather "Daisy" someone other than Westley, rename\
+If you would rather "Daisy" someone other than Westley, rename
 the program as needed.  :-)
 
 Read each block of code as if it were a piece of correspondence.
@@ -61,8 +68,8 @@ charlie,
 		signed charlotte
 ```
 
-The original source had control-L's after each code block.  To\
-make it easier on news readers, we converted each control-L to\
+The original source had control-L's after each code block.  To
+make it easier on news readers, we converted each control-L to
 a blank line.
 
 

--- a/bugs.md
+++ b/bugs.md
@@ -658,31 +658,8 @@ errors.
 That's about all I can say for how it works as other things have to be done too.
 Enjoy! :-)
 
+
 # 1990
-
-
-## 1990 jaw
-
-### STATUS: known bug - please help us fix
-### Source code: [1990/jaw/jaw.c](1990/jaw/jaw.c)
-### Information: [1990/jaw/README.md](1990/jaw/README.md)
-
-The command:
-
-```sh
-echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
-```
-
-just prints:
-
-```
-$ echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
-oops
-oops
-```
-
-Do you have a fix? We welcome it (Cody does have an idea and will look at it
-later but we also don't know what it's supposed to do now)!
 
 
 ## 1990 theorem
@@ -700,8 +677,6 @@ where this occurred was fixed but this one should not be fixed. Thank you.
 
 # 1991
 
-
-## 1991 dds
 
 ## 1991 westley
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -959,10 +959,9 @@ is 0 it shows what looks like an error.
 He added the [try.sh](1990/jaw/try.sh) to run the commands that we suggested at
 the time.
 
-However, there is a known bug still, see [1990 jaw in
-bugs.md](/bugs.md#1990-jaw) for details.
-
-NOTE: as `btoa` is not common we used a ruby script from Yusuke.
+NOTE: as `btoa` is not common we used a ruby script from Yusuke but with a minor
+fix applied by Cody that made the program just show `oops` twice from invalid
+input.
 
 
 ## [1990/pjr](1990/pjr/pjr.c) ([README.md](1990/pjr/README.md]))
@@ -1020,14 +1019,24 @@ again (since it did not work anyway a segfault prevention was added here). He
 also fixed some array addressing (some of which might not be strictly necessary
 but as he was testing the `fibonacci.c` bug he ended up changing it anyway).
 
-Finally he changed this program to use `fgets()` not `gets()` to make it safer
+BTW: why can't the fix:
+
+```c
+if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;
+```
+
+be changed to just test the value of `A` when `a` is argv and `A` is argc?
+
+
+Finally Cody changed this program to use `fgets()` not `gets()` to make it safer
 and to prevent a warning about `gets()` at linking or runtime. Since this
 program is so incredible the extra fixes were deemed worth having and this is why
 it was done.
 
-Cody disabled a warning in the Makefile that proved to be a problem only with
-clang in linux but which was defaulting to an error. This way was the simplest
-way to deal with the problem in question due to the way the entry works.
+Cody later disabled a warning in the Makefile that proved to be a problem only
+with clang in linux but which was defaulting to an error. This way was the
+simplest way to deal with the problem in question due to the way the entry
+works.
 
 Yusuke pointed out that `atof` nowadays needs `#include <stdlib.h>` which was
 used in order to get this to work initially (prior to this output was there but

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -948,10 +948,9 @@ with if the C preprocessor botches single quotes in cpp expansion.
 
 ## [1990/jaw](1990/jaw/jaw.c) ([README.md](1990/jaw/README.md]))
 
-Cody fixed the script to work properly in modern environments including paths,
-writing to and extracting from stdout, (to do with `$PATH`
-not having `.` in it) and relying on the exit code in the commands to allow for
-`&& ...`.
+Cody fixed the script to work properly in modern environments including writing
+to and extracting from `stdout` and relying on the exit code in the commands to
+allow for `&& ...`.
 
 He also changed the `perror(3)` call to `fprintf(3)` because in macOS when errno
 is 0 it shows what looks like an error.
@@ -961,7 +960,7 @@ the time.
 
 NOTE: as `btoa` is not common we used a ruby script from Yusuke but with a minor
 fix applied by Cody that made the program just show `oops` twice from invalid
-input.
+input but which now works.
 
 
 ## [1990/pjr](1990/pjr/pjr.c) ([README.md](1990/pjr/README.md]))


### PR DESCRIPTION

This also fixes a typo I introduced that would result in a syntax error
in use.

It also adds proper '### Alternate build' and '### Alternate use' 
sections.

I've decided that for the rest of the README.md files I will try not 
worrying much about grammar unless it makes it harder to understand the
information or it's very quick. This way all these can get done sooner.