### PR TITLE
Fix fix on 1991/buzzard

### DIFF
--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	-Wno-int-conversion -Wno-logical-op-parentheses -Wno-pedantic \
 	-Wno-return-type -Wno-unknown-escape-sequence -Wno-unused-value \
-	-Wno-deprecated-non-prototype
+	-Wno-deprecated-non-prototype -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -139,6 +139,10 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
 
 # data files
 #

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -28,9 +28,11 @@ bugs.md](/bugs.md#1991-buzzard).
 
 ## Alternate code:
 
-This version changes the keys `f` for forward, `l` for left and `r` for right to
-`k` for forward, `l` for right and `h` for left, which is more natural for those
-who use vi(m). Also one can just hit `q` followed by enter to quit the maze.
+This version changes the keys `f` for forward, `l` for left and `r` for right by
+default to `k` for forward, `l` for right and `h` for left, which is more
+natural for those who use vi(m). Also one can just hit `q` followed by enter to
+quit the maze. It is problematic to reconfigure the keys except by modifying the
+code directly so the keys are not made a `-D` at the compiler.
 
 
 ### Alternate build:

--- a/1991/buzzard/buzzard.alt.c
+++ b/1991/buzzard/buzzard.alt.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #define X(s) (!(s&3)-((s&3)==2))
 #define W while
-char Z[82][82],A,B,f,g=26;z(q)char**q;{return atoi(q);}m(d,l){return
+char Z[82][82],A,B,f,g=26;z(q)char*q;{return atoi(q);}m(d,l){return
 Z[   B       +    X      (   f     +
 3) * d+l *X(f+ 2 )][ A+X ( f ) * d +
 l* X           (     f     + 3 ) ] ;}int

--- a/1991/buzzard/buzzard.c
+++ b/1991/buzzard/buzzard.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #define X(s) (!(s&3)-((s&3)==2))
 #define W while
-char Z[82][82],A,B,f,g=26;z(q)char**q;{return atoi(q);}m(d,l){return
+char Z[82][82],A,B,f,g=26;z(q)char*q;{return atoi(q);}m(d,l){return
 Z[   B       +    X      (   f     +
 3) * d+l *X(f+ 2 )][ A+X ( f ) * d +
 l* X           (     f     + 3 ) ] ;}int


### PR DESCRIPTION
The parameter type of q in function z() should be a 'char *', not a 'char **'.

Added to CSILENCE -Wno-implicit-int.

Note that if including files for abs(3), strlen(3) or other functions implicitly declared the program will not work (or at least it won't work if at least one of them is #included?).