### PR TITLE
Greatly improve 1992/westley presentation

### DIFF
--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -121,7 +121,7 @@ ALT_TARGET= ${PROG}.alt
 # build the entry
 #################
 #
-all: data ${TARGET}
+all: data ${TARGET} whereami whereami.alt
 	@${TRUE}
 
 .PHONY: all alt data everything diff_orig_prog diff_prog_orig \
@@ -131,20 +131,23 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
-	${RM} -f whereami
-	${LN} $@ whereami
 	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
+
+whereami: whereami.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} -lcurses
 
 # alternative executable
 #
-alt: data ${ALT_TARGET}
+alt: data ${ALT_TARGET} whereami.alt
 	@${TRUE}
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
-	${RM} -f whereami.alt
-	${LN} $@ whereami.alt
 	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
+
+
+whereami.alt: whereami.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} -lcurses
 
 # data files
 #

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -24,12 +24,17 @@ If lost:
 
 ```sh
 ./whereami lat long
+
+# or, if you don't have curses installed:
+./westley lat long
 ```
 
 Where `lat` and `long` correspond to your latitude and longitude.
 
 NOTE: you **MUST** have a terminal that is at least 80 columns for this to show
-properly.
+properly. The `whereami` and `whereami.alt` code checks this but it is not
+prohibitive if it cannot be compiled and linked (it uses curses); instead one
+should just use the `westley` and `westley.alt` programs directly.
 
 
 ### Try:
@@ -37,6 +42,10 @@ properly.
 ```sh
 ./whereami 47 -122	# NOTE: - means west of meridian
 ./whereami 47 122
+
+# or if you don't have curses installed:
+./westley 47 -122
+./westley 47 122
 ```
 
 
@@ -56,6 +65,9 @@ make alt
 
 ```sh
 ./whereami.alt lat long
+
+# or if you don't have curses installed:
+./westley.alt lat long
 ```
 
 NOTE: this alternative version also needs a terminal with at least 80 columns.
@@ -67,6 +79,9 @@ To find the approximate place where this entry was judged, type:
 
 ```sh
 ./whereami 37 -122	# NOTE: - means west of meridian
+
+# or if you don't have curses installed:
+./westley 37 -122	# NOTE: - means west of meridian
 ```
 
 
@@ -95,6 +110,7 @@ checking the value that `putchar()` returns.  Scandalous!
 If you run it with fewer than 2 arguments, it will likely
 give you an exception, as it will access arguments that
 don't exist and characters before a string constant.
+
 
 ### How it works:
 

--- a/1992/westley/try.sh
+++ b/1992/westley/try.sh
@@ -1,57 +1,118 @@
 #!/usr/bin/env bash
+# 
+# script to run westley on a variety of locations to show different cities in
+# the world.
+#
+# This script will first try compiling the code and alt code (alt = US only with
+# higher resolution, based on the author's remarks) and then if all is OK it
+# tries to make the whereami and whereami.alt programs. If that fails the
+# programs used will be westley and westley.alt; otherwise the programs will be
+# whereami and whereami.alt.
+#
+# The difference between whereami and westley is that the former first checks
+# that the number of columns is at least 80. The programs whereami and
+# whereami.alt can be deceived by way of doing:
+#
+#   COLUMNS=100 ./whereami lat long
+#
+# even if the number of columns is < 80 but there's nothing that can be done
+# about that. This script does not have that problem, however, so it's nice to
+# use for that purpose if nothing else.
+#
+# If westley or westley.alt cannot compile then it is an error and the script
+# will exit 3, corresponding to the code if westley.c or westley.alt.c cannot be
+# compiled by the whereami.c and whereami.alt.c programs.
+#
+# If whereami or whereami.alt cannot compile or link, say because libcurses is
+# not installed, then it is not an error as such but westley and westley.alt
+# will be used instead unless of course there exists an executable of one or
+# both called whereami or whereami.alt or westley.c or westley.alt.c cannot be
+# compiled. It is an error in the script if either of westley.c or westley.alt.c
+# cannot be compiled.
+#
+# This is the best way to protect against showing poor output. We can't get the
+# environmental variable COLUMNS from a program or a script so it has to be done
+# this way. Note that in curses the COLUMNS is called COLS.
+#
+# This script knows which version, the entry or alt code, to use based on what
+# city is being shown.
+#
+# If whereami and whereami.alt can be built it is run once, ahead of time, and
+# if it exits non-zero then we exit to prevent repeatedly showing the error
+# message.
+#
+# Usage: ./try.sh
+#
 
-make everything || exit 1
+WESTLEY=""
+WESTLEY_ALT=""
+
+make westley westley.alt >/dev/null || exit 1
+make whereami whereami.alt >/dev/null
+
+# get the path to the right programs
+if [[ -x "whereami" ]]; then
+    WESTLEY="whereami"
+    ./"$WESTLEY" 0 0 >/dev/null || exit 1
+else
+    WESTLEY="westley"
+fi
+if [[ -x "whereami.alt" ]]; then
+    WESTLEY_ALT="whereami.alt"
+else
+    WESTLEY_ALT="westley"
+fi
 
 echo "New York:" 1>&2
 echo 1>&2
-./westley.alt 41 -74
+./"$WESTLEY_ALT" 41 -74
 echo 1>&2
 
 echo "London:" 1>&2
 echo 1>&2
-./westley 52 0
+./"$WESTLEY" 52 0
 echo 1>&2
 
 echo "Moscow:" 1>&2
 echo 1>&2
-./westley 56 38
+./"$WESTLEY" 56 38
 echo 1>&2
 
 echo "New Delhi:" 1>&2
 echo 1>&2
-./westley 29 77
+./"$WESTLEY" 29 77
 echo 1>&2
 
 echo "Sydney:" 1>&2
 echo 1>&2
-./westley -34 151
+./"$WESTLEY" -34 151
 echo 1>&2
 
 echo "Los Angeles:" 1>&2
 echo 1>&2
-./westley.alt 34 -118
+./"$WESTLEY_ALT" 34 -118
 echo 1>&2
 
 echo "Paris:" 1>&2
 echo 1>&2
-./westley 45 2
+./"$WESTLEY" 45 2
 echo 1>&2
 
 echo "Rio de Janeiro:" 1>&2
 echo 1>&2
-./westley -23 -43
+./"$WESTLEY" -23 -43
 echo 1>&2
 
 echo "Beijing:" 1>&2
 echo 1>&2
-./westley 40 116
+./"$WESTLEY" 40 116
 echo 1>&2
 
 echo "Tokyo:" 1>&2
 echo 1>&2
-./westley 36 140
+./"$WESTLEY" 36 140
 echo 1>&2
 
 echo "Approximate judging location:" 1>&2
 echo 1>&2
-./westley.alt 37 -122
+./"$WESTLEY_ALT" 37 -122

--- a/1992/westley/westley.alt.orig.c
+++ b/1992/westley/westley.alt.orig.c
@@ -1,0 +1,3 @@
+main(l,a,n,d)char**a;{for(d=atoi(a[1])/2*80-atoi(a[2])-2043;
+n="bnaBCOCXdBBHGYdAP[A M E R I C A].AqandkmavX|ELC}BOCd"
+[l++-3];)for(;n-->64;)putchar(!d+++33^l&1);}

--- a/1992/westley/whereami.alt.c
+++ b/1992/westley/whereami.alt.c
@@ -1,0 +1,48 @@
+/*
+ * whereami.alt.c: wrapper program to westley.alt.c that checks first the
+ * columns of the terminal, exiting if < 80 and otherwise running westley.alt
+ * with the specified args. It is an error to not specify two args but it is not
+ * an error to specify args that are not numbers. The atoi(3) function typically
+ * returns 0 in that case which westley.alt.c uses.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <curses.h>
+
+int main(int argc, char **argv)
+{
+    int cols;
+
+    if (argc < 3)
+    {
+	fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]);
+	exit(1);
+    }
+
+    /* init curses so we can get the number of columns */
+    initscr();
+    /* save columns */
+    cols = COLS;
+    /*
+     * end curses so that we can either report an error or compile and run
+     * westley.alt
+     */
+    endwin();
+
+    if (cols < 80)
+    {
+	fprintf(stderr, "your terminal must be at\nleast 80 columns wide\nbut is only %d, sorry.\n", COLS);
+	exit(2);
+    }
+
+    /* 
+     * compile westley.alt and run if successful
+     */
+    if (system("make westley.alt >/dev/null"))
+    {
+	fprintf(stderr, "couldn't compile westley.alt.c, sorry.\n");
+	exit(3);
+    }
+    execl("./westley.alt", "./westley.alt", argv[1], argv[2], NULL);
+}

--- a/1992/westley/whereami.c
+++ b/1992/westley/whereami.c
@@ -1,0 +1,48 @@
+/*
+ * whereami.c: wrapper program to westley.c that checks first the
+ * columns of the terminal, exiting if < 80 and otherwise running westley
+ * with the specified args. It is an error to not specify two args but it is not
+ * an error to specify args that are not numbers. The atoi(3) function typically
+ * returns 0 in that case which westley.c uses.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <curses.h>
+
+int main(int argc, char **argv)
+{
+    int cols;
+
+    if (argc < 3)
+    {
+	fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]);
+	exit(1);
+    }
+
+    /* init curses so we can get the number of columns */
+    initscr();
+    /* save columns */
+    cols = COLS;
+    /*
+     * end curses so that we can either report an error or compile and run
+     * westley
+     */
+    endwin();
+
+    if (cols < 80)
+    {
+	fprintf(stderr, "your terminal must be at\nleast 80 columns wide\nbut is only %d, sorry.\n", COLS);
+	exit(2);
+    }
+
+    /* 
+     * compile westley and run if successful
+     */
+    if (system("make westley >/dev/null"))
+    {
+	fprintf(stderr, "couldn't compile westley.c, sorry.\n");
+	exit(3);
+    }
+    execl("./westley", "./westley", argv[1], argv[2], NULL);
+}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1439,9 +1439,21 @@ the final loop it prints another newline. This fix has another bonus in that
 resizing the terminal after running it should not mess up the display either,
 unless of course it becomes too small.
 
+Cody added the programs [whereami.c](1992/westley/whereami.c) and
+[whereami.alt](1992/westley/whereami.alt.c) which correspond to the entry and
+the alt code but which, by way of curses, checks for the number of columns; if
+all is good it will try compiling the program or alt program, respectively, and
+then if successful run the program. Otherwise, if there are not enough columns
+it is an error. It is always an error if the compilation of the program itself
+(westley.c, westley.alt.c) fails.
+
 Cody added the [try.sh](1992/westley/try.sh) script that shows the different
 cities that the author recommended one try, labelling each city and printing a
-newline before the next city.
+newline before the next city. The try.sh script uses the `whereami` code, if it
+can be compiled and linked, but otherwise it uses `westley` code instead, either
+the entry or alt code. The try.sh cannot be deceived by way of `COLUMNS=81
+./try.sh` but the `whereami`/`whereami.alt` code can be deceived if directly
+called. This is a feature, not a bug: or maybe a limitation of curses.
 
 Cody also added an arg check because the program and the
 [alternate version](1992/westley/westley.alt.c) might have crashed or


### PR DESCRIPTION
Added whereami.c and whereami.alt.c which, using curses, gets the number of columns of the terminal. If < 80 it is an error. Otherwise it will try compiling the westley.c or westley.alt.c and if successful it will run the program with the args specified.

The try.sh script will use whereami or whereami.alt if it's possible to compile and link (it might not if curses is not installed) and otherwise westley and westley.alt.

Running make all will compile westley.c and also whereami.c; running make alt will compile westley.alt.c and whereami.alt.c. The try.sh script does NOT use that but instead uses make westley alt: this is because we need to be sure that westley.c and westley.alt.c can compile but it is NOT an error if whereami.c or whereami.alt.c cannot compile. So the Makefile was done in a special way for this to not be a problem.

The original code of westley.alt.c has been added in westley.alt.orig.c.

The README.md has been updated for these improvements and this should complete 1992/westley.