### PR TITLE
Format/typo fixes in 1994/shapiro

### DIFF
--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -114,10 +114,10 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA= gtface.data
-TARGET= ${PROG} gtface ${PROG}.alt
+TARGET= ${PROG} gtface
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o gtface.o
+ALT_TARGET= ${PROG}.alt gtface
 
 
 #################

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -14,22 +14,42 @@ make all
 `A`, `B`, `C` and `D` are numeric arguments.
 
 
+
+### Try:
+
+
 ```sh
 ./horton 3 2 1 0
 ```
 
+Also try:
+
+```sh
+./gtface  < gtface.data
+```
 
 ## Alternate code:
 
 This confuses cb greatly. See [horton.alt.c](horton.alt.c) for an unobfuscated/enhanced
-version. To run this alternate version:
+version.
+
+
+### Alternate build:
+
 
 ```sh
 make alt
+```
+
+
+### Alternate use:
+
+
+```sh
 ./horton.alt A B C D
 ```
 
-Use `horton.alt` as you would `horton` above.
+Where A, B, C and D are like with `horton`.
 
 
 ## Judges' remarks:

--- a/1994/imc/README.md
+++ b/1994/imc/README.md
@@ -37,16 +37,16 @@ This program may be compiled with an ANSI or K&R compiler.  A few
 harmless warnings are displayed only if `gcc -Wall` is used.
 
 This entry is really a set of library functions, but an example
-main function has been added so that the library can be tested.  If
-the program appears too large, consider that functions `o` and `s` can
+`main()` function has been added so that the library can be tested.  If
+the program appears too large, consider that functions `o()` and `s()` can
 each be separated from the rest of the program (except for the short
-functions `p` and `r`, which they require) and used alone.  However, the
+functions `p()` and `r()`, which they require) and used alone.  However, the
 main part of the program is the function `e`, which does require all the
-other functions (apart from `main`).
+other functions (apart from `main()`).
 
 The program should be supplied with an integer parameter.  If no
 parameter or an invalid parameter is given, then 5 is assumed.  The
-maximum parameter is determined only by the amount of cpu time, virtual
+maximum parameter is determined only by the amount of CPU time, virtual
 memory and display (or file) space available.
 
 ### SPOILER:
@@ -55,13 +55,13 @@ OK, so you have probably seen magic square printers before.  But what
 about one that deals with even sizes as well as odd ones, or one that
 prints out a different one each time (or attempts to, at any rate)?
 
-I have formatted the important functions `o`, `s` and `e` to show how useful
-the word "for" is, and (in function `e`) how useful the words "if" and
-"else" are.  In fact, hardly anything happens that isn't in one of these
+I have formatted the important functions `o()`, `s()` and `e()` to show how useful
+the word `for` is, and (in function `e()`) how useful the words `if` and
+`else` are.  In fact, hardly anything happens that isn't in one of these
 instructions.  I did this in order to simplify the code - the algorithms
 used to make the random squares are quite complex without being shrouded
 in obfuscated code! :-)  Incidentally, I was surprised to find out how
-useful the exclusive-or operator was while writing function `s`.
+useful the exclusive-or operator was while writing function `s()`.
 
 Here are the descriptions of the functions in the library:
 

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -111,12 +111,12 @@ First off, a secret message becomes visible that was not visible
 in the original program.  Also, much of the code shows up in
 different places in the flipped program than it appeared in the
 first program.  My first version of this program was perfectly
-symmetrical along the diagonal, but later found out there were
+symmetrical along the diagonal, but I later found out there were
 interesting ways to break the symmetry.  The best way to see this
 is to load both the original and flipped versions of the program
 into an editor and switch back and forth between them rapidly.
 
-C tokens longer than a character (such as "main") proved difficult
+C tokens longer than a character (such as `main()`) proved difficult
 to use in both the original and flipped versions (after flipping,
 they show up as a string of single letters on successive lines).
 However, I found that it was possible to get around this through
@@ -125,9 +125,7 @@ used nearly every single-character token in the "shared" area;
 however, it proved to be too large for contest guidelines (although
 the code itself is only about 300 characters, the extra whitespace
 needed to pad it put it over the limit -- it nearly filled a 79 by
-79 area, adding up to over 4000 total characters).  I will provide
-this other version to anyone interested -- contact me by email
-at schnitzi@east.isx.com.
+79 area, adding up to over 4000 total characters).
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -30,12 +30,14 @@ For more detailed information see [1994 shapiro in bugs.md](/bugs.md#1994-shapir
 ^Z
 bg
 ps x
+fg
 ^C
 
 ./shapiro_t1
 ```
 
-Notice what you see in the output of `ps`!
+Notice what you see in the output of `ps`! Observe too that after you bring it
+back to the foreground what happens.
 
 
 ## Judges' remarks:
@@ -60,29 +62,27 @@ The basic theme (pun) of this program is:
 >       ~~~~
 
 
-My entry ([shapiro.c](shapiro.c)) is mostly comment, formatted in the shape of a\
-clock. If you strip out the comments and look at the code you will\
-quickly realize that the comments were the important part and that\
-the code does very little (see pun above). It writes (to stdout)\
-another C program ([shapiro_t2.c](shapiro_t2.c)). This is the first level of\
+My entry ([shapiro.c](shapiro.c)) is mostly comments, formatted in the shape of a
+clock. If you strip out the comments and look at the code you will
+quickly realize that the comments were the important part and that
+the code does very little (see pun above). It writes (to `stdout`)
+another C program ([shapiro_t2.c](shapiro_t2.c)). This is the first level of
 obfuscation.
 
-The second program ([shapiro_t2.c](shapiro_t2.c) if you use the Makefile
+The second program ([shapiro_t2.c](shapiro_t2.c) (use `make everything` first)
 prints a clock in the upper right hand corner of your VTxxx/ANSI display.
 
 Most of the surface obfuscation in the second program
-([shapiro_t2.c](shapiro_t2.c))\
-was an attempt to make it as small as possible. You should be able to\
-see around this with cb(1) and some more intelligent variable names.\
-Once you get past this you will realize that the third level of\
-obfuscation is a six member client/server hierarchy.\
-(See the [shapiro.md](shapiro.md) file for a detailed description of the
-algorithm.)
+([shapiro_t2.c](shapiro_t2.c)) was an attempt to make it as small as possible.
+You should be able to see around this with `cb(1)` and some more intelligent
+variable names.  Once you get past this you will realize that the third level of
+obfuscation is a six member client/server hierarchy.  (See the
+[shapiro.md](shapiro.md) file for a detailed description of the algorithm.)
 
 `lint` complains about: precedence confusion, `K` may be used before set,
-main() returns random value to invocation environment, value type used\
-inconsistently, value type declared inconsistently, function argument\
-(number) used inconsistently, function returns value which is always\
+`main()` returns random value to invocation environment, value type used
+inconsistently, value type declared inconsistently, function argument
+(number) used inconsistently, function returns value which is always
 ignored, function returns value which is sometimes ignored.
 All of which are harmless (famous last words).
 

--- a/1994/shapiro/shapiro.md
+++ b/1994/shapiro/shapiro.md
@@ -1,6 +1,6 @@
 # HINTS
 
-For the first program (prog.c):
+For the first program ([shapiro.c](shapiro.c)):
 
 
 This is a very simple program:
@@ -20,15 +20,14 @@ This is a very simple program:
 12. exit(0);}
 ```
 
-Lines 1-5 are basic stuff. Line 6 opens the source code for input. Line 7
-is the loop. Line 8 is read in each character in the file (placed in `L`)
-while not `EOF` (usually `-1`). Line 9 is an if expression which filters out all 
-characters not between `J` and `J + 15`. Line 10 uses `M` to execute two different
-paths the first just stores the character in `K`. The second path combines
-the last two characters read in as high and low nibbles of a byte and 
-outputs them. In effect this is a very poor ASCII to binary decoder.
-The last line is necessary so that make will not stop when it executes 
-this program.
+Lines 1-5 are basic stuff. Line 6 opens the source code for input. Line 7 is the
+loop. Line 8 reads in each character in the file (placed in `L`) while not >= 0.
+Line 9 is an `if` expression which filters out all characters not between `J`
+and `J + 15`. Line 10 uses `M` to execute two different paths; the first just
+stores the character in `K` and the second path combines the last two characters
+read in as high and low nibbles of a byte and outputs them. In effect this is a
+very poor ASCII to binary decoder.  The last line is necessary so that make will
+not stop when it executes this program.
 
 The second program is encoded into this format and then included (mostly) 
 as a comment.
@@ -37,6 +36,7 @@ Notice that it is impossible to write this program while leaving 16
 contiguous ASCII characters free for the encoding. Because of this the
 second program is mostly included as a comment. However, some of the
 characters of the encoded program are also source code for the decoder.
+
 
 ### For the second program (with time.h):
 
@@ -72,37 +72,37 @@ characters of the encoded program are also source code for the decoder.
 
 ```
 
-Lines 1 and 2 have to be. Think of `o` in line 3 as send message with
-`j`,`k` and `m` as where, format and what. Lines 4 and 5 are all the text 
-strings. Line 6 is the offsets into the time string for the hours, 
-minutes and seconds. Lines 7-13 are basic stuff. Line 14 is the crux of
-the biscuit. 14 forks off `f` (6) processes each of which is connected to 
-the ones above and below it with a Unix pipe. It was too difficult to 
-recover the actual FD numbers for the pipe ends in line 14 so I regenerate 
-them and `fdopen()` them (for use with the standard C library functions) on lines
-15 and 16. Now we have six almost identical processes. Each of which has
-two files open `h` and `i` (up and down). The only difference in each process
-is the value of `f` (`0 <= f < 6`). The five processes where `f !=0` are the
-slave processes and `f == 0` is the master. Line 17 says we are going to do
-this forever. Lines 18 and 23 differentiate between the master and the 
-slaves. 
+Lines 1 and 2 have to be there. Think of `o` in line 3 as send message with
+`j`,`k` and `m` as where, format and what. Lines 4 and 5 are all the text
+strings. Line 6 is the offsets into the time string for the hours, minutes and
+seconds. Lines 7-13 are basic stuff. Line 14 is the crux of the biscuit. 14
+forks off `f` (6) processes each of which is connected to the ones above and
+below it with a Unix pipe. It was too difficult to recover the actual FD numbers
+for the pipe ends in line 14 so I regenerate them and `fdopen()` them (for use
+with the standard C library functions) on lines 15 and 16. Now we have six
+almost identical processes each of which has two files open, `h` and `i` (up and
+down). The only difference in each process is the value of `f` (`0 <= f < 6`).
+The five processes where `f !=0` are the slave processes and `f == 0` is the
+master. Line 17 says we are going to do this forever. Lines 18 and 23
+differentiate between the master and the slaves.
 
 Lines 19 to 22 are the slave code. Here we read in a line of text from
-`i` (down)(line 19) and remove the end of line char (line 20). On line
+`i` (down, line 19) and remove the newline char (line 20). On line
 21 if this message is for us (if the first character is our number, `f`,
 in ASCII) we do two things: 
 
-1. We copy the text of the message to `*c` which is really argv[0].  If you are
+1. We copy the text of the message to `*c` which is really `argv[0]`.  If you are
 on the correct flavor of Unix this will change the output of the `ps(1)` command
 to the string we just put there.
-2. We send the message (not including the number) to stdout with format number 6
+2. We send the message (not including the number) to `stdout` with format number 6
 (`"\0337\033[%d;65;H%s\0338"`) If you can read VTxxx (and I read books printed
 as ANSI/VTxxx codes for fun :-) ) you know this is the sequence for:
 
-			remember where we are, 
-                        go somewhere else, 
-                        print the message, 
-                        and return to where we started. 
+			remember where we are,\ 
+                        go somewhere else,\ 
+                        print the message,\
+                        and return to where we started.
+
 
 Line 22 says if this message is not for us (the number is bigger than ours) 
 send it to `h` (up).

--- a/1994/shapiro/shapiro.md
+++ b/1994/shapiro/shapiro.md
@@ -98,11 +98,12 @@ to the string we just put there.
 (`"\0337\033[%d;65;H%s\0338"`) If you can read VTxxx (and I read books printed
 as ANSI/VTxxx codes for fun :-) ) you know this is the sequence for:
 
-			remember where we are,\ 
-                        go somewhere else,\ 
-                        print the message,\
-                        and return to where we started.
-
+```
+remember where we are,
+go somewhere else,
+print the message,
+and return to where we started.
+```
 
 Line 22 says if this message is not for us (the number is bigger than ours) 
 send it to `h` (up).

--- a/faq.md
+++ b/faq.md
@@ -297,9 +297,12 @@ Some entries should not have modern system versions replaced. See below.
 
 ## Q: I can't get some entries to work in 64-bit systems that don't support 32-bit!
 
-Unfortunately some older entries are non-portable and require 32-bit support of
+Unfortunately some older entries are non-portable and require 32-bit support or
 32-bit binaries. A problem system here is macOS Catalina (10.15) as as of that
-version macOS no longer supports 32-bit binaries.
+version macOS no longer supports 32-bit binaries. If the entry acts on a certain
+type of binary, say ELF, then that will also be a problem depending on the
+entry. For example [2001/anonymous](2001/anonymous/README.md) requires 32-bit
+ELF binaries.
 
 There are numerous example entries that require 32-bit binaries. We have tried
 to note these in both the respective Makefiles and README.md files but it is
@@ -308,6 +311,9 @@ possible that some were missed. These entries are very likely in the
 for 64-bit systems. Many were fixed to work with modern systems but some are
 supposed to only work with 32-bit systems so any updated version of these
 entries should be an alternate version.
+
+Other entries like [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd)
+now work with 32-bit AND 64-bit systems.
 
 
 ## Q: Under macOS I can't compile some entries and/or they don't work right. Why?

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1760,7 +1760,12 @@ bugs.md](/bugs.md#1994-dodsond2) for more details.
 
 Cody fixed this to check that four args were specified. With the use of the C
 pre-processor macro and inclusion of stdlib.h in the Makefile the layout of the
-source is exactly the same column width and no additional lines were added.
+source is exactly the same column width and no additional lines were added. This
+was done during one of the times where this was changed to bug status, for
+better or worse.
+
+Cody also fixed the Makefile which was causing alt code to be compiled when it
+shouldn't be.
 
 
 ## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md]))


### PR DESCRIPTION

This completes 1994/shapiro as long as a formatting change in shapiro.md
is correct. That will be checked and if necessary it will be fixed.