### PR TITLE
Updates and improvements to 2000/thadgavin

### DIFF
--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -62,7 +62,7 @@ CDEFINE= -DZ=30 -DZS=150000
 
 # Include files that are needed to compile
 #
-CINCLUDE= -include unistd.h
+CINCLUDE= -include unistd.h -include stdlib.h
 
 # Optimization
 #
@@ -112,10 +112,10 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG}
+TARGET= ${PROG} ${PROG}_sdl
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o ${PROG}.alt_sdl.o
+ALT_TARGET= ${PROG}.alt ${PROG}.alt_sdl
 
 
 #################
@@ -145,9 +145,9 @@ alt: data ${ALT_TARGET}
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
-
 ${PROG}.alt_sdl: ${PROG}.alt.c
 	${CC} ${CFLAGS} -DSDL `${SDL1_CONFIG} --cflags` $< -o $@ ${LDFLAGS} `${SDL1_CONFIG} --libs`
+
 
 # data files
 #

--- a/2000/thadgavin/README.md
+++ b/2000/thadgavin/README.md
@@ -1,73 +1,98 @@
 ## To build:
 
-```sh
-make
-```
-
-NOTE: the author suggested `-O6` but at least some gcc versions support no more
-than level 3 which is what the Makefile has.
-
-To use the SDL version that works independently from the curses version:
-
-```sh
-make thadgavin_sdl
-```
-
-Use `thadgavin_sdl` as you would `thadgavin` below.
-
-
-## To use:
-
-```sh
-./thadgavin
-```
-
-WARNING: if you are sensitive to rapid movement or if you want to see better
-what is going on then please see the Alternate code section.
-
-NOTE: in curses mode you might want to type `reset` after execution of this
-program as the program does not call `endwin()`. Using `reset` will clear the
-screen.
-
-
-### Try:
-
-```sh
-echo "Do or do not. There is no try."
-```
-
-
-## Alternate code:
-
-An alternate version exists which allows you to slow down the printing of the
-characters, useful for those with modern systems or those who are sensitive to
-rapid moving swirling. To use:
+If you don't have curses or SDL1 installed both modes will fail to compile. In
+that case see the [FAQ 3.8 - How do I compile an IOCCC winner that requires SDL1
+or SDL2?](/faq.md#faq_38) and [FAQ 3.9  - How do I compile an IOCCC winner that
+requires (n)curses?](/faq.md#faq3_9) for more information.
 
 
 ```sh
 make alt
 ```
 
-To make the SDL version:
+We recommend that you use the alternate code in modern systems. See the
+[original code](#original-code) section for more details on why this is.
+
+
+## To use:
 
 ```sh
-make thadgavin.alt_sdl
+./thadgavin.alt
 ```
 
-If you wish to reconfigure the delay you can do so like:
+You can press 'q' at any time to exit.
+
+### Try:
+
+If you have SDL1 installed:
 
 ```sh
-make -DZ=50 clobber alt
-make -DZS=5000 clobber thadgavin.alt_sdl
+./thadgavin_sdl
 ```
 
-Use `thadgavin.alt` and `thadgavin.alt_sdl` as you would `thadgavin` and
-`thadgavin_sdl` above.
+Whereas the curses version has an early exit the SDL version does not. You will
+have to kill it yourself.
 
-The default for the curses alt version is 30 and for SDL it is 150000. The
-different macros is because the curses version is already slower but it's better
-to not tie the two values together. The reason for such drastically different
-numbers is because curses is already slower than SDL.
+You might also care to reconfigure the speed at which the programs run. The code
+calls `usleep(3)` with two default values, one for SDL and one for curses. The
+curses and SDL macros are defined respectively in the Makefile:
+
+```
+-DZ=30 -DZS=150000
+```
+
+which corresponds to how long the program sleeps (in microseconds) between
+output. In the code if either is undefined (`#ifndef..#endif`) they will be set
+to the defaults as above so that you don't have to specify both just to
+configure one. To change the SDL one to something like `15000` you can do:
+
+```sh
+make CDEFINE="-DZS=15000" clobber alt
+```
+
+and to change the curses one to `40`:
+
+```sh
+make CDEFINE="-DZ=40" clobber alt
+```
+
+Then use the program(s) in the same way.
+
+The different macros is because the curses version is already much slower and so
+it's better to not tie the two values together.
+
+
+## Original code:
+
+WARNING: if you are sensitive to rapid movement or if you want to see better
+what is going on then please use the alternate code as described above. If you
+wish to see the original entry see below.
+
+NOTE: in curses mode you might want to type `reset` after execution of this
+program as the program does not call `endwin()`. Using `reset` will clear the
+screen. The alt code, as noted above, allows one to quit early so this is not a
+problem there.
+
+
+### Original build:
+
+```sh
+make all
+```
+
+### Original use:
+
+```sh
+./thadgavin
+```
+
+### Original try:
+
+If you have SDL1 installed:
+
+```sh
+./thadgavin_sdl
+```
 
 
 ## Judges' remarks:
@@ -80,6 +105,7 @@ less than dazzling. We could not test this entry in DOS mode.
 
 ## Authors' remarks:
 
+
 ### To use under DOS:
 
 Compile using DJGPP as follows:
@@ -88,10 +114,19 @@ Compile using DJGPP as follows:
 gcc thadgavin.c -o thadgavin.exe -Wall -lm -O6 -mpentium -fomit-frame-pointer -ffast-math
 ```
 
-### To use under Windows, X-Windows or MacOS using the Simple DirectMedia Layer:
+
+### To use under Windows, X-Windows or macOS using the Simple DirectMedia Layer:
 
 ```sh
 gcc -O6 -lpthread -g -o thadgavin thadgavin.c -lSDL -DSDL -lm
+```
+
+
+### To use curses:
+
+
+```sh
+gcc -O6 -lpthread -g -o thadgavin thadgavin.c -lncurses -lm
 ```
 
 
@@ -116,7 +151,7 @@ char ', possible loss of data
 
 But don't worry, this is completely normal.
 
-Recommended dosage:
+### Recommended dosage:
 
 At least 3 minutes taken 3 times a day when tired.
 

--- a/2000/thadgavin/thadgavin.alt.c
+++ b/2000/thadgavin/thadgavin.alt.c
@@ -1,4 +1,9 @@
-
+#ifndef Z
+#define Z 30
+#endif
+#ifndef ZS
+#define ZS 150000
+#endif
                       int
                    X=320      ,Y=200,
                  n=0,m,     x,y,   j=1024;
@@ -37,6 +42,7 @@
          out,C8),m     )W W W; ++h; } dosmemput
    (v,X*Y,0xA0000   ); } else{       r.x.ax=
  0x13;            __dpmi_int(    0x10,&r); } }
+		     void E(void){}
                    #elif defined(SDL)
               #include <SDL.h>
           SDL_Surface    *s; void
@@ -45,6 +51,7 @@
      (s,0,0,0,        0); usleep(ZS); } else {  SDL_Init( 
        SDL_INIT_VIDEO); s=SDL_SetVideoMode
        (X,Y,8,0);       v=s->pixels; } }
+		void E(void){}
                   #else
                #include "curses.h"
              void F(i){ if(i){ for(y=0;
@@ -54,7 +61,10 @@
         ",:+"   "=@#"   ]); usleep(Z); } ;  refresh
         (); }     else{          initscr
         (),x=     COLS&~1,X=x<X?x:X,y=
-         LINES      &~1,Y=y<Y?y:Y; } }
+         LINES      &~1,Y=y<Y?y:Y; 
+		nodelay(stdscr,1);}}
+	     void E(void){if(getch()=='q')
+		{endwin();exit(0);}}
           #endif
 
 main(int argc, char **argv)
@@ -88,6 +98,8 @@ main(int argc, char **argv)
 
             if (f>T*2)
                 C[0]=sin(f)+sin(f*2)/2;
+
         }
+	E();
     }
 }

--- a/faq.md
+++ b/faq.md
@@ -28,8 +28,9 @@
 - [3.6  - An IOCCC winner missed by my terminal application, how do I fix this?](#faq3_6)
 - [3.7  - How do I compile and use on macOS, an IOCCC winner that requires X11?](#faq3_7)
 - [3.8  - How do I compile an IOCCC winner that requires SDL1 or SDL2?](#faq3_8)
-- [3.9  - How do I compile and use on macOS, an IOCCC winner that requires sound?](#faq3_9)
-- [3.10 - Why do Makefiles use -Weverything with clang?](#faq3_10)
+- [3.9  - How do I compile an IOCCC winner that requires (n)curses?](#faq3_9)
+- [3.10 - How do I compile and use on macOS, an IOCCC winner that requires sound?](#faq3_10)
+- [3.11 - Why do Makefiles use -Weverything with clang?](#faq3_11)
 
 ## Section  4 - [Changes made to IOCCC winners](#faq4)
 - [4.0  - Why are some winning author remarks incongruent with the winning IOCCC code?](#faq4_0)
@@ -796,7 +797,52 @@ details. If something is not noted you're welcome to report it as an issue or
 fix it and make a new pull request.
 
 
-### <a name="faq3_9"></a>FAQ 3.9: How do I compile and use on macOS, an IOCCC winner that requires sound?
+### <a name="faq3_9"></a>FAQ 3.9: How do I compile an IOCCC winner that requires (n)curses?
+
+This depends on your operating system but below are instructions for Linux and
+macOS with alternative methods for macOS and different package managers with Linux.
+
+#### Red Hat based linux
+
+Execute one of the following as root or via sudo:
+
+```sh
+dnf install ncurses ncurses-devel
+yum install ncurses ncurses-devel
+```
+
+
+#### Debian based linux
+
+Execute the following as root or via sudo:
+
+```sh
+apt-get install libncurses5-dev libncursesw5-dev
+```
+
+and then try `make all` again.
+
+
+#### Other linux distributions
+
+Use your package manager to install the appropriate packages. Try the search
+feature of the package manager to determine which packages you need to install.
+Note that you might have to install both the library and the developmental
+packages: one for compiling and one for linking / running.
+
+
+#### macOS
+
+With macOS it should already be installed. If it is not you might have to do:
+
+```sh
+xcode-select --install
+```
+
+and agree to the terms and conditions and proceed with the install.
+
+
+### <a name="faq3_10"></a>FAQ 3.10: How do I compile and use on macOS, an IOCCC winner that requires sound?
 
 This might depend on the entry but in some cases like
 [2001/coupard](2001/coupard/coupard.c) one needs to do more work in order to get
@@ -831,7 +877,7 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
 
-### <a name="faq3_10"></a>FAQ 3.10: Why do Makefiles use -Weverything with clang?
+### <a name="faq3_11"></a>FAQ 3.10: Why do Makefiles use -Weverything with clang?
 
 While we know that use of `-Weverything` is generally not recommended
 by `clang` C compiler developers, we do use the `-Weverything`

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2302,12 +2302,16 @@ Cody made this more portable by changing the `void main` to `int main`.
 Cody fixed the code and added an appropriate make rule so that the SDL version
 works independent from the curses version (using the same code).
 
+Cody also added alt code to allow one to slow down the code. This code also, at
+least for the curses mode, allows one to quit at any time by pressing 'q'. See
+below for more details.
+
 Due to a terrible design choice of the SDL1 developers something had to be
 changed. As was noted in the log:
 
 ```
 The SDL version did not work for a number of reasons. First of all the
-code requires that SDL is defined. Second the path wrong header file was
+code requires that SDL is defined. Second the path[sic] wrong header file was
 included. Third the SDL1 developers thought it would be a great idea
 (but obviously it's a terrible idea) to redefine main() (!!) so that any
 program that uses SDL1 has to have the same args as their definition.


### PR DESCRIPTION
The alt code now allows one to quit early (in curses mode) and this calls endwin() to restore terminal sanity. Due to the way the code is designed the function which does that has to be defined three times but only one has any code in it, that of the curses one. This means that nodelay() is also called when initialising curses. At least at this time the original entry does not have this feature and so one will have to type 'reset' after they end the program to restore terminal sanity.

The alt code has been improved in another way too: now one does not have to specify both macros at the command line when wishing to configure only one of the programs. This is accomplished by #ifndef..#endif blocks at the beginning of the file. That has not been done in other entries but probably should be to help out.

The README.md file has been typo/format checked/fixed.

The FAQ has been updated as well: a question about how to use entries that require curses has been added. This required some minor reordering of the numbers but I believe that I got everything okay.