### PR TITLE
Format fix in 1990/pjr

### DIFF
--- a/1990/pjr/README.md
+++ b/1990/pjr/README.md
@@ -70,7 +70,7 @@ It is simple to make the program print other strings.  Each
 alphabetical character from a to z is printed out as its
 opposite:
 
-```c
+```
 a->z b->y c->x etc
 ```
 


### PR DESCRIPTION
A code block was erroneously stated to be C due to the -> operator being there but actually it's not any operator but rather a transition from one to the next.