### PR TITLE
Add 1998/dloweneil alt code + formatting

### DIFF
--- a/1998/dloweneil/.gitignore
+++ b/1998/dloweneil/.gitignore
@@ -1,4 +1,6 @@
 dloweneil
+dloweneil.alt
 pootris
+pootris.alt
 dloweneil.orig
 prog.orig

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -111,8 +111,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG} pootris
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt pootris.alt
 
 
 #################
@@ -138,6 +138,14 @@ pootris: ${PROG}
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+pootris.alt: ${PROG}.alt
+	${RM} -f $@
+	${CP} $< $@
+
 
 # data files
 #

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -4,6 +4,10 @@
 make all
 ```
 
+There is an alternate version available that has a key configuration that will
+be more familiar to vi(m) users and also allows one to quit. See [alternate
+code](#alternate-code) below.
+
 
 ### Bugs and (Mis)features:
 
@@ -32,6 +36,27 @@ of the playing field.
 Pressing `d` drops the current letter onto the board.
 
 
+## Alternate code:
+
+This version has it so that where in addition to `a` moving you
+anticlockwise/counterclockwise `h` does as well; and in addition to `s` moving
+clockwise `l` does as well. Instead of using `d` to drop the letter you can do
+`j` or space. Finally to quit this version you can press `q`.
+
+
+### Alternate build:
+
+```sh
+make alt
+```
+
+### Alternate use:
+
+```sh
+./pootris.alt
+```
+
+
 ## Judges' remarks:
 
 Read the authors' remarks below to find out how to play.  We believe that your
@@ -54,25 +79,27 @@ I spelled my first "poot".  I was hooked ...
 
 ### Synopsis
 
-The object of this game is to spell "POOT" as much as possible.  There
+The object of this game is to spell `POOT` as much as possible.  There
 is no time pressure.  You're given one letter at a time (sort of randomly
 chosen from the set 'P', 'O', and 'T') and you get to move it freely
 around the border of the playing board, and decide when and where to drop
 it into the board.  Sound easy?  Of course, there's a catch...
 
+
 ### Controls
 
 Only three controls:
 
-'a' moves the current letter one position counterclockwise around
-    the border of the playing field.
+`a`: moves the current letter one position counterclockwise around
+     the border of the playing field.
 
-'s' moves the current letter one position clockwise around the border
-    of the playing field.
+`s`: moves the current letter one position clockwise around the border
+     of the playing field.
 
-'d' drops the current letter onto the board.
+`d`: drops the current letter onto the board.
 
 To quit, send a fatal signal to the process.
+
 
 ### Rules of motion
 
@@ -93,6 +120,7 @@ a side wall.
 
 The letters stop when they hit another letter or the bottom of the board.
 
+
 ### Rules of spelling
 
 - When you spell `POOT` on the board, in any direction, the letters comprising
@@ -102,6 +130,7 @@ disappeared letters will 'fall'.
 - Letters can be used in multiple spellings of `POOT`.
 
 - Chain reactions are possible.
+
 
 ### Rules of scoring
 
@@ -135,10 +164,11 @@ systems when dropping pieces into the game board.
 
 - Simple and silly ones: short, meaningless (and sometimes misleading (see `x`))
 variable names; hard-coded ASCII numeric values used for character constants;
-using goto for fun and profit; reusing and re-purposing variables in different
+using `goto` for fun and profit; reusing and re-purposing variables in different
 places.
 
 - The game itself is simple, but still weird and quite difficult.
+
 
 ### Some things I wish I could have fit into this, but didn't have the space:
 

--- a/1998/dloweneil/dloweneil.alt.c
+++ b/1998/dloweneil/dloweneil.alt.c
@@ -1,0 +1,67 @@
+#include<curses.h>
+#include<stdlib.h>
+#include<unistd.h>
+#define E x/Y
+#define F x%Y
+#define P(  o  ,  O  ,  t  )  move  (  o  +  3  ,  O  +  3  )  ;  addch  ( t );
+#define I(n) ( 2 * ( n / ( X + Y ) ) - 1 + ( ( n % ( X + Y ) - X ) < 0 ? 1 :2))
+#define D(T) switch(I(p)){ case 3:P(2*(X+Y)-1-p,-2,T); break; case 2:P(Y+1,2*X\
++ Y-p -1, T);  break;  case 1:P(p-X, 1 +X, T);  break;  case 0: P( -2, p, T); }
+#define R for(x=0; x<X*Y; x++){ P(F,E,(L[E][F]>84)?42:L[E][F]); } move(5+Y,2) \
+;  clrtoeol();  printw("score: %d", s);  move(0, 0);  clrtoeol() ;  refresh() ;
+
+ int main(int t, char *u[]) { char c, *C="POOT", L[99
+ ][                                                99
+ ]; int X, Y, n, x, a, b, A,  B, p, s, S ; X = Y=  p=
+                          s=  0;               if  (t
+                          ==  3)               {   X=
+                          atoi (               u[ 1])
+                           ; Y  = atoi(u[2]); }   if
+                            (X                   <6
+                             || X > 98|| Y > 98 ||
+
+      Y < 6 ) { X = 15 ; Y = 12; }
+  initscr                      (); for
+ (x        =0; x < X * Y; x++        ){
+ L[     E][F                ]=32    ; P
+ (-    1,                      E,    45
+ );    P(                      Y,    E,
+ 45     ); P                (F,-     1,
+ 124       ); P(F, X, 124); }        P(
+  -1, -1,                      43); P(
+      -1, X, 43) ; P(Y, -1, 43 ) ;
+
+      P(Y,X,43); c=C[random()%4];
+  D(c); R                     ; for(; 
+ ; )      { switch (x = getch       ()
+ ){case 113:endwin();exit(0);case 97:case       104:     D(
+ 32    );                     if   (--
+ p<    0)                     p=    (X
+  +Y    )*2-1;           break;   case
+ 115:case 108:D(32); if(++p >       (X
+  +Y)* 2-                     1) p =0
+      ; break ;case 32:  case 106:a=((
+                                    n=I(p))%2)
+                                    ?X      +(
+                                    n/2)*(  1-
+                                        X)  -1
+                                        :(  1-
+n)*p+(n/2)*(2*X+Y-1); b = (n%2)?((n/2)?(2*  (X
++Y                                          )-
+p-1): (p-X)) :Y+ ((2-n) /2) *(1-Y)-1; if(L  [a
+                                        ][  b]
+                                        !=  32
+                                    )break ; A
+                                    =(      n%
+                                    2)?n-2:(n-
+
+1)*((c%3-1)*-1); B=(n%2)?(n-2)*((c%3-1)*(-1)):(n-1)*-1; D(32); for(; ; ){ P(b,
+a,32); if((!a)&&A<0)if(!B){ A=0; B=1; } else A*=-1; if((!b)&&B<0)B*=-1; if(( a
+==(X-1))&&A>0)if(!B){ A=0; B=1; } else A*=-1; if(((b==(Y-1))&&B>0)||(L[a+A][b+
+B]!=32))break; a+=A; b+=B; P(b,a,c); move(0,0); refresh(); usleep(5000); } ++s
+; L[a][b]=c; c=C[random()%4]; p=0; f:for(S=1,x=0; x<X*Y; x++)for(A=-1; A<2; ++
+A)for(B=-1; B<2; ++B)for(n=0; n<4; n++){ a=E+n*A; b=F+n*B; if((!(a<X&&b<Y&&a>=
+0&&b>=0))||((L[a][b]!=C[n])&&((L[a][b]-9)!=C[n])))break; if(n==3)for(n=0; n<4;
+n++,S*=2)L[E+n*A][F+n*B]+=9; } if(S>1){ R; sleep(1); s+=S; for(x=0; x<X; x++ )
+do for(n=0,a=Y-1; a>=0; a--){ if(L[x][a]>84)n=1; if(n)L[x][a]=a>0?L[x][a-1]:32
+;   }  while  (  n  )  ;  R  ;  goto  f  ;  }   }  D  (  c  )  ;  R  ;   }   }

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2048,6 +2048,13 @@ Cody added a call to `endwin()` to restore terminal sanity (echo etc.) when
 exiting the program.
 
 
+## [1998/dloweneil](1998/dloweneil/dloweneil.c) ([README.md](1998/dloweneil/README.md]))
+
+Cody added [alt code](1998/dloweneil/dloweneil.alt.c) which has vi(m) movement
+(in addition to the other keys except for dropping it's not `d` but `j` or
+space) keys as well as allowing one to quit the game.
+
+
 ## [1998/dorssel](1998/dorssel/dorssel.c) ([README.md](1998/dorssel/README.md]))
 
 Cody added the [try.sh](1998/dorssel/try.sh) script.


### PR DESCRIPTION
The alt code should feel more at home for vi(m) users with movements. With the exception of the drop key (d in the original) you can use the original keys as well. Keys to drop the letter in alt version j or space, whichever you prefer. Also you can quit the game gracefully (q). That was something the author(s)? noted as something they wish they could have done but due to contest size restrictions they could not.

The README.md file has been format and typo checked and this should complete the review of this entry.