### PR TITLE
Remove 80 column limitation in 1992/westley

### DIFF
--- a/1992/westley/.gitignore
+++ b/1992/westley/.gitignore
@@ -1,5 +1,6 @@
 westley
 whereami
+whereami.alt
 westley.alt
 westley.orig
 prog.orig

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
-	-Wno-parentheses -Wno-pedantic -Wno-deprecated-non-prototype -Wno-int-conversion
+	-Wno-parentheses -Wno-pedantic -Wno-deprecated-non-prototype -Wno-int-conversion \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -129,17 +130,21 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: your terminal must wrap at 80 columns for this to work right!"
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
-
-whereami: ${PROG}
-	${RM} -f $@
-	${LN} $< $@
+	${RM} -f whereami
+	${LN} $@ whereami
+	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${RM} -f whereami.alt
+	${LN} $@ whereami.alt
+	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
 
 # data files
 #
@@ -206,7 +211,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -f whereami
+	${RM} -f whereami whereami.alt
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/1992/westley/westley.alt.c
+++ b/1992/westley/westley.alt.c
@@ -1,5 +1,4 @@
-pain(l,a,n,d)char**a,**n,**d;{int N=n,D=d;for(D=atoi(a[1])/2*80-atoi(a[2])-2043;
+pain(l,a,n,d)char**a,**n,**d;{int N=n,D=d,e;for(e=0,D=atoi(a[1])/2*80-atoi(a[2])-2043;
 N="bnaBCOCXdBBHGYdAP[A M E R I C A].AqandkmavX|ELC}BOCd"
-[l++-3];)for(;N-->64;)putchar(!D+++33^l&1);}
+[l++-3];)for(;N-->64;){putchar(!D+++33^l&1);if(!(++e%80))putchar('\n');}return 0;}
 main(l,a)char**a;{pain(l,a,0,0);}
-

--- a/1992/westley/westley.c
+++ b/1992/westley/westley.c
@@ -1,12 +1,12 @@
            main(l
-  ,a)char**a;{int n;int d;
-if (l>2)for(d=atoi(a[1])/10
+  ,a)char**a;{int n;int d,e;
+if (l>2)for(e=0,d=atoi(a[1])/10
 *80-atoi(a[2])/5-596;n="@NKA\
 CLCCGZAAQBEAADAFaISADJABBA^\
 SNLGAQABDAXIMBAACTBATAHDBAN\
 ZcEMMCCCCAAhEIJFAEAAABAfHJE\
 TBdFLDAANEfDNBPHdBcBBBEA_AL\
  H E L L O,    W O R L D! "
-   [l++-3];)for(;n-->64;)
-      putchar(!d+++33^
-           l&1);}
+   [l++-3];)for(;n-->64;){
+   putchar(!d+++33^l&1);if(!
+   (++e%80))putchar('\n');}}

--- a/bugs.md
+++ b/bugs.md
@@ -817,6 +817,22 @@ Hello World.
 Can you help us?
 
 
+## 1992 westley
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1992/westley/westley.c](1992/westley/westley.c)
+### Information: [1992/westley/README.md](1992/westley/README.md)
+
+Cody improved the usability of this program by making it so that as long as the
+terminal columns is >= 80 it will display properly. However due to the nature of
+the program if the terminal is < 80 in column width it will not display right.
+To see the number of columns in your terminal try:
+
+```sh
+echo $COLUMNS
+```
+
+
 
 # 1993
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1307,9 +1307,9 @@ Later Cody improved the change to `fgets()` to make it slightly more like the
 original. This still requires the additional stripping of the newline inside the
 loop but now it uses what looks like before, just a call to `gets()`.
 
-One might think that simply changing the gets() to fgets() (with stdin) would
-work but it did not because `fgets()` stores the newline and `gets()` does not.
-The code was relying on not having this newline. With `fgets()` the code
+One might think that simply changing the `gets()` to `fgets()` (with `stdin`)
+would work but it did not because `fgets()` stores the newline and `gets()` does
+not.  The code was relying on not having this newline. With `fgets()` the code
 `if(A(Y)) puts(Y);` ended up printing an extra line which made the generation of
 some files (like `adhead.c`) fail to compile. Why? There was a blank line after
 a `\` at the end of the first line of a macro definition!  Thus the code now
@@ -1420,6 +1420,13 @@ specifically for the USA rather than the world. This had to be fixed for clang
 as well to make the args of `main()` be the correct type and by moving the body
 of main() to another function, `pain()`, which does the work since not all
 versions of clang support four args to `main()`.
+
+Cody also removed the restriction that one has a terminal that wraps at 80
+columns so that as long as the terminal's columns count (try `echo $COLUMNS`) is
+>= 80 it should work. As most people have wider terminals than back in 1992 this
+should help make it much easier to use. Note that if the number of columns is <
+80 it will not work right. The way this was done is that every 80 iterations in
+the final loop it prints another newline.
 
 Cody also added an arg check because the program and the
 [alternate version](1992/westley/westley.alt.c) might have crashed or


### PR DESCRIPTION
Because most people have much wider terminals nowadays and since not all can be resized I have changed the code a bit so that every 80 iterations (in the final loop) a newline is printed. This way as long as the terminal is at least 80 columns the program will show the map correctly. The alt version has been updated for this as well.

The Makefile now does not require one to run 'make whereami' to get the link: one simply needs to run 'make' or 'make all' or 'make everything'. For the alt program (the author provided one that I put into alt code that is strictly for the US) running make alt or make everything will do the same only it's whereami.alt.

The bugs.md has been updated noting that the terminal must be AT LEAST 80 columns. The README.md file has not been updated which means referring to the bugs.md has not been done yet either. The Makefile note about it requiring a terminal that wraps at 80 columns has been changed to note that it needs a terminal that is at least 80 columns. The note has been moved to after making the link (actually not a symlink but perhaps it should be).