### PR TITLE
Improve 1992/westley/try.sh + whereami code

### DIFF
--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-return-type \
-	-Wno-strict-prototypes
+	-Wno-strict-prototypes -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -62,7 +62,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdio.h
 
 # Optimization
 #

--- a/1988/westley/try.sh
+++ b/1988/westley/try.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1988/westley
+#
 
-clear
-
-if [[ ! -x "westley" ]]; then
-    echo "$ cc westley.c -o westley"
-    cc -std=gnu89 -Wno-error -Wno-implicit-function-declaration -Wno-return-type    -O3 westley.c -o westley || exit 1
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
 fi
 
-echo "$ cat westley.c"
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ cat westley.c" 1>&2
 cat westley.c
 sleep 1
-
-echo "$ ./westley"
+echo "$ ./westley" 1>&2
 ./westley

--- a/1988/westley/westley.c
+++ b/1988/westley/westley.c
@@ -1,5 +1,5 @@
 #define _ F-->00||-F-OO--;
-int F=00,OO=00;main(){F_OO();printf("%1.3f\n",4.*-F/OO/OO);}F_OO()
+float F=00,OO=00;main(){F_OO();printf("%1.3f\n",4.*-F/OO/OO);}F_OO()
 {
             _-_-_-_
        _-_-_-_-_-_-_-_-_

--- a/1991/fine/try.sh
+++ b/1991/fine/try.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 #
-# demo.sh - script to demonstrate IOCCC entry 1991/fine
+# try.sh - script to demonstrate IOCCC winner 1991/fine
 #
 
-make all || exit 1
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen to remove any compiler message to make the entry stand out more
+clear
 
 echo -n "Green terra <-> "
 echo "Green terra" | ./fine

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pedantic \
-	-Wno-unused-parameter -Wno-deprecated-non-prototype
+	-Wno-unused-parameter -Wno-deprecated-non-prototype -Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1992/buzzard.1/try.sh
+++ b/1992/buzzard.1/try.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
+#
+# try.sh - show IOCCC winner 1992/buzzard.1
 
-make all >/dev/null || exit 1
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen so only entry is shown
+#
+clear
 
 echo "$ ./buzzard.1 0 10" 1>&2
 ./buzzard.1 0 10

--- a/1992/nathan/try.sh
+++ b/1992/nathan/try.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
+#
+# 1992/nathan/try.sh - show IOCCC winner 1992/nathan
 
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
 
 echo "$ ./nathan obfuscate < nathan.c > foobarf.c" 1>&2
 ./nathan obfuscate < nathan.c > foobarf.c

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
 	-Wno-parentheses -Wno-pedantic -Wno-deprecated-non-prototype -Wno-int-conversion \
-	-Wno-implicit-int
+	-Wno-implicit-int -Wno-comma -Wno-missing-prototypes -Wno-return-type
 
 # Common C compiler warning flags
 #

--- a/1992/westley/try.sh
+++ b/1992/westley/try.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# 
-# script to run westley on a variety of locations to show different cities in
-# the world.
+#
+# try.sh - script to show IOCCC winner 1992/westley
+#
+# This script runs westley on a variety of locations to show different cities in
+# the world, based on the author's remarks and the judges' remarks.
 #
 # This script will first try compiling the code and alt code (alt = US only with
 # higher resolution, based on the author's remarks) and then if all is OK it
 # tries to make the whereami and whereami.alt programs. If that fails the
 # programs used will be westley and westley.alt; otherwise the programs will be
-# whereami and whereami.alt.
+# whereami and whereami.alt. One can pass CC=foo to set the compiler, defaulting
+# to cc.
 #
 # The difference between whereami and westley is that the former first checks
 # that the number of columns is at least 80. The programs whereami and
@@ -20,8 +23,8 @@
 # use for that purpose if nothing else.
 #
 # If westley or westley.alt cannot compile then it is an error and the script
-# will exit 3, corresponding to the code if westley.c or westley.alt.c cannot be
-# compiled by the whereami.c and whereami.alt.c programs.
+# will exit 4, corresponding to the same code that whereami.c and whereami.alt.c
+# exit with if westley.c or westley.alt.c cannot be compiled.
 #
 # If whereami or whereami.alt cannot compile or link, say because libcurses is
 # not installed, then it is not an error as such but westley and westley.alt
@@ -39,7 +42,7 @@
 #
 # If whereami and whereami.alt can be built it is run once, ahead of time, and
 # if it exits non-zero then we exit to prevent repeatedly showing the error
-# message.
+# message. Otherwise we will call westley or westley.alt directly.
 #
 # Usage: ./try.sh
 #
@@ -47,20 +50,26 @@
 WESTLEY=""
 WESTLEY_ALT=""
 
-make westley westley.alt >/dev/null || exit 1
-make whereami whereami.alt >/dev/null
+# get CC
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" westley westley.alt >/dev/null || exit 4
+make CC="$CC" whereami whereami.alt >/dev/null || exit 4
 
 # get the path to the right programs
 if [[ -x "whereami" ]]; then
     WESTLEY="whereami"
-    ./"$WESTLEY" 0 0 >/dev/null || exit 1
+    CC="$CC" ./"$WESTLEY" 0 0 >/dev/null || exit 1
 else
     WESTLEY="westley"
 fi
 if [[ -x "whereami.alt" ]]; then
     WESTLEY_ALT="whereami.alt"
+    CC="$CC" ./"$WESTLEY_ALT" 0 0 >/dev/null || exit 1
 else
-    WESTLEY_ALT="westley"
+    WESTLEY_ALT="westley.alt"
 fi
 
 echo "New York:" 1>&2

--- a/1992/westley/whereami.alt.c
+++ b/1992/westley/whereami.alt.c
@@ -1,9 +1,17 @@
 /*
  * whereami.alt.c: wrapper program to westley.alt.c that checks first the
- * columns of the terminal, exiting if < 80 and otherwise running westley.alt
- * with the specified args. It is an error to not specify two args but it is not
- * an error to specify args that are not numbers. The atoi(3) function typically
- * returns 0 in that case which westley.alt.c uses.
+ * columns of the terminal, exiting if < 80 and otherwise try compiling
+ * westley.alt.c (with make) and then if is already compiled or ends up being
+ * compiled it will be run with the specified args to this program.
+ *
+ * It is an error to not specify two args but it is not an error to specify args
+ * that are not numbers. The atoi(3) function typically returns 0 in that case
+ * which westley.alt.c uses.
+ *
+ * The reason to use this wrapper is because westley.alt.c needs at least 80
+ * columns to show the output right. Previously it required 80 column wrapping
+ * but in 2023 this limitation was removed, allowing it to work as long as there
+ * are at least 80 columns.
  */
 #include <stdlib.h>
 #include <stdio.h>
@@ -13,15 +21,27 @@
 int main(int argc, char **argv)
 {
     int cols;
+    char *cc = NULL; /* for if the user passes in CC=foo */
+    char *buf = NULL;
 
     if (argc < 3)
-    {
-	fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]);
-	exit(1);
-    }
+	exit(fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]));
+
+    /* try and get compiler to use */
+    cc = getenv("CC");
+    if (!cc)
+	cc = "cc";
+
+    buf = calloc(1, strlen(cc) + strlen("CC=") + 1);
+    if (buf != NULL)
+	sprintf(buf, "CC=%s", cc);
+    else
+	buf = "CC=cc";
 
     /* init curses so we can get the number of columns */
-    initscr();
+    if (!initscr())
+	exit(2);
+
     /* save columns */
     cols = COLS;
     /*
@@ -33,16 +53,27 @@ int main(int argc, char **argv)
     if (cols < 80)
     {
 	fprintf(stderr, "your terminal must be at\nleast 80 columns wide\nbut is only %d, sorry.\n", COLS);
-	exit(2);
+	exit(3);
     }
 
     /* 
-     * compile westley.alt and run if successful
+     * compile westley.alt.c and run if successful
      */
-    if (system("make westley.alt >/dev/null"))
+    buf = calloc(1, strlen("make CC=") + strlen(cc) + strlen("westley.alt") + strlen(">/dev/null") + 1);
+    if (buf)
+	sprintf(buf, "make CC=%s westley.alt >/dev/null", cc);
+    else
+	buf = "make westley.alt >/dev/null";
+
+    /* compile source file */
+    if (system(buf))
     {
 	fprintf(stderr, "couldn't compile westley.alt.c, sorry.\n");
-	exit(3);
+	exit(4);
     }
+
+    /* if we get here we compiled the code or it was already compiled so run it */
     execl("./westley.alt", "./westley.alt", argv[1], argv[2], NULL);
+
+    return 0;
 }

--- a/1992/westley/whereami.c
+++ b/1992/westley/whereami.c
@@ -1,9 +1,17 @@
 /*
  * whereami.c: wrapper program to westley.c that checks first the
- * columns of the terminal, exiting if < 80 and otherwise running westley
- * with the specified args. It is an error to not specify two args but it is not
- * an error to specify args that are not numbers. The atoi(3) function typically
- * returns 0 in that case which westley.c uses.
+ * columns of the terminal, exiting if < 80 and otherwise try compiling
+ * westley.c (with make) and then if is already compiled or ends up being
+ * compiled it will be run with the specified args to this program.
+ *
+ * It is an error to not specify two args but it is not an error to specify args
+ * that are not numbers. The atoi(3) function typically returns 0 in that case
+ * which westley.c uses.
+ *
+ * The reason to use this wrapper is because westley.c needs at least 80 columns
+ * to show the output right. Previously it required 80 column wrapping but in
+ * 2023 this limitation was removed, allowing it to work as long as there are at
+ * least 80 columns.
  */
 #include <stdlib.h>
 #include <stdio.h>
@@ -13,12 +21,26 @@
 int main(int argc, char **argv)
 {
     int cols;
+    char *cc = NULL; /* for if the user passes in CC=foo */
+    char *buf = NULL;
 
     if (argc < 3)
     {
 	fprintf(stderr, "usage: %s <lat> <long>\n", argv[0]);
 	exit(1);
     }
+
+    /* try and get compiler to use */
+    cc = getenv("CC");
+    if (!cc)
+	cc = "cc";
+
+    buf = calloc(1, strlen(cc) + strlen("CC=") + 1);
+    if (buf != NULL)
+	sprintf(buf, "CC=%s", cc);
+    else
+	buf = "CC=cc";
+
 
     /* init curses so we can get the number of columns */
     initscr();
@@ -37,12 +59,22 @@ int main(int argc, char **argv)
     }
 
     /* 
-     * compile westley and run if successful
+     * compile westley.c and run if successful
      */
-    if (system("make westley >/dev/null"))
+    buf = calloc(1, strlen("make CC=") + strlen(cc) + strlen("westley") + strlen(">/dev/null") + 1);
+    if (buf)
+	sprintf(buf, "make CC=%s westley >/dev/null", cc);
+    else
+	buf = "make westley >/dev/null";
+
+    /* compile source file */
+    if (system(buf))
     {
 	fprintf(stderr, "couldn't compile westley.c, sorry.\n");
-	exit(3);
+	exit(4);
     }
+    /* if we get here we compiled the code or it was already compiled so run it */
     execl("./westley", "./westley", argv[1], argv[2], NULL);
+
+    return 0;
 }

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -758,6 +758,9 @@ was fixed by Misha Dynin, based on the judges' remarks, so that this would work
 with modern C compilers. We encourage you to try the alternate version to see
 what happens with current compilers! See the README.md files for details.
 
+Cody changed the `int`s to be `float` as that's what they are printed as: not
+strictly necessary but nonetheless more correct, even if not warned against.
+
 Cody added the [try.sh](1988/westley/try.sh) script to show the magic of the
 entry as seeing the code with the result at once is far more beautiful.
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1626,7 +1626,8 @@ it is an error. It is always an error if the compilation of the program itself
 (westley.c, westley.alt.c) fails.
 
 Cody added the [try.sh](1992/westley/try.sh) script that shows the different
-cities that the author recommended one try, labelling each city and printing a
+cities that the author recommended one try as well as the one recommended by the
+judges (approximate judging location), labelling each city and printing a
 newline before the next city. The try.sh script uses the `whereami` code, if it
 can be compiled and linked, but otherwise it uses `westley` code instead, either
 the entry or alt code. The try.sh cannot be deceived by way of `COLUMNS=81


### PR DESCRIPTION
    
The try.sh now allows for specifying CC=foo.

The whereami.c and whereami.alt.c also allows for this. It leaks memory
but the OS should reclaim it and it's not a lot. It leaks memory because
if calloc(3) returns NULL it sets the string to a literal string to
prevent any problems with it (though one might wonder if the rest of it
will work).

