### PR TITLE
Make 1992/kivinen/kivinen.c alt code

### DIFF
--- a/1991/ant/ant.alt.c
+++ b/1991/ant/ant.alt.c
@@ -1,0 +1,28 @@
+#include <ctype.h>
+#include <curses.h>
+#define T isspace(*(t=Z(p)))&&
+#define V return
+#define _ while
+int d,i,j,m,n,p,q,x,y;char*c,b[BUF],*f,*g=b,*h,k[]="hjklbJKw0$tbixWRq",*t;
+char*Z(a){if(a<0)V b;V b+a+(b+a<g?0:h-g);}P(a)char*a;{V
+a-b-(a<h?0:h-g);}S(){p=0;}bf(){n=p=P(c);}Q(){q=1;}C(){clear();Y();}
+G(){t=Z(p);_(t<g)*--h= *--g;_(h<t)*g++= *h++;p=P(h);}B(){_(!T b<t)--p;_(T
+b<t)--p;}M(a){_(b<(t=Z(--a))&&*t-'\n');V
+b<t?++a:0;}N(a){_((t=Z(a++))<c&&*t-'\n');V
+t<c?a:P(c);}A(a,j){i=0;_((t=Z(a))<c&&*t-'\n'&&i<j){i+= *t-'\t'?1:8-(i&7);++a;}V
+a;}L(){0<p&&--p;}R(){p<P(c)&&++p;}U(){p=A(M(M(p)-1),x);}
+D(){p=A(N(p),x);}H(){p=M(p);}E(){p=N(p);L();}
+J(){m=p=M(n-1);_(0<y--)D();n=P(c);}K(){j=d;_(0<--j)m=M(m-1),U();}
+I(){G();_((j=getch())-'\x1b'){if(j-'\b')g-h&&(*g++=j-'\r'?j:'\n');else
+b<g&&--g;p=P(h);Y();}}X(){G();p=h<c?P(++h):p;}
+F(){j=p;p=0;G();write(i=creat(f,MODE),h,(int)(c-h));close(i);p=j;}W(){_(!T
+t<c)++p;_(T
+t<c)++p;}int(*z[])()={L,D,U,R,B,J,K,W,H,E,S,bf,I,X,F,C,Q,G};
+Y(){m=p<m?M(p):m;if(n<=p){m=N(p);i=m-P(c)?d:d-2;_(0<i--)m=M(m-1);}
+move(0,0);i=j=0;n=m;_(1){p-n||(y=i,x=j);t=Z(n);if(d<=i||c<=t)break;
+if(*t-'\r')addch(*t),j+= *t-'\t'?1:8-(j&7);if(*t=='\n'||COLS<=j)
+++i,j=0;++n;}clrtobot();++i<d&&mvaddstr(i,0,"<< EOF >>");move(y,x);
+refresh();}main(u,v)char**v;{h=c=b+BUF;if(u<2)V
+2;initscr();d=LINES;raw();noecho();idlok(stdscr,1);if(0<(i=open(f= *++v,0))){
+g+=read(i,b,BUF);g=g<b?b:g;close(i);}S();_(!q){Y();i=0;j=getch();
+_(k[i]&&j-k[i])++i;(*z[i])();}endwin();V 0;}

--- a/1992/kivinen/.gitignore
+++ b/1992/kivinen/.gitignore
@@ -1,3 +1,4 @@
 kivinen
+kivinen.alt
 kivinen.orig
 prog.orig

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -58,7 +58,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -DZ=15000
+CDEFINE= -DZ=20000
 
 # Include files that are needed to compile
 #
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1992/kivinen/README.md
+++ b/1992/kivinen/README.md
@@ -3,14 +3,14 @@
 If your machine support the X Window System, Version 11:
 
 ```sh
-make all
+make alt
 ```
 
-NOTE: this entry requires `X11/Xlib.h` header file and the X11 library to
-compile. macOS users running Mountain Lion and later will need to download and
-install [XQuartz](https://www.xquartz.org) in order to compile and run this
-entry.
+We recommend the alt version first as the original goes too fast on modern
+systems. See [original code](#original-code) for the original should you wish to
+see what we mean.
 
+You can reconfigure the value to `usleep(3)`; see [try](#try) section below.
 
 ### Bugs and (Mis)features:
 
@@ -26,14 +26,44 @@ For more detailed information see [1992 kivinen in bugs.md](/bugs.md#1992-kivine
 ### Try:
 
 ```sh
-./kivinen
+./kivinen.alt
 
-./kivinen a
+./kivinen.alt a
 
-./kivinen a b
+./kivinen.alt a b
 ```
 
 See also the author's remarks for other variations.
+
+Also try changing the speed this game moves. For instance if you wish to change
+the `usleep(3)` value to `30000` from `20000`, try:
+
+```sh
+make clobber CDEFINE="-DZ=30000" alt # make it slower
+
+make clobber CDEFINE="-DZ=10000" alt # make it faster
+```
+
+Then use the same syntax as above and described by the author.
+
+
+## Original code:
+
+As noted above, the alt version is recommended because the code goes too fast in
+modern systems. If you wish to see the original you may do so with the original
+code.
+
+
+### Original build:
+
+```sh
+make all
+```
+
+
+### Original use:
+
+Use `kivinen` as you would `kivinen.alt`.
 
 
 ## Judges' remarks:

--- a/1992/kivinen/kivinen.alt.c
+++ b/1992/kivinen/kivinen.alt.c
@@ -35,5 +35,5 @@
       (s[w]		      ==S.window)x&&v||			 w ^1?
       XUnmapWindow		   (d,s[w])		  ,s[w]=0,c--:
       0,l=1; if(!x&&l)j=			    -j,l=0; if(l&x&&!v
-      )u=~19,c--,l=0;t=(!x||!v)		     &&(y<5&&t<0||y>95&&t>0)?0
-	 :t;s[1]?X(1,y+=x&v?t:t/(x+1),130):exit(++c);};return(c);}
+      )u=~19,c--,l=0;t=(!x||!v)		   &&(y<5&&t<0||y>95&&t>0)?0:t
+      ;s[1]?X(1,y+=x&v?t:t/(x+1),130):exit(++c);usleep(Z);};return c;}

--- a/2006/toledo2/toledo2.alt.c
+++ b/2006/toledo2/toledo2.alt.c
@@ -1,0 +1,62 @@
+                               #include <stdio.h>
+                               #include <stdlib.h>
+                               #include <unistd.h>
+			       #include <conio.h>
+			       #include <signal.h>
+           #define n(o,p,e)=y=(z=a(e)%16 p x%16 p o,a(e)p x p o),h(
+                                #define s 6[o]
+             #define p z=l[d(9)]|l[d(9)+1]<<8,1<(9[o]+=2)||++8[o]
+                                #define Q a(7)
+           #define w 254>(9[o]-=2)||--8[o],l[d(9)]=z,l[1+d(9)]=z>>8
+                               #define O )):((
+                  #define b (y&1?~s:s)>>"\6\0\2\7"[y/2]&1?0:(
+                               #define S )?(z-=
+                    #define a(f)*((7&f)-6?&o[f&7]:&l[d(5)])
+                               #define C S 5 S 3
+                       #define D(E)x/8!=16+E&198+E*8!=x?
+                             #define B(C)fclose((C))
+                       #define q (c+=2,0[c-2]|1[c-2]<<8)
+                          #define m x=64&x?*c++:a(x),
+                         #define A(F)=fopen((F),"rb+")
+                    unsigned char o[10],l[78114],*c=l,*k=l
+                          #define d(e)o[e]+256*o[e-1]
+#define h(l)s=l>>8&1|128&y|!(y&255)*64|16&z|2,y^=y>>4,y^=y<<2,y^=~y>>1,s|=y&4
++64506; FILE *u, *v, *e, *V; int x,y,z,Z; main(r,U)char**U;{
+
+     { { { } } }       { { { } } }       { { { } } }       { { { } } }
+    { { {   } } }     { { {   } } }     { { {   } } }     { { {   } } }
+   { { {     } } }   { { {     } } }   { { {     } } }   { { {     } } }
+   { { {     } } }   { { {     } } }   { { {     } } }   { { {     } } }
+   { { {     } } }   { { {     } } }   { { {     } } }   { { {     } } }
+    { { {   } } }    { { {     } } }    { { {   } } }    { { {     } } }
+      { { ; } }      { { {     } } }      { { ; } }      { { {     } } }
+    { { {   } } }    { { {     } } }    { { {   } } }    { { {     } } }
+   { { {     } } }   { { {     } } }   { { {     } } }   { { {     } } }
+   { { {     } } }   { { {     } } }   { { {     } } }   { { {     } } }
+   { { {     } } }   { { {     } } }   { { {     } } }   { { {     } } }
+    { { {   } } }     { { {   } } }     { { {   } } }     { { {   } } }
+     { { { } } }       { { { } } }       { { { } } }       { { { } } }
+
+
+signal(SIGINT, SIG_IGN); for(v A((u A((e A((r-2?0:(V A(1[U])),"C")
+),fread(l,78114,1,e),B(e),"B")),"A")); 118-(x
+=*c++); (y=x/8%8,z=(x&199)-4 S 1 S 1 S 186 S 2 S 2 S 3 S 0,r=(y>5)*2+y,z=(x&
+207)-1 S 2 S 6 S 2 S 182 S 4)?D(0)D(1)D(2)D(3)D(4)D(5)D(6)D(7)(z=x-2 C C C C
+C C C C+129 S 6 S 4 S 6 S 8 S 8 S 6 S 2 S 2 S 12)?x/64-1?((0 O a(y)=a(x) O 9
+[o]=a(5),8[o]=a(4) O 237==*c++?((int (*)())(2-*c++?fwrite:fread))(l+*k+1[k]*
+256,128,1,(fseek(y=5[k]-1?u:v,((3[k]|4[k]<<8)<<7|2[k])<<7,Q=0),y)):0 O y=a(5
+),z=a(4),a(5)=a(3),a(4)=a(2),a(3)=y,a(2)=z O c=l+d(5) O y=l[x=d(9)],z=l[++x]
+,x[l]=a(4),l[--x]=a(5),a(5)=y,a(4)=z O 2-*c?Z||Z=kbhit()?getch():0,1&*c++?Q=Z,Z=0:(
+Q=!!Z):(c++,Q=r=V?fgetc(V):-1,s=s&~1|r<0) O++c,putchar(7[o]) O z=c+2-l,w,
+c=l+q O p,c=l+z O c=l+q O s^=1 O Q=q[l] O s|=1 O q[l]=Q O Q=~Q O a(5)=l[x=q]
+,a(4)=l[++x] O s|=s&16|9<Q%16?Q+=6,16:0,z=s|=1&s|Q>159?Q+=96,1:0,y=Q,h(s<<8)
+O l[x=q]=a(5),l[++x]=a(4) O x=Q%2,Q=Q/2+s%2*128,s=s&~1|x O Q=l[d(3)]O x=Q  /
+128,Q=Q*2+s%2,s=s&~1|x O l[d(3)]=Q O s=s&~1|1&Q,Q=Q/2|Q<<7 O Q=l[d(1)]O s=~1
+&s|Q>>7,Q=Q*2|Q>>7 O l[d(1)]=Q O m y n(0,-,7)y) O m z=0,y=Q|=x,h(y) O m z=0,
+y=Q^=x,h(y) O m z=Q*2|2*x,y=Q&=x,h(y) O m Q n(s%2,-,7)y) O m Q n(0,-,7)y)  O
+m Q n(s%2,+,7)y) O m Q n(0,+,7)y) O z=r-8?d(r+1):s|Q<<8,w O p,r-8?o[r+1]=z,r
+[o]=z>>8:(s=~40&z|2,Q=z>>8) O r[o]--||--o[r-1]O a(5)=z=a(5)+r[o],a(4)=z=a(4)
++o[r-1]+z/256,s=~1&s|z>>8 O ++o[r+1]||r[o]++O o[r+1]=*c++,r[o]=*c++O z=c-l,w
+,c=y*8+l O x=q,b z=c-l,w,c=l+x) O x=q,b c=l+x) O b p,c=l+z) O a(y)=*c++O r=y
+,x=0,a(r)n(1,-,y)s<<8) O r=y,x=0,a(r)n(1,+,y)s<<8))));
+system("stty cooked echo"); B((B((V?B(V):0,u)),v)); }

--- a/bugs.md
+++ b/bugs.md
@@ -1026,8 +1026,8 @@ not exist in the archive. Do you have it? Please provide it!
 ### Source code: [1993/cmills/cmills.c](1993/cmills/cmills.c)
 ### Information: [1993/cmills/README.md](1993/cmills/README.md)
 
-We are unsure if this is a problem with multiple platforms but in macOS at least
-the program appears to just shows a black screen.
+In multiple platforms, both macOS and also linux (in particular a RHEL 9.3
+system), this entry just shows a blank screen.
 
 Can you fix it? We welcome your help.
 

--- a/bugs.md
+++ b/bugs.md
@@ -1041,7 +1041,8 @@ Can you fix it? We welcome your help.
 This entry relied on a bug in gcc that was fixed with gcc version 2.3.3. This
 cannot be fixed for modern systems as the bug is long gone.
 
-An alternate version, however, does exist. See the README.md file for details.
+An alternate version that will work for modern systems, however, does exist. See
+the README.md file for details.
 
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1391,15 +1391,16 @@ should have been removed.
 ## [1992/adrian](1992/adrian/adrian.c) ([README.md](1992/adrian/README.md]))
 
 Cody fixed the code so that it will try opening the file the code was compiled
-from (`__FILE__`), not	`adgrep.c`, as
-the latter does not exist: `adgrep` is simply a link to `adrian` as `adgrep` is
-what the program was submitted as but the winner is `adrian.c`.
+from (`__FILE__`), not	`adgrep.c`, as the latter does not exist: `adgrep` is
+simply a link to `adrian` as `adgrep` is what the program was submitted as but
+the winner is `adrian.c`.
 
-Not fixing this would cause the program to crash if no arg was specified as the
-file did not exist. In doing this, at first the change to check for a NULL file
-was added. Then it was noticed that the problem is that `adgrep.c` was an
-incorrect reference that was never fixed in any of the files, not the code or
-the documentation. A fun fact is that one can do:
+Not fixing the above problem would have also cause the program to crash if no
+arg was specified as the file doesn't exist. In making the above fix, at first
+the change to check for a `NULL` file was added. Then it was noticed that the
+problem is that `adgrep.c` was an incorrect reference that never existed and it
+was never fixed in any of the files, not the code or the documentation, and thus
+was entirely incorrect code. A fun fact is that one can do:
 
 ```c
 W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(1);
@@ -1423,24 +1424,24 @@ Cody also restored a slightly more obscure line of code that had been changed:
 +   putc(i["}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR"]+i-9,stderr);
 ```
 
-though it's questionable how much more (if at all) obscure that is.
+though it's questionable how much more (if at all) obscure that is :-)
 
 Cody also changed the location that it used `gets()` to be `fgets()` instead to
 make it safer and to prevent annoying warnings during compiling, linking or
 runtime (interspersed with the program's output). This was complicated because
-of how the other source files are generated, as noted above; simply changing the
-code could cause invalid output in the program which made other files fail to
-compile (for this example specifically, see below).
+of how the other source files are generated (as above); simply changing the code
+could cause invalid output in the program which made other files fail to compile
+(for this example specifically, see below).
 
 One might think that simply changing the `gets()` to `fgets()` (with `stdin`)
 would work but it did not because `fgets()` stores the newline and `gets()` does
-not. That is well known but this code was relying on not having this newline
-(see also above).
+not. That is well known but this code was relying on not having this newline in
+a different way (see also above).
 
 With `fgets()` the code `if(A(Y)) puts(Y);` ended up printing an extra line
 which made the generation of some files (like `adhead.c`) fail to compile. Why?
-There was a blank line after a `\` at the end of the first line of a macro
-definition!  Thus the code now first trims off the last character of the buffer
+There was a blank line after a `\` at the end of the first line of a _macro
+definition_! Thus the code now first trims off the last character of the buffer
 read to get the same correct functionality but in a safe and non obnoxious way.
 
 Later Cody improved the change to `fgets()` to make it slightly more like the
@@ -1467,9 +1468,10 @@ the additional tools.
 
 Cody fixed this to compile with modern systems. Note that in 1996 a bug fix was
 applied to the code, provided as the alt code as that version is not obfuscated.
-Thus Cody's fixed applies to the original entry. The problems were that
-`malloc.h` is not the correct header file now and a non-void (implicit int)
-function returning without a value. The function was changed to return void.
+Thus Cody's fix applies to the original entry. The problems were that `malloc.h`
+is not the correct header file now (at least in some systems?) and a non-void
+(implicit int) function returning without a value. That function was changed to
+return void.
 
 
 ## [1992/ant](1992/ant/ant.c) ([README.md](1992/ant/README.md]))
@@ -1495,7 +1497,8 @@ necessary to include `time.h` so Cody did this as well.
 
 Cody added a check for the right number of args, exiting 1 if not enough (2)
 used. This was not originally done but at a time it was changed to be considered
-a bug so it was fixed at that point as it only took a few seconds.
+a bug so it was fixed at that point as it only took a few seconds and had to be
+verified that it was consistent with the [bugs.md](/bugs.md) file.
 
 He also added the [try.sh](1991/buzzard.1/try.sh) script to try out some
 commands that we suggested and some additional ones that provide for some fun.
@@ -1522,14 +1525,15 @@ loop).
 
 Cody also added the [mkdict.sh](1992/gson/mkdict.sh) script that the author
 included in their remarks. See the README.md for its purpose. It was NOT fixed
-for ShellCheck because the author deliberately obfuscated it.
+for ShellCheck because the author deliberately obfuscated it so **PLEASE DO NOT
+FIX THIS**.
 
 
 ## [1992/imc](1992/imc/imc.c) ([README.md](1992/imc/README.md]))
 
 The original code, [imc.orig.c](1992/imc/imc.orig.c), assumed that `exit(3)`
 returned a value but this will cause problems where `exit(3)` returns void. The
-source code was modified to avoid this problem but like Cody did with otherfixes
+source code was modified to avoid this problem but like Cody did with other fixes
 he made this more like the original by redefining `exit` to use the comma
 operator so that it could be used in binary expressions.
 
@@ -1537,8 +1541,8 @@ operator so that it could be used in binary expressions.
 ## [1992/kivinen](1992/kivinen/kivinen.c) ([README.md](1992/kivinen/README.md]))
 
 It was observed that on modern systems this goes much too quick. Yusuke created
-a patch that calls `usleep()` but Cody thought the value was too slow so he made
-it a macro in the Makefile `Z`, defaulting at 15000. You can reconfigure it
+a patch that calls `usleep(3)` but Cody thought the value was too slow so he
+made it a macro in the Makefile `Z`, defaulting at 15000. You can reconfigure it
 like:
 
 ```sh

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1542,15 +1542,16 @@ operator so that it could be used in binary expressions.
 
 It was observed that on modern systems this goes much too quick. Yusuke created
 a patch that calls `usleep(3)` but Cody thought the value was too slow so he
-made it a macro in the Makefile `Z`, defaulting at 15000. You can reconfigure it
-like:
+made it a macro in the Makefile `Z`, defaulting at 15000. This was made an [alt
+version](1992/kivinen/kivinen.alt.c) and it is recommended one use the alt
+version first. See the README.md file to see how to reconfigure it.
 
-```sh
-make clobber Z=1000 all
-```
-
-This was not made an alternate version because it moves so fast that it's nigh
-impossible to use otherwise.
+Cody also made the fixed version (the code relied on `exit(3)` returning to use
+in binary expressions) (and alt code from it) more like the original by renaming
+the `ext` macro to be `exit` which uses the comma operator. He made it so the
+line lengths match the original code, at least as best as possible (if not
+perfectly), including start and end columns, often (if not all) with the same
+start and end character.
 
 Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back.


### PR DESCRIPTION

Originally the main version was changed to have a call to usleep(3) as
the game moves so fast. It was discussed a while back however to in
cases like this to make it so that the build/use/try sections refer to
the alt code and then instead of an alternate code section have an
original code section. Because of this the modified code was changed to
be an alt version and then restore the original with the fixed code.

As for the fixed code (and also alt code) I have made it look more like 
the original by changing the 'ext' macro to be 'exit' (with the comma
operator). I tried and believe I succeeded (mostly if not totally) in
making the lines start and end on the same columns and in at least some
lines the same character starts and ends the lines as the original.