### PR TITLE
Format/typo checks in 1995/leo + add spoiler1.md

### DIFF
--- a/1995/dodsond1/README.md
+++ b/1995/dodsond1/README.md
@@ -33,7 +33,7 @@ giraffes.
 ... which can be done like:
 
 ```c
-./dodsond1 < try.this.txt
+./try.sh
 ```
 
 
@@ -47,11 +47,11 @@ The obfuscation is on several levels.
 Most obviously, the shape of the program.
 
 Underneath that, the variable names are in pig Latin, as are the
-names of the standard C functions, such as putchar.  Even main is
+names of the standard C functions, such as `putchar()`.  Even main is
 written as `ainma`.
 
 The program construction is also very obfuscated, with all of the
-code being inside the ()'s of one of the 6 `orfa` loops.
+code being inside the `()`'s of one of the 6 `orfa` loops.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1995/dodsond1/try.sh
+++ b/1995/dodsond1/try.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+make all >/dev/null || exit 1
+
+echo "$ cat try.this.txt"
+cat try.this.txt
+
+echo "$ ./dodsond1 < try.this.txt"
+./dodsond1 < try.this.txt

--- a/1995/esde/README.md
+++ b/1995/esde/README.md
@@ -17,9 +17,7 @@ where data-file contains lines of < 255 chars in length.
 ### Try:
 
 ```sh
-./esde esde.data Johanson
-./esde esde.data2 read
-./esde README.md date
+./try.sh
 ```
 
 
@@ -45,10 +43,10 @@ Soundex code begins with the first letter of the word followed by a
 three-digit code. This is the algorithm:
 
 0. Every letter in the word beyond the first letter is replaced by a digit.
-1. Replace all pairs of the same code by single code (ex. R011235 -> R01235).
-2. Remove all 0-codes (ex. R01235 -> R1235).
-3. If length of code is > 4, get only first 4 codes (ex. R1235 -> R123).
-4. If length of code is < 4, add zeros (ex. T12 -> T120).
+1. Replace all pairs of the same code by single code (e.g. `R011235` -> `R01235`).
+2. Remove all zeroes (e.g. `R01235` -> `R1235`).
+3. If length of code is > 4, get only first 4 characters (e.g. `R1235` -> `R123`).
+4. If length of code is < 4, add zeros (e.g. `T12` -> `T120`).
 
 These are the codes:
 

--- a/1995/esde/try.sh
+++ b/1995/esde/try.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+make all >/dev/null || exit 1
+
+echo "$ ./esde esde.data Johanson"
+./esde esde.data Johanson
+echo
+
+echo "$ ./esde esde.data2 read"
+./esde esde.data2 read
+echo
+
+echo "$ ./esde README.md date"
+./esde README.md date

--- a/1995/garry/README.md
+++ b/1995/garry/README.md
@@ -64,7 +64,7 @@ This program is a file filter, designed to do environment-expansion and
 incorporating the ability to create binary from escaped data in the
 environment variables.
 
-The calling syntax is pretty simple, just use it with stdio-redirection
+The calling syntax is pretty simple, just use it with `stdio`-redirection
 or inside pipelines, e.g.:
 
 ```sh
@@ -79,10 +79,12 @@ cat all_my_files/* | ./garry | lp
 
 The syntax of the conversion of the input file is as follows: To include the
 value of an environment variable in the output file, place the name of the
-variable between "$"-signs in the input, e.g.:
+variable between `$`-signs in the input, e.g.:
 
-	My Home-Directory is: $HOME$
-	I'm using the path: $PATH$
+```
+My Home-Directory is: $HOME$
+I'm using the path: $PATH$
+```
 
 Unknown Env-variables or malformed expressions are ignored and kept intact.
 

--- a/1995/garry/garry.alt.test.sh
+++ b/1995/garry/garry.alt.test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+#
+# garry.alt.test.sh - example of how to use garry.alt
+
+EXAMPLEON="\33\133\61\73\67\155"
+EXAMPLEOFF="\33\133\155"
+DOLLAR="$"
+export EXAMPLEON EXAMPLEOFF DOLLAR
+
+# make sure alt code is built, first
+make alt || exit 1
+
+./garry.alt <garry.data

--- a/1995/heathbar/README.md
+++ b/1995/heathbar/README.md
@@ -37,7 +37,7 @@ end, I made three critical observations:
 
 1. If there's one thing computers are good at, it's math.
 2. Simple operations take less time than complicated ones.
-3. Every C program seems to contain the word "main".
+3. Every C program seems to contain the word `main`.
 
 Based on #1, I knew that the Fastest Program had to be one that
 performed addition. From #2, I reasoned that it ought to directly
@@ -46,7 +46,7 @@ high-level, fuzzy-logic, artificial-intelligence, neural-net,
 client-server, object-oriented abstractions like the C language "+"
 operator. And it was obvious from #3 that the program should
 resemble, as closely as possible, a long sequence of the familiar
-word "main" repeated over and over, so the computer would be
+word `main` repeated over and over, so the computer would be
 comfortable running the program and wouldn't get distracted dealing
 with unfamiliar variable names.
 

--- a/1995/leo/README.md
+++ b/1995/leo/README.md
@@ -58,13 +58,13 @@ The usage is:
 
 where the first three are literal words, `cycle` is a positive integer (0 is
 ignored), and `freq` is an integer (default = 0) that's supposed to be in the
-range 0..100 (bigger values are allowed, however).  Invalid parameters and
-options usually stop the command line parsing (but not always, why?). The actual
+range `0..100` (bigger values are allowed, however).  Invalid parameters and
+options usually stop the command line parsing (not always but why?). The actual
 position of the word options does not matter, so `./leo right Variable 1 70` is
 equivalent to `./leo 0 0 0 1 Variable 70 right`, etc.
 
-If `Variable' is used, `cycle' is almost ignored (see below) but has
-to be present if you want to enter `freq' (and you usually do).
+If `Variable` is used, `cycle` is almost ignored (see below) but has
+to be present if you want to enter `freq` (and you usually do).
 
 Some options to try (besides the obvious):
 
@@ -77,7 +77,9 @@ This draws the basic pattern I invented in high school:
 You take a big sheet of "arithmetic" paper and draw a line
 of length 1 (between 2 crossings) at the center of the sheet:
 
+```
 				|
+```
 
 This makes 2 open ends (I think the notion of an "open end" doesn't
 require explanations) in step 1. Now, until there are open ends in step N,
@@ -162,7 +164,7 @@ Step 6:
 
 depending on the desired "hairiness". The original (paper-based)
 algorithm was "hairy", but it didn't look as good on the screen.
-\
+
 The program cannot handle non-hairy mode 100% correctly - step 6 happens
 to be
 
@@ -179,7 +181,7 @@ to be
 
 ```
 
-and so on: the horisontal symmetry has been lost. That's why
+and so on: the horizontal symmetry has been lost. That's why
 the opening for step 1 is not a single line but a cross:
 
 ```
@@ -187,7 +189,7 @@ the opening for step 1 is not a single line but a cross:
                                 / \
 ```
 
-To watch it repeatedly (as a screensaver), use:
+To watch it repeatedly (as a screen saver), use:
 
 ```sh
 ./leo 2 | cat - /dev/tty | gs -
@@ -201,7 +203,7 @@ The command line:
 
 draws the same as above. Try:
 
-```sh\
+```sh
 ./leo Variable 1 1 | cat - /dev/tty | gs -
 ```
 
@@ -218,7 +220,7 @@ if you want to pipe the output to a printer.
 begin 664 spoiler1
 M*%1H92!C;VQO;B J:7,J('1H92!S96-R970@<W=I=&-H("T@=&AE('-P86-E
 =(&)E9F]R92!I="!I<R!N;W0@82!M:7-T86ME*0II
-\
+
 end
 ```
 
@@ -231,7 +233,7 @@ as far as it is > 1. To figure out what difference
 ```
 
 and other values of `cycle`; smaller values usually require
-smaller values of `freq` for the patterns to be non-trivial
+smaller values of `freq` for the patterns to be non-trivial.
 
 The options `deep` and `right` make the patterns to be drawn in different
 manners. Try all the examples above with `deep` and with `right`.
@@ -256,8 +258,10 @@ even want to explain what it does. You've been warned!
 Special thanks:
 
 - to PostScript syntax designers for the curly braces;
-- to Dmitry Mendeleyev for his periodic table of elements;
-- to Hydrogen for having 2 more isotopes.
+- to [Dmitry Mendeleyev](https://en.wikipedia.org/wiki/Dmitri_Mendeleev) for his
+[periodic table of elements](https://en.wikipedia.org/wiki/Periodic_table);
+- to [Hydrogen](https://en.wikipedia.org/wiki/Hydrogen) for having 2 more
+[isotopes](https://en.wikipedia.org/wiki/Isotope).
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/1995/leo/spoiler1.md
+++ b/1995/leo/spoiler1.md
@@ -1,0 +1,1 @@
+(The colon *is* the secret switch - the space before it is not a mistake)

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -60,7 +60,7 @@ never be placed on top of a smaller disk.
 
 Our program solves the Towers of Hanoi problem.  Well, that's
 not exactly true; actually, it's the compiler that solves the
-problem.  The resulting program just prints out the correct\
+problem.  The resulting program just prints out the correct
 solution.
 
 How do you trick a compiler into actually solving the problem?
@@ -76,25 +76,24 @@ gcc hanoi.c -o hanoi -Dn=4
 
 A default value of `5` will be used for `n` if you do not define
 it on the command line.  The value of `n` cannot be greater than
-fifteen (the compiler we used to test has a limit on the #include
-depth).  The compiler then solves the problem using binary\
+fifteen (the compiler we used to test has a limit on the `#include`
+depth).  The compiler then solves the problem using binary
 arithmetic based on whether particular symbols are defined or not.
 
-To loop, the program `#include`s itself.  This is, of course,
-expensive; one compile we did with `n=14` took about fifty
-minutes to compile on our system (compiling with `n=15` caused our system to
-crash).
+To loop, the program `#include`s itself.  This is, of course, expensive; one
+compile we did with `n=14` took about fifty minutes to compile on our system
+(compiling with `n=15` caused our system to crash).
 
 The resulting program that the compiler generates simply
 prints out the answer.  Did I say "simply"?  Actually, the
-whole resulting program consists of a single printf statement,
+whole resulting program consists of a single `printf(3)` statement,
 consisting of a massive string constant of length `35*(2^n-1)`,
 followed by `3*(2^n-1)` integers which get formatted into the
 string.  For our `n=14` run, this adds up to a string constant
 of length 573405, followed by 49149 integers delimited by
 commas.  (Generating the string constant depends on the
 ANSI C feature in which adjacent character strings are
-catenated; a version that does not use this feature has been
+concatenated; a version that does not use this feature has been
 included for people who can only run K&R).  A good way to see
 the resulting program (on a Unix system) is to do the command
 
@@ -104,91 +103,93 @@ gcc hanoi.c -E -Dn=5 | grep -v \# | grep -v ^\$
 
 For an odd number of disks, the program will provide a
 solution wherein the disks end up on peg 2; for an even
-number of disks, they will end on peg 3.  This should\
+number of disks, they will end on peg 3.  This should
 provide some hint as to what sort of algorithm is used.
 
 We have included a [spoiler](spoiler.c) version of the program, with
 meaningful symbol names and comments, but we encourage you
 to try to decipher the program without it...
 
-    begin 444 spoiler.c
-    M(VEF;F1E9B`@24Y)5$E!3$E:140*"B\J"B`J("!)9B!N(&ES;B=T(&1E9FEN
-    M960L(&UA:V4@:70@-0H@*B\*(VEF;F1E9B`@;@HC9&5F:6YE("!N(#`U"B-E
-    M;F1I9@H*+RH*("H@4V]M92!U<V5F=6P@=F%R:6%B;&5S"B`J+PHC9&5F:6YE
-    M("!42$E37T9)3$4@7U]&24Q%7U\@"B-D969I;F4@($9/4DU!5%]35%))3D<@
-    M(DUO=F4@9&ES:R`E9"!F<F]M('!E9R`E9"!T;R!P96<@)61<;B(*(V1E9FEN
-    M92`@24Y)5$E!3$E:140*"B\J"B`J(%1R86YS;&%T92!N(&EN=&\@8FET<PH@
-    M*B\*(VEF("`@("`@;B8P,0HC9&5F:6YE("!B:70P"B-E;F1I9@HC:68@("`@
-    M("!N)C`R"B-D969I;F4@(&)I=#$*(V5N9&EF"B-I9B`@("`@(&XF,#0*(V1E
-    M9FEN92`@8FET,@HC96YD:68*(VEF("`@("`@;CX^,PHC9&5F:6YE("!B:70S
-    M"B-E;F1I9@H*+RH*("H@2&5R92=S('1H92!P<F]G<F%M(0H@*B\*;6%I;B@I
-    M>PIP<FEN=&8H"B-I;F-L=61E(%1(25-?1DE,10HC9&5F:6YE("!.3U=?1$]?
-    M5$A%7TY534)%4E,*(VEN8VQU9&4@5$A)4U]&24Q%"BD[?0H*(V5L<V4*"B\J
-    M"B`J($-H96-K('1O('-E92!I9B!T:&4@;G5M8F5R(&ES('IE<F\@*&)O='1O
-    M;2!O9B!R96-U<G-I;VXI"B`J+PHC:69D968@("!B:70P"B-D969I;F4@($Y?
-    M25-?3D]47UI%4D\*(V5N9&EF"B-I9F1E9B`@(&)I=#$*(V1E9FEN92`@3E])
-    M4U].3U1?6D523PHC96YD:68*(VEF9&5F("`@8FET,@HC9&5F:6YE("!.7TE3
-    M7TY/5%]:15)/"B-E;F1I9@HC:69D968@("!B:70S"B-D969I;F4@($Y?25-?
-    M3D]47UI%4D\*(V5N9&EF"@HC:69D968@("!.7TE37TY/5%]:15)/"B-U;F1E
-    M9B`@($Y?25-?3D]47UI%4D\*"B\J"B`J($1E8W)E;65N="!N"B`J+PHC:69N
-    M9&5F("!B:70P"B-D969I;F4@(&)I=#`*(VEF;F1E9B`@8FET,0HC9&5F:6YE
-    M("!B:70Q"B-I9FYD968@(&)I=#(*(V1E9FEN92`@8FET,@HC:69N9&5F("!B
-    M:70S"B-D969I;F4@(&)I=#,*(V5L<V4*(W5N9&5F("`@8FET,PHC96YD:68*
-    M(V5L<V4*(W5N9&5F("`@8FET,@HC96YD:68*(V5L<V4*(W5N9&5F("`@8FET
-    M,0HC96YD:68*(V5L<V4*(W5N9&5F("`@8FET,`HC96YD:68*"B\J"B`J("!(
-    M97)E)W,@<F5C=7)S:6]N"B`J+PHC:6YC;'5D92!42$E37T9)3$4*"B\J"B`J
-    M("!.;W1E.B!/9&0@;G5M8F5R960@9&ES:W,@86QW87ES(&-Y8VQE(&9R;VT@
-    M,2`]/B`R(#T^(#,@/3X@,2`]/B`R(#T^(#,*("H@($5V96X@;G5M8F5R960@
-    M9&ES:W,@86QW87ES(&-Y8VQE(&9R;VT@,2`]/B`S(#T^(#(@/3X@,2`]/B`S
-    M(#T^(#(*("HO"@HO*@H@*B!#:&5C:R!T;R!S964@:68@;B!I<R!Z97)O+B!)
-    M9B!S;RP@=V4G<F4@;6]V:6YG(&1I<VL@,2X*("H@26X@9V5N97)A;"P@9F]R
-    M(&%N>2!N('=E)W)E(&UO=FEN9R!D:7-K(&XK,2X@5&AA="!M96%N<R!T:&%T
-    M"B`J('=H96X@;B!I<R!O9&0L('=E)W)E(&UO=FEN9R!A;B!E=F5N(&1I<VLL
-    M(&%N9"!V:6-E('9E<G-A+@H@*B\*(VEF;F1E9B`@8FET,`HC:69N9&5F("!B
-    M:70Q"B-I9FYD968@(&)I=#(*(VEF;F1E9B`@8FET,PHC9&5F:6YE("!.7TE3
-    M7UI%4D\*(V5N9&EF"B-E;F1I9@HC96YD:68*(V5N9&EF"@HC:69D968@("!.
-    M7TE37UI%4D\*(W5N9&5F("`@3E])4U]:15)/"@HC:69N9&5F("!.3U=?1$]?
-    M5$A%7TY534)%4E,*1D]234%47U-44DE.1PHC96QS90H*+RH*("H@($EF(&1I
-    M<VL@,2!I<R!O;B!P96<@,BP@;6]V92!I="`R(#T^(#,*("HO"B-I9F1E9B`@
-    M($1)4TM?3TY%7TE37T].7U!%1U]45T\*+#$L,BPS"B-U;F1E9B`@($1)4TM?
-    M3TY%7TE37T].7U!%1U]45T\*(V1E9FEN92`@1$E32U]/3D5?25-?3TY?4$5'
-    M7U1(4D5%"B-E;'-E"@HO*@H@*B`@268@9&ES:R`Q(&ES(&]N('!E9R`S+"!M
-    M;W9E(&ET(#,@/3X@,0H@*B\*(VEF9&5F("`@1$E32U]/3D5?25-?3TY?4$5'
-    M7U1(4D5%"BPQ+#,L,0HC=6YD968@("!$25-+7T].15])4U]/3E]014=?5$A2
-    M144*(V5L<V4*"B\J"B`J("!$:7-K(#$@;75S="!B92!O;B!P96<@,2X@36]V
-    M92!I="`Q(#T^(#(*("HO"BPQ+#$L,@HC9&5F:6YE("!$25-+7T].15])4U]/
-    M3E]014=?5%=/"B-E;F1I9@HC96YD:68*(V5N9&EF"B-E;'-E"@HO*@H@*B`@
-    M2&5R92P@=V4@:&%N9&QE(&1I<VMS(#XQ+B!296UE;6)E<B!T:&%T(&]D9',@
-    M8WEC;&4@,2`]/B`R(#T^(#,@/3X@,2P*("H@(&%N9"!E=F5N<R!C>6-L92`Q
-    M(#T^(#(@/3X@,R`]/B`Q+B!#;VUB:6YE('1H:7,@=VET:"!T:&4@:VYO=VQE
-    M9&=E"B`J("!O9B!W:&5R92!D:7-K(#$@:7,L(&%N9"!W92!C86X@9&5T97)M
-    M:6YE(&AO=R!T;R!M;W9E(&%N>2!D:7-K+@H@*B\*(VEF;F1E9B`@3D]77T1/
-    M7U1(15].54U"15)3"D9/4DU!5%]35%))3D<*(V5L<V4*"B\J"B`J("!0<FEN
-    M="!T:&4@9&ES:R!N=6UB97(N(%)E;65M8F5R+"!D:7-K(&YU;6)E<B`](&XK
-    M,0H@*B\*+#$*(VEF9&5F("`@8FET,`HK,0HC96YD:68*(VEF9&5F("`@8FET
-    M,0HK,@HC96YD:68*(VEF9&5F("`@8FET,@HK-`HC96YD:68*(VEF9&5F("`@
-    M8FET,PHK.`HC96YD:68*"B\J"B`J("!$:7-K(#$@;VX@<&5G(#(@"B`J+PHC
-    M:69D968@("!$25-+7T].15])4U]/3E]014=?5%=/"B-I9F1E9B`@(&)I=#`*
-    M+#$L,R`@("`O*B!%=F5N.B`Q(#T^(#,@("AN(&ES(&]D9"P@<V\@=&AE(&1I
-    M<VL@:7,@979E;BD@*B\*(V5L<V4*+#,L,2`@("`O*B`@3V1D.B`S(#T^(#$@
-    M("HO"B-E;F1I9@HC96QS90H*+RH*("H@($1I<VL@,2!O;B!P96<@,R`*("HO
-    M"B-I9F1E9B`@($1)4TM?3TY%7TE37T].7U!%1U]42%)%10HC:69D968@("!B
-    M:70P"BPR+#$@("`@+RH@179E;CH@,B`]/B`Q("HO"B-E;'-E"BPQ+#(@("`@
-    M+RH@($]D9#H@,2`]/B`R("HO"B-E;F1I9@HC96QS90H*+RH*("H@($1I<VL@
-    M,2!O;B!P96<@,2`*("HO"B-I9F1E9B`@(&)I=#`*+#,L,B`@("`O*B!%=F5N
-    M.B`S(#T^(#(@*B\*(V5L<V4*+#(L,R`@("`O*B`@3V1D.B`R(#T^(#,@*B\*
-    M(V5N9&EF"B-E;F1I9@HC96YD:68*(V5N9&EF"B-E;F1I9@H*+RH*("H@($UO
-    M<F4@<F5C=7)S:6]N"B`J+PHC:6YC;'5D92!42$E37T9)3$4*"B\J"B`J("!)
-    M;F-R96UE;G0@;@H@*B\*(VEF9&5F("`@8FET,`HC=6YD968@("!B:70P"B-I
-    M9F1E9B`@(&)I=#$*(W5N9&5F("`@8FET,0HC:69D968@("!B:70R"B-U;F1E
-    M9B`@(&)I=#(*(VEF9&5F("`@8FET,PHC=6YD968@("!B:70S"B-E;'-E"B-D
-    M969I;F4@(&)I=#,*(V5N9&EF"B-E;'-E"B-D969I;F4@(&)I=#(*(V5N9&EF
-    M"B-E;'-E"B-D969I;F4@(&)I=#$*(V5N9&EF"B-E;'-E"B-D969I;F4@(&)I
-    M=#`*(V5N9&EF"@HC96YD:68@("\J("-I9F1E9B!.7TE37TY/5%]:15)/("HO
-    M"@HC96YD:68@("\J("-E;'-E(&]F("-I9FYD968@24Y)5$E!3$E:140@*B\*
-    `
-    end
+```
+begin 444 spoiler.c
+M(VEF;F1E9B`@24Y)5$E!3$E:140*"B\J"B`J("!)9B!N(&ES;B=T(&1E9FEN
+M960L(&UA:V4@:70@-0H@*B\*(VEF;F1E9B`@;@HC9&5F:6YE("!N(#`U"B-E
+M;F1I9@H*+RH*("H@4V]M92!U<V5F=6P@=F%R:6%B;&5S"B`J+PHC9&5F:6YE
+M("!42$E37T9)3$4@7U]&24Q%7U\@"B-D969I;F4@($9/4DU!5%]35%))3D<@
+M(DUO=F4@9&ES:R`E9"!F<F]M('!E9R`E9"!T;R!P96<@)61<;B(*(V1E9FEN
+M92`@24Y)5$E!3$E:140*"B\J"B`J(%1R86YS;&%T92!N(&EN=&\@8FET<PH@
+M*B\*(VEF("`@("`@;B8P,0HC9&5F:6YE("!B:70P"B-E;F1I9@HC:68@("`@
+M("!N)C`R"B-D969I;F4@(&)I=#$*(V5N9&EF"B-I9B`@("`@(&XF,#0*(V1E
+M9FEN92`@8FET,@HC96YD:68*(VEF("`@("`@;CX^,PHC9&5F:6YE("!B:70S
+M"B-E;F1I9@H*+RH*("H@2&5R92=S('1H92!P<F]G<F%M(0H@*B\*;6%I;B@I
+M>PIP<FEN=&8H"B-I;F-L=61E(%1(25-?1DE,10HC9&5F:6YE("!.3U=?1$]?
+M5$A%7TY534)%4E,*(VEN8VQU9&4@5$A)4U]&24Q%"BD[?0H*(V5L<V4*"B\J
+M"B`J($-H96-K('1O('-E92!I9B!T:&4@;G5M8F5R(&ES('IE<F\@*&)O='1O
+M;2!O9B!R96-U<G-I;VXI"B`J+PHC:69D968@("!B:70P"B-D969I;F4@($Y?
+M25-?3D]47UI%4D\*(V5N9&EF"B-I9F1E9B`@(&)I=#$*(V1E9FEN92`@3E])
+M4U].3U1?6D523PHC96YD:68*(VEF9&5F("`@8FET,@HC9&5F:6YE("!.7TE3
+M7TY/5%]:15)/"B-E;F1I9@HC:69D968@("!B:70S"B-D969I;F4@($Y?25-?
+M3D]47UI%4D\*(V5N9&EF"@HC:69D968@("!.7TE37TY/5%]:15)/"B-U;F1E
+M9B`@($Y?25-?3D]47UI%4D\*"B\J"B`J($1E8W)E;65N="!N"B`J+PHC:69N
+M9&5F("!B:70P"B-D969I;F4@(&)I=#`*(VEF;F1E9B`@8FET,0HC9&5F:6YE
+M("!B:70Q"B-I9FYD968@(&)I=#(*(V1E9FEN92`@8FET,@HC:69N9&5F("!B
+M:70S"B-D969I;F4@(&)I=#,*(V5L<V4*(W5N9&5F("`@8FET,PHC96YD:68*
+M(V5L<V4*(W5N9&5F("`@8FET,@HC96YD:68*(V5L<V4*(W5N9&5F("`@8FET
+M,0HC96YD:68*(V5L<V4*(W5N9&5F("`@8FET,`HC96YD:68*"B\J"B`J("!(
+M97)E)W,@<F5C=7)S:6]N"B`J+PHC:6YC;'5D92!42$E37T9)3$4*"B\J"B`J
+M("!.;W1E.B!/9&0@;G5M8F5R960@9&ES:W,@86QW87ES(&-Y8VQE(&9R;VT@
+M,2`]/B`R(#T^(#,@/3X@,2`]/B`R(#T^(#,*("H@($5V96X@;G5M8F5R960@
+M9&ES:W,@86QW87ES(&-Y8VQE(&9R;VT@,2`]/B`S(#T^(#(@/3X@,2`]/B`S
+M(#T^(#(*("HO"@HO*@H@*B!#:&5C:R!T;R!S964@:68@;B!I<R!Z97)O+B!)
+M9B!S;RP@=V4G<F4@;6]V:6YG(&1I<VL@,2X*("H@26X@9V5N97)A;"P@9F]R
+M(&%N>2!N('=E)W)E(&UO=FEN9R!D:7-K(&XK,2X@5&AA="!M96%N<R!T:&%T
+M"B`J('=H96X@;B!I<R!O9&0L('=E)W)E(&UO=FEN9R!A;B!E=F5N(&1I<VLL
+M(&%N9"!V:6-E('9E<G-A+@H@*B\*(VEF;F1E9B`@8FET,`HC:69N9&5F("!B
+M:70Q"B-I9FYD968@(&)I=#(*(VEF;F1E9B`@8FET,PHC9&5F:6YE("!.7TE3
+M7UI%4D\*(V5N9&EF"B-E;F1I9@HC96YD:68*(V5N9&EF"@HC:69D968@("!.
+M7TE37UI%4D\*(W5N9&5F("`@3E])4U]:15)/"@HC:69N9&5F("!.3U=?1$]?
+M5$A%7TY534)%4E,*1D]234%47U-44DE.1PHC96QS90H*+RH*("H@($EF(&1I
+M<VL@,2!I<R!O;B!P96<@,BP@;6]V92!I="`R(#T^(#,*("HO"B-I9F1E9B`@
+M($1)4TM?3TY%7TE37T].7U!%1U]45T\*+#$L,BPS"B-U;F1E9B`@($1)4TM?
+M3TY%7TE37T].7U!%1U]45T\*(V1E9FEN92`@1$E32U]/3D5?25-?3TY?4$5'
+M7U1(4D5%"B-E;'-E"@HO*@H@*B`@268@9&ES:R`Q(&ES(&]N('!E9R`S+"!M
+M;W9E(&ET(#,@/3X@,0H@*B\*(VEF9&5F("`@1$E32U]/3D5?25-?3TY?4$5'
+M7U1(4D5%"BPQ+#,L,0HC=6YD968@("!$25-+7T].15])4U]/3E]014=?5$A2
+M144*(V5L<V4*"B\J"B`J("!$:7-K(#$@;75S="!B92!O;B!P96<@,2X@36]V
+M92!I="`Q(#T^(#(*("HO"BPQ+#$L,@HC9&5F:6YE("!$25-+7T].15])4U]/
+M3E]014=?5%=/"B-E;F1I9@HC96YD:68*(V5N9&EF"B-E;'-E"@HO*@H@*B`@
+M2&5R92P@=V4@:&%N9&QE(&1I<VMS(#XQ+B!296UE;6)E<B!T:&%T(&]D9',@
+M8WEC;&4@,2`]/B`R(#T^(#,@/3X@,2P*("H@(&%N9"!E=F5N<R!C>6-L92`Q
+M(#T^(#(@/3X@,R`]/B`Q+B!#;VUB:6YE('1H:7,@=VET:"!T:&4@:VYO=VQE
+M9&=E"B`J("!O9B!W:&5R92!D:7-K(#$@:7,L(&%N9"!W92!C86X@9&5T97)M
+M:6YE(&AO=R!T;R!M;W9E(&%N>2!D:7-K+@H@*B\*(VEF;F1E9B`@3D]77T1/
+M7U1(15].54U"15)3"D9/4DU!5%]35%))3D<*(V5L<V4*"B\J"B`J("!0<FEN
+M="!T:&4@9&ES:R!N=6UB97(N(%)E;65M8F5R+"!D:7-K(&YU;6)E<B`](&XK
+M,0H@*B\*+#$*(VEF9&5F("`@8FET,`HK,0HC96YD:68*(VEF9&5F("`@8FET
+M,0HK,@HC96YD:68*(VEF9&5F("`@8FET,@HK-`HC96YD:68*(VEF9&5F("`@
+M8FET,PHK.`HC96YD:68*"B\J"B`J("!$:7-K(#$@;VX@<&5G(#(@"B`J+PHC
+M:69D968@("!$25-+7T].15])4U]/3E]014=?5%=/"B-I9F1E9B`@(&)I=#`*
+M+#$L,R`@("`O*B!%=F5N.B`Q(#T^(#,@("AN(&ES(&]D9"P@<V\@=&AE(&1I
+M<VL@:7,@979E;BD@*B\*(V5L<V4*+#,L,2`@("`O*B`@3V1D.B`S(#T^(#$@
+M("HO"B-E;F1I9@HC96QS90H*+RH*("H@($1I<VL@,2!O;B!P96<@,R`*("HO
+M"B-I9F1E9B`@($1)4TM?3TY%7TE37T].7U!%1U]42%)%10HC:69D968@("!B
+M:70P"BPR+#$@("`@+RH@179E;CH@,B`]/B`Q("HO"B-E;'-E"BPQ+#(@("`@
+M+RH@($]D9#H@,2`]/B`R("HO"B-E;F1I9@HC96QS90H*+RH*("H@($1I<VL@
+M,2!O;B!P96<@,2`*("HO"B-I9F1E9B`@(&)I=#`*+#,L,B`@("`O*B!%=F5N
+M.B`S(#T^(#(@*B\*(V5L<V4*+#(L,R`@("`O*B`@3V1D.B`R(#T^(#,@*B\*
+M(V5N9&EF"B-E;F1I9@HC96YD:68*(V5N9&EF"B-E;F1I9@H*+RH*("H@($UO
+M<F4@<F5C=7)S:6]N"B`J+PHC:6YC;'5D92!42$E37T9)3$4*"B\J"B`J("!)
+M;F-R96UE;G0@;@H@*B\*(VEF9&5F("`@8FET,`HC=6YD968@("!B:70P"B-I
+M9F1E9B`@(&)I=#$*(W5N9&5F("`@8FET,0HC:69D968@("!B:70R"B-U;F1E
+M9B`@(&)I=#(*(VEF9&5F("`@8FET,PHC=6YD968@("!B:70S"B-E;'-E"B-D
+M969I;F4@(&)I=#,*(V5N9&EF"B-E;'-E"B-D969I;F4@(&)I=#(*(V5N9&EF
+M"B-E;'-E"B-D969I;F4@(&)I=#$*(V5N9&EF"B-E;'-E"B-D969I;F4@(&)I
+M=#`*(V5N9&EF"@HC96YD:68@("\J("-I9F1E9B!.7TE37TY/5%]:15)/("HO
+M"@HC96YD:68@("\J("-E;'-E(&]F("-I9FYD968@24Y)5$E!3$E:140@*B\*
+`
+end
 
+```
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1865,6 +1865,11 @@ Cody added the [try.sh](1995/dodsond1/try.sh) script that uses the text file he
 provided which is input we suggested one try with the entry.
 
 
+## [1995/esde](1995/esde/esde.c) ([README.md](1995/esde/README.md]))
+
+Cody added the [try.sh](1995/esde/try.sh) script.
+
+
 ## [1995/garry](1995/garry/garry.c) ([README.md](1995/garry/README.md]))
 
 Cody fixed the alt code so that it will compile with modern compilers. The

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1859,6 +1859,12 @@ are too fast ... if there is such a thing anyway :-) ). See the README.md for
 details on this.
 
 
+## [1995/dodsond1](1995/dodsond1/dodsond1.c) ([README.md](1995/dodsond1/README.md]))
+
+Cody added the [try.sh](1995/dodsond1/try.sh) script that uses the text file he
+provided which is input we suggested one try with the entry.
+
+
 ## [1995/garry](1995/garry/garry.c) ([README.md](1995/garry/README.md]))
 
 Cody fixed the alt code so that it will compile with modern compilers. The

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1888,6 +1888,12 @@ to specify which one to use is to make it easier on the user as typing
 running `./garry.alt.test.sh`.
 
 
+## [1995/leo](1995/leo/leo.c) ([README.md](1995/leo/README.md]))
+
+At our change in how to deal with spoilers, Cody uudecoded the spoiler provided
+by the author, putting it in [spoiler1.md](1995/leo/spoiler1.md).
+
+
 ## [1995/makarios](1995/makarios/makarios.c) ([README.md](1995/makarios/README.md))
 
 Cody fixed this so that it will compile with versions of clang that has a defect


### PR DESCRIPTION

The spoiler1.md file is what was once uuencoded (and still is in the
author's remarks) but is no longer desired to be so.

This should complete 1995/leo and I believe this finishes 1995 too.