### PR TITLE
Fix 1992/albert, swap alt/main code

### DIFF
--- a/1992/albert/.gitignore
+++ b/1992/albert/.gitignore
@@ -1,3 +1,4 @@
 albert
+albert.alt
 albert.orig
 prog.orig

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -42,8 +42,8 @@ Both albert and albert.orig loop without printing anything, although
 the first factor is 101 and is usually found in an instant.
 ```
 
-The [albert.c](albert.c) file is the fixed file, whereas the
-[albert.alt.c](albert.alt.c) is the file before applying Leo Broukhis' fix.
+The [albert.alt.c](albert.c) file is the fixed file, whereas the
+[albert.c](albert.c) is the file before applying Leo Broukhis' fix.
 
 To compile this alternate version:
 
@@ -65,8 +65,8 @@ a long.
 
 The Obfuscated version of the Horst algorithm.
 
-This program will factor unlimited length numbers and print the\
-factors in ascending order. Numbers of one digit (e.g. 8)\
+This program will factor unlimited length numbers and print the
+factors in ascending order. Numbers of one digit (e.g. 8)
 are rejected without notice.
 
 It quits as soon as there is at most one factor left, but that factor will not

--- a/1992/albert/albert.alt.c
+++ b/1992/albert/albert.alt.c
@@ -1,152 +1,34 @@
 #include <stdio.h>
-#include <malloc.h>
-#include <setjmp.h>
-#include <ctype.h>
-#define new(PP) (PP *) malloc(sizeof(PP)) 
-typedef struct q {
-    jmp_buf ppp;
-    long qq;
-    struct q *P;
-    struct q *p;
-} 
-PP;
 
-PP *P;
-int aaaaaa=2;
-int aaaaaaa=1;
-
-long qqq;
-
-
-aaAaaa(aa,aaa)
-char *aa;
-char *aaa;
+main(argc,argv)
+int argc;
+char **argv;
 {
-    char aaaa = 0;
-    if ((((( aaa )))))
-    {
-        aaaa = *aa;
-        *aa=0;
-        aa+=strlen(aa+1);
-        P =new(PP);
-        P->P=P;
-        P->p=P;
-    }
+        long arg[100];
+        int i,j;
+        int base = 10;
+        int start = 0;
+        int end= strlen(argv[1]);
 
-    if ((((( !setjmp(P->ppp) ))))) 
+
+        for (i=0;i<end;i++)
+                 arg[i] = argv[1][i]-'0';
+
+        while ( end-start > 2 )
         {
-        if ((((( !isdigit(*aa) )))))
-            longjmp(P->ppp,aaaaaaa);
-        else {
-            P->p->P = new(PP);
-            P->p->P->P = P;
-            P->p->P->p = P->p;
-            P->p = P->p->P;
+                while ( arg[end-1] == 0 ) {
+			printf("%d\n",base);
+			end--;
+		}
+                while ( arg[start] == 0 ) start +=1;
+                base += 1;
 
-            P->qq = *aa--;
-            P = P->p;
-            aaAaaa(aa,0);
+                for (i=start+1;i<end;i++)
+                        for (j=i;j>start;j--)
+                                if ( (arg[j]-=arg[j-1])<0 )
+                                {
+                                    arg[j]+=base;
+                                    arg[j-1] -= 1;
+                                }
         }
-    } else {
-        if ( !aaaa&&!*aa ) 
-           longjmp(P->p->ppp,aaaaaaa);
-
-        if ((((( (P->qq=aaaa)<10     &&!
-                 (isdigit(aaaa))     ||!
-                 (isdigit(*aa)       ||!
-                 *aa                        )))))) 
-        {
-            fprintf(stderr,"Usage %c%s <number>\n",
-            (aaa[0]?7:aaaa),aaa+!aaa[0]);
-            exit(1);
-        }
-    }
 }
-
-
-ppPppp(pp,ppp)
-PP **pp, *ppp;
-{
-    int aa;
-    if ((((( !(aa=setjmp(ppp->ppp))||aa==aaaaaa )))))
-    {
-        if ((((( *pp==ppp )))))
-        {
-            ppp = (*pp)->p;
-
-            if ( qqq<47 ) return;
-            if ( ppp->qq!=48 ) return;
-
-            while ( ppp->qq==48 ) 
-            {
-                printf("%ld\n",qqq-45);
-                *pp = ppp;
-                ppp = ppp->p;
-            }
-            qqq -= 1;
-            longjmp(ppp->ppp,aaaaaaa);
-        } else {
-            PP *p;
-
-            ppPppp(pp,ppp->p);
-            for (p=ppp;p!=*pp;p=p->p)
-            {
-                int qq=4;
-                if ((((( qqq<47                            &&
-                         (qq=0,p->qq+=p->p->qq-96)>=48-qqq ||
-                         qqq>46                            &&
-                         (p->qq-=p->p->qq)<0                   ))))) 
-                {
-                    p->qq += qqq+qq;
-                    if ( p->p==P && qqq<=46 )
-                    {
-                        P->p->P = new(PP);
-                        P->p->P->P = P;
-                        P->p->P->p = P->p;
-                        *pp = P = P->p = P->p->P;
-                        P->qq = 48;
-                    }
-
-                    p->p->qq+=qq==0;
-                    p->p->qq-=qq!=0;
-                }
-                else
-                {
-                    p->qq += 48;
-                }
-            }
-            if ( ppp->P==P ) longjmp(ppp->ppp,aaaaaaa);
-        }
-    }
-    else
-    {
-        qqq += 1; 
-
-        while (48==P->qq )
-        {
-            P->P->p = P->p;
-            P = P->p->P = P->P;
-
-        }
-
-        if (ppp!=ppp->p->p )
-            longjmp(ppp->ppp,aaaaaa);
-        else
-        {
-            printf("At most one remains\n");
-            exit(0);
-        }
-    }
-}
-
-
-main(aaa,aaaa)
-int aaa;
-char **aaaa;
-{
-    aaAaaa(aaa==aaaaaaa?aaaa[0]:aaaa[1],aaaa[0]);
-    qqq = 39;
-    ppPppp(&P,P->p);
-}
-
-

--- a/1992/albert/albert.c
+++ b/1992/albert/albert.c
@@ -1,34 +1,152 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <ctype.h>
+#define new(PP) (PP *) malloc(sizeof(PP)) 
+typedef struct q {
+    jmp_buf ppp;
+    long qq;
+    struct q *P;
+    struct q *p;
+} 
+PP;
 
-main(argc,argv)
-int argc;
-char **argv;
+PP *P;
+int aaaaaa=2;
+int aaaaaaa=1;
+
+long qqq;
+
+
+aaAaaa(aa,aaa)
+char *aa;
+char *aaa;
 {
-        long arg[100];
-        int i,j;
-        int base = 10;
-        int start = 0;
-        int end= strlen(argv[1]);
+    char aaaa = 0;
+    if ((((( aaa )))))
+    {
+        aaaa = *aa;
+        *aa=0;
+        aa+=strlen(aa+1);
+        P =new(PP);
+        P->P=P;
+        P->p=P;
+    }
 
-
-        for (i=0;i<end;i++)
-                 arg[i] = argv[1][i]-'0';
-
-        while ( end-start > 2 )
+    if ((((( !setjmp(P->ppp) ))))) 
         {
-                while ( arg[end-1] == 0 ) {
-			printf("%d\n",base);
-			end--;
-		}
-                while ( arg[start] == 0 ) start +=1;
-                base += 1;
+        if ((((( !isdigit(*aa) )))))
+            longjmp(P->ppp,aaaaaaa);
+        else {
+            P->p->P = new(PP);
+            P->p->P->P = P;
+            P->p->P->p = P->p;
+            P->p = P->p->P;
 
-                for (i=start+1;i<end;i++)
-                        for (j=i;j>start;j--)
-                                if ( (arg[j]-=arg[j-1])<0 )
-                                {
-                                    arg[j]+=base;
-                                    arg[j-1] -= 1;
-                                }
+            P->qq = *aa--;
+            P = P->p;
+            aaAaaa(aa,0);
         }
+    } else {
+        if ( !aaaa&&!*aa ) 
+           longjmp(P->p->ppp,aaaaaaa);
+
+        if ((((( (P->qq=aaaa)<10     &&!
+                 (isdigit(aaaa))     ||!
+                 (isdigit(*aa)       ||!
+                 *aa                        )))))) 
+        {
+            fprintf(stderr,"Usage %c%s <number>\n",
+            (aaa[0]?7:aaaa),aaa+!aaa[0]);
+            exit(1);
+        }
+    }
 }
+
+
+void ppPppp(pp,ppp)
+PP **pp, *ppp;
+{
+    int aa;
+    if ((((( !(aa=setjmp(ppp->ppp))||aa==aaaaaa )))))
+    {
+        if ((((( *pp==ppp )))))
+        {
+            ppp = (*pp)->p;
+
+            if ( qqq<47 ) return;
+            if ( ppp->qq!=48 ) return;
+
+            while ( ppp->qq==48 ) 
+            {
+                printf("%ld\n",qqq-45);
+                *pp = ppp;
+                ppp = ppp->p;
+            }
+            qqq -= 1;
+            longjmp(ppp->ppp,aaaaaaa);
+        } else {
+            PP *p;
+
+            ppPppp(pp,ppp->p);
+            for (p=ppp;p!=*pp;p=p->p)
+            {
+                int qq=4;
+                if ((((( qqq<47                            &&
+                         (qq=0,p->qq+=p->p->qq-96)>=48-qqq ||
+                         qqq>46                            &&
+                         (p->qq-=p->p->qq)<0                   ))))) 
+                {
+                    p->qq += qqq+qq;
+                    if ( p->p==P && qqq<=46 )
+                    {
+                        P->p->P = new(PP);
+                        P->p->P->P = P;
+                        P->p->P->p = P->p;
+                        *pp = P = P->p = P->p->P;
+                        P->qq = 48;
+                    }
+
+                    p->p->qq+=qq==0;
+                    p->p->qq-=qq!=0;
+                }
+                else
+                {
+                    p->qq += 48;
+                }
+            }
+            if ( ppp->P==P ) longjmp(ppp->ppp,aaaaaaa);
+        }
+    }
+    else
+    {
+        qqq += 1; 
+
+        while (48==P->qq )
+        {
+            P->P->p = P->p;
+            P = P->p->P = P->P;
+
+        }
+
+        if (ppp!=ppp->p->p )
+            longjmp(ppp->ppp,aaaaaa);
+        else
+        {
+            printf("At most one remains\n");
+            exit(0);
+        }
+    }
+}
+
+
+main(aaa,aaaa)
+int aaa;
+char **aaaa;
+{
+    aaAaaa(aaa==aaaaaaa?aaaa[0]:aaaa[1],aaaa[0]);
+    qqq = 39;
+    ppPppp(&P,P->p);
+}
+
+

--- a/1992/westley/.gitignore
+++ b/1992/westley/.gitignore
@@ -1,5 +1,6 @@
 westley
 whereami
+whereami.alt
 westley.alt
 westley.orig
 prog.orig

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
-	-Wno-parentheses -Wno-pedantic -Wno-deprecated-non-prototype -Wno-int-conversion
+	-Wno-parentheses -Wno-pedantic -Wno-deprecated-non-prototype -Wno-int-conversion \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -129,17 +130,21 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: your terminal must wrap at 80 columns for this to work right!"
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
-
-whereami: ${PROG}
-	${RM} -f $@
-	${LN} $< $@
+	${RM} -f whereami
+	${LN} $@ whereami
+	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${RM} -f whereami.alt
+	${LN} $@ whereami.alt
+	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
 
 # data files
 #
@@ -206,7 +211,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -f whereami
+	${RM} -f whereami whereami.alt
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -4,25 +4,32 @@
 make all
 ```
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+STATUS: known bug - please help us fix
+```
+
+For more detailed information see [1992 westley in bugs.md](/bugs.md#1992-westley).
+
+
 
 ## To use:
 
 If lost:
 
-```sh
-make whereami
-```
-
-Then run:
 
 ```sh
 ./whereami lat long
 ```
 
-Where lat and long correspond to your latitude and longitude.
+Where `lat` and `long` correspond to your latitude and longitude.
 
-NOTE: you **MUST** have a terminal that wraps at 80 columns (!) in order for this to
-show correctly!
+NOTE: you **MUST** have a terminal that is at least 80 columns for this to show
+properly.
 
 
 ### Try:
@@ -48,10 +55,10 @@ make alt
 ### Alternate use:
 
 ```sh
-./westley.alt lat long
+./whereami.alt lat long
 ```
 
-NOTE: this alternative version also needs a terminal that wraps at 80 columns.
+NOTE: this alternative version also needs a terminal with at least 80 columns.
 
 
 ## Judges' remarks:
@@ -66,24 +73,24 @@ To find the approximate place where this entry was judged, type:
 ## Author's remarks:
 
 Run the program with your latitude & longitude as integer
-arguments; it will produce a map made up of '!' with the given
-position marked with either a '"' (if the position is over a '!')
-or a '#' (if the position is over a space).  Southern latitudes
+arguments; it will produce a map made up of `'!'` with the given
+position marked with either a `'"'` (if the position is over a `'!'`)
+or a `#` (if the position is over a space).  Southern latitudes
 and western longitudes are entered as negative numbers.  For
-example, to find San Francisco, run with "prog 38 -122".  The
+example, to find San Francisco, run with `./whereami 38 -122`.  The
 resolution of the map is five degrees horizontally, ten degrees
 vertically.  The map is a Mercator projection with equal spacing
 of the latitudes, so the areas near the poles are very distorted.
 Latitudes near the poles and Antarctica are not shown.
 
-The program requires the ASCII character set, putchar(), atoi(),
+The program requires the ASCII character set, `putchar()`, `atoi()`,
 and a display that auto-wraps at 80 characters(!).  If your display
 does not work this way, you will have to massage the output;
-for example, you can pipe it to a file and edit it with vi,
+for example, you can redirect it to a file and edit it with vi,
 which will do auto-wrap for you.
 
-Lint complains that main() returns a random value and I'm not
-checking the value that putchar() returns.  Scandalous!
+Lint complains that `main()` returns a random value and I'm not
+checking the value that `putchar()` returns.  Scandalous!
 
 If you run it with fewer than 2 arguments, it will likely
 give you an exception, as it will access arguments that
@@ -91,15 +98,15 @@ don't exist and characters before a string constant.
 
 ### How it works:
 
-The map is printed as one long string of ' ' and '!' characters,
+The map is printed as one long string of `' '` and `'!'` characters,
 with the auto-wrap used to stack up slices of 80.  The map data is
-a string; the first character is how many '!'s are printed
-('A'=1, 'B'=2, etc), the second character is how many ' 's, the
-third is how many '!'s, etc.  ASCII characters less than 'A'
+a string; the first character is how many `!`s are printed
+(`'A'`=1, `'B'`=2, etc), the second character is how many `' '`s, the
+third is how many `!`s, etc.  ASCII characters less than `'A'`
 print no characters but still change the polarity, so any map
-of ' 's and '!'s is possible.  This is done in the putchar()
+of `' '`s and `'!'`s is possible.  This is done in the `putchar()`
 argument as `33^l&1`, where `l` is the character `position+4`; if
-`l` is odd, ' ' is printed, if `l` is even, '!' is printed.
+`l` is odd, `' '` is printed, if `l` is even, `'!'` is printed.
 
 The position of latitude & longitude is changed into a single
 character position within the one long string via the first
@@ -113,16 +120,18 @@ are opposite because latitude is decreasing and longitude is
 increasing as you go from upper left to lower right.  The offset
 is where the origin (latitude=0, longitude=0) is found.
 
-The position counting down to zero changes the putchar() from
-printing ('!' or ' ') to printing ('"' or '#').
+The position counting down to zero changes the `putchar()` from
+printing (`'!'` or `' '`) to printing (`'"'` or `'#'`).
 
-The "H E L L O,   W O R L D!" string inside the data string
-prints the line of blanks past Tierra del Fuego and the last
+The `"H E L L O,   W O R L D!"` string inside the data string
+prints the line of blanks past [Tierra del
+Fuego](https://en.wikipedia.org/wiki/Tierra_del_Fuego) and the last
 blank line.  It's just for show, really.
 
 Since the resolution is coarse, a few coastal cities are shown to
 be just off the map; this is an unavoidable artifact.  The map
 is reasonably accurate.
+
 
 ### Here are some cities you might like to try:
 
@@ -136,6 +145,7 @@ is reasonably accurate.
 - Rio de Janeiro    -23  -43
 - Beijing	    40   116
 - Tokyo		    36   140
+
 
 For a domestic (US) version with higher resolution, try:
 

--- a/1992/westley/try.sh
+++ b/1992/westley/try.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+make everything || exit 1
+
+echo "New York:" 1>&2
+echo 1>&2
+./westley.alt 41 -74
+echo 1>&2
+
+echo "London:" 1>&2
+echo 1>&2
+./westley 52 0
+echo 1>&2
+
+echo "Moscow:" 1>&2
+echo 1>&2
+./westley 56 38
+echo 1>&2
+
+echo "New Delhi:" 1>&2
+echo 1>&2
+./westley 29 77
+echo 1>&2
+
+echo "Sydney:" 1>&2
+echo 1>&2
+./westley -34 151
+echo 1>&2
+
+echo "Los Angeles:" 1>&2
+echo 1>&2
+./westley.alt 34 -118
+echo 1>&2
+
+echo "Paris:" 1>&2
+echo 1>&2
+./westley 45 2
+echo 1>&2
+
+echo "Rio de Janeiro:" 1>&2
+echo 1>&2
+./westley -23 -43
+echo 1>&2
+
+echo "Beijing:" 1>&2
+echo 1>&2
+./westley 40 116
+echo 1>&2
+
+echo "Tokyo:" 1>&2
+echo 1>&2
+./westley 36 140
+echo 1>&2
+
+echo "Approximate judging location:" 1>&2
+echo 1>&2
+./westley.alt 37 -122

--- a/1992/westley/westley.alt.c
+++ b/1992/westley/westley.alt.c
@@ -1,5 +1,4 @@
-pain(l,a,n,d)char**a,**n,**d;{int N=n,D=d;for(D=atoi(a[1])/2*80-atoi(a[2])-2043;
+pain(l,a,n,d)char**a,**n,**d;{int N=n,D=d,e;for(e=0,D=atoi(a[1])/2*80-atoi(a[2])-2043;
 N="bnaBCOCXdBBHGYdAP[A M E R I C A].AqandkmavX|ELC}BOCd"
-[l++-3];)for(;N-->64;)putchar(!D+++33^l&1);}
+[l++-3];)for(;N-->64;){putchar(!D+++33^l&1);if(!(++e%80))putchar('\n');}return 0;}
 main(l,a)char**a;{pain(l,a,0,0);}
-

--- a/1992/westley/westley.c
+++ b/1992/westley/westley.c
@@ -1,12 +1,12 @@
            main(l
-  ,a)char**a;{int n;int d;
-if (l>2)for(d=atoi(a[1])/10
+  ,a)char**a;{int n;int d,e;
+if (l>2)for(e=0,d=atoi(a[1])/10
 *80-atoi(a[2])/5-596;n="@NKA\
 CLCCGZAAQBEAADAFaISADJABBA^\
 SNLGAQABDAXIMBAACTBATAHDBAN\
 ZcEMMCCCCAAhEIJFAEAAABAfHJE\
 TBdFLDAANEfDNBPHdBcBBBEA_AL\
  H E L L O,    W O R L D! "
-   [l++-3];)for(;n-->64;)
-      putchar(!d+++33^
-           l&1);}
+   [l++-3];)for(;n-->64;){
+   putchar(!d+++33^l&1);if(!
+   (++e%80))putchar('\n');}}

--- a/bugs.md
+++ b/bugs.md
@@ -824,9 +824,10 @@ Can you help us?
 ### Information: [1992/westley/README.md](1992/westley/README.md)
 
 Cody improved the usability of this program by making it so that as long as the
-terminal columns is >= 80 it will display properly. However due to the nature of
-the program if the terminal is < 80 in column width it will not display right.
-To see the number of columns in your terminal try:
+terminal columns is >= 80 it will display properly, rather than having to wrap
+at 80 columns. However due to the nature of the program if the terminal is < 80
+in column width it will not display right.  To see the number of columns in your
+terminal try:
 
 ```sh
 echo $COLUMNS

--- a/bugs.md
+++ b/bugs.md
@@ -834,6 +834,25 @@ echo $COLUMNS
 ```
 
 
+### STATUS: known bug - please help us fix
+
+The author suggested that the alternate version, which Cody added (but fixed for
+modern systems), should print
+
+```c
+main(l,a,n,d)...
+[A M E R I C A]...
+```
+
+...going down the left edge if your terminal auto-wraps at 80 characters.
+
+This however does not seem to work. It does not appear to be because of the fix
+for modern systems as it doesn't work for gcc either, even before any changes.
+This might be a misunderstanding or it might be that having 80 columns (resized)
+does not count (though the output before the fix of the 80 column requirement
+showed was correct when at 80-columns so it seems like this could be a bug if
+not a misunderstanding).
+
 
 # 1993
 

--- a/bugs.md
+++ b/bugs.md
@@ -817,6 +817,22 @@ Hello World.
 Can you help us?
 
 
+## 1992 westley
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1992/westley/westley.c](1992/westley/westley.c)
+### Information: [1992/westley/README.md](1992/westley/README.md)
+
+Cody improved the usability of this program by making it so that as long as the
+terminal columns is >= 80 it will display properly. However due to the nature of
+the program if the terminal is < 80 in column width it will not display right.
+To see the number of columns in your terminal try:
+
+```sh
+echo $COLUMNS
+```
+
+
 
 # 1993
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1430,6 +1430,10 @@ the final loop it prints another newline. This fix has another bonus in that
 resizing the terminal after running it should not mess up the display either,
 unless of course it becomes too small.
 
+Cody added the [try.sh](1992/westley/try.sh) script that shows the different
+cities that the author recommended one try, labelling each city and printing a
+newline before the next city.
+
 Cody also added an arg check because the program and the
 [alternate version](1992/westley/westley.alt.c) might have crashed or
 [nuked](https://en.wikipedia.org/wiki/Nuclear_weapon) the [entire

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1307,9 +1307,9 @@ Later Cody improved the change to `fgets()` to make it slightly more like the
 original. This still requires the additional stripping of the newline inside the
 loop but now it uses what looks like before, just a call to `gets()`.
 
-One might think that simply changing the gets() to fgets() (with stdin) would
-work but it did not because `fgets()` stores the newline and `gets()` does not.
-The code was relying on not having this newline. With `fgets()` the code
+One might think that simply changing the `gets()` to `fgets()` (with `stdin`)
+would work but it did not because `fgets()` stores the newline and `gets()` does
+not.  The code was relying on not having this newline. With `fgets()` the code
 `if(A(Y)) puts(Y);` ended up printing an extra line which made the generation of
 some files (like `adhead.c`) fail to compile. Why? There was a blank line after
 a `\` at the end of the first line of a macro definition!  Thus the code now
@@ -1420,6 +1420,13 @@ specifically for the USA rather than the world. This had to be fixed for clang
 as well to make the args of `main()` be the correct type and by moving the body
 of main() to another function, `pain()`, which does the work since not all
 versions of clang support four args to `main()`.
+
+Cody also removed the restriction that one has a terminal that wraps at 80
+columns so that as long as the terminal's columns count (try `echo $COLUMNS`) is
+>= 80 it should work. As most people have wider terminals than back in 1992 this
+should help make it much easier to use. Note that if the number of columns is <
+80 it will not work right. The way this was done is that every 80 iterations in
+the final loop it prints another newline.
 
 Cody also added an arg check because the program and the
 [alternate version](1992/westley/westley.alt.c) might have crashed or

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1331,6 +1331,15 @@ This is a complex change due to the way the program and Makefile generate
 additional tools.
 
 
+## [1992/albert](1992/albert/albert.c) ([README.md](1992/albert/README.md]))
+
+Cody fixed this to compile with modern systems. Note that in 1996 a bug fix was
+applied to the code, provided as the alt code as that version is not obfuscated.
+Thus Cody's fixed applies to the original entry. The problems were that
+`malloc.h` is not the correct header file now and a non-void (implicit int)
+function returning without a value. The function was changed to return void.
+
+
 ## [1992/buzzard.1](1992/buzzard.1/buzzard.1.c) ([README.md](1992/buzzard.1/README.md))
 
 Cody added a check for the right number of args, exiting 1 if not enough (2)

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1421,12 +1421,14 @@ as well to make the args of `main()` be the correct type and by moving the body
 of main() to another function, `pain()`, which does the work since not all
 versions of clang support four args to `main()`.
 
-Cody also removed the restriction that one has a terminal that wraps at 80
-columns so that as long as the terminal's columns count (try `echo $COLUMNS`) is
->= 80 it should work. As most people have wider terminals than back in 1992 this
+Cody also removed the restriction that one has to have a terminal that wraps at
+80 columns so that as long as the terminal's columns (try `echo $COLUMNS`) is >=
+80 it should work. As most people have wider terminals than back in 1992 this
 should help make it much easier to use. Note that if the number of columns is <
 80 it will not work right. The way this was done is that every 80 iterations in
-the final loop it prints another newline.
+the final loop it prints another newline. This fix has another bonus in that
+resizing the terminal after running it should not mess up the display either,
+unless of course it becomes too small.
 
 Cody also added an arg check because the program and the
 [alternate version](1992/westley/westley.alt.c) might have crashed or


### PR DESCRIPTION

The alt code was the original; the entry was a bug fixed version by Leo
(before he was a judge). However that version, the fixed version, was
not obfuscated and as the judges say in the FAQ:

    the contest is called the IOCCC, not the INVOCCC :-)

so it seems better to have the version that has a bug as the entry. But
that code no longer compiled. This has been fixed. 

Updated .gitignore.

Minor changes to README.md wrt the swapping of alt code/entry code. The
formatting has not been checked and no typos have been fixed either. 
These will come later.
