### PR TITLE
Make 1992/imc more like original + formatting

### DIFF
--- a/1991/dds/dds.c
+++ b/1991/dds/dds.c
@@ -9,11 +9,11 @@ R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
 \\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
 aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
 P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
-s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.jodmvef!tuejp/i!b/d";
-int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '&&(*
-q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=s;;p
-++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("}}\n"
-,o);fclose(o);return system(q-86);}*r=0 B'P':while(*p!='`')fputc(*p++,o)B'O':
-Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k= *p;
-if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!= k)p++;p++B'N':R[*p-'0'
-][0]++;}}}
+s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jod\
+mvef!tuejp/i!b/d";int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;
+*q;q++)*q>' '&&(* q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)
+return 1;for(p=s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k
+==EOF){fputs("}}\n",o);fclose(o);return system(q-104);}*r=0 B'P':while(*p!='\
+`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),
+k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!=k
+)p++;p++B'N':R[*p-'0'][0]++;}}}

--- a/1992/imc/README.md
+++ b/1992/imc/README.md
@@ -23,21 +23,23 @@ output.
 
 Of course, the source (layout) is self-documenting!  :-)
 
-NOTE: The original winning source assumed that exit() returned a value which cause
-problems for some systems where exit() returns a void.  The file [imc.c](imc.c) has been
-modified to avoid this problem.
+NOTE: The original winning source assumed that `exit(3)` returned a value which
+cause problems for some systems where `exit(3)` returns a void.  The file
+[imc.c](imc.c) has been modified to avoid this problem. The original file also
+declared argc to be a `long` which was fixed.
+
 
 
 ## Author's remarks:
 
 ### Portability
 
-This program depends upon the ASCII character set, and makes certain
-assumptions about the architecture. It naughtily declares the first
-argument to main as a long, and passes a pointer to long instead of char
-to fwrite, giving a length value of 32 bytes for an array of 8 longs. I
-guess that makes this program OK on most flavours of unix, but not on
-PCs.
+This program depends upon the ASCII character set, and makes certain assumptions
+about the architecture. It naughtily declares the first argument to `main()` as
+a `long`, and passes a pointer to `long` instead of `char` to `fwrite(3)`,
+giving a length value of 32 bytes for an array of 8 `long`s. I guess that makes
+this program OK on most flavours of unix, but not on PCs.
+
 
 ### About the program
 
@@ -45,9 +47,9 @@ This program has several parameters; each of them has a default, so the
 program runs happily without any parameters. If you supply an incorrect
 parameter, an obfuscated error message results! :-) Should you want to
 run the program without knowing what it does, then supplying the single
-letter t as a parameter is a good move. Otherwise, direct the output
+letter `t` as a parameter is a good move. Otherwise, direct the output
 into a file. The resulting file is most useful on SunOS, where the
-`file` command will tell you what to do with it. For best results with
+`file(1)` command will tell you what to do with it. For best results with
 the `t` option, you may want to change the definition of the `I` macro :-)
 Details appear later, though the formatting of the code is a large clue.
 
@@ -56,8 +58,8 @@ All the code in this program appears between the `;` and `)` in
 merely because it makes the code so much more impenetrable :-) In fact
 running a pretty printer on the code hardly improves it at all. This
 program has the obligatory macros with unmatched parentheses, and the
-cleverly arranged macro names and parameters to spell out "Ian Colliers
-Obfuscated C Code". If you expand macros, bear in mind that the more
+cleverly arranged macro names and parameters to spell out `"Ian Colliers
+Obfuscated C Code"`. If you expand macros, bear in mind that the more
 complex ones are best left as macros, because they have well-defined and
 nontrivial (IMHO) functions. These macros help to give the program's
 parameter format its flexibility. The parameters are sorted out in a
@@ -69,20 +71,20 @@ you see a `,` doesn't mean it has anything to do with commas! So I hope
 you will agree that this program is more than a little obfuscated...
 
 This is a Mandelbrot/Julia drawer. Normally it produces a monochrome
-Sun-format raster file. The version of xloadimage we have is able to
-view such files, and so is Sun's screenload command. [Note: the header
+Sun-format raster file. The version of `xloadimage` we have is able to
+view such files, and so is Sun's `screenload` command. [Note: the header
 contains eight 4-byte integers, the byte order in which depends upon the
 machine. On Sun workstations they are stored MSB first].
 
 The program may be asked to produce text output instead of a raster
 file. Then the characters defined in the `I` macro will be used to create
 up to 16 different shades of grey. Quite a respectable picture can be
-gained by printing a `130x110` output on a dot matrix 132 column printer
-with the linefeed set to 7 points. Text output also gives a good picture
-when used in an X window with small characters having a square aspect
-ratio.
+gained by printing a `130x110` output on a [dot matrix 132 column
+printer](https://en.wikipedia.org/wiki/Dot_matrix_printing) with the linefeed
+set to 7 points. Text output also gives a good picture when used in an X window
+with small characters having a square aspect ratio.
 
-The options accepted by the program follow. Each option is a letter; it
+The options accepted by the program follow. Each option is a single letter; it
 may be preceded with a minus sign (or any character in `[!-/]`) and may be
 followed by other letters, so for example:
 
@@ -105,7 +107,7 @@ be appended to the single-letter option, so
 
 all mean the same (note that in `-size123` all characters following the
 initial `s` are ignored). Numbers need not be specified, as each has a
-default value. In all cases except `j` and `t`, and `s` whenever it
+default value. In all cases except for `j`, `t`, and `s` whenever it
 appears before `t`, specifying an option without numbers has no effect.
 (specifying `-s -t` has the effect of producing text with the default
 raster size; not a good idea!).
@@ -114,28 +116,30 @@ raster size; not a good idea!).
 
 The options of this program are:
 
-`-centre x y`  (float x,y) Centre the picture at `x+iy` in the complex
-			 plane (default `x=0 y=0`)
+```
+-centre x y  (float x,y) Centre the picture at x+iy in the complex
+			 plane (default x=0 y=0)
 
 
-`-factor f`    (float f)   Use `f` pixels per unit of the plane (default
-			 `f=x/4` where `x` is the width)
+-factor f    (float f)   Use f pixels per unit of the plane (default
+			 f=x/4 where x is the width)
 
 
-`-julia  x y`  (float x,y) Draw a julia set. Use `x+iy` as the constant
-			 to add after squaring (default `x=0 y=0`)
+-julia  x y  (float x,y) Draw a julia set. Use x+iy as the constant
+			 to add after squaring (default x=0 y=0)
 
-`-limit  l`    (int l)     Use `l` iterations maximum (default `l=128`)
+-limit  l    (int l)     Use l iterations maximum (default l=128)
 
-`-mask   m`    (int m)     Use `m` as a mask in deciding the colour of each
-			 pixel (see below) (default `m=1`)
+-mask   m    (int m)     Use m as a mask in deciding the colour of each
+			 pixel (see below) (default m=1)
 
-`-size   x y`  (int x,y)   Produce an x-by-y output (default for raster
-			 `x=768 y=768`; default for text `x=63 y=23`)
+-size   x y  (int x,y)   Produce an x-by-y output (default for raster
+			 x=768 y=768; default for text x=63 y=23)
 
-`-text`                    Produce text instead of raster.
+-text                    Produce text instead of raster.
+```
 
-The colour of each point is determined by taking the bit-and of the
+The colour of each point is determined by taking the bitwise AND of the
 number of iterations and the mask. For a raster, the point is black
 (1-bit) if the result is zero, white otherwise. For text, the result of
 the operation determines the greyness of the character produced, with a

--- a/1992/imc/imc.c
+++ b/1992/imc/imc.c
@@ -1,5 +1,5 @@
 #include		     <stdio.h> 
-#define			  ext(a) (exit(a),0)
+#define			  exit(a) (exit(a),0)
 #define I		  " .:\';+<?F7RQ&%#*"
 #define a			"%s?\n"
 #define n			"0?\n"
@@ -9,7 +9,7 @@
 #define L			sscanf
 #define i			stderr
 #define e			stdout
-#define r		       ext   (1)
+#define r		       exit   (1)
 #define s(O,B)	   L(++J,O,&B)!=1&&c>++q&&L(v[q],O,&B)!=1&&--q
 #define F(U,S,C,A) t=0,*++J&&(t=L(J,U,&C,&A)),(!t&&c>++q&&!(t=L(v[q],U,\
 		   &C,&A)))?--q:(t<2&&c>++q&&!(t=L(v[q],S,&A))&&--q
@@ -38,13 +38,13 @@
   )||(perror("malloc"),r),S-=(N/2)/f,x+=(U/2)/f):A==1?(B<U?(A=2,V
 	=    0,Q=x-B/f,j ||(R=Q),W&&E('\n',e),E(46,i)):(W&&E('\n',
 	     e),E('\n',i  ),h[1]=N,h[2]=U,h[4]=q,W||(fwrite(h,1,32,
-	      e),fwrite   (J,1,q,e)),free(J),ext(0))):A==2?(V<N?(j?
+	      e),fwrite   (J,1,q,e)),free(J),exit(0))):A==2?(V<N?(j?
 		(H=V/f	   +S,M=Q):(G=V/f+S,H=M=0),Y=0,A=03):((m&0x80
 		   )	   ||(m=0x80,p++),b&&(J[p++]=0),A=1,B++)):((Y
 			    <k&&(P=H*H)+(z=M*M)<4.)?(M=2*H*M+R,H=P-z
 			     +G,Y++):(W&&E(I[0x0f*(Y&K)/K],e),Y&K?J
 			         [p]&=~m:(J[p]|=m),(m>>=1)||/*/
-				  (m=128,u--),A==6?ext(1):B<u
+				  (m=128,u--),A==6?exit(1):B<u
 				 .	  e=3,l=2*c*/(       m
 					     =0x80,
 					    p++),V++

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1151,9 +1151,9 @@ Furthermore he changed it so that the C from the BASIC uses `fgets()`, not
 `gets()`. For the magic of clang and `fgets()` see below.
 
 Clang (at least in some systems?) defaults to having `-Werror` and the code that
-the entry generates had some warnings that were causing compilation to fail as
-it just ran `cc a.c`. It ran it by what was once `system(q-6);` but with clang
-this was not enough.
+the entry generates had some warnings that were causing compilation to fail if
+`cc` is clang as it just ran `cc a.c`. It ran it by what was once `system(q-6);`
+but if `cc` is clang like in macOS this is not enough.
 
 (Cody stupidly did the below manually until he thought to write a simple program
 to do the conversions which he used for `gets()` to `fgets()`.)
@@ -1227,6 +1227,27 @@ efdmbsbujpo!
 which is the end of the warning disabled for clang as described above.
 
 But now the `system(q-69);` had to be changed to `system(q-86);`.
+
+Then, later on, Cody discovered that in some systems, clang triggers even more
+warnings so this had to be corrected too. Thus the string had to be changed to,
+in full:
+
+```c
+char s[]="Qjou!s\\311^-g\\311^-n\\311^-c\\::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q<nbj\
+o)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<aN2!Q\
+\ndbtf!aP2Q;m>aP2Q<a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4\nJUJT%UQm>aP4HC%T\
+Qs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQUaP1H\
+R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
+\\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
+aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
+P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
+s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jod\
+mvef!tuejp/i!b/d";
+```
+
+and then the `system(q-86)` had to be changed to `system(q-104)`. It is hoped
+that this is the last time the string has to be updated to work with all
+versions of clang but if not the above is how it works.
 
 With these changes in place it will compile and work with both gcc and clang and
 the C code generated will use `fgets()`, not `gets()`, therefore removing the

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1329,7 +1329,7 @@ should have been removed.
 Cody fixed the code so that it will try opening the file the code was compiled
 from (`__FILE__`), not	`adgrep.c`, as
 the latter does not exist: `adgrep` is simply a link to `adrian` as `adgrep` is
-what the program was submitted as but the winner is `adrian`.
+what the program was submitted as but the winner is `adrian.c`.
 
 Not fixing this would cause the program to crash if no arg was specified as the
 file did not exist. In doing this, at first the change to check for a NULL file
@@ -1430,7 +1430,8 @@ necessary to include `time.h` so Cody did this as well.
 ## [1992/buzzard.1](1992/buzzard.1/buzzard.1.c) ([README.md](1992/buzzard.1/README.md))
 
 Cody added a check for the right number of args, exiting 1 if not enough (2)
-used.
+used. This was not originally done but at a time it was changed to be considered
+a bug so it was fixed at that point as it only took a few seconds.
 
 He also added the [try.sh](1991/buzzard.1/try.sh) script to try out some
 commands that we suggested and some additional ones that provide for some fun.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1461,6 +1461,16 @@ included in their remarks. See the README.md for its purpose. It was NOT fixed
 for ShellCheck because the author deliberately obfuscated it.
 
 
+## [1992/imc](1992/imc/imc.c) ([README.md](1992/imc/README.md]))
+
+The original code, [imc.orig.c](1992/imc/imc.orig.c), assumed that `exit(3)`
+returned a value but this will cause problems where `exit(3)` returns void. The
+source code was modified to avoid this problem but like Cody did with otherfixes
+he made this more like the original by redefining `exit` to use the comma
+operator so that it could be used in binary expressions.
+
+
+
 ## [1992/kivinen](1992/kivinen/kivinen.c) ([README.md](1992/kivinen/README.md]))
 
 It was observed that on modern systems this goes much too quick. Yusuke created


### PR DESCRIPTION

The original imc code assumed that exit(3) returns a value but it was
changed to use the comma operator:

 
    #define                       ext(a) (exit(a),0)

Instead of this, I redefined exit like I have done with other fixes, to
make it more like the original.

I also format/typo checked the README.md file.

I cannot test the raster files as I don't have access to a Sun box but 
the text seems good. I tried some of the example commands given by the 
author but I did not try all the options. What I tested looks good as 
best I can tell.

For fun and because I have fond memories I added a link to dot matrix 
printers where the author noted that they are useful, though I guess 
most people don't have access to them nowadays (and many don't even know
what they are which is another reason for a link :-) ).

This should complete 1992/imc.
