### PR TITLE
Various bug/format fixes in 1992/adrian

### DIFF
--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-comment -Wno-deprecated-declarations 
 	-Wno-logical-op-parentheses -Wno-macro-redefined -Wno-parentheses \
 	-Wno-return-type -Wno-uninitialized -Wno-unused-value -Wno-unused-variable \
 	-Wno-unused-but-set-variable -Wno-unsequenced -Wno-unused-parameter \
-	-Wno-empty-translation-unit
+	-Wno-empty-translation-unit -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -118,7 +118,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG}
+TARGET= ${PROG} adgrep
 #
 ALT_OBJ=
 ALT_TARGET=

--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -4,6 +4,17 @@
 make all
 ```
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: known bug - please help us fix
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1992 adrian in bugs.md](/bugs.md#1992-adrian).
+
 
 ### Try:
 
@@ -17,7 +28,8 @@ For the slow minded, try:
 ./adsleep 32767
 ```
 
-NOTE: if you do not specify an arg to the program it will segfault.
+NOTE: if you do not specify an arg some of the programs such as `adsleep` it
+will very likely segfault do something funny. This is supposed to happen.
 
 
 ## Judges' remarks:
@@ -32,9 +44,9 @@ NOTE: Some compilers have had trouble optimizing this entry.
 
 ### ADrian's GREP (adgrep)
 
-For those confused by the complexity of full-blown egrep style regular
-expressions, this program offers an alternative.  It implements an
-equivalent search, using a deterministic finite automaton.
+For those confused by the complexity of full-blown `egrep(1)` style regular
+expressions, this program offers an alternative.  It implements an equivalent
+search, using a deterministic finite automaton.
 
 A deterministic finite automaton consists of a finite set of states,
 along with transition rules to move from one state to another, an initial
@@ -48,25 +60,30 @@ accepting states, then the string is accepted.
 The deterministic finite automaton is specified as a series of rules for
 each state:
 
-       <state> chars1 <dest1> chars2 <dest2> ...
+```
+<state> chars1 <dest1> chars2 <dest2> ...
+```
 
-`chars1` is a list of characters (only the first 8 are significant) which
+`chars1` is a list of characters (_only the first 8_ are significant) which
 should trigger a transition to `<dest1>`.  `<dest1>` is another state which
 should have a similar specification somewhere.  A state is accepting if
-it is specified in square brackets: `[final]`, and state strings are
-significant to only eight characters.
+it is specified in square brackets: `[final]`; state strings are
+significant to only eight characters like `chars1`.
+
 
 ### Example 1: matches `^abc$`
 
-    <q0> a <q1>          The first state to appear is the start state
-    <q1> b <q2>
-    <q2> c [q3]
-    [q3]
+```
+<q0> a <q1>          The first state to appear is the start state
+<q1> b <q2>
+<q2> c [q3]
+[q3]
+```
 
 Technically, a deterministic finite automaton should have a rule for each
 possible input character at each state.  To simplify descriptions of the
 automata, if no rule is present, the string will not be accepted. Also,
-the `'.'` character matches any character if it occurs first in the
+the `.` character matches any character if it occurs first in the
 character list.
 
 
@@ -116,55 +133,55 @@ character list.
 [q5]
 ```
 
-
-With the automaton specification in 'filename', invoke the program by
+With the automaton specification in `filename`, invoke the program by
 typing
 
 ```sh
-./adgrep 'filename'
+./adrian filename
 ```
 
 
-It will read stdin and print out all the lines which the automaton
+It will read the file and print out all the lines which the automaton
 accepts.  If the file cannot be opened, a system error message will
 be printed.  If the input contains errors, then an error message along
-with the number of the offending line will be printed to stderr.  The\
-number of rules for each state is limited to 17.  If more than 17 rules\
-are present, you get the error `too_many_rules`, and the state that was\
-being processed is printed.  Error `no_destination` occurs if you specify a\
+with the number of the offending line will be printed to stderr.  The
+number of rules for each state is limited to 17.  If more than 17 rules
+are present, you get the error `too_many_rules`, and the state that was
+being processed is printed.  Error `no_destination` occurs if you specify a
 set of characters, but no destination state, and error `too_many_states`
 occurs if your automaton has more than 257 states.
 
 Running:
 
 ```sh
-./adgrep from < your_mailbox
+./adrian from < your_mailbox
 ```
 
-will perform a function similar to that of the unix from command.
+will perform a function similar to that of the unix `from` command.
 
-If no filename is specified on the command line, then `"adgrep.c"` is used
-as the specification for the automaton.  (This file has been renamed\
-to `adrian.c` by the judges.)  In this case, the program will search for\
+If no filename is specified on the command line, then `__FILE__` is used
+as the specification for the automaton.  (Originally `"adgrep.c"` the file was renamed
+to `adrian.c` by the judges but for more portability the arg was changed to
+`__FILE__`.)  In this case, the program will search for
 matches to the regular expression:
 
 ```
 ^.[^|C][^w[Q]*(Q|[w[]c).*|^.[C|]$
 ```
 
-I suggest using `adgrep.c` as input, and storing the output in `adwc.c`:
+I suggest using `adrian.c` as input, and storing the output in `adwc.c`:
 
 ```sh
-./adgrep < adgrep.c > adwc.c
+./adrian < adrian.c > adwc.c
 ```
 
-Compiling the new file, `mywc.c`, yields a clone of the unix wc command. It
-runs on one file (defaulting to `"adgrep.c"` if no file is given) and
-displays the number of lines, words, and bytes in the input file.
-
+Compiling the new file, `adwc.c`, yields a clone of the unix `wc` command. It
+runs on one file, defaulting to `"adrian.c"` if no file is given (again, this
+was changed to be `__FILE__`) and displays the number of lines, words, and bytes
+in the input file.
 
 Another possibly interesting automaton can be created by slightly
-adjusting the `adgrep.c` file.  Change the first line to read
+adjusting the `adrian.c` file.  Change the first line to read
 
 ```c
 /* . echo| . */
@@ -173,7 +190,7 @@ adjusting the `adgrep.c` file.  Change the first line to read
 and repeat the process above
 
 ```sh
-./adgrep <adgrep.c > adecho.c
+./adrian <adrian.c > adecho.c
 ```
 
 The new file now contains all lines which match
@@ -182,7 +199,7 @@ The new file now contains all lines which match
 ^.[^5|m^]*[m^]([e=p,;]|[^e=+p,;].*)$
 ```
 
-Compile and run.  This is an echo clone.  Note the efficient algorithm
+Compile and run.  This is an `echo(1)` clone.  Note the efficient algorithm
 employed.
 
 
@@ -199,10 +216,10 @@ you can search for matches to
 ^.[^W]*W..*$
 ```
 
-By some freak happenstance, lines of adgrep.c which match this regular
-expression form a unix head command.  It prints the first ten lines of
-the file specified on the command line (or adgrep.c if no file is
-specified).
+By some freak happenstance, lines of `adrian.c` which match this regular
+expression form a unix `head(1)` command.  It prints the first ten lines of
+the file specified on the command line or adrian.c if no file is
+specified (again this was changed to `__FILE__`).
 
 By setting the first line to
 
@@ -210,14 +227,14 @@ By setting the first line to
 /* . basename . */
 ```
 
-a clone of the unix basename command can be unearthed. The automaton will
+a clone of the unix `basename(1)` command can be unearthed. The automaton will
 search for
 
 ```
 ^.[^j]*jr.*$
 ```
 
-on standard input.  And the program which results by running adgrep.c
+on standard input.  And the program which results by running `adrian.c`
 through this filter requires two parameters.  The first is meant to be a
 filename, and the second, an extension.  All leading pathname components
 are removed from the filename, and the extension is removed if present.
@@ -235,11 +252,11 @@ you can search for
 ^.[^(~][^s]*sl.*$
 ```
 
-Filtering adgrep.c through this search yields a clone of the sleep
-command.  Invoke with a single integer parameter, and it will pause
-for that many seconds.
+Filtering `adrian.c` through this search yields a clone of the `sleep(1)`
+command.  Invoke with a single integer parameter, and it will pause for that
+many seconds.
 
-If either adbasename or adsleep is invoked with too few parameters,
+If either `adbasename` or `adsleep` is invoked with too few parameters,
 the program will print the error message:
 
 > Segmentation fault (core dumped)
@@ -248,15 +265,16 @@ the program will print the error message:
 machine.)  The four programs which read from stdin require lines
 shorter than 999 characters.
 
-The other info files are adrian.grep.[1-6] which contain the six
+The other info files are `adrian.grep.[1-6]` which contain the six
 examples that appear above, and from, which is used to emulate the
-unix from command.  For reasons of clarity, the name "from" should
-probably not be changed if possible.  I wouldn't want to be accused of\
+unix `from` command.  For reasons of clarity, the name `"from"` should
+probably not be changed if possible.  I wouldn't want to be accused of
 confusing people by giving the input files weird names.
 
 If you want to change the default input filename (line 80) you must be
 careful to choose a name that doesn't match the wrong search patterns,
-introducing extra lines into one of the programs.
+introducing extra lines into one of the programs (again, this was changed to be
+`__FILE__`).
 
 The program will produce at least one warning and possible several
 when compiled depending on the compiler.

--- a/1992/adrian/adrian.c
+++ b/1992/adrian/adrian.c
@@ -23,7 +23,7 @@ int L=0,j= -28;
 void E(int i, int m,char*c)
 {   
  for(; i<43; i+=3) 
-   putc("}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR"[i]+i-9,stderr);
+   putc(i["}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR"]+i-9,stderr);
  fprintf(stderr,"(%d): %s\n" ,m,c);
  exit(1);
 }
@@ -77,7 +77,7 @@ main(int sl,char *j[]){
  v(s = V[1]; if (*V=strrchr(s,'/'))s=*V+1;  if(( !strncmp( s + (jr=strlen(s)) -
   (q=strlen(V[2]) ),V[2],q))&&jr!=q) s[jr-q] = 0;  puts(s); )
  int e,p,C=0,Q ,basename;
- W= fopen(wc>= 2 ? V[1] : "adgrep.c","rt");
+ W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(1);
 echo| m^ e| 5| (int) .8| echo|
 wc |C ==o[o[C] .e] . 
 e| e==+p,p; s[o[C] .e ] 

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -121,7 +121,7 @@ ALT_TARGET= ${PROG}.alt
 # build the entry
 #################
 #
-all: data ${TARGET}
+all: data ${TARGET} whereami whereami.alt
 	@${TRUE}
 
 .PHONY: all alt data everything diff_orig_prog diff_prog_orig \
@@ -131,20 +131,23 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
-	${RM} -f whereami
-	${LN} $@ whereami
 	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
+
+whereami: whereami.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} -lcurses
 
 # alternative executable
 #
-alt: data ${ALT_TARGET}
+alt: data ${ALT_TARGET} whereami.alt
 	@${TRUE}
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
-	${RM} -f whereami.alt
-	${LN} $@ whereami.alt
 	@echo "NOTE: your terminal must be at least 80 columns wide for this to work right"
+
+
+whereami.alt: whereami.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} -lcurses
 
 # data files
 #

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -24,12 +24,17 @@ If lost:
 
 ```sh
 ./whereami lat long
+
+# or, if you don't have curses installed:
+./westley lat long
 ```
 
 Where `lat` and `long` correspond to your latitude and longitude.
 
 NOTE: you **MUST** have a terminal that is at least 80 columns for this to show
-properly.
+properly. The `whereami` and `whereami.alt` code checks this but it is not
+prohibitive if it cannot be compiled and linked (it uses curses); instead one
+should just use the `westley` and `westley.alt` programs directly.
 
 
 ### Try:
@@ -37,6 +42,10 @@ properly.
 ```sh
 ./whereami 47 -122	# NOTE: - means west of meridian
 ./whereami 47 122
+
+# or if you don't have curses installed:
+./westley 47 -122
+./westley 47 122
 ```
 
 
@@ -56,6 +65,9 @@ make alt
 
 ```sh
 ./whereami.alt lat long
+
+# or if you don't have curses installed:
+./westley.alt lat long
 ```
 
 NOTE: this alternative version also needs a terminal with at least 80 columns.
@@ -67,6 +79,9 @@ To find the approximate place where this entry was judged, type:
 
 ```sh
 ./whereami 37 -122	# NOTE: - means west of meridian
+
+# or if you don't have curses installed:
+./westley 37 -122	# NOTE: - means west of meridian
 ```
 
 
@@ -95,6 +110,7 @@ checking the value that `putchar()` returns.  Scandalous!
 If you run it with fewer than 2 arguments, it will likely
 give you an exception, as it will access arguments that
 don't exist and characters before a string constant.
+
 
 ### How it works:
 

--- a/1992/westley/try.sh
+++ b/1992/westley/try.sh
@@ -1,57 +1,118 @@
 #!/usr/bin/env bash
+# 
+# script to run westley on a variety of locations to show different cities in
+# the world.
+#
+# This script will first try compiling the code and alt code (alt = US only with
+# higher resolution, based on the author's remarks) and then if all is OK it
+# tries to make the whereami and whereami.alt programs. If that fails the
+# programs used will be westley and westley.alt; otherwise the programs will be
+# whereami and whereami.alt.
+#
+# The difference between whereami and westley is that the former first checks
+# that the number of columns is at least 80. The programs whereami and
+# whereami.alt can be deceived by way of doing:
+#
+#   COLUMNS=100 ./whereami lat long
+#
+# even if the number of columns is < 80 but there's nothing that can be done
+# about that. This script does not have that problem, however, so it's nice to
+# use for that purpose if nothing else.
+#
+# If westley or westley.alt cannot compile then it is an error and the script
+# will exit 3, corresponding to the code if westley.c or westley.alt.c cannot be
+# compiled by the whereami.c and whereami.alt.c programs.
+#
+# If whereami or whereami.alt cannot compile or link, say because libcurses is
+# not installed, then it is not an error as such but westley and westley.alt
+# will be used instead unless of course there exists an executable of one or
+# both called whereami or whereami.alt or westley.c or westley.alt.c cannot be
+# compiled. It is an error in the script if either of westley.c or westley.alt.c
+# cannot be compiled.
+#
+# This is the best way to protect against showing poor output. We can't get the
+# environmental variable COLUMNS from a program or a script so it has to be done
+# this way. Note that in curses the COLUMNS is called COLS.
+#
+# This script knows which version, the entry or alt code, to use based on what
+# city is being shown.
+#
+# If whereami and whereami.alt can be built it is run once, ahead of time, and
+# if it exits non-zero then we exit to prevent repeatedly showing the error
+# message.
+#
+# Usage: ./try.sh
+#
 
-make everything || exit 1
+WESTLEY=""
+WESTLEY_ALT=""
+
+make westley westley.alt >/dev/null || exit 1
+make whereami whereami.alt >/dev/null
+
+# get the path to the right programs
+if [[ -x "whereami" ]]; then
+    WESTLEY="whereami"
+    ./"$WESTLEY" 0 0 >/dev/null || exit 1
+else
+    WESTLEY="westley"
+fi
+if [[ -x "whereami.alt" ]]; then
+    WESTLEY_ALT="whereami.alt"
+else
+    WESTLEY_ALT="westley"
+fi
 
 echo "New York:" 1>&2
 echo 1>&2
-./westley.alt 41 -74
+./"$WESTLEY_ALT" 41 -74
 echo 1>&2
 
 echo "London:" 1>&2
 echo 1>&2
-./westley 52 0
+./"$WESTLEY" 52 0
 echo 1>&2
 
 echo "Moscow:" 1>&2
 echo 1>&2
-./westley 56 38
+./"$WESTLEY" 56 38
 echo 1>&2
 
 echo "New Delhi:" 1>&2
 echo 1>&2
-./westley 29 77
+./"$WESTLEY" 29 77
 echo 1>&2
 
 echo "Sydney:" 1>&2
 echo 1>&2
-./westley -34 151
+./"$WESTLEY" -34 151
 echo 1>&2
 
 echo "Los Angeles:" 1>&2
 echo 1>&2
-./westley.alt 34 -118
+./"$WESTLEY_ALT" 34 -118
 echo 1>&2
 
 echo "Paris:" 1>&2
 echo 1>&2
-./westley 45 2
+./"$WESTLEY" 45 2
 echo 1>&2
 
 echo "Rio de Janeiro:" 1>&2
 echo 1>&2
-./westley -23 -43
+./"$WESTLEY" -23 -43
 echo 1>&2
 
 echo "Beijing:" 1>&2
 echo 1>&2
-./westley 40 116
+./"$WESTLEY" 40 116
 echo 1>&2
 
 echo "Tokyo:" 1>&2
 echo 1>&2
-./westley 36 140
+./"$WESTLEY" 36 140
 echo 1>&2
 
 echo "Approximate judging location:" 1>&2
 echo 1>&2
-./westley.alt 37 -122
+./"$WESTLEY_ALT" 37 -122

--- a/1992/westley/westley.alt.orig.c
+++ b/1992/westley/westley.alt.orig.c
@@ -1,0 +1,3 @@
+main(l,a,n,d)char**a;{for(d=atoi(a[1])/2*80-atoi(a[2])-2043;
+n="bnaBCOCXdBBHGYdAP[A M E R I C A].AqandkmavX|ELC}BOCd"
+[l++-3];)for(;n-->64;)putchar(!d+++33^l&1);}

--- a/1992/westley/whereami.alt.c
+++ b/1992/westley/whereami.alt.c
@@ -1,0 +1,48 @@
+/*
+ * whereami.alt.c: wrapper program to westley.alt.c that checks first the
+ * columns of the terminal, exiting if < 80 and otherwise running westley.alt
+ * with the specified args. It is an error to not specify two args but it is not
+ * an error to specify args that are not numbers. The atoi(3) function typically
+ * returns 0 in that case which westley.alt.c uses.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <curses.h>
+
+int main(int argc, char **argv)
+{
+    int cols;
+
+    if (argc < 3)
+    {
+	fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]);
+	exit(1);
+    }
+
+    /* init curses so we can get the number of columns */
+    initscr();
+    /* save columns */
+    cols = COLS;
+    /*
+     * end curses so that we can either report an error or compile and run
+     * westley.alt
+     */
+    endwin();
+
+    if (cols < 80)
+    {
+	fprintf(stderr, "your terminal must be at\nleast 80 columns wide\nbut is only %d, sorry.\n", COLS);
+	exit(2);
+    }
+
+    /* 
+     * compile westley.alt and run if successful
+     */
+    if (system("make westley.alt >/dev/null"))
+    {
+	fprintf(stderr, "couldn't compile westley.alt.c, sorry.\n");
+	exit(3);
+    }
+    execl("./westley.alt", "./westley.alt", argv[1], argv[2], NULL);
+}

--- a/1992/westley/whereami.c
+++ b/1992/westley/whereami.c
@@ -1,0 +1,48 @@
+/*
+ * whereami.c: wrapper program to westley.c that checks first the
+ * columns of the terminal, exiting if < 80 and otherwise running westley
+ * with the specified args. It is an error to not specify two args but it is not
+ * an error to specify args that are not numbers. The atoi(3) function typically
+ * returns 0 in that case which westley.c uses.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <curses.h>
+
+int main(int argc, char **argv)
+{
+    int cols;
+
+    if (argc < 3)
+    {
+	fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]);
+	exit(1);
+    }
+
+    /* init curses so we can get the number of columns */
+    initscr();
+    /* save columns */
+    cols = COLS;
+    /*
+     * end curses so that we can either report an error or compile and run
+     * westley
+     */
+    endwin();
+
+    if (cols < 80)
+    {
+	fprintf(stderr, "your terminal must be at\nleast 80 columns wide\nbut is only %d, sorry.\n", COLS);
+	exit(2);
+    }
+
+    /* 
+     * compile westley and run if successful
+     */
+    if (system("make westley >/dev/null"))
+    {
+	fprintf(stderr, "couldn't compile westley.c, sorry.\n");
+	exit(3);
+    }
+    execl("./westley", "./westley", argv[1], argv[2], NULL);
+}

--- a/bugs.md
+++ b/bugs.md
@@ -707,6 +707,59 @@ when you're cheating it ends up winning! Can you figure that out as well?
 
 # 1992
 
+## 1992 adrian
+
+### STATUS: known bug - please help us fix
+### Source code: [1992/adrian/westley.c](1992/westley/westley.c)
+### Information: [1992/adrian/README.md](1992/westley/README.md)
+
+The author states that:
+
+```
+If the input contains errors, then an error message along
+with the number of the offending line will be printed to stderr.  The
+number of rules for each state is limited to 17.  If more than 17 rules
+are present, you get the error 'too_many_rules', and the state that was
+being processed is printed.  Error 'no_destination' occurs if you specify a
+set of characters, but no destination state, and error 'too_many_states'
+occurs if your automaton has more than 257 states.
+```
+
+but only `no_destination` appears to occur. It is possible that this is invalid
+test cases but it's also possible it simply is a bug.
+
+You are welcome to try and fix these problem(s).
+
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1992/adrian/westley.c](1992/westley/westley.c)
+### Information: [1992/adrian/README.md](1992/westley/README.md)
+
+The author stated that if the file cannot be opened then it will print a system
+error but this is not the case unless it's showing a fault. However this was
+instead fixed by Cody as part of another problem that was detected so that the
+program just exits 1 if the file cannot be opened.
+
+Also, if _some_ of the programs are not given an arg they will very likely crash
+or do something funny. For instance `adsleep` and `adbasename`. This is very
+simple to fix but the author explicitly noted that this will segfault and it is
+that that is the error message.
+
+Another thing is that the code:
+
+```c
+printf((W,Y));
+```
+
+appears to be wrong because `W` is a `FILE *` and `Y` is a `char[]` but if one
+changes it to use `fprintf()` on the file (which, incidentally, is opened in
+read only mode which is another reason) with the `%s` specifier it will make
+`adhead` not work: it'll print nothing at all! So this code should not be
+changed either even if it appears to be wrong. Notice too a curious thing: if
+you did change it to fprintf, even if you have the right number of args, you'd
+have to remove the outer `()` pair.
+
+
 ## 1992 gson
 
 ### STATUS: uses gets() - change to fgets() if possible

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1439,9 +1439,21 @@ the final loop it prints another newline. This fix has another bonus in that
 resizing the terminal after running it should not mess up the display either,
 unless of course it becomes too small.
 
+Cody added the programs [whereami.c](1992/westley/whereami.c) and
+[whereami.alt](1992/westley/whereami.alt.c) which correspond to the entry and
+the alt code but which, by way of curses, checks for the number of columns; if
+all is good it will try compiling the program or alt program, respectively, and
+then if successful run the program. Otherwise, if there are not enough columns
+it is an error. It is always an error if the compilation of the program itself
+(westley.c, westley.alt.c) fails.
+
 Cody added the [try.sh](1992/westley/try.sh) script that shows the different
 cities that the author recommended one try, labelling each city and printing a
-newline before the next city.
+newline before the next city. The try.sh script uses the `whereami` code, if it
+can be compiled and linked, but otherwise it uses `westley` code instead, either
+the entry or alt code. The try.sh cannot be deceived by way of `COLUMNS=81
+./try.sh` but the `whereami`/`whereami.alt` code can be deceived if directly
+called. This is a feature, not a bug: or maybe a limitation of curses.
 
 Cody also added an arg check because the program and the
 [alternate version](1992/westley/westley.alt.c) might have crashed or

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -12,22 +12,22 @@ contributed thousands, that we wish to thank.
 We call out the extensive contributions of [Cody Boone
 Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
 responsible for most of the improvements and fixes including many **EXTREMELY
-CHALLENGING bug fixes** like
+HARD bug fixes** like
 [1988/phillipps](/thanks-for-fixes.md#1988phillipps-readmemd),
 [2001/anonymous](/thanks-for-fixes.md#2001anonymous-readmemd) and
 [2004/burley](/thanks-for-fixes.md#2004burley-readmemd), making entries like
 [1985/sicherman](/thanks-for-fixes.md#1985sicherman-readmemd) and
 [1986/wall](/thanks-for-fixes.md#1986wall-readmemd) not need `-traditional-cpp`
-(all **EXTREMELY CHALLENGING**), fixing entries to work with clang (some being
-**EXTREMELY CHALLENGING** like
+(all **EXTREMELY HARD**), fixing entries to work with clang (some being
+**EXTREMELY HARD** like
 [1991/dds](/thanks-for-fixes.md#1991dds-readmemd)) or as much as possible (like
 [1989/westley](/thanks-for-fixes.md#1989westley-readmemd), a true masterpiece
 that is **INCREDIBLY HARD, _MUCH, MUCH MORE SO_ than any other fix!**), porting
-entries to macOS (some being **EXTREMELY CHALLENGING** like
+entries to macOS (some being **EXTREMELY HARD** like
 [1998/schweikh1](/thanks-for-fixes.md#1998schweikh1-readmemd)), fixing code like
 [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd) to work in both
-32-bit/64-bit which *can be* **EXTREMELY CHALLENGING**, providing alternate code
-where useful/necessary, fixing where possible dead links or removing them,
+32-bit/64-bit which *can be* **EXTREMELY HARD**, providing alternate code
+where useful/necessary, fixing where possible/removing dead links,
 typo/consistency fixes, improving **ALL _Makefiles_** and writing
 [sgit](https://github.com/xexyl/sgit) that we installed locally to easily run
 `sed` on files in the repo to help build the website. **THANK YOU VERY MUCH**
@@ -122,9 +122,15 @@ $ warning: this program uses gets(), which is unsafe.
 whereas without the warning it's much easier to see that it's a prompt.
 
 In some entries this change is not possible, in one-liners it might make them
-too long and in some entries it's more complicated than others because of the
-annoying fact that for '"compatibility" reasons' `fgets()` retains the newline
-and `gets()` does not. Nevertheless some of the entries have been updated this
+too long (though it's also been possible to do this in some cases) and in some
+entries it's more complicated than others because of the annoying fact that for
+'"compatibility" reasons' `fgets()` retains the newline and `gets()` does not.
+Some entries like [1992/adrian](1992/adrian/README.md) are more complicated in
+other ways due to the code generating other output; and because of how it works
+it would generate code that could not be compiled, simply because of spaces
+being added (a number of other fixes in that entry were also made)!
+
+Nevertheless some of the entries have been updated this
 way for the reasons described above and in the [FAQ](/faq.md).
 
 
@@ -143,7 +149,7 @@ the second line starts with `o, world!\n"`.
 
 By request, the original code is provided as
 [anonymous.alt.c](1984/anonymous/anonymous.alt.c) so that one can look at it and
-the famous tattoo:
+the famous tattoo which we also include here:
 
 ![1984-anonymous-tattoo.jpg](1984/anonymous/1984-anonymous-tattoo.jpg)
 
@@ -1299,27 +1305,68 @@ should have been removed.
 
 ## [1992/adrian](1992/adrian/adrian.c) ([README.md](1992/adrian/README.md]))
 
-Cody changed the location that it used `gets()` to be `fgets()` instead to make
-it safer and to prevent annoying warnings during compiling, linking or runtime
-(interspersed with the program's output).
+Cody fixed the code so that it will try opening the file the code was compiled
+from (`__FILE__`), not	`adgrep.c`, as
+the latter does not exist: `adgrep` is simply a link to `adrian` as `adgrep` is
+what the program was submitted as but the winner is `adrian`.
+
+Not fixing this would cause the program to crash if no arg was specified as the
+file did not exist. In doing this, at first the change to check for a NULL file
+was added. Then it was noticed that the problem is that `adgrep.c` was an
+incorrect reference that was never fixed in any of the files, not the code or
+the documentation. A fun fact is that one can do:
+
+```c
+W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(1);
+```
+
+but one _CANNOT_ do:
+
+```c
+W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(1);
+if (W==NULL)exit(1);
+```
+
+because `adwc.c` will be empty! The difference is it is on a newline, the check.
+This is an example of how a simple change in code can break it and this is also
+true of another change as further below.
+
+Cody also restored a slightly more obscure line of code that had been changed:
+
+```diff
+-   putc("}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR"[i]+i-9,stderr);
++   putc(i["}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR"]+i-9,stderr);
+```
+
+though it's questionable how much more (if at all) obscure that is.
+
+Cody also changed the location that it used `gets()` to be `fgets()` instead to
+make it safer and to prevent annoying warnings during compiling, linking or
+runtime (interspersed with the program's output). This was complicated because
+of how the other source files are generated, as noted above; simply changing the
+code could cause invalid output in the program which made other files fail to
+compile (for this example specifically, see below).
+
+One might think that simply changing the `gets()` to `fgets()` (with `stdin`)
+would work but it did not because `fgets()` stores the newline and `gets()` does
+not. That is well known but this code was relying on not having this newline
+(see also above).
+
+With `fgets()` the code `if(A(Y)) puts(Y);` ended up printing an extra line
+which made the generation of some files (like `adhead.c`) fail to compile. Why?
+There was a blank line after a `\` at the end of the first line of a macro
+definition!  Thus the code now first trims off the last character of the buffer
+read to get the same correct functionality but in a safe and non obnoxious way.
 
 Later Cody improved the change to `fgets()` to make it slightly more like the
 original. This still requires the additional stripping of the newline inside the
 loop but now it uses what looks like before, just a call to `gets()`.
 
-One might think that simply changing the `gets()` to `fgets()` (with `stdin`)
-would work but it did not because `fgets()` stores the newline and `gets()` does
-not.  The code was relying on not having this newline. With `fgets()` the code
-`if(A(Y)) puts(Y);` ended up printing an extra line which made the generation of
-some files (like `adhead.c`) fail to compile. Why? There was a blank line after
-a `\` at the end of the first line of a macro definition!  Thus the code now
-first trims off the last character of the buffer read to get the same correct
-functionality but in a safe way and non obnoxious way.
-
 But the improvement so that it uses `gets()` could not be changed to have the
 macro do the removal of the extra line (as in with a comma operator or a `&&`)
-as this caused compilation errors with another generated file (`adwc.c`). Thus
-after the `gets()` call in the line that looks like:
+as this, as might be expected from the above, caused compilation errors with
+another generated file (`adwc.c`)! Thus after the `gets()` call in the line that
+looks like:
 
 ```c
 while( gets(Y) ){ Y[strlen(Y)-1]='\0'; if(A(Y)) puts(Y); }
@@ -1327,8 +1374,8 @@ while( gets(Y) ){ Y[strlen(Y)-1]='\0'; if(A(Y)) puts(Y); }
 
 one must keep the `Y[strlen(Y)-1]='\0';` part and keep it there.
 
-This is a complex change due to the way the program and Makefile generate
-additional tools.
+These fixes are complex changes due to the way the program and Makefile generate
+the additional tools.
 
 
 ## [1992/albert](1992/albert/albert.c) ([README.md](1992/albert/README.md]))


### PR DESCRIPTION

The default file to open in the code did not exist: it was submitted as
adgrep.c but the judges changed the entry to be adrian.c. The adgrep is
a link to adrian but adgrep.c does not exist. Instead of changing it to
be adrian.c, however, I changed it to __FILE__.

If the file cannot be opened it no longer will segfault. This is the
only crash that was fixed; two are explicitly noted by the author as
features though it could possibly be implied that the same goes for the
entry itself.

The bugs.md has had some bugs that seem to be genuine bugs that might
want to be fixed and it also has had features added, things that should
not be fixed (including adsleep and adbasename crashing if no arg
specified).
 
The README.md file was typo/format checked/fixed.

The Makefile had several fixes, most importantly that now running 'make' 
will link adgrep as it's now a target.

The thanks file has been updated as well as various things have, as 
noted above, changed.
