### PR TITLE
Add try.sh to 1995/dodsond1 + format/typo checks

### DIFF
--- a/1995/dodsond1/README.md
+++ b/1995/dodsond1/README.md
@@ -33,7 +33,7 @@ giraffes.
 ... which can be done like:
 
 ```c
-./dodsond1 < try.this.txt
+./try.sh
 ```
 
 
@@ -47,11 +47,11 @@ The obfuscation is on several levels.
 Most obviously, the shape of the program.
 
 Underneath that, the variable names are in pig Latin, as are the
-names of the standard C functions, such as putchar.  Even main is
+names of the standard C functions, such as `putchar()`.  Even main is
 written as `ainma`.
 
 The program construction is also very obfuscated, with all of the
-code being inside the ()'s of one of the 6 `orfa` loops.
+code being inside the `()`'s of one of the 6 `orfa` loops.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1995/dodsond1/try.sh
+++ b/1995/dodsond1/try.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+make all >/dev/null || exit 1
+
+echo "$ cat try.this.txt"
+cat try.this.txt
+
+echo "$ ./dodsond1 < try.this.txt"
+./dodsond1 < try.this.txt

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1859,6 +1859,12 @@ are too fast ... if there is such a thing anyway :-) ). See the README.md for
 details on this.
 
 
+## [1995/dodsond1](1995/dodsond1/dodsond1.c) ([README.md](1995/dodsond1/README.md]))
+
+Cody added the [try.sh](1995/dodsond1/try.sh) script that uses the text file he
+provided which is input we suggested one try with the entry.
+
+
 ## [1995/garry](1995/garry/garry.c) ([README.md](1995/garry/README.md]))
 
 Cody fixed the alt code so that it will compile with modern compilers. The


### PR DESCRIPTION
The try.sh script uses the text file that I added a while back which has the text that the judges recommended one try with the program.