### PR TITLE
Add alt code to 1985/shapiro

### DIFF
--- a/1985/shapiro/.gitignore
+++ b/1985/shapiro/.gitignore
@@ -1,3 +1,4 @@
 shapiro
+shapiro.alt
 shapiro.orig
 prog.orig

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -58,7 +58,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DC=39
 
 # Include files that are needed to compile
 #
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1985/shapiro/README.md
+++ b/1985/shapiro/README.md
@@ -4,12 +4,52 @@
 make all
 ```
 
+There is alternate code which allows one to change the size of the maze. See
+[alternate code](#alternate-code) below.
 
-### Try:
+
+### To run:
 
 ```sh
 ./shapiro
 ```
+
+## Alternate code:
+
+The code has a define `C` set to 39 but this can be modified to change the size
+of the maze. The alt code allows one to easily do this.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+### Alternate try:
+
+If you wish to change the value you can do it like:
+
+```sh
+make clobber CDEFINE="-DC=5" alt
+```
+
+Note that if it is not a number then obviously there will be a compilation
+error. If it's <= 0 || >= 5000 then it is set to 39, the default.
+
+You might also wish to try:
+
+```sh
+./try.alt.sh
+```
+
+This script will compile the program five times with a random value and then
+prompt you in an infinite loop for values to try, exiting only if non-digits are
+in the input.
+
+Also try printing out various sized mazes and solving them with pencil or pen or
+in your head.
 
 
 ## Judges' remarks:

--- a/1985/shapiro/shapiro.alt.c
+++ b/1985/shapiro/shapiro.alt.c
@@ -1,0 +1,14 @@
+#define P(X)j=write(1,X,1)
+#ifndef C
+#define C 39
+#elif C <= 0 || C >= 5000
+#undef C
+#define C 39
+#endif
+int M[5000]={2},*u=M,N[5000],R=22,a[4],l[]={0,-1,C-1,-1},m[]={1,-C,-1,C},*b=N,
+*d=N,c,e,f,g,i,j,k,s;main(){for(M[i=C*R-1]=24;f|d>=b;){c=M[g=i];i=e;for(s=f=0;
+s<4;s++)if((k=m[s]+g)>=0&&k<C*R&&l[s]!=k%C&&(!M[k]||!j&&c>=16!=M[k]>=16))a[f++
+]=s;if(f){f=M[e=m[s=a[rand()/(1+2147483647/f)]]+g];j=j<f?f:j;f+=c&-16*!j;M[g]=
+c|1<<s;M[*d++=e]=f|1<<(s+2)%4;}else e=d>b++?b[-1]:e;}P(" ");for(s=C;--s;P("_")
+)P(" ");for(;P("\n"),R--;P("|"))for(e=C;e--;P("_ "+(*u++/8)%2))P("| "+(*u/4)%2
+);}

--- a/1985/shapiro/try.alt.sh
+++ b/1985/shapiro/try.alt.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1985/shapiro alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# run with default first
+make clobber CC="$CC" alt >/dev/null || exit 1
+./shapiro.alt
+
+i=0
+# while i < 5 randomly select a size and recompile it and run
+while ((i < 5)); do
+    # get random value in range RANDOM % 38. <=0 sets to 39 in the code but
+    # since 1 is kind of pointless so we set it to 2 if it's < 2.
+    C=$((RANDOM % 38))
+    if [[ "$C" -lt 2 ]]; then
+	C=2
+    fi
+
+    read -r -n 1 -p "Press any key to set to $C: "
+    make clobber CC="$CC" CDEFINE="-DC=$C" alt >/dev/null
+    ./shapiro.alt
+    ((i++))
+done
+
+# while input is only numbers recompile the alt code with that value.  If number
+# is <=0 it sets to 39 in the code but here if one enters a negative number it
+# will exit due to the '-'. 1 is rather pointless but we don't check for
+# it either.
+while :; do
+    read -r -p "Enter a value (any non-digit = quit): "
+    # ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].
+    # shellcheck disable=SC2143
+    if [[ $(echo "$REPLY" | grep -E '\<[0-9]+\>') ]]; then
+	make clobber CC="$CC" CDEFINE="-DC=\"$REPLY\"" alt >/dev/null
+	./shapiro.alt
+    else
+	exit 0
+    fi
+done

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -334,6 +334,16 @@ Yusuke provided some useful information that amounts to an alternate version
 that Cody added. See the README.md for details.
 
 
+## [1985/shapiro](1985/shapiro/shapiro.c) ([README.md](1985/shapiro/README.md]))
+
+Cody added the alt code which allows one to resize the maze and he also added
+the [try.alt.sh](1985/shapiro/try.alt.sh) script that randomly selects sizes
+(five times) and compiles and runs it. After the five runs it prompts you to
+enter a number, in an infinite loop, exiting if any non-digits are in input
+(this includes negative numbers which in the code actually sets it back to 39,
+the default).
+
+
 ## [1985/sicherman](1985/sicherman/sicherman.c) ([README.md](1985/sicherman/README.md]))
 
 Cody fixed this _very twisted entry_ to not require `-traditional-cpp`.  Fixing


### PR DESCRIPTION
This alt code allows one to resize the maze. Obviously if one uses -D with a value that's not a number it will fail to compile. If it's <= 0 || >= 5000 it will set to the default of 39.

The try.alt.sh script plays with this, first selecting a random number (in range $RANDOM % 38) to compile with and then run. After that it runs in an infinite loop, exiting only if input includes non-digit characters. A value >= 5000 sets it to the default of 39 (in the code).