### PR TITLE
Further improvements to 1991/dds fix

### DIFF
--- a/1991/dds/dds.c
+++ b/1991/dds/dds.c
@@ -1,19 +1,19 @@
 #include <stdio.h>
 #define Q r=R[*p++-'0'];while(
 #define B ;break;case
-char s[]="Qjou!s\\311^-g\\311^-n\\311^-c\\::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q<nbj\
-o)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<aN2!Q\
-\ndbtf!aP2Q;m>aP2Q<a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4\nJUJT%UQm>aP4HC%T\
-Qs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQUaP1H\
-R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
-\\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
-aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
-P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
-s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jod\
-mvef!tuejp/i!b/d";int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;
-*q;q++)*q>' '&&(* q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)
-return 1;for(p=s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k
-==EOF){fputs("}}\n",o);fclose(o);return system(q-104);}*r=0 B'P':while(*p!='\
-`')fputc(*p++,o)B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),
-k++);*r=0 B'I':k= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!=k
-)p++;p++B'N':R[*p-'0'][0]++;}}}
+char s[]="Qjou!s\\311^-g\\311^-n\\311^-c\\::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q<n\
+bjo)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso!2<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<a\
+N2!Q\ndbtf!aP2Q;m>aP2Q<a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4\nJUJT%UQm>aP4\
+HC%TQs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQU\
+aP1HR%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3\
+Q=>n\\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qq\
+vut)aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%\
+LN1UP1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.\
+fssps!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jodmvef!tuejp/i!\
+b/d";int k;char R[4][99];main(c,v)char**v;{char*p,*r,*q;for(q=s;*q;q++)*q>' '
+&&(* q)--;{FILE*i=fopen(v[1],"r"),*o=fopen(q-3,"w");if(!i||!o)return 1;for(p=
+s;;p++)switch(*p++){B'M':Q(k=fgetc(i))!=EOF&&k!=*p)*r++=k;if(k==EOF){fputs("\
+}}\n",o);fclose(o);return system(q-87);}*r=0 B'P':while(*p!='`')fputc(*p++,o)
+B'O':Q*r)fputc(*r++,o);p--B'C':k=0;Q k<*p-'0')(*r++=fgetc(i),k++);*r=0 B'I':k
+= *p;if(**R==k)goto G B'G':k= *p;G:p=s;while(*p!='$'||p[1]!=k)p++;p++B'N':R[*
+p-'0'][0]++;}}}

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -114,10 +114,10 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA= gtface.data
-TARGET= ${PROG} gtface ${PROG}.alt
+TARGET= ${PROG} gtface
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o gtface.o
+ALT_TARGET= ${PROG}.alt gtface
 
 
 #################

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -14,22 +14,42 @@ make all
 `A`, `B`, `C` and `D` are numeric arguments.
 
 
+
+### Try:
+
+
 ```sh
 ./horton 3 2 1 0
 ```
 
+Also try:
+
+```sh
+./gtface  < gtface.data
+```
 
 ## Alternate code:
 
 This confuses cb greatly. See [horton.alt.c](horton.alt.c) for an unobfuscated/enhanced
-version. To run this alternate version:
+version.
+
+
+### Alternate build:
+
 
 ```sh
 make alt
+```
+
+
+### Alternate use:
+
+
+```sh
 ./horton.alt A B C D
 ```
 
-Use `horton.alt` as you would `horton` above.
+Where A, B, C and D are like with `horton`.
 
 
 ## Judges' remarks:

--- a/1994/imc/README.md
+++ b/1994/imc/README.md
@@ -37,16 +37,16 @@ This program may be compiled with an ANSI or K&R compiler.  A few
 harmless warnings are displayed only if `gcc -Wall` is used.
 
 This entry is really a set of library functions, but an example
-main function has been added so that the library can be tested.  If
-the program appears too large, consider that functions `o` and `s` can
+`main()` function has been added so that the library can be tested.  If
+the program appears too large, consider that functions `o()` and `s()` can
 each be separated from the rest of the program (except for the short
-functions `p` and `r`, which they require) and used alone.  However, the
+functions `p()` and `r()`, which they require) and used alone.  However, the
 main part of the program is the function `e`, which does require all the
-other functions (apart from `main`).
+other functions (apart from `main()`).
 
 The program should be supplied with an integer parameter.  If no
 parameter or an invalid parameter is given, then 5 is assumed.  The
-maximum parameter is determined only by the amount of cpu time, virtual
+maximum parameter is determined only by the amount of CPU time, virtual
 memory and display (or file) space available.
 
 ### SPOILER:
@@ -55,13 +55,13 @@ OK, so you have probably seen magic square printers before.  But what
 about one that deals with even sizes as well as odd ones, or one that
 prints out a different one each time (or attempts to, at any rate)?
 
-I have formatted the important functions `o`, `s` and `e` to show how useful
-the word "for" is, and (in function `e`) how useful the words "if" and
-"else" are.  In fact, hardly anything happens that isn't in one of these
+I have formatted the important functions `o()`, `s()` and `e()` to show how useful
+the word `for` is, and (in function `e()`) how useful the words `if` and
+`else` are.  In fact, hardly anything happens that isn't in one of these
 instructions.  I did this in order to simplify the code - the algorithms
 used to make the random squares are quite complex without being shrouded
 in obfuscated code! :-)  Incidentally, I was surprised to find out how
-useful the exclusive-or operator was while writing function `s`.
+useful the exclusive-or operator was while writing function `s()`.
 
 Here are the descriptions of the functions in the library:
 

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -111,12 +111,12 @@ First off, a secret message becomes visible that was not visible
 in the original program.  Also, much of the code shows up in
 different places in the flipped program than it appeared in the
 first program.  My first version of this program was perfectly
-symmetrical along the diagonal, but later found out there were
+symmetrical along the diagonal, but I later found out there were
 interesting ways to break the symmetry.  The best way to see this
 is to load both the original and flipped versions of the program
 into an editor and switch back and forth between them rapidly.
 
-C tokens longer than a character (such as "main") proved difficult
+C tokens longer than a character (such as `main()`) proved difficult
 to use in both the original and flipped versions (after flipping,
 they show up as a string of single letters on successive lines).
 However, I found that it was possible to get around this through
@@ -125,9 +125,7 @@ used nearly every single-character token in the "shared" area;
 however, it proved to be too large for contest guidelines (although
 the code itself is only about 300 characters, the extra whitespace
 needed to pad it put it over the limit -- it nearly filled a 79 by
-79 area, adding up to over 4000 total characters).  I will provide
-this other version to anyone interested -- contact me by email
-at schnitzi@east.isx.com.
+79 area, adding up to over 4000 total characters).
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -30,12 +30,14 @@ For more detailed information see [1994 shapiro in bugs.md](/bugs.md#1994-shapir
 ^Z
 bg
 ps x
+fg
 ^C
 
 ./shapiro_t1
 ```
 
-Notice what you see in the output of `ps`!
+Notice what you see in the output of `ps`! Observe too that after you bring it
+back to the foreground what happens.
 
 
 ## Judges' remarks:
@@ -60,29 +62,27 @@ The basic theme (pun) of this program is:
 >       ~~~~
 
 
-My entry ([shapiro.c](shapiro.c)) is mostly comment, formatted in the shape of a\
-clock. If you strip out the comments and look at the code you will\
-quickly realize that the comments were the important part and that\
-the code does very little (see pun above). It writes (to stdout)\
-another C program ([shapiro_t2.c](shapiro_t2.c)). This is the first level of\
+My entry ([shapiro.c](shapiro.c)) is mostly comments, formatted in the shape of a
+clock. If you strip out the comments and look at the code you will
+quickly realize that the comments were the important part and that
+the code does very little (see pun above). It writes (to `stdout`)
+another C program ([shapiro_t2.c](shapiro_t2.c)). This is the first level of
 obfuscation.
 
-The second program ([shapiro_t2.c](shapiro_t2.c) if you use the Makefile
+The second program ([shapiro_t2.c](shapiro_t2.c) (use `make everything` first)
 prints a clock in the upper right hand corner of your VTxxx/ANSI display.
 
 Most of the surface obfuscation in the second program
-([shapiro_t2.c](shapiro_t2.c))\
-was an attempt to make it as small as possible. You should be able to\
-see around this with cb(1) and some more intelligent variable names.\
-Once you get past this you will realize that the third level of\
-obfuscation is a six member client/server hierarchy.\
-(See the [shapiro.md](shapiro.md) file for a detailed description of the
-algorithm.)
+([shapiro_t2.c](shapiro_t2.c)) was an attempt to make it as small as possible.
+You should be able to see around this with `cb(1)` and some more intelligent
+variable names.  Once you get past this you will realize that the third level of
+obfuscation is a six member client/server hierarchy.  (See the
+[shapiro.md](shapiro.md) file for a detailed description of the algorithm.)
 
 `lint` complains about: precedence confusion, `K` may be used before set,
-main() returns random value to invocation environment, value type used\
-inconsistently, value type declared inconsistently, function argument\
-(number) used inconsistently, function returns value which is always\
+`main()` returns random value to invocation environment, value type used
+inconsistently, value type declared inconsistently, function argument
+(number) used inconsistently, function returns value which is always
 ignored, function returns value which is sometimes ignored.
 All of which are harmless (famous last words).
 

--- a/1994/shapiro/shapiro.md
+++ b/1994/shapiro/shapiro.md
@@ -1,6 +1,6 @@
 # HINTS
 
-For the first program (prog.c):
+For the first program ([shapiro.c](shapiro.c)):
 
 
 This is a very simple program:
@@ -20,15 +20,14 @@ This is a very simple program:
 12. exit(0);}
 ```
 
-Lines 1-5 are basic stuff. Line 6 opens the source code for input. Line 7
-is the loop. Line 8 is read in each character in the file (placed in `L`)
-while not `EOF` (usually `-1`). Line 9 is an if expression which filters out all 
-characters not between `J` and `J + 15`. Line 10 uses `M` to execute two different
-paths the first just stores the character in `K`. The second path combines
-the last two characters read in as high and low nibbles of a byte and 
-outputs them. In effect this is a very poor ASCII to binary decoder.
-The last line is necessary so that make will not stop when it executes 
-this program.
+Lines 1-5 are basic stuff. Line 6 opens the source code for input. Line 7 is the
+loop. Line 8 reads in each character in the file (placed in `L`) while not >= 0.
+Line 9 is an `if` expression which filters out all characters not between `J`
+and `J + 15`. Line 10 uses `M` to execute two different paths; the first just
+stores the character in `K` and the second path combines the last two characters
+read in as high and low nibbles of a byte and outputs them. In effect this is a
+very poor ASCII to binary decoder.  The last line is necessary so that make will
+not stop when it executes this program.
 
 The second program is encoded into this format and then included (mostly) 
 as a comment.
@@ -37,6 +36,7 @@ Notice that it is impossible to write this program while leaving 16
 contiguous ASCII characters free for the encoding. Because of this the
 second program is mostly included as a comment. However, some of the
 characters of the encoded program are also source code for the decoder.
+
 
 ### For the second program (with time.h):
 
@@ -72,37 +72,37 @@ characters of the encoded program are also source code for the decoder.
 
 ```
 
-Lines 1 and 2 have to be. Think of `o` in line 3 as send message with
-`j`,`k` and `m` as where, format and what. Lines 4 and 5 are all the text 
-strings. Line 6 is the offsets into the time string for the hours, 
-minutes and seconds. Lines 7-13 are basic stuff. Line 14 is the crux of
-the biscuit. 14 forks off `f` (6) processes each of which is connected to 
-the ones above and below it with a Unix pipe. It was too difficult to 
-recover the actual FD numbers for the pipe ends in line 14 so I regenerate 
-them and `fdopen()` them (for use with the standard C library functions) on lines
-15 and 16. Now we have six almost identical processes. Each of which has
-two files open `h` and `i` (up and down). The only difference in each process
-is the value of `f` (`0 <= f < 6`). The five processes where `f !=0` are the
-slave processes and `f == 0` is the master. Line 17 says we are going to do
-this forever. Lines 18 and 23 differentiate between the master and the 
-slaves. 
+Lines 1 and 2 have to be there. Think of `o` in line 3 as send message with
+`j`,`k` and `m` as where, format and what. Lines 4 and 5 are all the text
+strings. Line 6 is the offsets into the time string for the hours, minutes and
+seconds. Lines 7-13 are basic stuff. Line 14 is the crux of the biscuit. 14
+forks off `f` (6) processes each of which is connected to the ones above and
+below it with a Unix pipe. It was too difficult to recover the actual FD numbers
+for the pipe ends in line 14 so I regenerate them and `fdopen()` them (for use
+with the standard C library functions) on lines 15 and 16. Now we have six
+almost identical processes each of which has two files open, `h` and `i` (up and
+down). The only difference in each process is the value of `f` (`0 <= f < 6`).
+The five processes where `f !=0` are the slave processes and `f == 0` is the
+master. Line 17 says we are going to do this forever. Lines 18 and 23
+differentiate between the master and the slaves.
 
 Lines 19 to 22 are the slave code. Here we read in a line of text from
-`i` (down)(line 19) and remove the end of line char (line 20). On line
+`i` (down, line 19) and remove the newline char (line 20). On line
 21 if this message is for us (if the first character is our number, `f`,
 in ASCII) we do two things: 
 
-1. We copy the text of the message to `*c` which is really argv[0].  If you are
+1. We copy the text of the message to `*c` which is really `argv[0]`.  If you are
 on the correct flavor of Unix this will change the output of the `ps(1)` command
 to the string we just put there.
-2. We send the message (not including the number) to stdout with format number 6
+2. We send the message (not including the number) to `stdout` with format number 6
 (`"\0337\033[%d;65;H%s\0338"`) If you can read VTxxx (and I read books printed
 as ANSI/VTxxx codes for fun :-) ) you know this is the sequence for:
 
-			remember where we are, 
-                        go somewhere else, 
-                        print the message, 
-                        and return to where we started. 
+			remember where we are,\ 
+                        go somewhere else,\ 
+                        print the message,\
+                        and return to where we started.
+
 
 Line 22 says if this message is not for us (the number is bigger than ours) 
 send it to `h` (up).

--- a/1994/shapiro/shapiro.md
+++ b/1994/shapiro/shapiro.md
@@ -98,11 +98,12 @@ to the string we just put there.
 (`"\0337\033[%d;65;H%s\0338"`) If you can read VTxxx (and I read books printed
 as ANSI/VTxxx codes for fun :-) ) you know this is the sequence for:
 
-			remember where we are,\ 
-                        go somewhere else,\ 
-                        print the message,\
-                        and return to where we started.
-
+```
+remember where we are,
+go somewhere else,
+print the message,
+and return to where we started.
+```
 
 Line 22 says if this message is not for us (the number is bigger than ours) 
 send it to `h` (up).

--- a/1994/smr/README.md
+++ b/1994/smr/README.md
@@ -21,17 +21,17 @@ make all
 
 ## Judges' remarks:
 
-Nearly every year, one or more people would submit what they claimed\
+Nearly every year, one or more people would submit what they claimed
 was the world's smallest self reproducing program.  While the sizes
 of these submissions varied, a quick glance would reveal that they
 were too big, until this entry came along.
 
-While strictly speaking, smr.c is not a valid C program, it is
-not an invalid C program either!  Some C compilers will compile
-an empty file into a program that does nothing.  But even if your
-compiler can't, the build instructions supplied with this entry
-will produce an executable file.  On most systems, the stdout
-from the executable will exactly match original source.
+While strictly speaking, [smr.c](smr.c) is not a valid C program, it is not an
+invalid C program either!  Some C compilers will compile an empty file into a
+program that does nothing.  But even if your compiler can't, the build
+instructions supplied with this entry will produce an executable file.  On most
+systems, the `stdout` from the executable will exactly match the original
+source.
 
 In the future, the contest rules will specify a minimum size that is one
 character larger than this entry, forever eliminating this sort of program from
@@ -41,7 +41,7 @@ the contest.  After all, how many variations can one make on this entry? :-)
 ## Author's remarks:
 
 The world's smallest self-replicating program. Guaranteed.
-Produces a listing of itself on stdout.
+Produces a listing of itself on `stdout`.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -63,7 +63,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11
+CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11 -include stdio.h
 
 # Optimization
 #

--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -4,6 +4,17 @@
 make all
 ```
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: known bug - please help us fix
+STATUS: uses gets() - change to fgets() if possible
+```
+
+For more detailed information see [1994 tvr in bugs.md](/bugs.md#1994-tvr).
+
 
 ## To use:
 
@@ -54,9 +65,11 @@ fix it without breaking something else?
 
 This program contains four pairs of fractals/effects and three methods of
 animating them. There are two windows for a pair of fractals, one of which
-contains static fractal (e.g. Mandelbrot set) and the other an animating one
-(e.g. Julian set) which is derived from the same formula as the static one. Only
-one pair of fractals can be displayed in one process.
+contains static fractal (e.g. [Mandelbrot
+set](https://en.wikipedia.org/wiki/Mandelbrot_set)) and the other an animating
+one (e.g. [Julia set](https://en.wikipedia.org/wiki/Julia_set)) which is derived
+from the same formula as the static one. Only one pair of fractals can be
+displayed in one process.
 
 To animate the fractal, you must move your mouse on the static
 fractal window and the animated fractal will be calculated based
@@ -64,14 +77,13 @@ on mouse coordinates. If you are on one of the two non-stable
 modes (more about them later) you can stabilize the picture by
 pressing a mouse button. Pressing it does nothing on stable mode.
 
-
 The three modes are:
 
 - non-stable mode with simple 'attractor searcher'
 - non-stable mode
 - stable mode
 
-On Mandelbrot/Julian mode the stable mode calculates normal Julian set according
+On Mandelbrot/Julia mode the stable mode calculates normal Julia set according
 to the Mandelbrot coordinates (mouse position). On non-stable modes the picture
 slowly transforms to the same picture as on the stable mode but transformation
 can take some time. Usually, and especially if changes are relatively small
@@ -83,11 +95,9 @@ when you first move your mouse to non-black areas of the Mandelbrot set, then
 back to near the center. In some cases 'attractor searcher' can be seen as
 noise.
 
-
-The first of the fractal pairs is Mandelbrot/Julian set as mentioned before. The
-second is a variation of that. The third makes nice 3d-look-a-like effects and
+The first of the fractal pairs is Mandelbrot/Julia set as mentioned before. The
+second is a variation of that. The third makes nice 3D-look-a-like effects and
 the fourth is a variation of that with more nice effects.
-
 
 
 ### Usage:
@@ -103,8 +113,9 @@ actual `screenlength/width`. I.e. if you use 128 as a second parameter, you will
 get two 256x256 windows.
 
 The program needs reasonable values for both of these parameters to
-operate. A good first try could be "0 128" or "8 128". The `colormap` has
-to be redirected into the programs standard input via the `colormapfile`.
+operate. A good first try could be `0 128` or `8 128`. The `colormap` has
+to be redirected into the programs standard input via the `colormapfile`
+parameter as shown above.
 
 Note that you will need approximately `(second_parameter^2)*64` bytes of free
 main memory or the machine will swap heavily (memory references are quite random
@@ -179,7 +190,7 @@ Mandelbrot set is calculated from the formula
 		       n+1   n    0
 ```
 
-and the Julian set is calculated from the formula
+and the Julia set is calculated from the formula
 
 ```
 
@@ -193,7 +204,7 @@ where `C` is the same throughout the picture.  Both calculation are finished
 when `|Z| >= 2.0`.  For the other fractals, the basic methods are the same but
 the formula is different (look at the source ;) )
 
-Note that Mandelbrot and Julian on this program aren't exactly correct. Find out
+Note that Mandelbrot and Julia on this program aren't exactly correct. Find out
 why ;)
 
 
@@ -203,7 +214,7 @@ why ;)
 happen if a request of some of the resources fails e.g. getting colors.
 - No expose event handling.
 - It may be possible that the program starts drawing before window is mapped as
-there is no XSync(). In that case drawn data is lost. Also, some window manager
+there is no `XSync()`. In that case drawn data is lost. Also, some window manager
 configurations places the second window on top of the first and again drawn
 data will be lost. By default, windows are placed next to the other in the
 top left corner of the screen.

--- a/1994/tvr/tvr.c
+++ b/1994/tvr/tvr.c
@@ -1,4 +1,5 @@
 #include <X11/Xlib.h>
+#define gets(B) fgets((B),C-(B)+256,stdin),(B[strlen(B)-1]='\0'),1
 #define M     typedef
 #define N(	 a)=r=(a)+j
 #define S f(; G; )D[B[R=i[--G]]=F+=F<p]++

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pointer-to-int-cast \
-	-Wno-shift-op-parentheses
+	-Wno-shift-op-parentheses -Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1994/weisberg/README.md
+++ b/1994/weisberg/README.md
@@ -31,10 +31,11 @@ a core file.  :-)
 
 This entry confuses some C-preprocessors and some C-beautifiers.
 We found one cpp that processed this source differently when
-it was read on stdin instead of via `cc -E`.
+it was read on `stdin` instead of via `cc -E`.
 
 
 ## Author's remarks:
+
 
 ### Description
 
@@ -46,15 +47,17 @@ run to completion, so as an added feature, it will cease execution upon
 reception of a signal (any will do equally well), as well as in the
 event of a system shutdown or reboot.
 
+
 ### Bugs
 
-The alternative version ([weisberg.alt](weisberg.alt.c)) has never actually run
+The alternative version ([weisberg.alt.c](weisberg.alt.c)) has never actually run
 to completion. After running for close to a week it had reached somewhere around
 250e6, when it became necessary to test the reboot feature (which worked
 remarkably well). As there are quite a lot of primes to be found before reaching
-`INT_MAX`, the output produced can be quite overwhelming, it recommended to pipe
+`INT_MAX`, the output produced can be quite overwhelming so it's recommended to pipe
 the output through your favorite pager (`more` or `less`), and not output to a
 paper output device (unless you have *LOTS* of paper).
+
 
 ### Technical
 

--- a/1994/westley/README.md
+++ b/1994/westley/README.md
@@ -94,7 +94,8 @@ with "verbose" turned on).
 The goal of the game is to escape the dungeon.
 
 Here is a walk-through for the game, including a few dead-ends:
-\
+
+
 ### SPOILER
 
 ```sh

--- a/bugs.md
+++ b/bugs.md
@@ -1332,6 +1332,32 @@ if it checked for `!= EOF`.
 Since it works there is no need to fix this except for a challenge to yourself.
 
 
+## 1994 tvr
+
+### STATUS: known bug - please help us fix
+### Source code: [1994/tvr/tvr.c](1994/tvr/tvr.c)
+### Information: [1994/tvr/README.md](1994/tvr/README.md)
+
+
+
+The judges said the following in their remarks:
+
+```
+The fractally minded may be able to detect that mode 0 does not calculate
+Mandelbrot/Julian sets correctly.  Can you find the bug?  Better still, can you
+fix it without breaking something else?
+```
+
+You are welcome to try and fix it and open a pull request, providing that it
+doesn't break something else.
+
+
+### STATUS: uses gets() - change to fgets() if possible
+
+Although the entry itself was changed to use `fgets(3)` the alt code was not. It
+would be better if both used `fgets(3)`.
+
+
 # 1995
 
 

--- a/faq.md
+++ b/faq.md
@@ -297,9 +297,12 @@ Some entries should not have modern system versions replaced. See below.
 
 ## Q: I can't get some entries to work in 64-bit systems that don't support 32-bit!
 
-Unfortunately some older entries are non-portable and require 32-bit support of
+Unfortunately some older entries are non-portable and require 32-bit support or
 32-bit binaries. A problem system here is macOS Catalina (10.15) as as of that
-version macOS no longer supports 32-bit binaries.
+version macOS no longer supports 32-bit binaries. If the entry acts on a certain
+type of binary, say ELF, then that will also be a problem depending on the
+entry. For example [2001/anonymous](2001/anonymous/README.md) requires 32-bit
+ELF binaries.
 
 There are numerous example entries that require 32-bit binaries. We have tried
 to note these in both the respective Makefiles and README.md files but it is
@@ -308,6 +311,9 @@ possible that some were missed. These entries are very likely in the
 for 64-bit systems. Many were fixed to work with modern systems but some are
 supposed to only work with 32-bit systems so any updated version of these
 entries should be an alternate version.
+
+Other entries like [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd)
+now work with 32-bit AND 64-bit systems.
 
 
 ## Q: Under macOS I can't compile some entries and/or they don't work right. Why?

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1837,7 +1837,8 @@ Note that the alt code does not use `fgets(3)` but rather `gets(3)`.
 
 Cody converted the spoiler compiler options (provided by the author) to be
 compiler commands and added a script [spoiler.sh](1994/westley/spoiler.sh) to
-automate the spoiler commands to make it easier to see the game in action.
+automate the spoiler commands to make it easier to see the game in action from
+start to finish.
 
 
 ## [1995/cdua](1995/cdua/cdua.c) ([README.md](1995/cdua/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1760,7 +1760,12 @@ bugs.md](/bugs.md#1994-dodsond2) for more details.
 
 Cody fixed this to check that four args were specified. With the use of the C
 pre-processor macro and inclusion of stdlib.h in the Makefile the layout of the
-source is exactly the same column width and no additional lines were added.
+source is exactly the same column width and no additional lines were added. This
+was done during one of the times where this was changed to bug status, for
+better or worse.
+
+Cody also fixed the Makefile which was causing alt code to be compiled when it
+shouldn't be.
 
 
 ## [1994/ldb](1994/ldb/ldb.c) ([README.md](1994/ldb/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1823,6 +1823,16 @@ For an interesting problem that occurred here and what was done to solve it,
 check the [bugs.md](bugs.md) file.
 
 
+## [1994/tvr](1994/tvr/tvr.c) ([README.md](1994/tvr/README.md]))
+
+Cody made this use `fgets(3)` instead of `gets(3)`. In this case the newline had
+to be terminated but it was a pretty straightforward fix. `gets()` was defined
+to use `fgets()` and the inclusion of `stdio.h` had to be added but to make it
+more like the original entry this was done in the Makefile.
+
+Note that the alt code does not use `fgets(3)` but rather `gets(3)`.
+
+
 ## [1994/westley](1994/westley/westley.c) ([README.md](1994/westley/README.md]))
 
 Cody converted the spoiler compiler options (provided by the author) to be

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1212,8 +1212,10 @@ the entry generates had some warnings that were causing compilation to fail if
 `cc` is clang as it just ran `cc a.c`. It ran it by what was once `system(q-6);`
 but if `cc` is clang like in macOS this is not enough.
 
-(Cody stupidly did the below manually until he thought to write a simple program
-to do the conversions which he used for `gets()` to `fgets()`.)
+(Cody said he stupidly did the below manually until he thought to write a simple
+program to do the conversions which he used for `gets()` to `fgets()` and for
+making the generated code return a value from `main()` rather than just
+`return;`).
 
 The following had to be added to the string `s` (which to fix the segfault was
 changed from `char*s` to `char s[]`):
@@ -1286,25 +1288,30 @@ which is the end of the warning disabled for clang as described above.
 But now the `system(q-69);` had to be changed to `system(q-86);`.
 
 Then, later on, Cody discovered that in some systems, clang triggers even more
-warnings so this had to be corrected too. Thus the string had to be changed to,
-in full:
+warnings so this had to be corrected too so the string was updated again and
+the `system(q-86)` had to be changed to `system(q-104)`.
+
+But then to prevent the need for disabling a warning and to be more correct
+code, the generated code was changed to `return 1;` rather than just `return;`.
+Thus in full the string became:
 
 ```c
-char s[]="Qjou!s\\311^-g\\311^-n\\311^-c\\::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q<nbj\
-o)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<aN2!Q\
-\ndbtf!aP2Q;m>aP2Q<a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4\nJUJT%UQm>aP4HC%T\
-Qs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQUaP1H\
-R%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3Q=>n\
-\\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qqvut)\
-aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%LN1U\
-P1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.fssp\
-s!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jod\
-mvef!tuejp/i!b/d";
+char s[]="Qjou!s\\311^-g\\311^-n\\311^-c\\::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q<n\
+bjo)*|gps)<<*txjudi)m*|aQdbtf!::::;sfuvso!2<aQefgbvmu;aQ<m,,a%CQ<csfbla%bQ<a\
+N2!Q\ndbtf!aP2Q;m>aP2Q<a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4\nJUJT%UQm>aP4\
+HC%TQs\\q,,^>m,2<m>aP4HC%SD12N1\nJNQm>s\\..q^aHC%NHb%GN1!D32P3%RN1UP1D12JPQU\
+aP1HR%PN4\nQ<g\\(aP3Q(^>aP2Q,2<n\\(aP3Q(^>aP4Hb%OD12D12N2!N3\nJVP3Q,,<jg)aP3\
+Q=>n\\(aP3Q(^*m>g\\(aP3Q(^<fmtf!m,,aHC%QN1!N1\nJ#Qqsjoug)#&e]o#-aP1Q*aHb%#Qq\
+vut)aP1Q*aHb%FN1\nQm>::::aHC%VP3Q>bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%\
+LN1UP1D12JIQUaP1HL%IQ*m>aN2!N2\nP2Q<fmtf!m,,aHC%MN1!N2>P2Q>aN2\nP2Hbdd!.Xop.\
+fssps!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jodmvef!tuejp/i!\
+b/d";
 ```
 
-and then the `system(q-86)` had to be changed to `system(q-104)`. It is hoped
-that this is the last time the string has to be updated to work with all
-versions of clang but if not the above is how it works.
+and it now is `system(q-87);`.
+
+It is hoped that this is the last time the string has to be updated to work with
+all versions of clang but if not the above is how it works.
 
 With these changes in place it will compile and work with both gcc and clang and
 the C code generated will use `fgets()`, not `gets()`, therefore removing the


### PR DESCRIPTION

Rather than having the string that is run via system(3) use 
-Wno-return-type the generated code (also in the string) now returns 1;
rather than 'return;' so that main() has a proper return statement.

This means the string was updated and the call to system(3) was also 
updated but it is a bit better now. It is hoped that this is the last 
time (..yet again..) that this will have to be updated to work with 
various systems but as before the magic is in the thanks file, at least 
for now.
