### PR TITLE
Make 2013/birken restore sanity after exit

### DIFF
--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -61,7 +61,7 @@ CDEFINE= -DZ=15000
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include stdlib.h
 
 # Optimization
 #

--- a/2013/birken/README.md
+++ b/2013/birken/README.md
@@ -42,9 +42,16 @@ perl -e 'map{map{print int(rand()*8);}(0..16);print chr(10);}(0..30);' | tr '[0-
 ./try.sh
 ```
 
-If you wish to speed it up 200% you can use instead `-DZ=3750`. Doing this
-you might find the right value to your liking; use ctrl-c to terminate the
-program early.
+If you wish to speed that up 200% you can use instead `-DZ=3750`. Doing this you
+might find the right value to your liking; use ctrl-c to terminate the program
+early but note that the terminal is likely to be messed up. Try:
+
+
+```sh
+reset
+```
+
+to make it sane again (running to completion will do that for you).
 
 
 ## Original code:
@@ -69,8 +76,8 @@ PLEASE be careful if you are sensitive to flashing colours!
 
 ## Judges' remarks:
 
-This program also wins the "Most amusing abuse of the iocccsize tool" award; although not the
-absolute best: it is possible to achieve 0 by writing:
+This program also wins the "Most amusing abuse of the iocccsize tool" award;
+although not the absolute best: it is possible to achieve 0 by writing:
 
 ```c
     /* *\

--- a/2013/birken/birken.alt.c
+++ b/2013/birken/birken.alt.c
@@ -47,4 +47,4 @@ g[2][g[i][T]]=T; n(R+i)o(e,m              )if(G[T][e]+i) G[T][e]=g[2][G[T][e]]; 
 ; else if(G[R][T]+i) s++; if(s) { if(V>4){ V=9-V; D++; } V+=29; n(20) q(c[V][T][0],c
 [V][T][i],D); } } n(19) if((L=G[R][T])+i) { O=T-L; e=O>9; t=e?18-O :O; o(K,((t&3)-3?
 16:37)){ if(K){ L=c[t+19][K-i][0]; O=c[t+19][K-i][i] ; } q(L,O,K && e); } } if(s) q(
-c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m"); return 0; }
+c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m"); return system("reset"); }

--- a/2013/birken/birken.alt.c
+++ b/2013/birken/birken.alt.c
@@ -4,6 +4,7 @@ char*_ = "'""/*";
 #define m 21
 #define o(l, k) for(l=0; l<k; l++)
 #define n(k) o(T, k)
+#define exit(x) return system("reset")
 
 
               int E,L,O,R,G[42][m],h[2][42][m],g[3][8],c
@@ -47,4 +48,4 @@ g[2][g[i][T]]=T; n(R+i)o(e,m              )if(G[T][e]+i) G[T][e]=g[2][G[T][e]]; 
 ; else if(G[R][T]+i) s++; if(s) { if(V>4){ V=9-V; D++; } V+=29; n(20) q(c[V][T][0],c
 [V][T][i],D); } } n(19) if((L=G[R][T])+i) { O=T-L; e=O>9; t=e?18-O :O; o(K,((t&3)-3?
 16:37)){ if(K){ L=c[t+19][K-i][0]; O=c[t+19][K-i][i] ; } q(L,O,K && e); } } if(s) q(
-c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m"); return system("reset"); }
+c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m");  exit(0); }

--- a/2013/birken/birken.c
+++ b/2013/birken/birken.c
@@ -46,4 +46,4 @@ g[2][g[i][T]]=T; n(R+i)o(e,m              )if(G[T][e]+i) G[T][e]=g[2][G[T][e]]; 
 ; else if(G[R][T]+i) s++; if(s) { if(V>4){ V=9-V; D++; } V+=29; n(20) q(c[V][T][0],c
 [V][T][i],D); } } n(19) if((L=G[R][T])+i) { O=T-L; e=O>9; t=e?18-O :O; o(K,((t&3)-3?
 16:37)){ if(K){ L=c[t+19][K-i][0]; O=c[t+19][K-i][i] ; } q(L,O,K && e); } } if(s) q(
-c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m"); return 0; }
+c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m"); return system("reset");}

--- a/2013/birken/birken.c
+++ b/2013/birken/birken.c
@@ -3,6 +3,7 @@ char*_ = "'""/*";
 #define m 21
 #define o(l, k) for(l=0; l<k; l++)
 #define n(k) o(T, k)
+#define exit(x) return system("reset")
 
 
               int E,L,O,R,G[42][m],h[2][42][m],g[3][8],c
@@ -46,4 +47,4 @@ g[2][g[i][T]]=T; n(R+i)o(e,m              )if(G[T][e]+i) G[T][e]=g[2][G[T][e]]; 
 ; else if(G[R][T]+i) s++; if(s) { if(V>4){ V=9-V; D++; } V+=29; n(20) q(c[V][T][0],c
 [V][T][i],D); } } n(19) if((L=G[R][T])+i) { O=T-L; e=O>9; t=e?18-O :O; o(K,((t&3)-3?
 16:37)){ if(K){ L=c[t+19][K-i][0]; O=c[t+19][K-i][i] ; } q(L,O,K && e); } } if(s) q(
-c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m"); return system("reset");}
+c[V][20][0], c[V][20][i], D); R--; } printf("\33[47;1f\33[?25h\33[40m");  exit(0); }

--- a/2013/birken/try.sh
+++ b/2013/birken/try.sh
@@ -18,7 +18,7 @@ if [[ -z "$BIRKEN" ]]; then
     BIRKEN="birken.alt"
 fi
 
-trap "clear; exit" SIGINT
+trap 'reset; exit' 0 1 2 3 15
 
 for i in *.txt; do
     NAME="$(echo "$i" | awk '{ print toupper(substr($1,1,1)) substr($1,2)}'|sed -e 's/\.txt//g' \

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3040,13 +3040,17 @@ sure if he wants to be thanked either :-) but we appreciate it nonetheless.
 
 ## [2013/birken](2013/birken/birken.c) ([README.md](2013/birken/README.md]))
 
-Along with the [try.sh](2013/birken/try.sh) that he added, Cody also added an
-alternate version which allows one to control how fast the painting is done,
+Cody changed the `return 0;` at the end of the program to be `return
+system("reset");` so that as long as it runs to completion the terminal will be
+sane and the cursor will be visible.
+
+Cody also added the [try.sh](2013/birken/try.sh) script and the
+alternate version (that has the above fix) which allows one to control how fast the painting is done,
 based on the author's recommendations, except that Cody made it configurable at
-compile time just like he did with other entries (in all but one it was
-alternate code) that use `usleep()`. The alternate version and the original
-version were swapped in the `To build`, `To run` and `Try` sections, with what
-is normally `Alternate code` being `Original code`.
+compile time just like he did with other entries that use `usleep(3)`. The
+alternate version and the original version were swapped in the `To build`, `To
+run` and `Try` sections, with what is normally `Alternate code` being `Original
+code`.
 
 
 ## [2013/cable3](2013/cable3/cable3.c) ([README.md](2013/cable3/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3041,8 +3041,10 @@ sure if he wants to be thanked either :-) but we appreciate it nonetheless.
 ## [2013/birken](2013/birken/birken.c) ([README.md](2013/birken/README.md]))
 
 Cody changed the `return 0;` at the end of the program to be `return
-system("reset");` so that as long as it runs to completion the terminal will be
-sane and the cursor will be visible.
+system("reset");` (via redefining `exit(3)` so that the column ending would be
+the same) so that as long as it runs to completion the terminal will be sane and
+the cursor will be visible. Using `atexit(3)` will not work if the program is
+killed and signals are ugly so this was not done.
 
 Cody also added the [try.sh](2013/birken/try.sh) script and the
 alternate version (that has the above fix) which allows one to control how fast the painting is done,


### PR DESCRIPTION
    
As long as the program (alt code and otherwise) runs to completion the program will return instead of 0:

    system("reset");

so that the terminal becomes sane again (otherwise cursor is invisible).  One could also use 'tput cvvis' but this is longer and I wanted to make the column as close to the original ending as possible.

After that (next commit, meant to be commit --amend) it was changed to redefine exit(3) so that the line length would be the same as before.