### PR TITLE
(Some) fixes in 1991/ant/README.md

### DIFF
--- a/1991/ant/README.md
+++ b/1991/ant/README.md
@@ -1,12 +1,3 @@
-# Best Utility
-
-Anthony C Howe\
-Mortice Kern Systems Inc.	#CL-23\
-35 King St. N			268 Phillip St.\
-Waterloo, On			Waterloo, On\
-Canada, N2J 2W9			Canada, N2L 6G9
-
-
 ## To build:
 
 ```sh
@@ -75,7 +66,7 @@ results depending on the implementation of `curses`.
 -    W		    write buffer to file
 -    R		    refresh the screen
 -    Q		    quit
-\
+
 ### Exit status
 
 -    0		    success
@@ -98,10 +89,10 @@ to provide more portable code, since the compiler should handle the translation
 of them into the native character set.  Note that `'\f'` (form-feed) was used to
 exit insert mode because K&R C had no escape constant for the escape-key.
 
-My goals for this project were to learn and experiment with the\
-Buffer Gap Scheme [Fin80][net90], write a useful and *portable*\
-program, and meet the requirements of the IOCCC.  I initially\
-planned to have a mini `curses` built-in like the IOCCC Tetris entry\
+My goals for this project were to learn and experiment with the
+Buffer Gap Scheme [Fin80][net90], write a useful and *portable*
+program, and meet the requirements of the IOCCC.  I initially
+planned to have a mini `curses` built-in like the IOCCC Tetris entry
 from a previous year, however this was not as portable as using a
 `curses` library with `TERMINFO`/`TERMCAP` support.
 

--- a/1991/fine/try.sh
+++ b/1991/fine/try.sh
@@ -16,17 +16,46 @@ echo "Tang" | ./fine
 
 echo -n "Vend onyx <-> "
 echo "Vend onyx" | ./fine
+
 echo -n "Cheryl be flashy <-> "
 echo "Cheryl be flashy" | ./fine
+
 echo -n "Rail <-> "
 echo "Rail" | ./fine
+
 echo -n "Clerk <-> "
 echo "Clerk" | ./fine
+
 echo -n "Ones <-> "
 echo "Ones" | ./fine
+
 echo -n "Fur <-> "
 echo "Fur" | ./fine
+
 echo -n "Er <-> "
 echo "Er" | ./fine
+
+echo -n "IV <-> "
+echo "IV" | ./fine
+
+echo -n "NYC <-> "
+echo "NYC" | ./fine
+
+echo -n "Fubar <-> "
+echo "Fubar" | ./fine
+
+echo -n "DQ <-> "
+echo "DQ" | ./fine
+
+echo -n "Off <-> "
+echo "Off" | ./fine
+
+echo -n "Ire <-> "
+echo "Ire" | ./fine
+
+echo -n "PEP <-> "
+echo "PEP" | ./fine
+
+
 echo -n "The rug gary lenT <-> "
 echo "The rug gary lenT" | ./fine

--- a/1996/jonth/README.md
+++ b/1996/jonth/README.md
@@ -1,13 +1,3 @@
-# Best X11 Entry
-
-Jon Thingvold\
-University of Oslo\
-Gaustadveien 10B\
-N 0372 Oslo\
-Norway\
-<http://www.uio.no/~jonth/>
-
-
 ## To build:
 
 ```sh
@@ -25,6 +15,7 @@ entry.
 The current status of this entry is:
 
 ```
+STATUS: INABIAF - please **DO NOT** fix
 STATUS: missing or dead link - please provide them
 ```
 
@@ -35,6 +26,24 @@ For more detailed information see [1996 jonth in bugs.md](/bugs.md#1996-jonth).
 
 ```sh
 ./jonth :0 :0
+```
+
+NOTE: the two boards will be on top of each other so you will have to drag one
+off the other so that you can properly play.
+
+
+NOTE: if there is no X service open this will crash. If this is the case you
+might try:
+
+```sh
+./jonth
+```
+
+These are supposed to happen.  As is written in the
+[The Jargon File](http://catb.org/jargon/html/F/feature.html):
+
+```
+That's not a bug, that's a feature.
 ```
 
 
@@ -58,7 +67,7 @@ as arguments to this game.
 
 ### Known bugs:
 
-Sometimes on Solaris X gets confused and this program core dumps. The solution:
+Sometimes on Solaris, X gets confused and this program core dumps. The solution:
 give two display arguments (`./jonth host:0 host:0`).
 
 If one (or both) windows look like a copy of the window(s) below, try

--- a/bugs.md
+++ b/bugs.md
@@ -1068,11 +1068,22 @@ Do you have an updated link? We welcome your help!
 
 ## 1996 jonth
 
-### STATUS: missing or dead link - please provide them
+### STATUS: INABIAF - please **DO NOT** fix
+
+### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1996/jonth/jonth.c](1996/jonth/jonth.c)
 ### Information: [1996/jonth/README.md](1996/jonth/README.md)
 
-As well the link which was http://www.uio.no/~jonth is no longer valid and
+If X is not running this program will very likely crash or do something funny.
+This should NOT be fixed.
+
+NOTE: the two boards will be on top of each other so you will have to drag one
+off the other so that you can properly play.
+
+
+### STATUS: missing or dead link - please provide them
+
+As well: the link which was http://www.uio.no/~jonth is no longer valid and
 there's no archive on the Internet Wayback Machine. Do you know of a proper URL?
 We greatly appreciate your help here!
 

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@ When we do, we will announce restoration of Email service here.
 </UL><BR>
 
 <LI TYPE=none><B>2018-02-16</B>
-<UL><LI TYPE=square>Due to a scheduling conflict with one of the <A HREF="judges.html">IOCCC judges</A>, the 25<sup>th</sup> IOCCC end date is now the Ideas of March.
+<UL><LI TYPE=square>Due to a scheduling conflict with one of the <A HREF="judges.html">IOCCC judges</A>, the 25<sup>th</sup> IOCCC end date is now the Ides of March.
 <LI TYPE=square>Please <a href="https://submit.ioccc.org">submit</a> your entries by 2018-Mar-15 03:08:07 UTC.
 <LI TYPE=square>Updated: The 25<sup>th</sup> IOCCC will be open from <B>2017-Dec-29 05:38:51 UTC</B> to <B>2018-Mar-15 03:08:07 UTC</B>.
 </UL><BR>
@@ -430,7 +430,7 @@ When we do, we will announce restoration of Email service here.
 -->
 </UL>
 
-<P>Older news has been archived, but is not currently available</P>
+<P>Older news has been archived, but is not currently available.</P>
 
 <HR>
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1189,7 +1189,7 @@ between pointer and integer ('char **' and 'int')` but it works just fine).
 
 Cody also added the [try.sh](1991/fine/try.sh) script which feeds the program
 some fun input for fun but mostly different output. He added a great string from
-Brian Westley and Cody also added a few of his own (can you figure out exactly
+Brian Westley and Cody also added several of his own (can you figure out exactly
 which ones? :-) )
 
 

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -418,8 +418,8 @@ This file as the following fields:
 
 5. created_by:
 
-   The name of the program that creates this file, or null is the
-   file an original file.
+   The name of the program that creates this file, or null if the
+   file is an original file.
 
    NOTE: A null created_by value indicates that the file is part
    of the primary content.  A non-null created_by value indicates

--- a/tmp/run_all.sh
+++ b/tmp/run_all.sh
@@ -137,7 +137,7 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: WINNER_DIR_TXT=$WINNER_DIR_TXT" 1>&2
 fi
 
-# make is easier to process CSV files
+# make it easier to process CSV files
 #
 IFS="$IFS,"
 
@@ -163,11 +163,11 @@ if [[ ! -e $TOOL ]]; then
     exit 5
 fi
 if [[ ! -f $TOOL ]]; then
-    echo  "$0: ERROR: TOOL is not a file: $TOOL" 1>&2
+    echo  "$0: ERROR: TOOL is not a regular file: $TOOL" 1>&2
     exit 5
 fi
 if [[ ! -x $TOOL ]]; then
-    echo  "$0: ERROR: TOOL is not a executable file: $TOOL" 1>&2
+    echo  "$0: ERROR: TOOL is not an executable file: $TOOL" 1>&2
     exit 5
 fi
 


### PR DESCRIPTION

This file has not been completely checked but some fixes were made. As 
well since it has been requested that the award and author information 
be removed from the file, making '## To build:' the first line, this has
been done as these other changes were already made. When all README.md 
files have been updated a mass edit will be done for this. There 
currently are six others.