### PR TITLE
Rename 2019/karns/demo.sh try.sh

### DIFF
--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -114,7 +114,7 @@ PROG= prog
 #
 OBJ= ${PROG}.o
 CSRC= ${PROG}.o
-DATA= maze demo.sh
+DATA= maze try.sh
 TARGET= ${PROG}
 #
 ALT_OBJ=
@@ -141,8 +141,8 @@ ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 	${LN} -sf ${PROG} tbfs
 
-test: prog
-	${CAT} prog.c | ./prog
+test: ${PROG}
+	./${PROG} < ${PROG}.c
 
 
 # alternative executable

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -26,7 +26,7 @@ The last two can be done in a sequence, first showing the respective files at
 the terminal, like:
 
 ```sh
-./demo.sh
+./try.sh
 ```
 
 

--- a/2019/karns/try.sh
+++ b/2019/karns/try.sh
@@ -5,8 +5,17 @@
 # Doesn't run the program on README.md as it's longer and slower.
 #
 
-# make prog first and exit if failure
-make || exit
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
 
 # display prog.c to the user
 echo "$ cat prog.c"


### PR DESCRIPTION
It was already documented as such (in the thanks file) but it was still the old name (demo.sh). The README.md had demo.sh still but this has been updated as it's all for the try section.