### PR TITLE
Minor fix in 1993/cmills/Makefile

### DIFF
--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -141,7 +141,7 @@ chris: ${PROG}
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-${PROG}: ${PROG}.c
+${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files


### PR DESCRIPTION
When adding the alt code I yank pasted the rule for cmills but by accident neglected to add the '.alt' to the rule. This was not seen because of the way the Makefile 'alt' rule is designed (in some cases one need not have more than just that 'alt' rule) and other reasons besides.