### PR TITLE
Improve try.sh and compile.sh in 1989/westley

### DIFF
--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -40,8 +40,9 @@ include ../../var.mk
 #
 CSILENCE= -Wno-comment -Wno-error -Wno-implicit-function-declaration \
 	-Wno-logical-op-parentheses -Wno-deprecated-non-prototype \
-	-Wno-int-conversion -Wno-return-type \
-	-Wno-comma -Wno-missing-variable-declarations -Wno-unused-value
+	-Wno-int-conversion -Wno-return-type -Wno-parentheses \
+	-Wno-comma -Wno-missing-variable-declarations -Wno-unused-value \
+	-Wno-implicit-int -Wno-missing-parameter-type -Wno-pointer-to-int-cast
 
 # Common C compiler warning flags
 #

--- a/1989/westley/compile.sh
+++ b/1989/westley/compile.sh
@@ -5,39 +5,44 @@
 # To change what compiler is used you can do something like:
 #
 #	CC=/path/to/cc ./compile.sh
+#	CC=gcc ./compile.sh
 #
-# The following example was run on a MacBook Pro with the M1 Max which which
-# could not normally compile everything because macOS's compiler, even when run
-# as gcc, is actually clang:
+# The path is only necessary if the default using the shell would result in the
+# wrong one for instance in macOS /usr/bin/gcc is actually clang but if you have
+# gcc installed elsewhere you can specify the path. If CC is unset it will be
+# set to 'cc'.
 #
-#	CC=/opt/local/bin/gcc-mp-12 ./compile.sh	
+# The following example was run on a MacBook Pro (with the M1 Max) which which
+# could not normally compile everything by default because clang can only compile some of
+# the versions due to defects in clang. Getting clang to compile any version was
+# an incredible challenge but some versions of the generated code can be
+# compiled with clang. Nevertheless if you have gcc from, say, MacPorts,
+# installed, you could do:
 #
-# We sleep (by default) for approximately 1 second after each command so that
-# the you can read what is being done. If this is too fast you can change it in
-# a similar way to the above but using the variable DELAY like so:
+#	CC=/opt/local/bin/gcc-mp-13 ./compile.sh	
+#
+# If you don't specify a path the shell/script will figure it out.
+#
+# We sleep (by default) for 0 seconds after each command but one can set that to
+# a different value so that it's easier for them to read what is being done. For
+# instance to change it to 2 seconds:
 #
 #	DELAY=2 ./compile.sh
 #
 # You can of course use both variables in the same command line like:
 #
-#	CC=/opt/local/bin/gcc-mp-12 DELAY=2 ./compile.sh
-#	DELAY=2 CC=/opt/local/bin/gcc-mp-12 ./compile.sh
+#	CC=/opt/local/bin/gcc-mp-13 DELAY=2 ./compile.sh
+#	DELAY=2 CC=/opt/local/bin/gcc-mp-13 ./compile.sh
 #
 # ...and so on.
 
 # get the compiler using default cc if not specified in the command line
 #
-# we cannot use the form '${CC:=cc}' because at least in some versions of bash
-# it tries to invoke the command which would be an error by itself. Thus we just
-# check if it's empty before we set it.
 if [[ -z "$CC" ]]; then
     CC="cc"
 fi
 
 # get sleep duration
-# we cannot use the form '${DELAY:=5}' because at least in some versions of bash
-# it tries to invoke the command and obviously that won't work. Thus we check if
-# it's empty before setting the default.
 if [[ -z "$DELAY" ]]; then
     DELAY=0
 fi
@@ -45,7 +50,8 @@ fi
 # make clobber to make the directory clean and then compile westley which we
 # need to run everything else. Exit if make westley fails as there would be
 # nothing further that could be done in that case:
-echo "$ make clobber westley"
+#
+echo "$ make clobber westley" 1>&2
 sleep "$DELAY"
 make CC="$CC" clobber westley || exit 1
 sleep "$DELAY"

--- a/1989/westley/try.sh
+++ b/1989/westley/try.sh
@@ -1,93 +1,128 @@
 #!/usr/bin/env bash
+#
+# Script to automate the try commands of 1989/westley.
+#
+# If you need to pass a different compiler, say because your compiler is clang,
+# you can use the CC environmental variable like:
+#
+#   CC=gcc ./try.sh
+#
+# This will be passed to compile.sh.
+#
+# If CC is empty (not specified) it defaults to 'cc'. After it is set to either
+# 'cc' or the compiler specified it will use 'compile.sh' with the passed in (or
+# default 'cc') CC var to make use of it.
+#
+# If CC is a path it will use that; otherwise it will let the script find the
+# path via the shell. This is useful for this entry in particular because in
+# macOS /usr/bin/gcc is actually clang and some of the versions of this entry
+# will not compile with clang due to defects. Getting any version to compile
+# with clang was an incredible challenge and it seems impossible to get all the
+# versions to compile with clang but if you only have access to clang (for
+# example in macOS /usr/bin/gcc is actually clang) you can at least get some
+# entries to work.
+#
+# But if you have gcc installed, say with MacPorts, you could do something like:
+#
+#   CC=/opt/local/bin/gcc-mp-13 ./try.sh
+#
 
-# first compile everything or at least try to
-./compile.sh
+# get the compiler using default cc if not specified in the command line
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# first compile everything or at least try to with the $CC var.
+CC="$CC" ./compile.sh >/dev/null 2>&1
+
+# clear the screen after compilation
 
 if [[ -e "./westley" ]]; then
-    echo "$ echo IOCCC | ./westley"
+    echo "$ echo IOCCC | ./westley" 1>&2
     echo IOCCC | ./westley
     echo
 
-    echo "$ echo IOCCC | ./westley 1"
+    echo "$ echo IOCCC | ./westley 1" 1>&2
     echo IOCCC | ./westley 1
     echo
 
-    echo "$ echo IOCCC | ./westley 1 2"
+    echo "$ echo IOCCC | ./westley 1 2" 1>&2
     echo IOCCC | ./westley 1 2
     echo
 
-    echo "$ echo IOCCC | ./westley 1 2 3"
+    echo "$ echo IOCCC | ./westley 1 2 3" 1>&2
     echo IOCCC | ./westley 1 2 3
     echo
 fi
 
 if [[ -e "./ver0" ]]; then
-    echo "$ echo IOCCC | ./ver0"
+    echo "$ echo IOCCC | ./ver0" 1>&2
     echo IOCCC | ./ver0
     echo
 
-    echo "$ echo IOCCC | ./ver0 1"
+    echo "$ echo IOCCC | ./ver0 1" 1>&2
     echo IOCCC | ./ver0 1
     echo
 
-    echo "$ echo IOCCC | ./ver0 1 2"
+    echo "$ echo IOCCC | ./ver0 1 2" 1>&2
     echo IOCCC | ./ver0 1 2
     echo
 
-    echo "$ echo IOCCC | ./ver0 1 2 3"
+    echo "$ echo IOCCC | ./ver0 1 2 3" 1>&2
     echo IOCCC | ./ver0 1 2 3
     echo
 fi
 
 if [[ -e "./ver1" ]]; then
-    echo "$ echo Version 1 | ./ver1"
+    echo "$ echo Version 1 | ./ver1" 1>&2
     echo Version 1 | ./ver1
     echo
 
-    echo "$ echo Version 1 | ./ver1 1"
+    echo "$ echo Version 1 | ./ver1 1" 1>&2
     echo Version 1 | ./ver1 1
     echo
 
-    echo "$ echo Version 1 | ./ver1 1 2"
+    echo "$ echo Version 1 | ./ver1 1 2" 1>&2
     echo Version 1 | ./ver1 1 2
     echo
 
-    echo "$ echo Version 1 | ./ver1 1 2 3"
+    echo "$ echo Version 1 | ./ver1 1 2 3" 1>&2
     echo Version 1 | ./ver1 1 2 3
     echo
 fi
 
 if [[ -e "./ver2" ]]; then
-    echo "$ echo Version 2 | ./ver2"
+    echo "$ echo Version 2 | ./ver2" 1>&2
     echo Version 2 | ./ver2
     echo
 
-    echo "$ echo Version 2 | ./ver2 1"
+    echo "$ echo Version 2 | ./ver2 1" 1>&2
     echo Version 2 | ./ver2 1
     echo
 
-    echo "$ echo Version 2 | ./ver2 1 2"
+    echo "$ echo Version 2 | ./ver2 1 2" 1>&2
     echo Version 2 | ./ver2 1 2
     echo
 
-    echo "$ echo Version 2 | ./ver2 1 2 3"
+    echo "$ echo Version 2 | ./ver2 1 2 3" 1>&2
     echo Version 2 | ./ver2 1 2 3
     echo
 fi
 
 if [[ -e "./ver3" ]]; then
-    echo "$ echo Version 3 | ./ver3"
+    echo "$ echo Version 3 | ./ver3" 1>&2
     echo Version 3 | ./ver3
     echo
 
-    echo "$ echo Version 3 | ./ver3 1"
+    echo "$ echo Version 3 | ./ver3 1" 1>&2
     echo Version 3 | ./ver3 1
     echo
 
-    echo "$ echo Version 3 | ./ver3 1 2"
+    echo "$ echo Version 3 | ./ver3 1 2" 1>&2
     echo Version 3 | ./ver3 1 2
     echo
 
-    echo "$ echo Version 3 | ./ver3 1 2 3"
+    echo "$ echo Version 3 | ./ver3 1 2 3" 1>&2
     echo Version 3 | ./ver3 1 2 3
 fi
+echo 1>&2


### PR DESCRIPTION
The scripts now allow one to pass in CC=foo. If a path is specified it'll use that path (for instance in case you want a different version or because in macOS /usr/bin/gcc is actually clang); otherwise the shell will try working it out. If one does not do CC=foo then it'll default to 'cc'.

Both try.sh and compile.sh allow this and try.sh will pass CC to compile.sh before running the commands.

The CSILENCE variable in the Makefile has been updated as well. It is not possible to silence all warnings with clang but most of them are, at least in macOS clang (not tested linux yet).