### PR TITLE
Add alt code to 1991/ant and format README.md

### DIFF
--- a/1991/ant/.gitignore
+++ b/1991/ant/.gitignore
@@ -1,4 +1,5 @@
 ant
+ant.alt
 ant.orig
 hill
 mole

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -116,8 +116,8 @@ OBJ= ${PROG}.o
 DATA= README.md
 TARGET= ${PROG} hill mole
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1991/ant/README.md
+++ b/1991/ant/README.md
@@ -4,6 +4,9 @@
 make all
 ```
 
+There is an [alternate version](#alternate-code) that might feel a bit more
+familiar to vi(m) users.
+
 
 ## To use:
 
@@ -28,6 +31,33 @@ make mole
 ```
 
 
+## Alternate code:
+
+This version changes the commands slightly so that to go to the first column you
+should enter `0`, to go to the last column you should enter `$`, to quit you
+should enter `q`, to go back a word you should enter `b` and to go forwards a
+word you should enter `w`. Also, and perhaps most useful, rather than having to
+hit ctrl-L (form-feed, `\f`) to get back to command mode you can use the usual
+ESC (`\x1b`).
+
+These will make it slightly less unwieldy for those familiar with vi(m); the
+rest was unchanged.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+
+### Alternate use:
+
+Use `ant.alt` as you would `ant` above with the changes in the input keys. See
+the author's remarks for the remaining keys.
+
+
 ## Judges' remarks:
 
 The author was kind enough to supply a list of references below,
@@ -38,7 +68,7 @@ of characters you can put a user unfamiliar with vi(m) in a vi(m) session (in
 insert mode) and ask them to exit. Well in this case you're likely to have this
 problem if you ARE a vi(m) user! :-) ... especially if you don't read the
 information below. This means if you're reading this in vi(m) you'll have to
-exit this like in normal vi(m) and then exit `./ant` differently.
+exit this like in normal vi(m) and then try the same with `./ant` only to fail. :-)
 
 NOTE: to enter form feed you should be able to hit `ctrl-L`. This will allow you
 to exit insert mode rather than ESC like in normal vi(m). See the author's
@@ -55,6 +85,7 @@ Carriage return is mapped to newline on input and ignored on output.  Tab stops
 are every eight columns.  Non-printable characters may have unpredictable
 results depending on the implementation of `curses`.
 
+
 ### Commands
 
 -    h j k l	    left, down, up, right cursor movement
@@ -67,6 +98,7 @@ results depending on the implementation of `curses`.
 -    R		    refresh the screen
 -    Q		    quit
 
+
 ### Exit status
 
 -    0		    success
@@ -75,26 +107,26 @@ results depending on the implementation of `curses`.
 
 ### About this entry
 
-The BUF size should be set at compile time to 32767.  This value was used
+The `BUF` size should be set at compile time to 32767.  This value was used
 because the Sozobon C compiler for the Atari ST has 16 bit ints and a limit on
 the size of arrays & structures of 32k.  Also the WatCom C compiler for the PC
 also has 16 bits ints.  On machines that have 32 bit ints (most unix boxes), a
-larger value for BUF could be used.
+larger value for `BUF` could be used.
 
 It is recommend that compact memory model be used on PC class machines.  Small
-memory model may work too provided BUF is not too large.
+memory model may work too provided `BUF` is not too large.
 
 The character constants `'\b'`, `'\f'`, `'\n'`, `'\r'`, `'\t'` are used in order
 to provide more portable code, since the compiler should handle the translation
 of them into the native character set.  Note that `'\f'` (form-feed) was used to
 exit insert mode because K&R C had no escape constant for the escape-key.
 
-My goals for this project were to learn and experiment with the
-Buffer Gap Scheme [Fin80][net90], write a useful and *portable*
-program, and meet the requirements of the IOCCC.  I initially
-planned to have a mini `curses` built-in like the IOCCC Tetris entry
-from a previous year, however this was not as portable as using a
-`curses` library with `TERMINFO`/`TERMCAP` support.
+My goals for this project were to learn and experiment with the Buffer Gap
+Scheme [Fin80][net90], write a useful and *portable* program, and meet the
+requirements of the IOCCC.  I initially planned to have a mini `curses` built-in
+like the [IOCCC Tetris entry from a previous year](/1989/tromp/README.md),
+however this was not as portable as using a `curses` library with
+`TERMINFO`/`TERMCAP` support.
 
 I plan to post follow-ups such as unobfuscated versions and bugs fixes to
 comp.editors.  Reposts of the editor.101, gap.doc, and editor.102 can be found
@@ -102,6 +134,7 @@ in the same group every so often.
 
 This entry will display a file with long lines, but has trouble scrolling the
 screen with long lines.  Paging up and down should work correctly, however.
+
 
 ### References:
 

--- a/1991/buzzard/.gitignore
+++ b/1991/buzzard/.gitignore
@@ -1,3 +1,4 @@
 buzzard
+buzzard.alt
 buzzard.orig
 prog.orig

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -116,8 +116,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -4,11 +4,46 @@
 make all
 ```
 
+There is an [alternate version](#alternate-code) which might feel more at home
+for vi(m) users in navigation.
+
+
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1991 buzzard in
+bugs.md](/bugs.md#1991-buzzard).
+
 
 ## To use:
 
 ```sh
 ./buzzard
+```
+
+## Alternate code:
+
+This version changes the keys `f` for forward, `l` for left and `r` for right to
+`k` for forward, `l` for right and `h` for left, which is more natural for those
+who use vi(m).
+
+
+### Alternate build:
+
+```sh
+make alt
+```
+
+
+### Alternate use:
+
+```sh
+./buzzard.alt
 ```
 
 
@@ -21,13 +56,13 @@ You are invited to try to cheat, ... if you can figure out how!  :-)
 
 ## Author's remarks:
 
+
 ### How to play
 
-When the game starts, you are at the far end of the maze from the
-exit, looking down a corridor.  To move forward, type `f` and press
-return.  To turn 90 degrees right, type `r`; left, `l`.  You can
-put multiple commands on one line, and the new view will be drawn
-after all the moves.
+When the game starts, you are at the far end of the maze from the exit, looking
+down a corridor.  To move forward, type `f` and press return.  To turn 90
+degrees right, type `r`; and for left, `l`.  You can put multiple commands on
+one line, and the new view will be drawn after all the moves.
 
 The game ends if you get out the exit (you'll know it when you see
 it) or when you type `^D` (EOF).
@@ -51,10 +86,14 @@ separate physical rows in the maze; a space indicates a corridor,
 and any other character is a wall.  Tabs are also considered walls,
 so make sure to convert tabs to spaces before using it.
 
-Usage: buzzard [filename [escape-char [start-x start-yNNN
+Usage:
+
+```sh
+./buzzard [filename [escape-char [start-x start-yNNN
+```
 
 Filename is the name of the file containing the maze.  This
-defaults to 'buzzard.c'.
+defaults to `buzzard.c` or rather `__FILE__`.
 
 Escape-char is the character in the maze that represents the exit.
 You can put more than one exit in the maze (for example, you could
@@ -67,7 +106,7 @@ from 0.  The default is start-x = 4, start-y = 5, which is needed
 for the buzzard.c, but would probably be inappropriate for other
 mazes.
 
-BUGS:
+### BUGS:
 
 You can't change that at start you're facing down ("south").
 

--- a/1991/buzzard/buzzard.alt.c
+++ b/1991/buzzard/buzzard.alt.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#define X(s) (!(s&3)-((s&3)==2))
+#define W while
+char Z[82][82],A,B,f,g=26;z(q)char**q;{return atoi(q);}m(d,l){return
+Z[   B       +    X      (   f     +
+3) * d+l *X(f+ 2 )][ A+X ( f ) * d +
+l* X           (     f     + 3 ) ] ;}int
+h= 0;D(p,s)char*s; {W(h>>3<p>> 3 ) {putchar('\t'
+);           h =       (       h   +8
+)&~7 ;}W(h < p ){putchar(' ');++h; }(void)printf(
+"%s"   ,   s                 )     ;h+=strlen(s);}main(x,a)char **a; {
+# define P(x) (x?(5-(x))*(6-(x ))/2:11)
+int b; { char b[256],i,  j=0;  FILE*F;F=fopen(x-1?a[1]:__FILE__,"r");W(
+fgets( b ,256 ,F)){for(i=0;b[ i];++ i)
+Z[j][i ] =( b [     i   ]     ==' '?1:2*(b[i]==(x>2?*a[2]:'\\')));++j;}fclose
+(F);}A   =4 ; B = 3 ; f = 1;x >3? A=z(a[3]),B=z(a[4]):0;b='\n';do{if(b=='\n'
+){int y ,     s , d , p   , q       ,i;for
+(y=-11; y<= 11;++ y){ for(s = 1 ,d=0;s+3;s-=2){for
+(;d!=2    +       3   * s     ;     d+=s){
+if(m(d,0) !=1 ){p=P (d) ;if (abs( y )
+   <p&&   !   m       (       d   , 0 )||abs(y)>p)break;for
+(i  =-p;i<p;++i)D(g+i*2,"--");D(0,"\-");break;}if(d==5)continue;
+p=P(d+1);q=P(d);if
+(abs(y)		>q)continue;if 
+(abs(y)		<p)D(g-s*(2*p+1),"|");else if(m(d,s)){if
+(abs(y)		<=p)for(i=(s==1?-q:p);i!=(s==1?-p:q);
+(abs(y)		),++i)D(g+2*i+(s==-1),"--");}else if
+(abs(y)		==p)D(g-s*(2*p+1),"|");else D(g-
+(abs(y)		*s*2),(s==1)^(y>0)?"\\":"/");}d-=s;}puts(
+"");h=0;}}f+=(b=='l')-(b=='h');f&=3;if(b=='k'){if(!m(1,0))continue;
+A+=X(f);B+=X(f-1);}}W((b=getchar())!=-1&&m(0,0)==1);return 0;}

--- a/1991/buzzard/buzzard.c
+++ b/1991/buzzard/buzzard.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #define X(s) (!(s&3)-((s&3)==2))
 #define W while
-char Z[82][82],A,B,f,g=26;z(q){return atoi(q);}m(d,l){return
+char Z[82][82],A,B,f,g=26;z(q)char**q;{return atoi(q);}m(d,l){return
 Z[   B       +    X      (   f     +
 3) * d+l *X(f+ 2 )][ A+X ( f ) * d +
 l* X           (     f     + 3 ) ] ;}int
@@ -10,7 +10,7 @@ h= 0;D(p,s)char*s; {W(h>>3<p>> 3 ) {putchar('\t'
 )&~7 ;}W(h < p ){putchar(' ');++h; }(void)printf(
 "%s"   ,   s                 )     ;h+=strlen(s);}main(x,a)char **a; {
 # define P(x) (x?(5-(x))*(6-(x ))/2:11)
-int b; { char b[256],i,  j=0;  FILE*F;F=fopen(x-1?a[1]:"buzzard.c","r");W(
+int b; { char b[256],i,  j=0;  FILE*F;F=fopen(x-1?a[1]:__FILE__,"r");W(
 fgets( b ,256 ,F)){for(i=0;b[ i];++ i)
 Z[j][i ] =( b [     i   ]     ==' '?1:2*(b[i]==(x>2?*a[2]:'\\')));++j;}fclose
 (F);}A   =4 ; B = 3 ; f = 1;x >3? A=z(a[3]),B=z(a[4]):0;b='\n';do{if(b=='\n'

--- a/bugs.md
+++ b/bugs.md
@@ -677,6 +677,18 @@ where this occurred was fixed but this one should not be fixed. Thank you.
 
 # 1991
 
+## 1991 buzzard
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1991/buzzard/buzzard.c](1991/buzzard/buzzard.c)
+### Information: [1991/buzzard/README.md](1991/buzzard/README.md)
+
+If the maze file cannot be opened, either because the path specified does not
+exist or because the default (whatever the source file was at compilation time)
+file does not exist in the directory, this program will very likely crash.
+
+This is a feature, not a bug.
+
 
 ## 1991 westley
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1097,6 +1097,22 @@ Later on, Cody added back the macro `#define D define` to make it look ever so
 slightly more like the original, even though it's unused.
 
 
+## [1991/buzzard](1991/buzzard/buzzard.c) ([README.md](1991/buzzard/README.md]))
+
+Cody fixed this so that the coordinates being specified would not crash the
+program. This happened because the function that calls `atoi(3)` took an arg
+without any type specified and as an implicit int it was not a `char *` which
+crashed the program in modern systems.
+
+Cody also made the file name in the code (which is the default maze file) not
+hard-coded but instead be `__FILE__`.
+
+Finally Cody added the [alternate
+version](1991/buzzard/README.md#alternate-code) which will possibly feel more at
+home with those familiar with vi(m) (it certainly does feel more at home with
+him): `k` for forward, `h` for left and `l` for right.
+
+
 ## [1991/dds](1991/dds/dds.c) ([README.md](1991/dds/README.md]))
 
 Cody fixed a segfault that prevented this entry from working in any condition

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1084,6 +1084,21 @@ The alt code did NOT have arg checks added as it is actually a copy of the
 original code.
 
 
+## [1991/ant](1991/ant/ant.c) ([README.md](1991/ant/README.md]))
+
+Cody added [alt code](1991/ant/ant.alt.c) that will be a bit easier to use for
+those familiar with vim in the following ways:
+
+- Use `0` to go to first column.
+- Use `$` to go to last column.
+- Hit ESC to go back to command mode (instead of form-feed, ctrl-L).
+- Use `w` to go forwards one word.
+- Use `b` to go backwards one word.
+- Use `q` to exit.
+
+The other keys were left unchanged.
+
+
 ## [1991/brnstnd](1991/brnstnd/brnstnd.c) ([README.md](1991/brnstnd/README.md]))
 
 Cody fixed this for modern systems. There were two invalid operands to binary


### PR DESCRIPTION

The alt code will make it a bit less unwieldy for vi(m) users by 
changing the following input keys to be like in vi(m):

- Use 0 to go to first column.
- Use $ to go to last column.
- Hit ESC to go back to command mode (instead of form-feed, ctrl-L).
- Use w to go forwards one word.
- Use b to go backwards one word.
- Use q to exit.

The rest of the keys were left unchanged.

Format fix README.md file.

This completes 1991/ant checks unless I'm very much mistaken.