### PR TITLE
Further clang fixes for 1991/dds

### DIFF
--- a/1991/dds/dds.c
+++ b/1991/dds/dds.c
@@ -9,11 +9,11 @@ R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
 \\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
 aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
 P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
-s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.jodmvef!tuejp/i!b/d";
-int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*
-q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p
-++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n"
-,o);fclose(o);return system(q-86);}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':
-Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;
-if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'
-][0]++;}}}
+s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jod\
+mvef!tuejp/i!b/d";int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;
+*q;q++)*q>' '&&(* q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)
+return 1;for(p=s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k
+==EOF){fputs("}}\n",o);fclose(o);return system(q-104);}*r=0 B'P':while(*p!='\
+`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),
+k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!=k
+)p++;p++B'N':R[*p-'0'][0]++;}}}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1151,9 +1151,9 @@ Furthermore he changed it so that the C from the BASIC uses `fgets()`, not
 `gets()`. For the magic of clang and `fgets()` see below.
 
 Clang (at least in some systems?) defaults to having `-Werror` and the code that
-the entry generates had some warnings that were causing compilation to fail as
-it just ran `cc a.c`. It ran it by what was once `system(q-6);` but with clang
-this was not enough.
+the entry generates had some warnings that were causing compilation to fail if
+`cc` is clang as it just ran `cc a.c`. It ran it by what was once `system(q-6);`
+but if `cc` is clang like in macOS this is not enough.
 
 (Cody stupidly did the below manually until he thought to write a simple program
 to do the conversions which he used for `gets()` to `fgets()`.)
@@ -1227,6 +1227,27 @@ efdmbsbujpo!
 which is the end of the warning disabled for clang as described above.
 
 But now the `system(q-69);` had to be changed to `system(q-86);`.
+
+Then, later on, Cody discovered that in some systems, clang triggers even more
+warnings so this had to be corrected too. Thus the string had to be changed to,
+in full:
+
+```c
+char s[]="Qjou!s\\311^-g\\311^-n\\311^-c\\::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q<nbj\
+o)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<aN2!Q\
+\ndbtf!aP2Q;m>aP2Q<a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4\nJUJT%UQm>aP4HC%T\
+Qs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQUaP1H\
+R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
+\\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
+aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
+P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
+s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jod\
+mvef!tuejp/i!b/d";
+```
+
+and then the `system(q-86)` had to be changed to `system(q-104)`. It is hoped
+that this is the last time the string has to be updated to work with all
+versions of clang but if not the above is how it works.
 
 With these changes in place it will compile and work with both gcc and clang and
 the C code generated will use `fgets()`, not `gets()`, therefore removing the


### PR DESCRIPTION
It came to my attention that some versions of clang trigger and additional warning that has to be disabled in order to compile the a.c that the entry generates. This has been fixed.

I am NOT including the translate.c file that I wrote to come up with the proper string (it encrypts and decrypts though with some limitations) as I don't want to give it away too much. I MIGHT include it on my website another time in case it is ever necessary (though the hope and belief is it won't be but who knows with clang). This would be AFTER the website has been looked at. This has already taken too much time to fix. It is now time to finish 1992 and then go on to 1993.