### PR TITLE
Updates to 1993/cmills - alt code + bugs + format

### DIFF
--- a/1993/cmills/.gitignore
+++ b/1993/cmills/.gitignore
@@ -1,3 +1,4 @@
 cmills
+cmills.alt
 cmills.orig
 prog.orig

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -57,11 +57,11 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DZ=100
 
 # Include files that are needed to compile
 #
-CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11
+CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11 -include unistd.h
 
 # Optimization
 #
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -140,6 +140,9 @@ chris: ${PROG}
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}: ${PROG}.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1993/cmills/README.md
+++ b/1993/cmills/README.md
@@ -1,7 +1,18 @@
 ## To build:
 
+We recommend you try the alt version first as with modern systems the original
+goes too fast. See the [original code](#original-code) section below to run the
+original.
+
+
 ```sh
-make all
+make alt
+```
+
+To configure how many microseconds to sleep before updates try:
+
+```sh
+make clobber CDEFINE="-DZ=200" alt
 ```
 
 NOTE: this entry requires `X11/Xlib.h` header file and the X11 library to
@@ -10,12 +21,24 @@ install [XQuartz](https://www.xquartz.org) in order to compile and run this
 entry.
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: known bug - please help us fix
+```
+
+For more detailed information see [1993 cmills in bugs.md](/bugs.md#1993-cmills).
+
+
+
 ## To use:
 
 ```sh
-DISPLAY="your_X_server_display"\
+DISPLAY="your_X_server_display"
 export DISPLAY
-./cmills [speed]	# must be run on an X11 server
+./cmills.alt [speed]	# must be run on an X11 server
 ```
 
 where:
@@ -23,9 +46,26 @@ where:
 `speed` is update speed from 1 to 9 (default is 9).
 
 
+## Original code:
+
+We recommend the version that uses `usleep(3)` to more easily see what is going
+on but you can use the original without any delays if you wish.
+
+
+### Original build:
+
+```sh
+make all
+```
+
+### Original use:
+
+Use `cmills` as you would `cmills.alt` above.
+
+
 ## Judges' remarks:
 
-From the San Jose Mercury News (May 15, 1993 page 20A "West Hackers\
+From the San Jose Mercury News (May 15, 1993 page 20A "West Hackers
 trounce East in computer quiz game"):
 
 
@@ -43,7 +83,7 @@ it brought down the house of Apple partisans...
 [The expression on Bill Gates' face was a sight to behold, as reported
 to us by several who were there].
 
-You must set `$DISPLAY` in your environment or the program will\
+You must set `$DISPLAY` in your environment or the program will
 dump core.  This is not a bug as the author documented it as
 a feature.  :-)
 

--- a/1993/cmills/cmills.alt.c
+++ b/1993/cmills/cmills.alt.c
@@ -1,0 +1,56 @@
+long
+z[7992],W,H,*t=z,j,k,*T=z,n,b;
+#include<X11/Xlib.h>
+#include<stdlib.h>
+Window*E,D,s,w[999],*e=w;
+Display*d;
+Pixmap
+p;
+m(w,h,x,y,u,v){
+#define C XCreateSimpleWindow(d,
+XSetWindowBackgroundPixmap(d,s=C*e=C
+#define l(n)t[n]=T[n]+
+D,l(0)x,l(1)y,t[2]=w,t[3]=h,1,b,0),l(6)-x,l(7)-y,W,H,0,0,0),p);
+l(4)u;
+l(5)v;
+#define M XMapRaised(d,
+M
+s);
+M*e++);
+t+=8;
+}
+main(c,g)char**g;
+{
+XSetWindowAttributes
+a;
+XGCValues
+v;
+n=DefaultScreen(d=XOpenDisplay(0));
+p=XCreatePixmap(d,D=RootWindow(d,n),W=DisplayWidth(d,n),H=DisplayHeight(d,n),DefaultDepth(d,n));
+v.subwindow_mode=IncludeInferiors;
+XCopyArea(d,D,p,XCreateGC(d,D,GCSubwindowMode,&v),0,0,W,H,0,0);
+a.override_redirect=True;
+XChangeWindowAttributes(d,D=C
+D,0,0,W,H,0,0,b=BlackPixel(d,n)),CWOverrideRedirect,&a);
+M
+D);
+m(W,H,0,0,3,3);
+for(c=c^1?atoi(g[1]):9;
+;
+)for(T=z,n=e-(E=w);
+n--;
+T+=8,++E){
+XMoveWindow(d,*E,*T+=T[4]*c,T[1]+=T[5]*c);
+j=0;
+#define F(n,o,s)o+T[n-4]s-0&&++j&&T[n]s!1&&(T[n]=0-T[n])||
+if((F(4,0,<)F(4,T[2]-W,>)F(5,0,<)F(5,T[3]-H,>)1)&&j&&(j=T[2]/2)&&(k=T[3]/2)&&e-w<997&&rand()%32768<=T[2]*T[3]*(T[4]*T[4]+T[5]*T[5])/999){
+m(T[2]-j,T[3]-k,j,k,2,2);
+m(j,T[3]-k,0,k,-2,-2);
+m(T[2]-j,k,j,0,2,-2);
+T[7]-=2;
+XResizeWindow(d,*E,T[2]=j,T[3]=k);
+T[6]-=2;
+}
+usleep(Z);
+}
+}

--- a/1993/dgibson/README.md
+++ b/1993/dgibson/README.md
@@ -25,7 +25,7 @@ where:
 
 ## Judges' remarks:
 
-\
+
 We have provided the shell script [dgibson.sh](dgibson.sh) to make it easier
 to run this entry.  Run this shell script several times to
 see what happens.
@@ -69,7 +69,7 @@ small.
 When writing this program, my goal was to make each cell in the life
 grid expand to the code which calculates the fate of that cell.  In
 addition, the resulting program is a single expression, which makes it
-necessary to recurse on main in two "directions" simultaneously.
+necessary to recurse `main()` in two "directions" simultaneously.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1993/ejb/README.md
+++ b/1993/ejb/README.md
@@ -54,8 +54,8 @@ text description of how to solve the puzzle.
 
 For the patience puzzle, the output is a sequence binary codes representing
 successive states of the puzzle.  The rightmost digit represents the first ring.
-A "1" means the ring is on the U; a "0" means it is off the U.  The program
-prints the word "Invalid" in response to illegal command line parameters.
+A `1` means the ring is on the `U`; a `0` means it is off the `U`.  The program
+prints the word `"Invalid"` in response to illegal command line parameters.
 
 
 ### Motivation
@@ -67,14 +67,14 @@ This program serves to show that counting semicolons will not
 always provide a meaningful measure of code size.  This is
 especially true in this program where the number of semicolons
 itself is ambiguous.  Does it have two or three?  In addition, the
-only "C" keyword this program uses besides type names and
+only C keyword this program uses besides type names and
 qualifiers is `return`, and the only function defined in the code
-is `main`.  The level of complexity of the program without multiple
+is `main()`.  The level of complexity of the program without multiple
 semicolons, statements, and functions is achieved by abusing C
 operators, especially the comma operator.  Considerable use of `||`,
-`&&`, and `? :` helps too.  In addition, main is called recursively.
-The NULL pointer that terminates argv is used to pass additional
-information into main.  Even though the algorithms used by this
+`&&`, and `?:` helps too.  In addition, `main()` is called recursively.
+The NULL pointer that terminates `argv` is used to pass additional
+information into `main()`.  Even though the algorithms used by this
 code are simple, this program is still hard to follow even when
 indented properly.  (It is pretty hard to indent this code
 reasonably, however.)
@@ -85,7 +85,7 @@ preprocessor at all.  The only functions it uses are `atoi()`, `malloc()`,
 `memset()`, `printf()`, and `puts()`.  It does, however, require that the
 architecture it runs on have bytes that are at least eight bits long and
 pointers that are at least four bytes long.  In addition, it requires an ANSI
-compiler since it uses "signed char" and ANSI-style function declarations.
+compiler since it uses `signed char` and ANSI-style function declarations.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1993/ejb/patience.md
+++ b/1993/ejb/patience.md
@@ -21,38 +21,39 @@ ring at the end of the rod to its right.  The only rod free
 of this restriction is the rightmost rod.  What has been
 described so far is one of the two components of the puzzle.
 
-The other component is another iron rod shaped like a U.
-The U is as long from the tips to the base as the original
-piece of iron with the holes in it.  The ends of the U are
+The other component is another iron rod shaped like a `U`.
+The `U` is as long from the tips to the base as the original
+piece of iron with the holes in it.  The ends of the `U` are
 looped around another ring of about five centimeters in
-diameter.  In the puzzle's initial configuration, the U is
+diameter.  In the puzzle's initial configuration, the `U` is
 placed through the rings so that it is held in place by the
-iron rods.  Imagine starting with the U piece before the
-iron loop is placed at the end.  Slide the legs of the U
+iron rods.  Imagine starting with the `U` piece before the
+iron loop is placed at the end.  Slide the legs of the `U`
 through the loops so that the iron rods securing the loops
-to the metal strip go up the center of the U.  Placing the
-final ring at the ends of the U prevents it from coming out.
-The object of the puzzle is to free the U-shaped piece from
+to the metal strip go up the center of the `U`.  Placing the
+final ring at the ends of the `U` prevents it from coming out.
+The object of the puzzle is to free the `U`-shaped piece from
 the other piece.
 
 The following illustration (sideways) shows a three-ring
 case of this puzzle.  If you look carefully, you can see
-that the first ring could be lifted over the edge of the U
-and slid down through the center of the U, thereby freeing
-the U from the first iron rod.  The second ring can also be
+that the first ring could be lifted over the edge of the `U`
+and slid down through the center of the `U`, thereby freeing
+the `U` from the first iron rod.  The second ring can also be
 freed in the initial configuration since it is already over
 the rod for the first ring.  The third ring cannot be moved,
-however, since it is blocked by the iron rod two which the
+however, since it is blocked by the iron rod to which the
 first ring is attached.  If the first first is removed, then
 the third ring is no longer blocked by the first ring's iron
 rod and can be removed freely.  The second ring, however
 cannot be moved if the first ring is gone because it will
 then be blocked by the first ring in its new position
-outside of the U.
+outside of the `U`.
 
 Here is an illustration of the three-ring case.  The bottom
 of the puzzle is on the left-hand side of the page.
-
+
+```
 
 
 
@@ -105,7 +106,8 @@ of the puzzle is on the left-hand side of the page.
              \  |                \\ ||
               \ |                 \\||
                \|                  \||
-
+```
+
 This puzzle takes other forms as well.  One such puzzle is
 called "Spin-Out".  This puzzle consists of one plastic
 piece that encases another piece that can slide in and out
@@ -131,14 +133,14 @@ free to move.  The only other piece that is free to move is
 the second one that is still attached to the base it is
 trying to be freed from.  In the case of the original
 puzzle, consider the rings numbered from 1 to 6 with ring 1
-being the one at the closed send of the U.  Ring 1 can
-always be removed from or added to the U.  In the initial
-state, when all rings are around the U, ring 2 is the other
+being the one at the closed end of the `U`.  Ring 1 can
+always be removed from or added to the `U`.  In the initial
+state, when all rings are around the `U`, ring 2 is the other
 one that can be moved because it is second.  If ring 1 is
 removed, then only two operations are possible: the
 restoration of ring 1 and the removal of ring 3.  This is
 because ring 1 is always movable, and ring 3 is currently
-the second ring still attached to the U.  This constraint
+the second ring still attached to the `U`.  This constraint
 leads to a recursive solution to the puzzle.  Like the
 [Towers of Hanoi](hanoi.md), the number of steps to solve this puzzle is
 exponential in the number of rings.

--- a/1993/jonth/README.md
+++ b/1993/jonth/README.md
@@ -1,13 +1,13 @@
 ## To build:
 
-```sh
-make all
-```
-
 NOTE: this entry requires `X11/Xlib.h` header file and the X11 library to
 compile. macOS users running Mountain Lion and later will need to download and
 install [XQuartz](https://www.xquartz.org) in order to compile and run this
 entry.
+
+```sh
+make all
+```
 
 
 ## To use:
@@ -22,7 +22,7 @@ entry.
 Use `h` and `l` to shift objects left or right.  Use `k` to
 rotate and press SPACE to drop.
 
-This program's output may be even more obfuscated when played\
+This program's output may be even more obfuscated when played
 on inverse video.  :-)
 
 
@@ -30,7 +30,7 @@ on inverse video.  :-)
 
 This is `jonth` (`jon's t(h)etris`) for the X Window System.
 
-This program is also an example of data abstraction.  The X array is\
+This program is also an example of data abstraction.  The X array is
 after initialization hidden by the well defined macros `t`, `u` and `F`.
 
 This program is highly portable as it runs on a "Notebook" size SPARC.

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -111,7 +111,7 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG}
+TARGET= ${PROG} mind
 #
 ALT_OBJ=
 ALT_TARGET= mind

--- a/1993/leo/README.md
+++ b/1993/leo/README.md
@@ -30,16 +30,16 @@ By default, the number of colors is 6.  You may specify a
 value of between 1 and 15 colors.  See the author's notes
 for instructions of how to play.
 
-We look forward to more entries from the newer members of the\
+We look forward to more entries from the newer members of the
 International Internet community.
 
 
 ## Author's remarks:
 
 This program plays
-[Mastermind](https://en.wikipedia.org/wiki/Mastermind_(board_game), if you call it by a name ending by
-'d', otherwise it _solves_ Mastermind. Call it without parameters
-to use 6 digits (colors), or indicate the number of possible digits
+[Mastermind](https://en.wikipedia.org/wiki/Mastermind_(board_game), if you call
+it by a name ending by 'd', otherwise it _solves_ Mastermind. Call it without
+parameters to use 6 digits (colors), or indicate the number of possible digits
 (you cannot change the number of positions so easily).
 
 The number in parentheses is the number of possible combinations,
@@ -57,17 +57,22 @@ this.  An expression giving `(bulls * 16 + cows)` from two numbers
 is, however, quite straightforward :-) , as well as the arithmetic
 of binary coded colors-base numbers is.
 
+
 ### Limitations: maximum number of digits (colors) is 14 (1..F).
 
 Suggestions: Use terminal (or emulator) with non-destructive
 backspaces. Do "disable scrolling" on cmdtool or similar emulators.
 
-#### Bugs: Please don't type ^D at the prompt!!
+
+#### Bugs
+
+Please don't type ^D at the prompt!!
+
 
 ##### EXAMPLE: Suppose we think of 1234
 
 ```
-judges-385> ./leo
+$ ./leo
 (1296): 6433
 ?? 12       # one 3 is a bull, another is a cow, and 4 is a cow
 (160): 5363
@@ -83,7 +88,7 @@ judges-385> ./leo
 ##### EXAMPLE: Guess the computer's number
 
 ```
-judges-387> ./mind
+$ ./mind
 (1296): ???? 1122   # my strategy isn't the best, just as example
 00
 (256): ???? 3344

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -1,11 +1,5 @@
 ## To build:
 
-This entry will not compile with gcc < 2.3.3 as it relied on a bug which was
-fixed in gcc 2.3.3 which was fixed a very long time ago now. There is an
-alternate version for [those of
-us](https://www.collinsdictionary.com/dictionary/english/everyone) with gcc >=
-2.3.3. See Alternate code section below for more details.
-
 If you have gcc < 2.3.3 you can build this entry like:
 
 ```sh
@@ -18,10 +12,16 @@ would print `Hello World!` when compiled.
 For an explanation of why and how this works see the author's remarks. The gist
 of the entry itself, however, is the file name _itself **is** the code_.
 
-NOTE: we delete the bogus file whether or not the compilation succeeds.
+NOTE: we delete the temporary file whether or not the compilation succeeds
+because it is an unsafe filename and not doing so would cause problems for
+anyone running `make`.
 
-There is an alternate version which simply does what the program did with gcc <
-2.3.3.
+This entry will not compile with gcc < 2.3.3 as it relies on a bug which was
+fixed in gcc 2.3.3 which was fixed a very long time ago now. There is an
+alternate version for [those of
+us](https://www.collinsdictionary.com/dictionary/english/everyone) with gcc >=
+2.3.3. See [Alternate code](#alternate-code) section below for more details.
+
 
 
 ### Bugs and (Mis)features:
@@ -46,11 +46,18 @@ If you have gcc < 2.3.3 (i.e. the entry can compile):
 
 ## Alternate code:
 
-To use:
+This version does what the code did but in a way that will work with modern
+compilers. We'd like to say there's something special about it but there isn't.
+
+
+### Alternate build:
+
 
 ```sh
 make alt
 ```
+
+### Alternate use:
 
 Use `lmfjyh.alt` as you would `lmfjyh` above. Note that other code could also be
 done with this bug; see the author's remarks for more details.
@@ -58,13 +65,13 @@ done with this bug; see the author's remarks for more details.
 
 ## Judges' remarks:
 
-\
 There's more than one way to get around disk quotas. :-)
 
 
 ## Author's remarks:
 
 "Practical and efficient method of compressing source code".
+
 
 ### Introduction
 
@@ -74,6 +81,7 @@ best with C-source code.
 
 As an example, I have taken a simple "Hello world!" program
 that should be familiar to all C-programmers.
+
 
 #### Listing 1: A simple "Hello World" program
 
@@ -85,13 +93,15 @@ main()
 }
 ```
 
+
 ### Packing method
 
 Normally a file name is used only to identify the file, but this new
-revolutionary method introduces a totally new concept: THE FILE NAME IS THE
-PROGRAM. There is no need to waste valuable disk space to store source code. The
-program is embedded in the file name, only a minor portion of it is inside the
-file.
+revolutionary method introduces a totally new concept: **THE FILE NAME _IS_ THE
+PROGRAM**. There is no need to waste valuable disk space to store source code.
+The program is embedded in the file name, only a minor portion of it is inside
+the file.
+
 
 #### Listing 2: Compressed "Hello world"
 
@@ -129,7 +139,7 @@ code in a source file as presented in listing 1.
 In a UNIX environment it is possible to write almost any program by
 including the code in file names. Since `/` is used to separate
 path components and cannot therefore exist in a file name, all
-features of C-language cannot be used.
+features of the C language cannot be used.
 
 In C, the `/` is used as a division operator and it may also be a
 part of a comment start and end identifier. This, however, is not a
@@ -155,6 +165,7 @@ Any ANSI conforming C-compiler that runs under a REAL operating
 system should be able to compile the code (there might be problems
 with some older UNIX variants).
 
+
 ### Compilers
 
 These worked:
@@ -168,16 +179,19 @@ These failed miserably:
 - cc (SunOS/Solaris)      - could not start cpp properly
 - cc/xlc (AIX)            - could not open source
 
+
 ### Other tools
+
 
 #### Debuggers: (tested at SunOS 4.1.2)
 
-- dbx   - Quit with a very 'informative' error message:
-	    "dbx: fatal error: Is a directory"
+- `dbx`   - Quit with a very 'informative' error message:
+	    `"dbx: fatal error: Is a directory"`
 
-- gdb   - Printed almost the same error message ": Is a directory".
-	It was, however, possible to step through the code but\
+- gdb   - Printed almost the same error message `": Is a directory"`.
+	It was, however, possible to step through the code but
 	not list it.
+
 
 #### Lints
 
@@ -186,14 +200,13 @@ None of the lints tested environments were able to parse the file.
 
 ### Conclusions
 
-The method can be used to compress any types of files and the
-compression ratios are even better when compressing other files
-than C-source.  For example plain text files may be compressed with
-INFINITE compression ratio. It is trivial task to compress a 100
-kilobytes long text file in about 400 files whose lengths are zero
-bytes.  The drawback is that the files must be unpacked before they
-can be used, so a large amount of temporary disk space is needed,
-while C-source is totally usable in the compressed form.
+The method can be used to compress any type of file and the compression ratios
+are even better when compressing files other than C source.  For example plain
+text files may be compressed with INFINITE compression ratio. It is trivial task
+to compress a 100 kilobytes long text file in about 400 files whose lengths are
+zero bytes.  The drawback is that the files must be unpacked before they can be
+used, so a large amount of temporary disk space is needed, while C source is
+totally usable in the compressed form.
 
 Evidently, there is a long way to go before this new programming
 technique may be widely used, since currently there are only few

--- a/bugs.md
+++ b/bugs.md
@@ -999,6 +999,16 @@ not a misunderstanding).
 # 1993
 
 
+### STATUS: known bug - please help us fix
+### Source code: [1993/cmills/cmills.c](1993/cmills/cmills.c)
+### Information: [1993/cmills/README.md](1993/cmills/README.md)
+
+We are unsure if this is a problem with multiple platforms but in macOS at least
+the program appears to just shows a black screen.
+
+Can you fix it? We welcome your help.
+
+
 ## 1993 lmfjyh
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1570,6 +1570,14 @@ args (2). And not that we need the help or anything for this :-) but we
 encourage you to try the original :-)
 
 
+## [1993/cmills](1993/cmills/cmills.c) ([README.md](1993/cmills/README.md]))
+
+Yusuke suggested that with modern systems this goes too fast so he added a call
+to `usleep(3)` in a patch he made. Cody made it configurable at compilation by
+using a macro. This is in the alt version which is the recommended one to try
+first.
+
+
 ## [1993/dgibson](1993/dgibson/dgibson.c) ([README.md](1993/dgibson/README.md]))
 
 Cody fixed the script to work which assumed that `.` is in the path.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1570,6 +1570,11 @@ args (2). And not that we need the help or anything for this :-) but we
 encourage you to try the original :-)
 
 
+## [1993/dgibson](1993/dgibson/dgibson.c) ([README.md](1993/dgibson/README.md]))
+
+Cody fixed the script to work which assumed that `.` is in the path.
+
+
 ## [1993/jonth](1993/jonth/jonth.c) ([README.md](1993/jonth/README.md]))
 
 Both Cody and Yusuke fixed this so that it will work with modern systems. Yusuke


### PR DESCRIPTION

The README.md file has been format/typo checked.

The alt version uses usleep(3) with a configurable time (at compile 
time). This version is suggested first as it apparently goes too fast in
modern systems. I say apparently as it doesn't appear to work with 
macOS. I don't know if it works in other platforms but it is in bugs.md,
that there is a problem.