### PR TITLE
Fix 1991/rince and add two alt versions

### DIFF
--- a/1984/anonymous/README.md
+++ b/1984/anonymous/README.md
@@ -1,8 +1,3 @@
-# Dishonorable mention
-
-Anonymous
-
-
 ## To build:
 
 ```sh

--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -1,8 +1,3 @@
-# Second place award
-
-Dave Decot
-
-
 ## To build:
 
 ```sh

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -1,8 +1,3 @@
-# Third place
-
-Mike Laman
-
-
 ## To build:
 
 ```sh

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -1,11 +1,3 @@
-# Grand Prize
-
-Sjoerd Mullender\
-<https://github.com/sjoerdmullender>
-
-Robbert van Renesse
-
-
 ## To build:
 
 ```sh

--- a/1985/applin/README.md
+++ b/1985/applin/README.md
@@ -1,10 +1,3 @@
-# Best one liner
-
-Jack Applin [with help from Robert Heckendorn]\
-US\
-<https://www.cs.colostate.edu/~applin/>
-
-
 ## To build:
 
 ```sh

--- a/1985/august/README.md
+++ b/1985/august/README.md
@@ -1,9 +1,3 @@
-# Most obscure program
-
-Lennart Augustsson\
-<https://web.archive.org/web/20090831055828/http://www.cs.chalmers.se/~augustss>
-
-
 ## To build:
 
 ```sh

--- a/1985/lycklama/README.md
+++ b/1985/lycklama/README.md
@@ -1,8 +1,3 @@
-# Strangest appearing program
-
-Ed Lycklama
-
-
 ## To build:
 
 ```sh

--- a/1985/shapiro/README.md
+++ b/1985/shapiro/README.md
@@ -1,8 +1,3 @@
-# Grand prize for most well-rounded in confusion
-
-Carl Shapiro
-
-
 ## To build:
 
 ```sh

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -1,8 +1,3 @@
-# Worst abuse of the C preprocessor
-
-Col. G. L. Sicherman
-
-
 ## To build:
 
 ```sh

--- a/1986/applin/README.md
+++ b/1986/applin/README.md
@@ -1,10 +1,3 @@
-# Most adaptable program
-
-Jack Applin\
-US\
-<https://www.cs.colostate.edu/~applin/>
-
-
 ## To build:
 
 ```sh

--- a/1986/august/README.md
+++ b/1986/august/README.md
@@ -1,9 +1,3 @@
-# Best complex task done in a complex way
-
-Lennart Augustsson\
-<https://web.archive.org/web/20090831055828/http://www.cs.chalmers.se/~augustss>
-
-
 ## To build:
 
 ```sh

--- a/1986/bright/README.md
+++ b/1986/bright/README.md
@@ -1,8 +1,3 @@
-# Most useful obfuscation
-
-Walter Bright
-
-
 ## To build:
 
 ```sh

--- a/1986/hague/README.md
+++ b/1986/hague/README.md
@@ -1,9 +1,3 @@
-# Worst abuse of the C preprocessor
-
-Jim Hague\
-UK
-
-
 ## To build:
 
 ```sh

--- a/1986/holloway/README.md
+++ b/1986/holloway/README.md
@@ -1,9 +1,3 @@
-# Best simple task performed in a complex way
-
-Bruce Holloway\
-US
-
-
 ## To build:
 
 ```sh

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -1,8 +1,3 @@
-# Best layout
-
-Eric Marshall
-
-
 ## To build:
 
 ```sh

--- a/1986/pawka/README.md
+++ b/1986/pawka/README.md
@@ -1,9 +1,3 @@
-# Most illegible code
-
-Michael H. Pawka\
-US
-
-
 ## To build:
 
 ```sh

--- a/1986/stein/README.md
+++ b/1986/stein/README.md
@@ -1,8 +1,3 @@
-# Best one liner
-
-Jan Stein
-
-
 ## To build:
 
 ```sh

--- a/1986/wall/README.md
+++ b/1986/wall/README.md
@@ -1,9 +1,3 @@
-# Grand prize in most well-rounded in confusion
-
-Larry Wall\
-US
-
-
 ## To build:
 
 ```sh

--- a/1987/biggar/README.md
+++ b/1987/biggar/README.md
@@ -1,9 +1,3 @@
-# Best Abuse of the Rules
-
-Mark Biggar\
-US
-
-
 ## To build:
 
 ```sh

--- a/1987/heckbert/README.md
+++ b/1987/heckbert/README.md
@@ -1,8 +1,3 @@
-# Best Obfuscator of Programs
-
-Paul Heckbert
-
-
 ## To build:
 
 ```sh

--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -1,9 +1,3 @@
-# Worst Style
-
-Spencer Hines\
-US
-
-
 ## To build:
 
 ```sh

--- a/1987/korn/README.md
+++ b/1987/korn/README.md
@@ -1,9 +1,3 @@
-# Best One Liner
-
-David Korn\
-US
-
-
 ## To build:
 
 ```sh

--- a/1987/lievaart/README.md
+++ b/1987/lievaart/README.md
@@ -1,9 +1,3 @@
-# Grand Prize
-
-Roemer B. Lievaart\
-Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1987/wall/README.md
+++ b/1987/wall/README.md
@@ -1,9 +1,3 @@
-# Most Useful Obfuscation
-
-Larry Wall\
-US
-
-
 ## To build:
 
 ```sh

--- a/1987/westley/README.md
+++ b/1987/westley/README.md
@@ -1,10 +1,3 @@
-# Best Layout
-
-Brian Westley (aka Merlyn Leroy on usenet)\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1988/applin/README.md
+++ b/1988/applin/README.md
@@ -1,10 +1,3 @@
-# Best of show
-
-Jack Applin\
-US\
-<https://www.cs.colostate.edu/~applin/>
-
-
 ## To build:
 
 ```sh

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -1,9 +1,3 @@
-# Best abuse of system calls
-
-Paul Dale\
-Australia
-
-
 ## To build:
 
 ```sh

--- a/1988/isaak/README.md
+++ b/1988/isaak/README.md
@@ -1,9 +1,3 @@
-# Best visuals
-
-Mark Isaak\
-US
-
-
 ## To build:
 
 ```sh

--- a/1988/litmaath/README.md
+++ b/1988/litmaath/README.md
@@ -1,9 +1,3 @@
-# Best small program
-
-Maarten Litmaath\
-The Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1988/phillipps/README.md
+++ b/1988/phillipps/README.md
@@ -1,9 +1,3 @@
-# Least likely to compile successfully
-
-Ian Phillipps\
-UK
-
-
 ## To build:
 
 ```sh

--- a/1988/reddy/README.md
+++ b/1988/reddy/README.md
@@ -1,9 +1,3 @@
-# Most useful Obfuscated C program
-
-Gopi Reddy\
-US
-
-
 ## To build:
 
 ```sh

--- a/1988/robison/README.md
+++ b/1988/robison/README.md
@@ -1,9 +1,3 @@
-# Best abuse of C constructs
-
-Arch D. Robison\
-US
-
-
 ## To build:
 
 ```sh

--- a/1988/spinellis/README.md
+++ b/1988/spinellis/README.md
@@ -1,11 +1,3 @@
-# Best abuse of the rules
-
-Diomidis Spinellis\
-GR\
-<https://www.spinellis.gr/>\
-Mastodon: <https://mstdn.social/@DSpinellis>
-
-
 ## To build:
 
 ```sh

--- a/1988/westley/README.md
+++ b/1988/westley/README.md
@@ -1,10 +1,3 @@
-# Best layout
-
-Merlyn LeRoy (Brian Westley)\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1989/fubar/README.md
+++ b/1989/fubar/README.md
@@ -1,9 +1,3 @@
-# Best self-modifying program
-
-Jay Vosburgh\
-US
-
-
 ## To build:
 
 ```sh

--- a/1989/jar.1/README.md
+++ b/1989/jar.1/README.md
@@ -1,13 +1,3 @@
-# Strangest abuse of the rules
-
-Jari Arkko\
-Laboratory of Information Processing Science\
-Helsinki University of Technology\
-Otakaari 1\
-02150 Espoo\
-Finland
-
-
 ## To build:
 
 NOTE: this will run the program itself.

--- a/1989/jar.2/README.md
+++ b/1989/jar.2/README.md
@@ -1,13 +1,3 @@
-# Best of show
-
-Jari Arkko, Ora Lassila, Esko Nuutila\
-Laboratory of Information Processing Science\
-Helsinki University of Technology\
-Otakaari 1\
-02150 Espoo\
-Finland
-
-
 ## To build:
 
 ```sh

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -1,12 +1,3 @@
-# Most humorous output
-
-Oskar von der Luehe\
-Institut fuer Astronomie\
-ETH - Zentrum\
-8092 Zuerich\
-Switzerland
-
-
 ## To build:
 
 ```sh

--- a/1989/paul/README.md
+++ b/1989/paul/README.md
@@ -1,9 +1,3 @@
-# Most complex algorithm
-
-Paul E. Black\
-US
-
-
 ## To build:
 
 ```sh

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -1,9 +1,3 @@
-# Best minimal use of C
-
-Arch D. Robison\
-US
-
-
 ## To build:
 
 ```sh

--- a/1989/roemer/README.md
+++ b/1989/roemer/README.md
@@ -1,9 +1,3 @@
-# Best layout
-
-Lievaart, Roemer B.\
-Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1989/tromp/README.md
+++ b/1989/tromp/README.md
@@ -1,9 +1,3 @@
-# Best game
-
-John Tromp\
-Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1989/vanb/README.md
+++ b/1989/vanb/README.md
@@ -1,13 +1,3 @@
-# Best one liner
-
-David Van Brackle\
-Department of Computer Science\
-University of Central Florida\
-Orlando, Florida\
-32816\
-US
-
-
 ## To build:
 
 ```sh

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -1,10 +1,3 @@
-# Most algorithms in one program
-
-Merlyn LeRoy (Brian Westley)\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -1,12 +1,3 @@
-# Best Small Program
-
-Baruch Nissenbaum\
-Israel
-
-Doron Osovlanski\
-Israel
-
-
 ## To build:
 
 ```sh

--- a/1990/cmills/README.md
+++ b/1990/cmills/README.md
@@ -1,9 +1,3 @@
-# Best Game
-
-Chris Mills\
-US
-
-
 ## To build:
 
 ```sh

--- a/1990/dds/README.md
+++ b/1990/dds/README.md
@@ -1,11 +1,3 @@
-# Best Language Tool
-
-Diomidis Spinellis\
-Greece\
-<https://www.spinellis.gr/>\
-Mastodon: <https://mstdn.social/@DSpinellis>
-
-
 ## To build:
 
 ```sh

--- a/1990/dg/README.md
+++ b/1990/dg/README.md
@@ -1,12 +1,3 @@
-# Best Abuse of the C Preprocessor
-
-David Goodenough\
-anonymous organization\
-541 Commonwealth Ave\
-Newton, MA 02159\
-US
-
-
 ## To build:
 
 ```sh

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -1,15 +1,3 @@
-# Best Entropy-reducer
-
-James A. Woods\
-US
-
-Karl F. Fox\
-US
-
-Paul Eggert\
-US
-
-
 ## To build:
 
 ```sh

--- a/1990/pjr/README.md
+++ b/1990/pjr/README.md
@@ -1,9 +1,3 @@
-# Most Unusual Data Structure
-
-Peter J Ruczynski\
-England, U.K.
-
-
 ## To build:
 
 ```sh

--- a/1990/scjones/README.md
+++ b/1990/scjones/README.md
@@ -1,9 +1,3 @@
-# ANSI Committee's Worst Abuse of C
-
-Larry Jones\
-US
-
-
 ## To build:
 
 ```sh

--- a/1990/stig/README.md
+++ b/1990/stig/README.md
@@ -1,9 +1,3 @@
-# Strangest Abuse of the Rules
-
-Stig Hemmer\
-Norway
-
-
 ## To build:
 
 ```sh

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -1,12 +1,3 @@
-# Best Utility
-
-Byron Rakitzis\
-US
-
-Sean Dorward\
-US
-
-
 ## To build:
 
 ```sh

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -1,9 +1,3 @@
-# Best of Show
-
-Adrian Mariano\
-US
-
-
 ## To build:
 
 ```sh

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -1,10 +1,3 @@
-# Best Layout
-
-Brian Westley (Merlyn LeRoy on usenet)\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1991/ant/README.md
+++ b/1991/ant/README.md
@@ -1,12 +1,3 @@
-# Best Utility
-
-Anthony C Howe\
-Mortice Kern Systems Inc.	#CL-23\
-35 King St. N			268 Phillip St.\
-Waterloo, On			Waterloo, On\
-Canada, N2J 2W9			Canada, N2L 6G9
-
-
 ## To build:
 
 ```sh
@@ -75,7 +66,7 @@ results depending on the implementation of `curses`.
 -    W		    write buffer to file
 -    R		    refresh the screen
 -    Q		    quit
-\
+
 ### Exit status
 
 -    0		    success
@@ -98,10 +89,10 @@ to provide more portable code, since the compiler should handle the translation
 of them into the native character set.  Note that `'\f'` (form-feed) was used to
 exit insert mode because K&R C had no escape constant for the escape-key.
 
-My goals for this project were to learn and experiment with the\
-Buffer Gap Scheme [Fin80][net90], write a useful and *portable*\
-program, and meet the requirements of the IOCCC.  I initially\
-planned to have a mini `curses` built-in like the IOCCC Tetris entry\
+My goals for this project were to learn and experiment with the
+Buffer Gap Scheme [Fin80][net90], write a useful and *portable*
+program, and meet the requirements of the IOCCC.  I initially
+planned to have a mini `curses` built-in like the IOCCC Tetris entry
 from a previous year, however this was not as portable as using a
 `curses` library with `TERMINFO`/`TERMCAP` support.
 

--- a/1991/brnstnd/README.md
+++ b/1991/brnstnd/README.md
@@ -1,9 +1,3 @@
-# Best Of Show
-
-Daniel J. Bernstein\
-US
-
-
 ## To build:
 
 ```sh

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -1,12 +1,3 @@
-# Best Output
-
-Sean Barrett\
-University of Maryland\
-5407 20th Place\
-Hyattsville MD 20782\
-US
-
-
 ## To build:
 
 ```sh

--- a/1991/cdupont/README.md
+++ b/1991/cdupont/README.md
@@ -1,13 +1,3 @@
-# Most Useful Label
-
-Christian Dupont\
-Ecole Normale Superieure de Lyon\
-Laboratoire d'Informatique Parallele\
-42, Rue H.Berlioz\
-69009 Lyon\
-France
-
-
 ## To build:
 
 ```sh
@@ -40,11 +30,9 @@ this entry.
 
 ## Author's remarks:
 
-Spoiler:
-
 The source code holds the letters of the message. Each letter, combined
 with another key letter, is used to compute the coordinates of the next
-letter and key. Thus, the message is code.  That is why I use silly\
+letter and key. Thus, the message is code.  That is why I use silly
 comments, most often badly spaced.
 
 The space character sequence between the words is given by a simple

--- a/1991/davidguy/README.md
+++ b/1991/davidguy/README.md
@@ -1,19 +1,3 @@
-# Best X11 Graphics
-
-David Applegate\
-School of Computer Science\
-Carnegie Mellon University\
-Pittsburgh PA 15213\
-US
-
-
-Guy Jacobson\
-AT&T Bell Laboratories\
-600 Mountain Avenue\
-Murray Hill NJ 07974\
-US
-
-
 ## To build:
 
 ```sh

--- a/1991/dds/README.md
+++ b/1991/dds/README.md
@@ -1,11 +1,3 @@
-# Most Well Rounded
-
-Diomidis Spinellis\
-Greece\
-<https://www.spinellis.gr/>\
-Mastodon: <https://mstdn.social/@DSpinellis>
-
-
 ## To build:
 
 ```sh

--- a/1991/fine/README.md
+++ b/1991/fine/README.md
@@ -1,10 +1,3 @@
-# Best One Liner
-
-Thomas A. Fine\
-US\
-[@thomasafine@social.linux.pizza](https://social.linux.pizza/@thomasafine)
-
-
 ## To build:
 
 ```sh

--- a/1991/fine/try.sh
+++ b/1991/fine/try.sh
@@ -16,17 +16,46 @@ echo "Tang" | ./fine
 
 echo -n "Vend onyx <-> "
 echo "Vend onyx" | ./fine
+
 echo -n "Cheryl be flashy <-> "
 echo "Cheryl be flashy" | ./fine
+
 echo -n "Rail <-> "
 echo "Rail" | ./fine
+
 echo -n "Clerk <-> "
 echo "Clerk" | ./fine
+
 echo -n "Ones <-> "
 echo "Ones" | ./fine
+
 echo -n "Fur <-> "
 echo "Fur" | ./fine
+
 echo -n "Er <-> "
 echo "Er" | ./fine
+
+echo -n "IV <-> "
+echo "IV" | ./fine
+
+echo -n "NYC <-> "
+echo "NYC" | ./fine
+
+echo -n "Fubar <-> "
+echo "Fubar" | ./fine
+
+echo -n "DQ <-> "
+echo "DQ" | ./fine
+
+echo -n "Off <-> "
+echo "Off" | ./fine
+
+echo -n "Ire <-> "
+echo "Ire" | ./fine
+
+echo -n "PEP <-> "
+echo "PEP" | ./fine
+
+
 echo -n "The rug gary lenT <-> "
 echo "The rug gary lenT" | ./fine

--- a/1991/rince/.gitignore
+++ b/1991/rince/.gitignore
@@ -1,3 +1,5 @@
 rince
+rince.alt
+rince.alt2
 rince.orig
 prog.orig

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -58,7 +58,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DMAX_MOVES=484
 
 # Include files that are needed to compile
 #
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o ${PROG}.alt2.o
+ALT_TARGET= ${PROG}.alt ${PROG}.alt2
 
 
 #################
@@ -136,6 +136,12 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+${PROG}2.alt: ${PROG}.alt2.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1991/rince/README.md
+++ b/1991/rince/README.md
@@ -4,12 +4,64 @@
 make all
 ```
 
+There are two [alternate versions](#alternate-code) which allow one to not be
+restricted in movements or to change the maximum number of movements, even if
+that's fewer than the original program.
+
 
 ## To use:
 
 ```sh
 ./rince
 ```
+
+
+## Alternate code:
+
+The first alternate version, [rince.alt.c](rince.alt.c), disables a maximum move
+count so that anyone with enough patience and time can complete the puzzle,
+without having to worry about how many moves they make. The second version,
+[rince.alt2.c](rince.alt2.c), allows one to reconfigure at compilation the
+maximum number of moves, even if that is lowering the count.
+
+The author set the maximum number of moves to 484.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+This will build both alt versions where the first one, `rince.alt`, has no
+restrictions in the number of movements and the second one, `rince.alt2`, has a
+configurable maximum number of moves allowed, defaulting to the entry's max,
+484.
+
+To reconfigure the maximum number of moves:
+
+```sh
+make clobber CDEFINE+="-DMAX_MOVES=5" alt
+```
+
+### Alternate use:
+
+To run the first alt version:
+
+```sh
+./rince.alt
+```
+
+To run the second alt version:
+
+```sh
+./rince.alt2
+```
+
+Can you figure out how to make the two alternate versions equivalent in
+functionality without modifying the code? That is can you make the second alt
+version end up allowing any number of movements?
 
 
 ## Judges' remarks:
@@ -30,7 +82,7 @@ Key to map:
 
 ```
 			|
- ######                 | | | /\   /--\  ==|    /\ | |  Directonal keys\
+ ######                 | | | /\   /--\  ==|    /\ | |  Directonal keys
  ######  Solid Wall     | ----||    \/     /\   ||----  (unlock doors of
  ######                 |     \/  ==|     \--/  \/       the same direction)
 			|\
@@ -46,11 +98,12 @@ Key to map:
   /@@@\    boulder      |  <  >  around (if only!) or manufacture by pushing
   \@@@/                 |   \/   two 'crushable' rocks together.
 			|
+```
 
 The general idea of the game is to collect all the diamonds. This must
 be done in the minimum amount of moves. I've allowed a margin of 5
-moves which brings the moves allowed to 484. (alter the value of 'u' in
-the program to set the max moves allowed)
+moves which brings the moves allowed to `484`. (alter the value of `u` in
+the program to set the max moves allowed).
 
 There are two types of boulders. Both can be pushed around, but only
 the hollow (crushable) ones can be turned into diamonds (by pushing it
@@ -60,7 +113,7 @@ Of the four types of doors (and keys) only 3 have been defined. This
 was done to keep the source as low as possible (as I only used 3 in the
 map).  To unlock a door simply push a key into the corresponding door.
 Take care that it's facing in the correct direction.
-```
+
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/1991/rince/README.md
+++ b/1991/rince/README.md
@@ -1,14 +1,3 @@
-# Best Game
-
-James Bonfield\
-University of Warwick\
-7 Water End\
-Wrestlingworth\
-Sandy Beds\
-SG19 2HA\
-England
-
-
 ## To build:
 
 ```sh

--- a/1991/rince/rince.alt.c
+++ b/1991/rince/rince.alt.c
@@ -1,12 +1,12 @@
 #include <curses.h>
-int u=484,X[]={-1,0,0,1},Y[]={0,1,-1,0},x,y,D,i,j,a;
+int X[]={-1,0,0,1},Y[]={0,1,-1,0},x,y,D,i,j,a;
 char o,m,*t,*O="MNOH",*k="hjkl",*s="######\0######\0######\0      \0      \0      \0  ___ \0 /   \\\0 \\___/\0  ___ \0 /@@@\\\0 \\@@@/\0| | /\\\0----||\0    \\/\0  /--\\\0   \\/ \0 ==|  \0 ==|  \0   /\\ \0  \\--/\0 /O__o\0 \\___/\0 /_\\_ \0  <<  \0  <<  \0  <<  \0      \0vvvvvv\0      \0      \0^^^^^^\0      \0  /\\  \0 <  > \0  \\/  \0o__O\\ \0\\___/ \0 _/_\\ \0 O__O \0/----\\\0_/  \\_\0 ^__^ \0/----\\\0_/  \\_" ,
 M[12][22]={"AAAAAAAAAAAAAAAAAAAAAA" ,"ALCABBBBBBBABBCBBCABBA", "ACCABAKAAABAFBABABAEBA", "ABBBBABBIBBBBBEEABACLA", "ACCBNIBBAAAAGALBBBABCA", "AAAAAAAJACBABBCABAABCA", "ALLAACCBACBAAALLCABBBA", "ABDLAAABABCAAAALCABBLA", "ABCBIBBBBBBBBAAAAACBBA", "ABCCAABBADBBBBDBDBDBCA", "ALBBACCCCDBCABBBDBBBBA", "AAAAAAAAAAAAAAAAAAAAAA" };main(){initscr();clear();
-noecho();cbreak();x=y=4;D=39,o='M';m=M[y][x] ;while(D&&u){for(i=j=a=0;j<7;!(mvaddstr(
+noecho();cbreak();x=y=4;D=39,o='M';m=M[y][x] ;while(D){for(i=j=a=0;j<7;!(mvaddstr(
 j*3+a,i*6,s+(((M[((y-1)/5)*5+j][((x-1)/10)*10+i]-'A')*3+a++)*7)),a^3)&&(a=0,!
 (++i^12))&&(a=i=0,j++));refresh();M[y][x] ='B';if(t=(char*)strchr(k,getch())){int e=
 x,g=y,f=x,h=y,d=t-k;o=O[d];f=(e=x+X[d])+X[d];h=(g=y+Y[d])+Y[d];switch(M[g][e] ){case
-'B':x=e;y=g,u--;break ;case 'C':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g,u--; else if(M[h][f] =='C')M[h][f] =M[g][e] ='L';break ;case 'D':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g,u--; break ;case'L':x=e;y=g,u--;D
---;break ;case 'E':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g,u--; else if(M[h][f] =='I'&&d==0)M[h][f] =M[g][e] ='B';break ; case 'F':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g,u--; else if(M[h][f] =='J'&&d==1)M[h][f] =M[g][e] ='B';break ; case 'G':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g,u--; else if(M[h][f] =='K'&&d==2)M[h][f] =M[g][e] ='B';break ; }}m=M[y][x] ;M[y][x] =o;}clear();mvaddstr(12
-,31,u?"Well done!":"Too many moves");move(23,0);refresh();endwin();printf("%s\n",u?"Well done!":"Too many moves");return 0;}
+'B':x=e;y=g;break ;case 'C':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g; else if(M[h][f] =='C')M[h][f] =M[g][e] ='L';break ;case 'D':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g; break ;case'L':x=e;y=g;D
+--;break ;case 'E':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g; else if(M[h][f] =='I'&&d==0)M[h][f] =M[g][e] ='B';break ; case 'F':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g; else if(M[h][f] =='J'&&d==1)M[h][f] =M[g][e] ='B';break ; case 'G':if(M[h][f] =='B')M[h][f] =M[g][e] ,x=e,y=g; else if(M[h][f] =='K'&&d==2)M[h][f] =M[g][e] ='B';break ; }}m=M[y][x] ;M[y][x] =o;}clear();mvaddstr(12
+,31,"Well done!");move(23,0);refresh();endwin();printf("Well done!");return 0;}
 

--- a/1991/rince/rince.alt2.c
+++ b/1991/rince/rince.alt2.c
@@ -1,5 +1,5 @@
 #include <curses.h>
-int u=484,X[]={-1,0,0,1},Y[]={0,1,-1,0},x,y,D,i,j,a;
+int u=MAX_MOVES,X[]={-1,0,0,1},Y[]={0,1,-1,0},x,y,D,i,j,a;
 char o,m,*t,*O="MNOH",*k="hjkl",*s="######\0######\0######\0      \0      \0      \0  ___ \0 /   \\\0 \\___/\0  ___ \0 /@@@\\\0 \\@@@/\0| | /\\\0----||\0    \\/\0  /--\\\0   \\/ \0 ==|  \0 ==|  \0   /\\ \0  \\--/\0 /O__o\0 \\___/\0 /_\\_ \0  <<  \0  <<  \0  <<  \0      \0vvvvvv\0      \0      \0^^^^^^\0      \0  /\\  \0 <  > \0  \\/  \0o__O\\ \0\\___/ \0 _/_\\ \0 O__O \0/----\\\0_/  \\_\0 ^__^ \0/----\\\0_/  \\_" ,
 M[12][22]={"AAAAAAAAAAAAAAAAAAAAAA" ,"ALCABBBBBBBABBCBBCABBA", "ACCABAKAAABAFBABABAEBA", "ABBBBABBIBBBBBEEABACLA", "ACCBNIBBAAAAGALBBBABCA", "AAAAAAAJACBABBCABAABCA", "ALLAACCBACBAAALLCABBBA", "ABDLAAABABCAAAALCABBLA", "ABCBIBBBBBBBBAAAAACBBA", "ABCCAABBADBBBBDBDBDBCA", "ALBBACCCCDBCABBBDBBBBA", "AAAAAAAAAAAAAAAAAAAAAA" };main(){initscr();clear();
 noecho();cbreak();x=y=4;D=39,o='M';m=M[y][x] ;while(D&&u){for(i=j=a=0;j<7;!(mvaddstr(

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -1,13 +1,3 @@
-# Grand Prize
-
-Brian Westley (Merlyn LeRoy on usenet)\
-DigiBoard, Inc.\
-1026 Blair Ave.\
-St. Paul, MN  55104\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -1,9 +1,3 @@
-# Most Educational
-
-Adrian Mariano\
-US
-
-
 ## To build:
 
 ```sh

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -1,12 +1,3 @@
-# Most Useful Program
-
-Albert van der Horst\
-S P&A R&C\
-Oranjestraat 8\
-3511 RA UTRECHT\
-The Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1992/ant/README.md
+++ b/1992/ant/README.md
@@ -1,13 +1,3 @@
-# Best Utility
-
-Anthony C Howe\
-Mortice Kern Systems Inc.\
-Unit 1, 14 Weber Street North\
-Waterloo, Ontario\
-N2J 3G4\
-Canada
-
-
 ## To build:
 
 ```sh

--- a/1992/buzzard.1/README.md
+++ b/1992/buzzard.1/README.md
@@ -1,9 +1,3 @@
-# Most Obfuscated Algorithm
-
-Sean Barrett\
-US
-
-
 ## To build:
 
 ```sh

--- a/1992/buzzard.2/README.md
+++ b/1992/buzzard.2/README.md
@@ -1,12 +1,3 @@
-# Best Language Tool
-
-Sean Barrett\
-Software Construction Company\
-430 Southwest Parkway, #1906\
-College Station, TX 77840\
-US
-
-
 ## To build:
 
 ```sh

--- a/1992/gson/README.md
+++ b/1992/gson/README.md
@@ -1,9 +1,3 @@
-# Most Humorous Output
-
-Andreas Gustafsson\
-Finland
-
-
 ## To build:
 
 ```sh

--- a/1992/imc/README.md
+++ b/1992/imc/README.md
@@ -1,14 +1,3 @@
-# Best Output
-
-Ian Collier\
-Oxford University\
-The Queen's College\
-High Street\
-Oxford\
-OX1 4AW\
-England
-
-
 ## To build:
 
 ```sh

--- a/1992/kivinen/README.md
+++ b/1992/kivinen/README.md
@@ -1,12 +1,3 @@
-# Best X Program
-
-Tero Kivinen\
-Helsinki University of Technology\
-Klovinrinne 6b\
-02180 Espoo\
-Finland
-
-
 ## To build:
 
 If your machine support the X Window System, Version 11:

--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -1,9 +1,3 @@
-# Worst Abuse of the C Preprocessor
-
-Ed Luke\
-US
-
-
 ## To build:
 
 ```sh

--- a/1992/marangon/README.md
+++ b/1992/marangon/README.md
@@ -1,12 +1,3 @@
-# Best Game
-
-Marangoni Andrea\
-Department of Computer Science at Milano\
-Via Pausula, 72\
-62014 Corridonia (MC)\
-Italy
-
-
 ## To build:
 
 ```sh

--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -1,13 +1,3 @@
-# Worst Abuse of the Rules
-
-Nathan Sidwell\
-Inmos UK\
-1000 Aztec West\
-Almondsbury\
-Bristol\
-UK BS12 4SQ
-
-
 ## To build:
 
 ```sh

--- a/1992/vern/README.md
+++ b/1992/vern/README.md
@@ -1,14 +1,3 @@
-# Best of Show
-
-Vern Paxson\
-Lawrence Berkeley Laboratory\
-Computer Systems Engineering\
-Bldg. 46A, Room 1123\
-Lawrence Berkeley Laboratory\
-1 Cyclotron Rd.\
-Berkeley, CA 94720  US
-
-
 ## To build:
 
 ```sh

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -1,10 +1,3 @@
-# Best Small Program
-
-Brian Westley (aka Merlyn LeRoy)\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1993/ant/README.md
+++ b/1993/ant/README.md
@@ -1,12 +1,3 @@
-# Best Utility
-
-Anthony Howe\
-Mortice Kern Systems, Inc.\
-Unit 1, 14 Weber Street North\
-Waterloo, Ontario, N2J 3G4\
-Canada
-
-
 ## To build:
 
 ```sh

--- a/1993/cmills/README.md
+++ b/1993/cmills/README.md
@@ -1,12 +1,3 @@
-# "Bill Gates" Award
-
-Chris Mills\
-Pagine Corporation\
-1961-A Concourse Drive\
-San Jose, CA 95131\
-US
-
-
 ## To build:
 
 ```sh

--- a/1993/dgibson/README.md
+++ b/1993/dgibson/README.md
@@ -1,13 +1,3 @@
-# Best Abuse of the C Preprocessor
-
-David Gibson\
-University of Cape Town\
-1 Sweet Valley Road\
-Bergvliet\
-7945\
-South Africa
-
-
 ## To build:
 
 ```sh

--- a/1993/ejb/README.md
+++ b/1993/ejb/README.md
@@ -1,12 +1,3 @@
-# Best Obfuscated Algorithm
-
-E. Jay Berkenbilt\
-Engineering Research Associates\
-1595 Springhill Road\
-Vienna, VA 22182-2235\
-US
-
-
 ## To build:
 
 ```sh

--- a/1993/jonth/README.md
+++ b/1993/jonth/README.md
@@ -1,12 +1,3 @@
-# Most Obfuscated X Program
-
-Jon Thingvold\
-University of Oslo\
-Sogn Studentby 8231\
-N 0858 Oslo\
-Norway
-
-
 ## To build:
 
 ```sh

--- a/1993/leo/README.md
+++ b/1993/leo/README.md
@@ -1,12 +1,3 @@
-# Best Game
-
-Leonid A. Broukhis\
-Moscow Centre of SPARC Technology\
-123481 Liberty St.,\
-89-1-95 Moscow\
-Russia
-
-
 ## To build:
 
 ```sh

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -1,9 +1,3 @@
-# Most Versatile Source
-
-Jyrki Holopainen\
-Finland
-
-
 ## To build:
 
 This entry will not compile with gcc < 2.3.3 as it relied on a bug which was

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -1,11 +1,3 @@
-# Best One Liner
-
-Mark Plummer\
-2901 Reckord Road\
-Fallston, MD, 21047\
-US
-
-
 ## To build:
 
 ```sh

--- a/1993/rince/README.md
+++ b/1993/rince/README.md
@@ -1,9 +1,3 @@
-# Most Well Rounded
-
-James Bonfield\
-England
-
-
 ## To build:
 
 ```sh

--- a/1993/schnitzi/README.md
+++ b/1993/schnitzi/README.md
@@ -1,12 +1,3 @@
-# Obfuscated Intelligence Award
-
-Mark Schnitzius\
-1700 Woodbury Rd. #1208\
-Orlando, FL 32828\
-US\
-<http://computronium.org/ioccc.html>
-
-
 ## To build:
 
 ```sh

--- a/1993/vanb/README.md
+++ b/1993/vanb/README.md
@@ -1,12 +1,3 @@
-# Most Irregular Expression
-
-David Van Brackle\
-ISX Corporation\
-1165 Northchase Parkway, Suite 120\
-Marietta, GA 30067\
-US
-
-
 ## To build:
 
 ```sh

--- a/1994/dodsond1/README.md
+++ b/1994/dodsond1/README.md
@@ -1,12 +1,3 @@
-# Best Game
-
-Don Dodson\
-AG Communication Systems\
-17239 N. 19th Ave. #1003\
-Phoenix, AZ 85023\
-US
-
-
 ## To build:
 
 ```sh

--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -1,12 +1,3 @@
-# Most Obfuscated Packaging
-
-Don Dodson\
-AG Communication Systems\
-17239 N. 19th Ave. #1003\
-Phoenix, AZ 85023\
-US
-
-
 ## To build:
 
 ```sh

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -1,10 +1,3 @@
-# Best Utility
-
-Mary Ann Horton\
-US\
-<https://maryannhorton.com>
-
-
 ## To build:
 
 ```sh

--- a/1994/imc/README.md
+++ b/1994/imc/README.md
@@ -1,13 +1,3 @@
-# Most Obfuscated Algorithm
-
-Ian Collier\
-Oxford University\
-57 Wyndham Avenue        (home address)\
-Bolton\
-BL3 4LG\
-England
-
-
 ## To build:
 
 ```sh

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -1,10 +1,3 @@
-# Best One-liner
-
-Laurion Burchall\
-US\
-<https://web.archive.org/web/20070711215750/http://www.netspace.org/users/ldb/>
-
-
 ## To build:
 
 ```sh

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -1,10 +1,3 @@
-# Best Layout
-
-Mark Schnitzius\
-US\
-<http://computronium.org/ioccc.html>
-
-
 ## To build:
 
 ```sh

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -1,12 +1,3 @@
-# Most Well Rounded Obfuscation
-
-Andrew T. Shapiro\
-CSES/CIRES University of Colorado\
-Campus Box 216\
-Boulder, CO 80309-0216\
-US
-
-
 ## To build:
 
 ```sh

--- a/1994/smr/README.md
+++ b/1994/smr/README.md
@@ -1,12 +1,3 @@
-# Worst Abuse of the Rules
-
-Szymon Rusinkiewicz\
-Massachusetts Institute of Technology\
-305 Memorial Dr., Room 005B\
-Cambridge, Ma  02139\
-US
-
-
 ## To build:
 
 ```sh

--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -1,12 +1,3 @@
-# Best X11 Program
-
-Teemu Rantanen\
-Helsinki University of Technology\
-Melkonkatu 5 A 8\
-00210 Helsinki\
-Finland
-
-
 ## To build:
 
 ```sh

--- a/1994/weisberg/README.md
+++ b/1994/weisberg/README.md
@@ -1,13 +1,3 @@
-# Best Short Program
-
-Jeff Weisberg\
-University of Rochester\
-Dept of Electrical Engineering\
-Computer Studies Bldg\
-Rochester, NY 14627\
-US
-
-
 ## To build:
 
 ```sh

--- a/1994/westley/README.md
+++ b/1994/westley/README.md
@@ -1,13 +1,3 @@
-# Worst Abuse of the C Preprocessor
-
-Brian Westley (Merlyn LeRoy on Usenet)\
-Digi International\
-1906 James Ave.\
-St. Paul, MN  55105\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -1,9 +1,3 @@
-# Best Output
-
-Carlos Duarte\
-Portugal
-
-
 ## To build:
 
 We recommend that you try this alternate version first. For reasons why this is

--- a/1995/dodsond1/README.md
+++ b/1995/dodsond1/README.md
@@ -1,12 +1,3 @@
-# Most Humorous
-
-Don Dodson\
-AG Communication Systems\
-4101 W Union Hills Dr #1104\
-Glendale, AZ 85308\
-US
-
-
 ## To build:
 
 ```sh

--- a/1995/dodsond2/README.md
+++ b/1995/dodsond2/README.md
@@ -1,9 +1,3 @@
-# Best Game
-
-Don Dodson\
-US
-
-
 ## To build:
 
 ```sh

--- a/1995/esde/README.md
+++ b/1995/esde/README.md
@@ -1,11 +1,3 @@
-# Interesting Algorithm
-
-Sebastian Deorowicz\
-ul. Radzionkowska 71a\
-42-605 Tarnowskie Gory\
-Poland
-
-
 ## To build:
 
 ```sh

--- a/1995/garry/README.md
+++ b/1995/garry/README.md
@@ -1,10 +1,3 @@
-# Best Utility
-
-Garry Glendown\
-Germany\
-<https://web.archive.org/web/20011221120305/http://insider.regio.net/~garry/>
-
-
 ## To build:
 
 ```sh

--- a/1995/heathbar/README.md
+++ b/1995/heathbar/README.md
@@ -1,12 +1,3 @@
-# Best Layout
-
-Heather Downs & Selene Makarios\
-The Software Bungalow\
-900 High School Way, #2202\
-Mountain View, CA 94041\
-US
-
-
 ## To build:
 
 ```sh

--- a/1995/leo/README.md
+++ b/1995/leo/README.md
@@ -1,11 +1,3 @@
-# Best Use of Obfuscation
-
-Leonid A. Broukhis\
-46728 Crawford St., apt. 20\
-Fremont, CA 94539\
-US
-
-
 ## To build:
 
 ```sh

--- a/1995/makarios/README.md
+++ b/1995/makarios/README.md
@@ -1,12 +1,3 @@
-# Best Short Program
-
-Selene Makarios & Heather Downs\
-The Software Bungalow\
-900 High School Way, #2202\
-Mountain View, CA 94041\
-US
-
-
 ## To build:
 
 ```sh

--- a/1995/savastio/README.md
+++ b/1995/savastio/README.md
@@ -1,12 +1,3 @@
-# Most Obfuscated Syntax
-
-Michael Savastio\
-Securicor Telesciences\
-925 1/2 Anchor St, Apt 2\
-Philadelphia, PA  19124\
-US
-
-
 ## To build:
 
 ```sh

--- a/1995/schnitzi/README.md
+++ b/1995/schnitzi/README.md
@@ -1,13 +1,3 @@
-# Best One Liner
-
-Mark Schnitzius\
-ISX Corporation\
-3215-C Post Woods Dr.\
-Atlanta, GA 30339\
-US\
-<http://computronium.org/ioccc.html>
-
-
 ## To build:
 
 ```sh

--- a/1995/spinellis/README.md
+++ b/1995/spinellis/README.md
@@ -1,11 +1,3 @@
-# Abusing The Rules
-
-Diomidis Spinellis\
-Greece\
-<https://www.spinellis.gr/>\
-Mastodon: <https://mstdn.social/@DSpinellis>
-
-
 ## To build:
 
 ```sh

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -1,13 +1,3 @@
-# Worst Abuse of the C Preprocessor and Most Likely To Amaze
-
-Mark Schnitzius & David Van Brackle\
-ISX Corporation\
-1165 Northchase Parkway\
-Suite 120\
-Marietta, GA  30067\
-US
-
-
 ## To build:
 
 ```sh

--- a/1996/august/README.md
+++ b/1996/august/README.md
@@ -1,9 +1,3 @@
-# Best of Show
-
-Lennart Augustsson\
-<https://web.archive.org/web/20090831055828/http://www.cs.chalmers.se/~augustss>
-
-
 ## To build:
 
 ```sh

--- a/1996/dalbec/README.md
+++ b/1996/dalbec/README.md
@@ -1,12 +1,3 @@
-# Best Numerical Obfuscation
-
-John Dalbec\
-20 Squire's Ct.	(home address)\
-Canfield, OH 44406\
-US\
-<https://jpdalbec.people.ysu.edu>
-
-
 ## To build:
 
 ```sh

--- a/1996/eldby/README.md
+++ b/1996/eldby/README.md
@@ -1,9 +1,3 @@
-# Best Output
-
-Thor Eldby\
-Norway
-
-
 ## To build:
 
 ```sh

--- a/1996/gandalf/README.md
+++ b/1996/gandalf/README.md
@@ -1,14 +1,3 @@
-# Best Layout
-
-Dean Swift\
-Trinome Communications\
-7, Jeffries Passage\
-Guildford\
-Surrey\
-GU1 4AP\
-England
-
-
 ## To build:
 
 ```sh

--- a/1996/huffman/README.md
+++ b/1996/huffman/README.md
@@ -1,14 +1,3 @@
-# Best Obfuscated Character Set Utility
-
-Ken Huffman\
-Applied Innovation Inc\
-5800 Innovation Dr.\
-Dublin, OH 43016\
-US\
-<http://www.huffmancoding.com>\
-huffmancoding@gmail.com
-
-
 ## To build:
 
 ```sh

--- a/1996/jonth/README.md
+++ b/1996/jonth/README.md
@@ -1,13 +1,3 @@
-# Best X11 Entry
-
-Jon Thingvold\
-University of Oslo\
-Gaustadveien 10B\
-N 0372 Oslo\
-Norway\
-<http://www.uio.no/~jonth/>
-
-
 ## To build:
 
 ```sh
@@ -25,6 +15,7 @@ entry.
 The current status of this entry is:
 
 ```
+STATUS: INABIAF - please **DO NOT** fix
 STATUS: missing or dead link - please provide them
 ```
 
@@ -35,6 +26,24 @@ For more detailed information see [1996 jonth in bugs.md](/bugs.md#1996-jonth).
 
 ```sh
 ./jonth :0 :0
+```
+
+NOTE: the two boards will be on top of each other so you will have to drag one
+off the other so that you can properly play.
+
+
+NOTE: if there is no X service open this will crash. If this is the case you
+might try:
+
+```sh
+./jonth
+```
+
+These are supposed to happen.  As is written in the
+[The Jargon File](http://catb.org/jargon/html/F/feature.html):
+
+```
+That's not a bug, that's a feature.
 ```
 
 
@@ -58,7 +67,7 @@ as arguments to this game.
 
 ### Known bugs:
 
-Sometimes on Solaris X gets confused and this program core dumps. The solution:
+Sometimes on Solaris, X gets confused and this program core dumps. The solution:
 give two display arguments (`./jonth host:0 host:0`).
 
 If one (or both) windows look like a copy of the window(s) below, try

--- a/1996/rcm/README.md
+++ b/1996/rcm/README.md
@@ -1,11 +1,3 @@
-# Best RFC Obfuscation
-
-Ron McFarland\
-7941 Fawncreek Drive\
-Cincinnati, Ohio 45249\
-US
-
-
 ## To build:
 
 ```sh

--- a/1996/schweikh1/README.md
+++ b/1996/schweikh1/README.md
@@ -1,13 +1,3 @@
-# Worst Abuse of the C Preprocessor
-
-Jens Schweikhardt\
-DFN Network Operation Center\
-Schlartaeckerweg 3 (home address)\
-D-71384 Weinstadt\
-Germany\
-<http://www.schweikhardt.net>
-
-
 ## To build:
 
 ```sh

--- a/1996/schweikh2/README.md
+++ b/1996/schweikh2/README.md
@@ -1,13 +1,3 @@
-# Best Algorithm
-
-Jens Schweikhardt\
-DFN Network Operation Center\
-Schlartaeckerweg 3 (home address)\
-D-71384 Weinstadt\
-Germany\
-<http://www.schweikhardt.net>
-
-
 ## To build:
 
 ```sh

--- a/1996/schweikh3/README.md
+++ b/1996/schweikh3/README.md
@@ -1,13 +1,3 @@
-# Best Utility
-
-Jens Schweikhardt\
-DFN Network Operation Center\
-Schlartaeckerweg 3 (home address)\
-D-71384 Weinstadt\
-Germany\
-<http://www.schweikhardt.net>
-
-
 ## To build:
 
 ```sh

--- a/1996/westley/README.md
+++ b/1996/westley/README.md
@@ -1,12 +1,3 @@
-# Best One Liner
-
-Brian Westley (Merlyn LeRoy on Usenet)\
-1906 James Ave.\
-St. Paul, MN  55105\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/1998/banks/README.md
+++ b/1998/banks/README.md
@@ -1,13 +1,3 @@
-# Best of Show
-
-Carl Banks\
-Penn State Department of Aerospace Engineering\
-232 Hammond Building\
-University Park, PA 16802\
-US\
-<https://blog.aerojockey.com/post/iocccsim>
-
-
 ## To build:
 
 ```sh

--- a/1998/bas1/README.md
+++ b/1998/bas1/README.md
@@ -1,12 +1,3 @@
-# Best Encapsulation
-
-Bas de Bakker\
-Pica, Centre for Library Automation\
-Statenweg 154 B    (home address)\
-3039 JN Rotterdam\
-The Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1998/bas2/README.md
+++ b/1998/bas2/README.md
@@ -1,12 +1,3 @@
-# Best Small Program
-
-Bas de Bakker\
-Pica, Centre for Library Automation\
-Statenweg 154 B     (home address)\
-3039 JN Rotterdam\
-The Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1998/chaos/README.md
+++ b/1998/chaos/README.md
@@ -1,12 +1,3 @@
-# Best Object Orientation
-
-Alan De Smet\
-8531 Greenway Blvd. #206\
-Middleton, WI 53562\
-US\
-<http://www.highprogrammer.com/alan/>
-
-
 ## To build:
 
 ```sh

--- a/1998/df/README.md
+++ b/1998/df/README.md
@@ -1,12 +1,3 @@
-# Best Data Hiding
-
-Daniel Fischer\
-VNetx.com GbR\
-Salenbergstrasse 11		(home address)\
-D 72250 Freudenstadt\
-German Federal Republic
-
-
 ## To build:
 
 ```sh

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -1,11 +1,3 @@
-# Best Utility
-
-David Lowe\
-US\
-<j.david.lowe@gmail.com>\
-<https://github.com/dlowe>
-
-
 ## To build:
 
 ```sh
@@ -48,7 +40,7 @@ NOTE: The original entry was just a text based pootifier.  To build
 that version try:
 
 ```sh
-make dlowe.alt
+make alt
 ./dlowe.alt < anyfile > pootfile
 ```
 

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -1,13 +1,3 @@
-# Most Fun
-
-David Lowe\
-US\
-<https://github.com/dlowe>
-
-Neil Mix\
-US
-
-
 ## To build:
 
 ```sh

--- a/1998/dorssel/README.md
+++ b/1998/dorssel/README.md
@@ -1,12 +1,3 @@
-# Obsolescent Feature
-
-Frans van Dorsselaer\
-Bakker Industrial Automation\
-Kaiserstraat 35\
-NL-2311 GP   Leiden\
-The Netherlands
-
-
 ## To build:
 
 ```sh

--- a/1998/fanf/README.md
+++ b/1998/fanf/README.md
@@ -1,10 +1,3 @@
-# Most Obfuscated Translator
-
-Tony Finch\
-United Kingdom\
-<https://dotat.at>
-
-
 ## To build:
 
 ```sh

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -1,10 +1,3 @@
-# Best Flow Control
-
-Mark Schnitzius\
-US\
-<http://computronium.org/ioccc.html>
-
-
 ## To build:
 
 ```sh

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -1,13 +1,3 @@
-# CPP Abuse
-
-Jens Schweikhardt\
-DFN Network Operation Center\
-Schlartaeckerweg 3 (Home address)\
-D-71384 Weinstadt\
-Germany\
-<http://www.schweikhardt.net>
-
-
 ## To build:
 
 ```sh

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -1,10 +1,3 @@
-# Most Erratic Behavior
-
-Jens Schweikhardt\
-Germany\
-<http://www.schweikhardt.net>
-
-
 ## To build:
 
 ```sh

--- a/1998/schweikh3/README.md
+++ b/1998/schweikh3/README.md
@@ -1,10 +1,3 @@
-# Most Space Efficient
-
-Jens Schweikhardt <schweikh@schweikhardt.net>\
-<http://www.schweikhardt.net>\
-Germany
-
-
 ## To build:
 
 ```sh

--- a/1998/tomtorfs/README.md
+++ b/1998/tomtorfs/README.md
@@ -1,13 +1,3 @@
-# Best Self-Documenting
-
-Tom Torfs\
-De Nayer Instituut\
-Cuperuslei 12          (home address)\
-2220 Heist-op-den-Berg\
-Belgium\
-<https://web.archive.org/web/20010520021948/http://members.nbci.com/tomtorfs/>
-
-
 ## To build:
 
 ```sh

--- a/2000/anderson/README.md
+++ b/2000/anderson/README.md
@@ -1,12 +1,3 @@
-# Best Use of Flags
-
-Glyn Anderson\
-Jl. Raya Serang KM 18.2\
-Desa Bojong\
-Cikupa, Tangerang, 15710\
-Indonesia
-
-
 ## To build:
 
 ```sh

--- a/2000/bellard/README.md
+++ b/2000/bellard/README.md
@@ -1,12 +1,3 @@
-# Most Specific Output
-
-Fabrice Bellard\
-451 chemin du mas de Matour\
-34790 Grabels\
-France\
-<https://bellard.org>
-
-
 ## To build:
 
 ```sh

--- a/2000/bmeyer/README.md
+++ b/2000/bmeyer/README.md
@@ -1,13 +1,3 @@
-# Best Utility
-
-Bernd Meyer\
-Monash University, Melbourne, Australia\
-1/832 Blackburn Rd\
-Clayton, VIC 3168\
-Australia\
-<https://web.archive.org/web/20030212213342/http://byron.csse.monash.edu.au/realindex.html>
-
-
 ## To build:
 
 ```sh

--- a/2000/briddlebane/README.md
+++ b/2000/briddlebane/README.md
@@ -1,10 +1,3 @@
-# Best Abuse of User
-
-Moxen N. Briddlebane
-
-Lord Zarbon
-
-
 ## To build:
 
 ```sh

--- a/2000/dhyang/README.md
+++ b/2000/dhyang/README.md
@@ -1,13 +1,3 @@
-# Best Layout
-
-Don Yang\
-UCSD\
-259 E. Bellbrook St.\
-Covina, CA 91722\
-US\
-<http://uguu.org>
-
-
 ## To build:
 
 ```sh

--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -1,10 +1,3 @@
-# Worst Abuse of the Rules
-
-David Lowe\
-US\
-<https://github.com/dlowe>
-
-
 ## To build:
 
 ```sh

--- a/2000/jarijyrki/README.md
+++ b/2000/jarijyrki/README.md
@@ -1,18 +1,3 @@
-# Best of Show
-
-Jari Arkko\
-Kauppalantie 25A7\
-02700 Kauniainen\
-Finland\
-<http://www.arkko.com>
-
-Jyrki Holopainen\
-Forsellesintie 1-3A10\
-02700 Kauniainen\
-Finland\
-<https://web.archive.org/web/20061205082106/http://personal.eunet.fi/pp/halo/>
-
-
 ## To build:
 
 ```sh

--- a/2000/natori/README.md
+++ b/2000/natori/README.md
@@ -1,9 +1,3 @@
-# Best Small Program
-
-NATORI Shin\
-Japan
-
-
 ## To build:
 
 ```sh

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -1,8 +1,3 @@
-# Best Abuse of CPP
-
-Raymond Cheong
-
-
 ## To build:
 
 ```sh

--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -1,13 +1,3 @@
-# Astronomically Obfuscated
-
-James Bonfield\
-MRC Laboratory of Molcular Biology\
-Hills Road\
-Cambridge\
-CB2 2QH\
-England
-
-
 ## To build:
 
 ```sh

--- a/2000/robison/README.md
+++ b/2000/robison/README.md
@@ -1,11 +1,3 @@
-# Best game
-
-Arch D. Robison\
-1406 Country Lake Drive\
-Champaign IL 61821\
-US
-
-
 ## To build:
 
 ```sh

--- a/2000/schneiderwent/README.md
+++ b/2000/schneiderwent/README.md
@@ -1,9 +1,3 @@
-# Most Timely Output
-
-Craig Schneiderwent\
-WI, US
-
-
 ## To build:
 
 ```sh

--- a/2000/thadgavin/README.md
+++ b/2000/thadgavin/README.md
@@ -1,12 +1,3 @@
-# Most Portable Output
-
-Thaddaeus Frogley\
-UK
-
-Gavin Buttimore\
-UK
-
-
 ## To build:
 
 ```sh

--- a/2000/tomx/README.md
+++ b/2000/tomx/README.md
@@ -1,13 +1,3 @@
-# Most Complete Program
-
-Thomas P John\
-Mishybi Plamoottil\
-Parottukonam\
-Nalanchira P.O, Trivandrum-695015\
-India\
-<https://web.archive.org/web/20010720192926/http://tomx.tripod.com/>
-
-
 ## To build:
 
 ```sh

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -1,9 +1,3 @@
-# Dishonorable mention
-
-The author wishes to remain anonymous\
-Great Britain
-
-
 ## To build:
 
 ```sh

--- a/2001/bellard/README.md
+++ b/2001/bellard/README.md
@@ -1,9 +1,3 @@
-# Best abuse of the rules
-
-Fabrice Bellard\
-<https://bellard.org>
-
-
 ## To build:
 
 ```sh

--- a/2001/cheong/README.md
+++ b/2001/cheong/README.md
@@ -1,10 +1,3 @@
-# Best short program
-
-Raymond Cheong\
-US\
-<http://www.raymondcheong.com/index.html>
-
-
 ## To build:
 
 ```sh

--- a/2001/coupard/README.md
+++ b/2001/coupard/README.md
@@ -1,13 +1,3 @@
-# Most obfuscated sound
-
-Pierre-Philippe Coupard\
-Lineo, Inc.\
-ATTN : Pierre-Philippe Coupard\
-390 South 400 West\
-Lindon, UT 84042\
-US
-
-
 ## To build:
 
 ```sh

--- a/2001/ctk/README.md
+++ b/2001/ctk/README.md
@@ -1,11 +1,3 @@
-# Worst Driver
-
-Chris King\
-115 Foster Center Road\
-Foster, RI, 02825\
-US
-
-
 ## To build:
 
 ```sh

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -1,9 +1,3 @@
-# Best AI
-
-Doug Beardsley\
-US
-
-
 ## To build:
 
 ```sh

--- a/2001/herrmann1/README.md
+++ b/2001/herrmann1/README.md
@@ -1,10 +1,3 @@
-# Best abuse of the C preprocessor
-
-Immanuel Herrmann\
-Germany\
-<https://web.archive.org/web/20071018081145/http://pcpool.mathematik.uni-freiburg.de/~immi/>
-
-
 ## To build:
 
 ```sh

--- a/2001/herrmann2/README.md
+++ b/2001/herrmann2/README.md
@@ -1,10 +1,3 @@
-# Most eye-crossing
-
-Immanuel Herrmann\
-Germany\
-<https://web.archive.org/web/20071018081145/http://pcpool.mathematik.uni-freiburg.de/~immi/>
-
-
 ## To build:
 
 ```sh

--- a/2001/jason/README.md
+++ b/2001/jason/README.md
@@ -1,12 +1,3 @@
-# Best Of Show
-
-Jason Orendorff\
-5 Buchanan St.\
-Nashua, NH 03060\
-US\
-<http://jorendorff.blogspot.com>
-
-
 ## To build:
 
 ```sh

--- a/2001/kev/README.md
+++ b/2001/kev/README.md
@@ -1,11 +1,3 @@
-# Best Curses Game
-
-Kevin Pulo\
-Australia\
-<http://www.kev.pulo.com.au/>\
-Mastodon: <https://fosstodon.org/@devkev>
-
-
 ## To build:
 
 ```sh

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -1,10 +1,3 @@
-# Best of Show
-
-Nicolas Ollinger\
-France\
-<https://www.univ-orleans.fr/lifo/Members/Nicolas.Ollinger/>
-
-
 ## To build:
 
 ```sh

--- a/2001/rosten/README.md
+++ b/2001/rosten/README.md
@@ -1,10 +1,3 @@
-# Best abuse of the user
-
-Edward Rosten\
-UK\
-<https://www.edwardrosten.com>
-
-
 ## To build:
 
 ```sh

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -1,10 +1,3 @@
-# Best one-liner
-
-Jens Schweikhardt\
-Germany\
-<http://www.schweikhardt.net/>
-
-
 ## To build:
 
 ```sh

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -1,10 +1,3 @@
-# Best position-independent code
-
-Brian Westley\
-US\
-<http://www.westley.org>
-
-
 ## To build:
 
 ```sh

--- a/2001/williams/README.md
+++ b/2001/williams/README.md
@@ -1,9 +1,3 @@
-# Best Graphic Game
-
-John Williams\
-US
-
-
 ## To build:
 
 ```sh

--- a/2004/anonymous/README.md
+++ b/2004/anonymous/README.md
@@ -1,10 +1,3 @@
-# Best use of "Precious" Lines
-
-The author wishes to remain anonymous\
-Singapore\
-<https://web.archive.org/web/20040324155828/http://bicoherent.topcities.com/>
-
-
 ## To build:
 
 ```sh

--- a/2004/arachnid/README.md
+++ b/2004/arachnid/README.md
@@ -1,10 +1,3 @@
-# Best use of Vision
-
-Nick Johnson\
-New Zealand\
-<https://web.archive.org/web/20051030162356/http://www.notdot.net/>
-
-
 ## To build:
 
 ```sh

--- a/2004/burley/README.md
+++ b/2004/burley/README.md
@@ -1,9 +1,3 @@
-# Best Calculated Risk
-
-Brent Burley\
-US
-
-
 ## To build:
 
 ```sh

--- a/2004/gavare/README.md
+++ b/2004/gavare/README.md
@@ -1,10 +1,3 @@
-# Best Use of Light and Spheres
-
-Anders Gavare\
-Sweden\
-<https://gavare.se>
-
-
 ## To build:
 
 ```sh

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -1,9 +1,3 @@
-# Best of Show
-
-Gavin Barraclough\
-UK
-
-
 ## To build:
 
 ```sh

--- a/2004/hibachi/README.md
+++ b/2004/hibachi/README.md
@@ -1,10 +1,3 @@
-# Best Abuse of the Guidelines
-
-Anthony Howe\
-Canada\
-<http://www.snert.com/>
-
-
 ## To build:
 
 ```sh

--- a/2004/hoyle/README.md
+++ b/2004/hoyle/README.md
@@ -1,10 +1,3 @@
-# Most Functional Output
-
-Jonathan Hoyle\
-US\
-<http://www.jonhoyle.com>
-
-
 ## To build:
 
 ```sh

--- a/2004/jdalbec/README.md
+++ b/2004/jdalbec/README.md
@@ -1,10 +1,3 @@
-# Best Abuse of the Periodic Table
-
-John Dalbec\
-US\
-<https://jpdalbec.people.ysu.edu>
-
-
 ## To build:
 
 ```sh

--- a/2004/kopczynski/README.md
+++ b/2004/kopczynski/README.md
@@ -1,10 +1,3 @@
-# Best One-Liner
-
-Eryk Kopczynski\
-Poland\
-<http://www.mimuw.edu.pl/~erykk/>
-
-
 ## To build:
 
 ```sh

--- a/2004/newbern/README.md
+++ b/2004/newbern/README.md
@@ -1,9 +1,3 @@
-# Best Font Engine
-
-Jeff Newbern\
-US
-
-
 ## To build:
 
 ```sh

--- a/2004/omoikane/README.md
+++ b/2004/omoikane/README.md
@@ -1,10 +1,3 @@
-# Best Utility
-
-Don Yang\
-US\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2004/schnitzi/README.md
+++ b/2004/schnitzi/README.md
@@ -1,10 +1,3 @@
-# Best Non-Use of Curses
-
-Mark Schnitzius\
-Australia\
-<http://computronium.org/ioccc.html>
-
-
 ## To build:
 
 ```sh

--- a/2004/sds/README.md
+++ b/2004/sds/README.md
@@ -1,10 +1,3 @@
-# Best Abuse of Indentation
-
-Stephen Sykes\
-Finland\
-<https://web.archive.org/web/20160316092728/http://www.stephensykes.com/>
-
-
 ## To build:
 
 ```sh

--- a/2004/vik1/README.md
+++ b/2004/vik1/README.md
@@ -1,12 +1,3 @@
-# Best X11 Game
-
-Daniel Vik\
-US\
-<daniel@vik.cc>\
-<https://www.vik.cc/>\
-<http://danielvik.com/>
-
-
 ## To build:
 
 ```sh

--- a/2004/vik2/README.md
+++ b/2004/vik2/README.md
@@ -1,11 +1,3 @@
-# Best Abuse of CPP
-
-Daniel Vik\
-US\
-<https://www.vik.cc/>\
-<http://www.danielvik.com>
-
-
 ## To build:
 
 ```sh

--- a/2005/aidan/README.md
+++ b/2005/aidan/README.md
@@ -1,10 +1,3 @@
-# Most ingenious puzzle solution
-
-Aidan Thornton\
-United Kingdom\
-<makomk@lycos.co.uk>
-
-
 ## To build:
 
 ```sh

--- a/2005/anon/README.md
+++ b/2005/anon/README.md
@@ -1,8 +1,3 @@
-# Best 3D puzzle
-
-Anonymous
-
-
 ## To build:
 
 ```sh

--- a/2005/boutines/README.md
+++ b/2005/boutines/README.md
@@ -1,10 +1,3 @@
-# Most superfluous output
-
-Francois Boutines\
-Toulouse, France\
-<francois.boutines@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2005/chia/README.md
+++ b/2005/chia/README.md
@@ -1,10 +1,3 @@
-# Most ambiguous language
-
-V. Chia\
-Singapore\
-<bi@mncw.tk>
-
-
 ## To build:
 
 ```sh

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -1,10 +1,3 @@
-# Best 2D puzzle
-
-Gil Dogon\
-Israel\
-<gil_jade@netvision.net.il>
-
-
 ## To build:
 
 ```sh

--- a/2005/jetro/README.md
+++ b/2005/jetro/README.md
@@ -1,10 +1,3 @@
-# Most sonorous output
-
-Jetro Lauha\
-Finland\
-<http://jet.ro>
-
-
 ## To build:
 
 This entry requires SDL to be installed.

--- a/2005/klausler/README.md
+++ b/2005/klausler/README.md
@@ -1,10 +1,3 @@
-# Abuse of the rules
-
-Peter Klausler\
-US\
-<pmk@cray.com>
-
-
 ## To build:
 
 ```sh

--- a/2005/mikeash/README.md
+++ b/2005/mikeash/README.md
@@ -1,11 +1,3 @@
-# Best use of parenthesis
-
-Michael Ash\
-US\
-mike@mikeash.com\
-<https://mikeash.com>
-
-
 ## To build:
 
 ```sh

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -1,10 +1,3 @@
-# Best use of the WWW
-
-Anthony Howe\
-<achowe@snert.com>\
-<http://www.snert.com>
-
-
 ## To build:
 
 ```sh

--- a/2005/persano/README.md
+++ b/2005/persano/README.md
@@ -1,10 +1,3 @@
-# Best of Show
-
-Mauro Persano\
-Brazil\
-<mauro_persano@yahoo.com>
-
-
 ## To build:
 
 ```sh

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -1,10 +1,3 @@
-# Best Emulator
-
-Stephen Sykes\
-<sds@maxisat.fi>\
-<https://web.archive.org/web/20160316092728/http://www.stephensykes.com/>
-
-
 ## To build:
 
 ```sh

--- a/2005/timwi/README.md
+++ b/2005/timwi/README.md
@@ -1,10 +1,3 @@
-# Most discourteous interpreter
-
-Arne "Timwi" Heizmann\
-Germany\
-<timwi@gmx.net>
-
-
 ## To build:
 
 ```sh

--- a/2005/toledo/README.md
+++ b/2005/toledo/README.md
@@ -1,11 +1,3 @@
-# Best Game
-
-Oscar Toledo G.\
-Familia Toledo\
-Mexico\
-<https://nanochess.org>
-
-
 ## To build:
 
 ```sh

--- a/2005/vik/README.md
+++ b/2005/vik/README.md
@@ -1,11 +1,3 @@
-# Most circuitous walk
-
-Daniel Vik\
-US\
-<daniel@vik.cc>\
-<https://www.vik.cc>
-
-
 ## To build:
 
 ```sh

--- a/2005/vince/README.md
+++ b/2005/vince/README.md
@@ -1,11 +1,3 @@
-# Most beauteous visuals
-
-Vincent Weaver\
-US\
-<vince@deater.net>\
-<http://www.deater.net/weave/>
-
-
 ## To build:
 
 Before building, make sure that you have the OpenGL development libraries

--- a/2006/birken/README.md
+++ b/2006/birken/README.md
@@ -1,10 +1,3 @@
-# EDAMAME Award
-
-Michael Birken\
-US\
-<o__1@hotmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2006/borsanyi/README.md
+++ b/2006/borsanyi/README.md
@@ -1,10 +1,3 @@
-# Most Useful
-
-Szabolcs Borsanyi\
-United Kingdom\
-<s.borsanyi@sussex.ac.uk>
-
-
 ## To build:
 
 ```sh

--- a/2006/grothe/README.md
+++ b/2006/grothe/README.md
@@ -1,9 +1,3 @@
-# Most Obfuscated Audio
-
-Aaron Grothe\
-US
-
-
 ## To build:
 
 ```sh

--- a/2006/hamre/README.md
+++ b/2006/hamre/README.md
@@ -1,9 +1,3 @@
-# Most Irrational
-
-Steinar Hamre\
-Norway
-
-
 ## To build:
 
 ```sh

--- a/2006/meyer/README.md
+++ b/2006/meyer/README.md
@@ -1,9 +1,3 @@
-# Best Game
-
-Raphael Meyer\
-US
-
-
 ## To build:
 
 ```sh

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -1,10 +1,3 @@
-# Best Compiled Graphics
-
-Maurizio Monge\
-Italy\
-<maurizio.monge at gmail dot com>
-
-
 ## To build:
 
 Make sure you have the SDL1 (not SDL2!) development environment installed.

--- a/2006/night/README.md
+++ b/2006/night/README.md
@@ -1,10 +1,3 @@
-# Best Abuse of Computation
-
-Christopher Night\
-US\
-<https://web.archive.org/web/20090415070532/https://www.people.fas.harvard.edu/~night>
-
-
 ## To build:
 
 ```sh

--- a/2006/sloane/README.md
+++ b/2006/sloane/README.md
@@ -1,9 +1,3 @@
-# Homer's Favorite
-
-Andy Sloane\
-US
-
-
 ## To build:
 
 ```sh

--- a/2006/stewart/README.md
+++ b/2006/stewart/README.md
@@ -1,9 +1,3 @@
-# Best Computed Graphics
-
-Thomas Stewart\
-US
-
-
 ## To build:
 
 ```sh

--- a/2006/sykes1/README.md
+++ b/2006/sykes1/README.md
@@ -1,10 +1,3 @@
-# Best Assembler
-
-Stephen Sykes\
-Finland\
-<https://web.archive.org/web/20160316092728/http://www.stephensykes.com/>
-
-
 ## To build:
 
 ```sh

--- a/2006/sykes2/README.md
+++ b/2006/sykes2/README.md
@@ -1,10 +1,3 @@
-# Best One Liner
-
-Stephen Sykes\
-Finland\
-<https://web.archive.org/web/20160316092728/http://www.stephensykes.com/>
-
-
 ## To build:
 
 ```sh

--- a/2006/toledo1/README.md
+++ b/2006/toledo1/README.md
@@ -1,11 +1,3 @@
-# Best Small Program
-
-Oscar Toledo G.\
-Familia Toledo\
-Mexico\
-<https://nanochess.org>
-
-
 ## To build:
 
 ```sh

--- a/2006/toledo2/README.md
+++ b/2006/toledo2/README.md
@@ -1,11 +1,3 @@
-# Best of Show
-
-Oscar Toledo G.\
-Familia Toledo\
-Mexico\
-<https://nanochess.org>
-
-
 ## To build:
 
 ```sh

--- a/2006/toledo3/README.md
+++ b/2006/toledo3/README.md
@@ -1,11 +1,3 @@
-# Most Portable Chess Set
-
-Oscar Toledo G.\
-Familia Toledo\
-Mexico\
-<https://nanochess.org>
-
-
 ## To build:
 
 ```sh

--- a/2011/akari/README.md
+++ b/2011/akari/README.md
@@ -1,10 +1,3 @@
-# Best of Show - Most Shrinkable
-
-Don Yang\
-<omoikane@uguu.org>\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2011/blakely/README.md
+++ b/2011/blakely/README.md
@@ -1,10 +1,3 @@
-# Most devolving
-
-Philip Blakely\
-Cambridge, UK\
-<pmblakely@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/borsanyi/README.md
+++ b/2011/borsanyi/README.md
@@ -1,10 +1,3 @@
-# Best data utility
-
-Szabolcs Borsanyi\
-Germany\
-<borsanyi@uni-wuppertal.de>
-
-
 ## To build:
 
 ```sh

--- a/2011/dlowe/README.md
+++ b/2011/dlowe/README.md
@@ -1,11 +1,3 @@
-# Most self deprecating
-
-David Lowe\
-US\
-<j.david.lowe@gmail.com>\
-<https://github.com/dlowe>
-
-
 ## To build:
 
 ```sh

--- a/2011/eastman/README.md
+++ b/2011/eastman/README.md
@@ -1,9 +1,3 @@
-# Best ball
-
-Peter Eastman\
-<peter.eastman@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/fredriksson/README.md
+++ b/2011/fredriksson/README.md
@@ -1,9 +1,3 @@
-# Most useful
-
-Kimmo Fredriksson\
-<kimmo.k.k.fredriksson@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/goren/README.md
+++ b/2011/goren/README.md
@@ -1,9 +1,3 @@
-# Most artistic
-
-Uri Goren\
-<goren.uri@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/hamaji/README.md
+++ b/2011/hamaji/README.md
@@ -1,9 +1,3 @@
-# Best solved puzzle
-
-Shinichiro Hamaji\
-<shinichiro.hamaji@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/hou/README.md
+++ b/2011/hou/README.md
@@ -1,9 +1,3 @@
-# Best self documenting program
-
-Hou Qiming\
-<hqm03ster@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/konno/README.md
+++ b/2011/konno/README.md
@@ -1,10 +1,3 @@
-# Best one liner
-
-Taketo Konno\
-Japan\
-<inaniwa3@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/richards/README.md
+++ b/2011/richards/README.md
@@ -1,9 +1,3 @@
-# Most surprisingly portable
-
-Gregor Richards\
-<Richards@codu.org>
-
-
 ## To build:
 
 ```sh

--- a/2011/toledo/README.md
+++ b/2011/toledo/README.md
@@ -1,11 +1,3 @@
-# Best non-chess game
-
-Oscar Toledo G.\
-Mexico\
-<biyubi@gmail.com>\
-<https://nanochess.org>
-
-
 ## To build:
 
 ```sh

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -1,10 +1,3 @@
-# Most sound
-
-Daniel Vik\
-<daniel@vik.cc>\
-<http://www.danielvik.com>
-
-
 ## To build:
 
 ```sh

--- a/2011/zucker/README.md
+++ b/2011/zucker/README.md
@@ -1,10 +1,3 @@
-# Most shiny
-
-Matt Zucker\
-<mzucker1@swarthmore.edu>\
-<https://mzucker.github.io/swarthmore/>
-
-
 ## To build:
 
 ```sh

--- a/2012/blakely/README.md
+++ b/2012/blakely/README.md
@@ -1,10 +1,3 @@
-# Most GIFted expressions
-
-Philip Blakely\
-UK\
-<pmblakely@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2012/deckmyn/README.md
+++ b/2012/deckmyn/README.md
@@ -1,9 +1,3 @@
-# Most notable and best tool
-
-Alex Deckmyn\
-<alex.deckmyn@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2012/dlowe/README.md
+++ b/2012/dlowe/README.md
@@ -1,11 +1,3 @@
-# Best way to lose a life
-
-J. David Lowe\
-US\
-<j.david.lowe@gmail.com>\
-<https://github.com/dlowe>
-
-
 ## To build:
 
 ```sh

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -1,11 +1,3 @@
-# Most complex ASCII fluid - Honorable mention
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2012/endoh2/README.md
+++ b/2012/endoh2/README.md
@@ -1,11 +1,3 @@
-# PiE in the sky award
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2012/grothe/README.md
+++ b/2012/grothe/README.md
@@ -1,13 +1,3 @@
-# Most conspiratorial
-
-Aaron Grothe\
-US\
-<ajgrothe@yahoo.com>
-
-David Madore\
-<http://www.madore.org/~david/>
-
-
 ## To build:
 
 ```sh

--- a/2012/hamano/README.md
+++ b/2012/hamano/README.md
@@ -1,9 +1,3 @@
-# Most elementary use of C - Silver award
-
-Tsukasa Hamano\
-<hamano@cuspy.org>
-
-
 ## To build:
 
 ```sh

--- a/2012/hou/README.md
+++ b/2012/hou/README.md
@@ -1,10 +1,3 @@
-# Most useful obfuscation
-
-Qiming Hou\
-<hqm03ster@gmail.com>\
-<http://www.houqiming.net>
-
-
 ## To build:
 
 ```sh

--- a/2012/kang/README.md
+++ b/2012/kang/README.md
@@ -1,10 +1,3 @@
-# Best short program
-
-Seonghoon Kang\
-<kang.seonghoon@mearie.org>\
-<http://mearie.org>
-
-
 ## To build:
 
 ```sh

--- a/2012/konno/README.md
+++ b/2012/konno/README.md
@@ -1,10 +1,3 @@
-# Best one liner
-
-Taketo Konno\
-Japan\
-<inaniwa3@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2012/omoikane/README.md
+++ b/2012/omoikane/README.md
@@ -1,10 +1,3 @@
-# Most surreptitious
-
-Don Yang\
-<omoikane@uguu.org>\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2012/tromp/README.md
+++ b/2012/tromp/README.md
@@ -1,10 +1,3 @@
-# Most functional
-
-John Tromp\
-<john.tromp@gmail.com>\
-<http://tromp.github.io/>
-
-
 ## To build:
 
 ```sh

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -1,10 +1,3 @@
-# Best use of cocoa - Bronze award
-
-Daniel Vik\
-<daniel@vik.cc>\
-<http://danielvik.com/>
-
-
 ## To build:
 
 ```sh

--- a/2012/zeitak/README.md
+++ b/2012/zeitak/README.md
@@ -1,9 +1,3 @@
-# Balanced use of obfuscation - Gold award
-
-Adar Zeitak\
-<aa4z2@walla.co.il>
-
-
 ## To build:
 
 ```sh

--- a/2013/birken/README.md
+++ b/2013/birken/README.md
@@ -1,10 +1,3 @@
-# Best painting tool
-
-Michael Birken\
-<o__1@hotmail.com>\
-<http://www.meatfighter.com/>
-
-
 ## To build:
 
 ```sh

--- a/2013/cable1/README.md
+++ b/2013/cable1/README.md
@@ -1,9 +1,3 @@
-# Most partisan 1-liner
-
-Adrian Cable\
-<adrian.cable@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2013/cable2/README.md
+++ b/2013/cable2/README.md
@@ -1,9 +1,3 @@
-# Best of show
-
-Adrian Cable\
-<adrian.cable@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2013/cable3/README.md
+++ b/2013/cable3/README.md
@@ -1,9 +1,3 @@
-# Largest small system emulator
-
-Adrian Cable\
-<adrian.cable@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -1,11 +1,3 @@
-# Best sparkling utility
-
-J. David Lowe\
-US\
-<j.david.lowe@gmail.com>\
-<https://github.com/dlowe>
-
-
 ## To build:
 
 ```sh

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -1,11 +1,3 @@
-# Most lazy SKIer
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -1,11 +1,3 @@
-# Most recyclable
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -1,11 +1,3 @@
-# Most tweetable 1-liner
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -1,11 +1,3 @@
-# Most solid
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2013/hou/README.md
+++ b/2013/hou/README.md
@@ -1,10 +1,3 @@
-# Best use of 1 Infinite Loop
-
-Qiming Hou\
-<hqm03ster@gmail.com>\
-<http://www.houqiming.net>
-
-
 ## To build:
 
 ```sh

--- a/2013/mills/README.md
+++ b/2013/mills/README.md
@@ -1,9 +1,3 @@
-# Most timely rendered
-
-Christopher Mills\
-<mrxo@sonic.net>
-
-
 ## To build:
 
 ```sh

--- a/2013/misaka/README.md
+++ b/2013/misaka/README.md
@@ -1,10 +1,3 @@
-# Most catty
-
-Don Yang\
-<omoikane@uguu.org>\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2013/morgan1/README.md
+++ b/2013/morgan1/README.md
@@ -1,9 +1,3 @@
-# Smallest large system simulator
-
-Yves-Marie Morgan\
-<yves-marie.morgan@parrot.com>
-
-
 ## To build:
 
 ```sh

--- a/2013/morgan2/README.md
+++ b/2013/morgan2/README.md
@@ -1,9 +1,3 @@
-# Most playfully versatile
-
-Yves-Marie Morgan\
-<yves-marie.morgan@parrot.com>
-
-
 ## To build:
 
 ```sh

--- a/2013/robison/README.md
+++ b/2013/robison/README.md
@@ -1,9 +1,3 @@
-# Most poetic use of strings
-
-Arch D. Robison\
-<arch.d.robison@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -1,14 +1,3 @@
-# Best use of port 1701
-
-Michael Birken\
-<o__1@hotmail.com><br>\
-<http://www.meatfighter.com/>
-
-Alexander Prishchepov\
-<alepov-github@yahoo.com>\
-<https://github.com/sans17/>
-
-
 ## To build:
 
 ```sh

--- a/2014/deak/README.md
+++ b/2014/deak/README.md
@@ -1,9 +1,3 @@
-# Most underscored argument
-
-Ferenc Deak\
-<fritzone@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2014/endoh1/README.md
+++ b/2014/endoh1/README.md
@@ -1,11 +1,3 @@
-# Most square (YODA award)
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2014/endoh2/README.md
+++ b/2014/endoh2/README.md
@@ -1,11 +1,3 @@
-# Best use of bioinformatics
-
-Yusuke Endoh\
-<mame@ruby-lang.org>\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -1,10 +1,3 @@
-# Homage to a classic game
-
-Sandro Maffiodo\
-<smaffer@gmail.com>\
-<http://www.assezeta.com/sandromaffiodo>
-
-
 ## To build:
 
 This entry requires SDL to be installed. See the [faq.md](/faq.md) if you don't

--- a/2014/maffiodo2/README.md
+++ b/2014/maffiodo2/README.md
@@ -1,10 +1,3 @@
-# Most tweetable entry
-
-Sandro Maffiodo\
-<smaffer@gmail.com>\
-<http://www.assezeta.com/sandromaffiodo>
-
-
 ## To build:
 
 ```sh

--- a/2014/morgan/README.md
+++ b/2014/morgan/README.md
@@ -1,9 +1,3 @@
-# Most likely to succeed
-
-Yves-Marie Morgan\
-<yves-marie.morgan@parrot.com>
-
-
 ## To build:
 
 ```sh

--- a/2014/sinon/README.md
+++ b/2014/sinon/README.md
@@ -1,10 +1,3 @@
-# Best choice of optimization
-
-Don Yang\
-<omoikane@uguu.org>\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2014/skeggs/README.md
+++ b/2014/skeggs/README.md
@@ -1,10 +1,3 @@
-# Most dynamic
-
-Cel Skeggs\
-<ioccc@celskeggs.com>\
-<http://www.celskeggs.com>
-
-
 ## To build:
 
 ```sh

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -1,12 +1,3 @@
-# Best handling of beeps
-
-Daniel Vik\
-US\
-<daniel@vik.cc>\
-<https://www.vik.cc/>\
-<http://danielvik.com/>
-
-
 ## To build:
 
 ```sh

--- a/2014/wiedijk/README.md
+++ b/2014/wiedijk/README.md
@@ -1,9 +1,3 @@
-# Most functional
-
-Freek Wiedijk\
-<freek@cs.ru.nl>
-
-
 ## To build:
 
 ```sh

--- a/2015/burton/README.md
+++ b/2015/burton/README.md
@@ -1,10 +1,3 @@
-# Most Useful
-
-Dave Burton\
-<ioccc@snox.net>\
-<http://snox.net/ioccc>
-
-
 ## To build:
 
 ```sh

--- a/2015/dogon/README.md
+++ b/2015/dogon/README.md
@@ -1,9 +1,3 @@
-# Most Crafty
-
-Gil Dogon\
-<http://sokoban-gild.com>
-
-
 ## To build:
 
 ```sh

--- a/2015/duble/README.md
+++ b/2015/duble/README.md
@@ -1,9 +1,3 @@
-# Best Handwriting
-
-Etienne Duble <etienne.duble@imag.fr>\
-<http://lig-membres.imag.fr/duble>
-
-
 ## To build:
 
 ```sh

--- a/2015/endoh1/README.md
+++ b/2015/endoh1/README.md
@@ -1,12 +1,3 @@
-# Most Diffused Reaction
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-Someone Anonymous
-
-
 ## To build:
 
 ```sh

--- a/2015/endoh2/README.md
+++ b/2015/endoh2/README.md
@@ -1,10 +1,3 @@
-# Most Overlooked Obfuscation
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2015/endoh3/README.md
+++ b/2015/endoh3/README.md
@@ -1,10 +1,3 @@
-# Back to the Future Award
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2015/endoh4/README.md
+++ b/2015/endoh4/README.md
@@ -1,10 +1,3 @@
-# Best One-liner
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2015/hou/README.md
+++ b/2015/hou/README.md
@@ -1,9 +1,3 @@
-# Most Well-rounded Hash
-
-Qiming Hou <hqm03ster@gmail.com>\
-<http://www.houqiming.net/>
-
-
 ## To build:
 
 ```sh

--- a/2015/howe/README.md
+++ b/2015/howe/README.md
@@ -1,10 +1,3 @@
-# Most Different
-
-Anthony Howe <achowe@snert.com>\
-Montreal, Quebec, Canada\
-<http://www.snert.com/>
-
-
 ## To build:
 
 ```sh

--- a/2015/mills1/README.md
+++ b/2015/mills1/README.md
@@ -1,8 +1,3 @@
-# "For the Birds!" Award
-
-Chris Mills
-
-
 ## To build:
 
 ```sh

--- a/2015/mills2/README.md
+++ b/2015/mills2/README.md
@@ -1,8 +1,3 @@
-# Most Compact
-
-Chris Mills
-
-
 ## To build:
 
 ```sh

--- a/2015/muth/README.md
+++ b/2015/muth/README.md
@@ -1,9 +1,3 @@
-# Most Complete Use of CPP
-
-Dominik Muth\
-<muth.ioccc@freenet.de>
-
-
 ## To build:
 
 ```sh

--- a/2015/schweikhardt/README.md
+++ b/2015/schweikhardt/README.md
@@ -1,9 +1,3 @@
-# Best Documented
-
-Jens Schweikhardt\
-<http://www.schweikhardt.net>
-
-
 ## To build:
 
 ```sh

--- a/2015/yang/README.md
+++ b/2015/yang/README.md
@@ -1,9 +1,3 @@
-# Most Pointed Reaction
-
-Don Yang\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2018/algmyr/README.md
+++ b/2018/algmyr/README.md
@@ -1,8 +1,3 @@
-# Most cacophonic
-
-Anton Älgmyr
-
-
 ## To build:
 
 ```sh

--- a/2018/anderson/README.md
+++ b/2018/anderson/README.md
@@ -1,8 +1,3 @@
-# Most able to divine code gaps
-
-Derek Anderson
-
-
 ## To build:
 
 ```sh

--- a/2018/bellard/README.md
+++ b/2018/bellard/README.md
@@ -1,9 +1,3 @@
-# Most inflationary
-
-Fabrice Bellard\
-<https://bellard.org/>
-
-
 ## To build:
 
 ```sh

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -1,9 +1,3 @@
-# Best one-liner
-
-Dave Burton\
-<http://ioccc.snox.net>
-
-
 ## To build:
 
 ```sh

--- a/2018/burton2/README.md
+++ b/2018/burton2/README.md
@@ -1,9 +1,3 @@
-# Best abuse of the rules
-
-Dave Burton\
-<http://ioccc.snox.net>
-
-
 ## To build:
 
 ```sh

--- a/2018/ciura/README.md
+++ b/2018/ciura/README.md
@@ -1,9 +1,3 @@
-# Most likely to be awarded
-
-Marcin Ciura\
-<mciura@gmail.com>
-
-
 ## To build:
 
 ```sh

--- a/2018/endoh1/README.md
+++ b/2018/endoh1/README.md
@@ -1,10 +1,3 @@
-# Best tool to reveal holes
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2018/endoh2/README.md
+++ b/2018/endoh2/README.md
@@ -1,10 +1,3 @@
-# Best use of python
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -1,11 +1,3 @@
-# Best use of weasel words
-
-Cody Boone Ferguson <weasel@xexyl.net>\
-[https://ioccc.xexyl.net](https://ioccc.xexyl.net)\
-[https://xexyl.net](https://xexyl.net)\
-Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)
-
-
 ## To build:
 
 ```sh

--- a/2018/giles/README.md
+++ b/2018/giles/README.md
@@ -1,8 +1,3 @@
-# Most unstable
-
-Edward Giles
-
-
 ## To build:
 
 This entry requires SDL2 to be installed.

--- a/2018/hou/README.md
+++ b/2018/hou/README.md
@@ -1,8 +1,3 @@
-# Most likely to top the charts
-
-Qiming Hou
-
-
 ## To build:
 
 ```sh

--- a/2018/mills/README.md
+++ b/2018/mills/README.md
@@ -1,8 +1,3 @@
-# Best of show
-
-Christopher Mills <mrxo@sonic.net>
-
-
 ## To build:
 
 ```sh

--- a/2018/poikola/README.md
+++ b/2018/poikola/README.md
@@ -1,10 +1,3 @@
-# Most stellar
-
-Timo Poikola <ioccc2018@ig.fi>\
-<https://ig.fi/>\
-<https://ig.fi/other/ioccc>
-
-
 ## To build:
 
 ```sh

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -1,8 +1,3 @@
-# Most connected
-
-Scott Vokes
-
-
 ## To build:
 
 ```sh

--- a/2018/yang/README.md
+++ b/2018/yang/README.md
@@ -1,9 +1,3 @@
-# Most shifty
-
-Don Yang\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2019/adamovsky/README.md
+++ b/2019/adamovsky/README.md
@@ -1,9 +1,3 @@
-# Most functional interpreter
-
-Ondřej Adamovský\
-<oa@cmail.cz>
-
-
 ## To build:
 
 ```sh

--- a/2019/burton/README.md
+++ b/2019/burton/README.md
@@ -1,8 +1,3 @@
-# Best one-liner
-
-Dave Burton
-
-
 ## To build:
 
 ```sh

--- a/2019/ciura/README.md
+++ b/2019/ciura/README.md
@@ -1,8 +1,3 @@
-# Most alphabetic
-
-Marcin Ciura
-
-
 ## To build:
 
 ```sh

--- a/2019/diels-grabsch1/README.md
+++ b/2019/diels-grabsch1/README.md
@@ -1,9 +1,3 @@
-# Best small program
-
-Volker Diels-Grabsch\
-<https://njh.eu>
-
-
 ## To build:
 
 ```sh

--- a/2019/diels-grabsch2/README.md
+++ b/2019/diels-grabsch2/README.md
@@ -1,9 +1,3 @@
-# Most self-aware
-
-Volker Diels-Grabsch\
-<https://njh.eu>
-
-
 ## To build:
 
 ```sh

--- a/2019/dogon/README.md
+++ b/2019/dogon/README.md
@@ -1,8 +1,3 @@
-# Best use of space and time
-
-Gil Dogon
-
-
 ## To build:
 
 ```sh

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -1,9 +1,3 @@
-# Best collaborative graphics
-
-Etienne Duble\
-<https://lig-membres.imag.fr/duble>
-
-
 ## To build:
 
 ```sh

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -1,10 +1,3 @@
-# Most in need of debugging
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2019/giles/README.md
+++ b/2019/giles/README.md
@@ -1,8 +1,3 @@
-# Most in need of wide space
-
-Edward Giles
-
-
 ## To build:
 
 ```sh

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -1,8 +1,3 @@
-# Most in need of whitespace
-
-Joshua Karns
-
-
 ## To build:
 
 ```sh

--- a/2019/lynn/README.md
+++ b/2019/lynn/README.md
@@ -1,9 +1,3 @@
-# Most functional compiler
-
-Ben Lynn\
-<https://crypto.stanford.edu/~blynn/>
-
-
 ## To build:
 
 ```sh

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -1,8 +1,3 @@
-# Most in need to be tweeted
-
-Christopher Mills
-
-
 ## To build:
 
 ```sh

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -1,9 +1,3 @@
-# Most calendrical
-
-Timo Poikola\
-<https://ig.fi/other/ioccc>
-
-
 ## To build:
 
 ```sh

--- a/2019/yang/README.md
+++ b/2019/yang/README.md
@@ -1,9 +1,3 @@
-# Most in need of transparency
-
-Don Yang\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/2020/burton/README.md
+++ b/2020/burton/README.md
@@ -1,9 +1,3 @@
-# Best one-liner
-
-Dave Burton\
-<http://snox.net/ioccc>
-
-
 ## To build:
 
 ```sh

--- a/2020/carlini/README.md
+++ b/2020/carlini/README.md
@@ -1,9 +1,3 @@
-# Best of show - abuse of libc
-
-Nicholas Carlini <nicholas@carlini.com>\
-<https://nicholas.carlini.com>
-
-
 ## To build:
 
 ```sh

--- a/2020/endoh1/README.md
+++ b/2020/endoh1/README.md
@@ -1,10 +1,3 @@
-# Most explosive
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2020/endoh2/README.md
+++ b/2020/endoh2/README.md
@@ -1,10 +1,3 @@
-# Best perspective
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2020/endoh3/README.md
+++ b/2020/endoh3/README.md
@@ -1,10 +1,3 @@
-# Most head-turning
-
-Yusuke Endoh\
-<https://github.com/mame/>\
-Mastodon: [@mame@ruby.social](https://ruby.social/@mame)
-
-
 ## To build:
 
 ```sh

--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -1,11 +1,3 @@
-# Don't tread on me award
-
-Cody Boone Ferguson <ioccc@xexyl.net>\
-<https://ioccc.xexyl.net>\
-<https://xexyl.net>\
-Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)
-
-
 ## To build:
 
 ```sh

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -1,11 +1,3 @@
-# Most enigmatic
-
-Cody Boone Ferguson <ioccc@xexyl.net>\
-<https://ioccc.xexyl.net>\
-<https://xexyl.net>\
-Mastodon: [@xexyl@fosstodon.org](https://fosstodon.org/@xexyl)
-
-
 ## To build:
 
 ```sh

--- a/2020/giles/README.md
+++ b/2020/giles/README.md
@@ -1,9 +1,3 @@
-# Most phony
-
-Edward Giles\
-<https://id523a.com/>
-
-
 ## To build:
 
 ```sh

--- a/2020/kurdyukov1/README.md
+++ b/2020/kurdyukov1/README.md
@@ -1,9 +1,3 @@
-# Best utility
-
-Ilya Kurdyukov\
-<https://github.com/ilyakurdyukov>
-
-
 ## To build:
 
 ```sh

--- a/2020/kurdyukov2/README.md
+++ b/2020/kurdyukov2/README.md
@@ -1,9 +1,3 @@
-# Least detailed
-
-Ilya Kurdyukov\
-<https://github.com/ilyakurdyukov>
-
-
 ## To build:
 
 ```sh

--- a/2020/kurdyukov3/README.md
+++ b/2020/kurdyukov3/README.md
@@ -1,9 +1,3 @@
-# Bset slaml prragom
-
-Ilya Kurdyukov\
-<https://github.com/ilyakurdyukov>
-
-
 ## To build:
 
 ```sh

--- a/2020/kurdyukov4/README.md
+++ b/2020/kurdyukov4/README.md
@@ -1,9 +1,3 @@
-# Best abuse of lámatyávë
-
-Ilya Kurdyukov\
-<https://github.com/ilyakurdyukov>
-
-
 ## To build:
 
 ```sh

--- a/2020/otterness/README.md
+++ b/2020/otterness/README.md
@@ -1,9 +1,3 @@
-# Most percussive
-
-Nathan Otterness\
-<https://github.com/yalue>
-
-
 ## To build:
 
 ```sh

--- a/2020/tsoj/README.md
+++ b/2020/tsoj/README.md
@@ -1,9 +1,3 @@
-# Most misleading indentation
-
-tsoj <tsoj.tsoj@gmx.de>\
-<https://gitlab.com/tsoj>
-
-
 ## To build:
 
 ```sh

--- a/2020/yang/README.md
+++ b/2020/yang/README.md
@@ -1,9 +1,3 @@
-# Best abuse of CPP
-
-Don Yang\
-<http://uguu.org/>
-
-
 ## To build:
 
 ```sh

--- a/bugs.md
+++ b/bugs.md
@@ -1068,11 +1068,22 @@ Do you have an updated link? We welcome your help!
 
 ## 1996 jonth
 
-### STATUS: missing or dead link - please provide them
+### STATUS: INABIAF - please **DO NOT** fix
+
+### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1996/jonth/jonth.c](1996/jonth/jonth.c)
 ### Information: [1996/jonth/README.md](1996/jonth/README.md)
 
-As well the link which was http://www.uio.no/~jonth is no longer valid and
+If X is not running this program will very likely crash or do something funny.
+This should NOT be fixed.
+
+NOTE: the two boards will be on top of each other so you will have to drag one
+off the other so that you can properly play.
+
+
+### STATUS: missing or dead link - please provide them
+
+As well: the link which was http://www.uio.no/~jonth is no longer valid and
 there's no archive on the Internet Wayback Machine. Do you know of a proper URL?
 We greatly appreciate your help here!
 

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@ When we do, we will announce restoration of Email service here.
 </UL><BR>
 
 <LI TYPE=none><B>2018-02-16</B>
-<UL><LI TYPE=square>Due to a scheduling conflict with one of the <A HREF="judges.html">IOCCC judges</A>, the 25<sup>th</sup> IOCCC end date is now the Ideas of March.
+<UL><LI TYPE=square>Due to a scheduling conflict with one of the <A HREF="judges.html">IOCCC judges</A>, the 25<sup>th</sup> IOCCC end date is now the Ides of March.
 <LI TYPE=square>Please <a href="https://submit.ioccc.org">submit</a> your entries by 2018-Mar-15 03:08:07 UTC.
 <LI TYPE=square>Updated: The 25<sup>th</sup> IOCCC will be open from <B>2017-Dec-29 05:38:51 UTC</B> to <B>2018-Mar-15 03:08:07 UTC</B>.
 </UL><BR>
@@ -430,7 +430,7 @@ When we do, we will announce restoration of Email service here.
 -->
 </UL>
 
-<P>Older news has been archived, but is not currently available</P>
+<P>Older news has been archived, but is not currently available.</P>
 
 <HR>
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1189,7 +1189,7 @@ between pointer and integer ('char **' and 'int')` but it works just fine).
 
 Cody also added the [try.sh](1991/fine/try.sh) script which feeds the program
 some fun input for fun but mostly different output. He added a great string from
-Brian Westley and Cody also added a few of his own (can you figure out exactly
+Brian Westley and Cody also added several of his own (can you figure out exactly
 which ones? :-) )
 
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1192,6 +1192,20 @@ some fun input for fun but mostly different output. He added a great string from
 Brian Westley and Cody also added several of his own (can you figure out exactly
 which ones? :-) )
 
+## [1991/rince](1991/rince/rince.c) ([README.md](1991/rince/README.md))
+
+Cody fixed it so that the messages that show if you won or lost will be seen
+after the end of the game. The reason it did not work before is curses was ended
+at the end of the program which clears the screen. To make it look most like the
+original entry Cody left the message before ending curses in and printed another
+message of the same kind after `endwin()` was called with the exception that he
+added a newline at the end of the screen to be more user friendly.
+
+Cody also added two alt versions, one to remove the maximum number of moves you
+may make and another to let you configure the maximum number of moves, even if
+that is making it harder to win. Naturally the above fix was applied to these
+versions too.
+
 
 ## [1991/westley](1991/westley/westley.c) ([README.md](1991/westley/README.md]))
 

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -418,8 +418,8 @@ This file as the following fields:
 
 5. created_by:
 
-   The name of the program that creates this file, or null is the
-   file an original file.
+   The name of the program that creates this file, or null if the
+   file is an original file.
 
    NOTE: A null created_by value indicates that the file is part
    of the primary content.  A non-null created_by value indicates

--- a/tmp/run_all.sh
+++ b/tmp/run_all.sh
@@ -137,7 +137,7 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: WINNER_DIR_TXT=$WINNER_DIR_TXT" 1>&2
 fi
 
-# make is easier to process CSV files
+# make it easier to process CSV files
 #
 IFS="$IFS,"
 
@@ -163,11 +163,11 @@ if [[ ! -e $TOOL ]]; then
     exit 5
 fi
 if [[ ! -f $TOOL ]]; then
-    echo  "$0: ERROR: TOOL is not a file: $TOOL" 1>&2
+    echo  "$0: ERROR: TOOL is not a regular file: $TOOL" 1>&2
     exit 5
 fi
 if [[ ! -x $TOOL ]]; then
-    echo  "$0: ERROR: TOOL is not a executable file: $TOOL" 1>&2
+    echo  "$0: ERROR: TOOL is not an executable file: $TOOL" 1>&2
     exit 5
 fi
 


### PR DESCRIPTION

The program was supposed to print a message that indicates whether you 
won or lost but it did not show up because of endwin() being called 
after it. To keep the code as close to the original as possible that 
part was left in but an additional call to printf() was made after 
endwin() is called.

The first alt version removes the maximum number of moves so that 
everyone can finish, even people not good at this kind of puzzle. The 
second alt version allows you to reconfigure (at compile time) the 
maximum number of moves even if you wish to make it harder to win.

Format fix README.md file.

At this time I believe the edits necessary for 1991/rince are complete.