### PR TITLE
Fix 1994/horton/Makefile and README.md

### DIFF
--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -114,10 +114,10 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA= gtface.data
-TARGET= ${PROG} gtface ${PROG}.alt
+TARGET= ${PROG} gtface
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o gtface.o
+ALT_TARGET= ${PROG}.alt gtface
 
 
 #################

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -14,22 +14,42 @@ make all
 `A`, `B`, `C` and `D` are numeric arguments.
 
 
+
+### Try:
+
+
 ```sh
 ./horton 3 2 1 0
 ```
 
+Also try:
+
+```sh
+./gtface  < gtface.data
+```
 
 ## Alternate code:
 
 This confuses cb greatly. See [horton.alt.c](horton.alt.c) for an unobfuscated/enhanced
-version. To run this alternate version:
+version.
+
+
+### Alternate build:
+
 
 ```sh
 make alt
+```
+
+
+### Alternate use:
+
+
+```sh
 ./horton.alt A B C D
 ```
 
-Use `horton.alt` as you would `horton` above.
+Where A, B, C and D are like with `horton`.
 
 
 ## Judges' remarks:

--- a/faq.md
+++ b/faq.md
@@ -297,9 +297,12 @@ Some entries should not have modern system versions replaced. See below.
 
 ## Q: I can't get some entries to work in 64-bit systems that don't support 32-bit!
 
-Unfortunately some older entries are non-portable and require 32-bit support of
+Unfortunately some older entries are non-portable and require 32-bit support or
 32-bit binaries. A problem system here is macOS Catalina (10.15) as as of that
-version macOS no longer supports 32-bit binaries.
+version macOS no longer supports 32-bit binaries. If the entry acts on a certain
+type of binary, say ELF, then that will also be a problem depending on the
+entry. For example [2001/anonymous](2001/anonymous/README.md) requires 32-bit
+ELF binaries.
 
 There are numerous example entries that require 32-bit binaries. We have tried
 to note these in both the respective Makefiles and README.md files but it is
@@ -308,6 +311,9 @@ possible that some were missed. These entries are very likely in the
 for 64-bit systems. Many were fixed to work with modern systems but some are
 supposed to only work with 32-bit systems so any updated version of these
 entries should be an alternate version.
+
+Other entries like [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd)
+now work with 32-bit AND 64-bit systems.
 
 
 ## Q: Under macOS I can't compile some entries and/or they don't work right. Why?

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1760,7 +1760,12 @@ bugs.md](/bugs.md#1994-dodsond2) for more details.
 
 Cody fixed this to check that four args were specified. With the use of the C
 pre-processor macro and inclusion of stdlib.h in the Makefile the layout of the
-source is exactly the same column width and no additional lines were added.
+source is exactly the same column width and no additional lines were added. This
+was done during one of the times where this was changed to bug status, for
+better or worse.
+
+Cody also fixed the Makefile which was causing alt code to be compiled when it
+shouldn't be.
 
 
 ## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md]))


### PR DESCRIPTION

The alt code was being compiled with 'all' rather than 'alt'.

The README.md file also has had format updates including referring to
the alt code as well as the gtface.c.

This should complete 1994/horton.