### PR TITLE
Fix 2001/ollinger bug status in bugs.md

### DIFF
--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -145,9 +145,9 @@ ${PROG}: ${PROG}.c
 
 
 ${PROG}.ten: ${PROG}.ten.c
-	@echo "WARNING: ${PROG}.ten.c must be compiled as 32-bit to use with the entry itself;"
-	@echo "this is because the program works on 32-bit binaries. If you cannot use -m32 this"
-	@echo "will NOT work!"
+	@echo "WARNING: ${PROG}.ten.c must be compiled as a 32-bit ELF binary to use with"
+	@echo "the entry itself; this is because the program works on 32-bit ELF binaries."
+	@echo "If you cannot use -m32 this will NOT work!"
 	@echo
 	@echo "If you want to use it where this is not possible e.g. with a Mac, say to"
 	@echo "use by itself, try:"
@@ -165,9 +165,9 @@ ${PROG}.ten.64: ${PROG}.ten.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 ${PROG}.bed: ${PROG}.bed.c
-	@echo "WARNING: ${PROG}.bed.c must be compiled as 32-bit to use with the entry itself;"
-	@echo "this is because the program works on 32-bit binaries. If you cannot use -m32 this"
-	@echo "will NOT work!"
+	@echo "WARNING: ${PROG}.bed.c must be compiled as a 32-bit ELF binary to use with"
+	@echo "the entry itself; this is because the program works on 32-bit ELF binaries."
+	@echo "If you cannot use -m32 this will NOT work!"
 	@echo
 	@echo "If you want to use it where this is not possible e.g. with a Mac, say to"
 	@echo "use by itself, try:"

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -28,20 +28,21 @@ For more detailed information see [2001 anonymous in bugs.md](/bugs.md#2001-anon
 ```sh
 ./try.sh
 
-./anonymous anonymous.bed # if able to use -m32
+./anonymous anonymous.bed # if able to compile as a 32-bit (-m32) ELF binary
 ```
 
 NOTE: if the 32-bit version cannot be compiled the script will at least compile
-[anonymous.ten](anonymous.ten.c) as a 64-bit program and run it directly.
+[anonymous.ten](anonymous.ten.c) as a 64-bit program and run it directly. If it
+can be compiled but it's not an ELF binary the program is likely to crash.
 
 For fun and so that there's another program that is a bit different (it uses a `char
 *[]` array for example) that this program will still work on:
 
 ```sh
-make anonymous.bed # if able to use -m32
+make anonymous.bed # if able to compile as 32-bit (-m32) ELF binary
 ./anonymous anonymous.bed
 
-make anonymous.bed.64 # if unable to use -m32
+make anonymous.bed.64 # if unable to compile as a 32-bit (-m32) ELF binary
 ./anonymous.bed.64
 ```
 
@@ -61,7 +62,7 @@ that :-(
 If the program cannot be run (for instance under macOS as an ELF file) then
 the program will fail to execute it and might not even touch it.
 
-This is supposed to happen.  As is written in the
+These are supposed to happen.  As is written in the
 [The Jargon File](http://catb.org/jargon/html/F/feature.html):
 
 ```
@@ -79,6 +80,9 @@ no longer known exactly what is supposed to happen and possibly that the
 modification might not be entirely correct for that reason though it does appear
 to be correct.
 
+It appears that the corruption happens only if the modification fails in the
+middle of doing so so that might be why it's not yet been observed.
+
 
 ## Judges' remarks:
 
@@ -93,9 +97,12 @@ run x86 programs on any machine (x86 or otherwise).
 
 I have included a simple [10 Green
 Bottles](https://www.bbc.co.uk/teach/school-radio/nursery-rhymes-ten-green-bottles/zncyt39)
-[program](anonymous.ten.c) (try `make anonymous.ten`), meant to be compiled in 32-bit.
+[program](anonymous.ten.c) (try `make anonymous.ten`), meant to be compiled as a
+32-bit ELF binary.
+
 The program `anonymous.ten`, and its source (dull) are included as data
 files.
+
 
 ### Warning
 
@@ -114,7 +121,7 @@ generates a translation for an entire basic block of subject code.  Having
 translated a block once, the target code generated will be stored for the
 duration that the program is running, so as a program runs its performance will
 improve, as it hits cached blocks.  This can be clearly observed in the example
-program, [anonymous.ten](anonymous.ten.c) which must be compiled as a 32-bit
+program, [anonymous.ten](anonymous.ten.c) which must be compiled as a 32-bit ELF
 binary.
 
 ### Target Library Linking:
@@ -136,7 +143,9 @@ There are various problems raised when attempting to run little
 [PPC](https://en.wikipedia.org/wiki/PowerPC).  These problems are dealt
 with in a manner that is entirely transparent to the user.
 
+
 ### Configuration:
+
 
 #### Warnings:
 
@@ -149,12 +158,14 @@ error, or if the program generates any further error when compiled using
 your C compiler please remove the `-Dwarning='-Dprocessor'` line and the
 `$$warning` from the compiler invocation.
 
+
 ### Optimization
 
 The build script contains a `-O1` switch for the compiler.  Increasing
 the optimization level will make the program run *slower*, while
 compiling the program without any optimization will allow it to run
 *faster*.
+
 
 ### Obfuscation
 
@@ -170,7 +181,7 @@ not contained within the source code but instead is passed in on the command
 line.
 
 Buried under all this, and the fact that the entire program is just a
-call to `exit()`, there are some nice subtle little obfuscations.  For
+call to `exit(3)`, there are some nice subtle little obfuscations.  For
 example, you may notice that there are a couple of macros that use the
 `##` preprocessor operator to build pairs of functions.  One of these
 macros is used to build pairs of functions of which only one has
@@ -179,10 +190,11 @@ global state, and the other doesn't.
 
 There is also quite a nice trick where I wave a magic wand, and a chunk of code
 which should only be run when the program is run for the first time (setting the
-[PC / IP](https://en.wikipedia.org/wiki/Program_counter) to point at `main()`,
-etc) gets turned into a `frog^M^M^M^Mstring`.  The C compiler sees a string by
+[PC / IP](https://en.wikipedia.org/wiki/Program_counter) to point at `main()`
+etc.) gets turned into a <strike>frog</strike>string.  The C compiler sees a string by
 itself in the code, thinks "yup, that's a valid C expression", and quietly moves
 on to the next line of code.
+
 
 ### Limitations
 
@@ -200,19 +212,20 @@ turn up - yes the program is unsafe, but it's pretty cool anyway.
 Despite all this, the translator is not exclusively limited to running the
 [anonymous.ten](anonymous.ten.c) program.  Other trivial **_x86_** programs may
 run on the translator \- and I have successfully run a wide range of "Hello
-World" programs, including one of last years IOCCC winners,
+World" programs, including one of last year's IOCCC winners,
 [tomx](/2000/tomx/tomx.c).
+
 
 ### Complete Program
 
-The fact that the program makes calls to `system()` and `execv()` may imply that
+The fact that the program makes calls to `system(3)` and `execv(3)` may imply that
 it is not a complete program in its own right, as it relies on other programs.
-The call to `system()` is a call to ask gcc to recompile the translator with a
-new set of switches, and the call to `execv()` asks for the newly compiled
+The call to `system(3)` is a call to ask gcc to recompile the translator with a
+new set of switches, and the call to `execv(3)` asks for the newly compiled
 program to be executed.  I would point out that almost every other entry to this
 competition also require a C compiler (well, the published winners at any rate,
 and I recognize that a few don't).  There is little real difference between this
-program and one like last years entry [dhyang](/2000/dhyang/dhyang.c); both are
+program and one like last year's entry [dhyang](/2000/dhyang/dhyang.c); both are
 just C programs that generate C code as their output.
 
 Enjoy and thanks!

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -114,8 +114,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -137,6 +137,9 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/2001/ctk/README.md
+++ b/2001/ctk/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+There is an alternate version with vi(m) key movements. See [alternate
+code](#alternate code) below.
+
 
 ## To use:
 
@@ -12,14 +15,24 @@ make
 ```
 
 
-### Try:
+## Alternate code:
+
+This alternate version adds to the movement keys `l` for right, `h` for left and
+`k` for straight.
+
+
+### Alternate build:
+
 
 ```sh
-echo "Do or do not. There is no try."
+make alt
 ```
 
-Make sure to hit `q` to exit or else your terminal will be messed up (to restore
-it you can try `stty sane` or `reset`).
+### Alternate use:
+
+```sh
+./ctk.alt
+```
 
 
 ## Judges' remarks:
@@ -32,20 +45,19 @@ This is, of course, another of the retro games.
 
 ## Author's remarks:
 
-This is a game based on an Apple ][ Print Shop Companion [Easter
-egg][1] named 'DRIVER', in which the goal is to drive as fast as
-you can down a long twisty highway without running off the
-road.  Use `,./`, `[ ]`, or `bnm` to go left, straight, and
-right respectively. Use `1234` to switch gears. `q` quits. The
-faster you go and the thinner the road is, the more points you
-get. Most of the obfuscation is in the nonsensical if statements
-among other things. It works best on the Linux console: you
-get engine sound (!) and the * Lock keyboard lights tell you
-what gear you're in (none lit=4th).  The `q` argument (no
-leading `-`) will silence the sound. It won't work on a terminal
-smaller than 80x24, but it works fine with more (try it in an
-XTerm with the "Unreadable" font and the window maximized
-vertically!).
+This is a game based on an [Apple
+II](https://en.wikipedia.org/wiki/Apple_II_series) [Print Shop
+Companion](https://en.wikipedia.org/wiki/The_Print_Shop) [Easter egg][1] named
+'DRIVER', in which the goal is to drive as fast as you can down a long twisty
+highway without running off the road.  Use `,./`, `[ ]`, or `bnm` to go left,
+straight, and right respectively. Use `1234` to switch gears. `q` quits. The
+faster you go and the thinner the road is, the more points you get. Most of the
+obfuscation is in the nonsensical if statements among other things. It works
+best on the Linux console: you get engine sound (!) and the * Lock keyboard
+lights tell you what gear you're in (none lit=4th).  The `q` argument (no
+leading `-`) will silence the sound. It won't work on a terminal smaller than
+80x24, but it works fine with more (try it in an XTerm with the "Unreadable"
+font and the window maximized vertically!).
 
 [1]: https://en.wikipedia.org/wiki/Easter_egg_(media)#In_computing
 

--- a/2001/ctk/ctk.c
+++ b/2001/ctk/ctk.c
@@ -22,4 +22,4 @@ SIG_IGN);printf("\e[0q\ecScore: %u\n",s);system("stty echo -cbreak");}int main
 int)0x756E696C||C==(int)0x6C696E75);srand(getpid());system("stty -echo cbreak"
 );h(0);u(14);for(;;)switch(getchar()){case 113:return 0;case 91:case 98:c(44,k
 =-1);case 32:case 110:c(46,k=0);case 93:case 109:c(47,k=1);c(49,h(0));c(50,h(1
-));c(51,h(2));c(52,h(3));}}
+));c(51,h(2));c(52,h(3));}e();}

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+There is an alternate version based on the author's remarks. See [alternate
+code](#alternate-code) below for more details.
+
 
 ### Bugs and (Mis)features:
 
@@ -27,16 +30,28 @@ For more detailed information see [2001 dgbeards in bugs.md](/bugs.md#2001-dgbea
 
 The author provided a way to speed it up a bit and also how to make it so it
 doesn't crash on losing.  The idea that it crashes on losing was too good to
-lose but this alternate version has the former change.
+lose but this alternate version has the former change. If you wish to remove
+this you can look at the author's remarks and make the change.
 
-To compile:
+
+### Alternate build:
 
 ```sh
 make alt
 ```
 
-Use `dgbeards.alt` as you would `dgbeards` above. Can you find a flaw in this
-version that the author did not note?
+
+### Alternate use:
+
+```sh
+./dgbeards.alt
+```
+
+
+### Try:
+
+See if you can figure out how to make the computer always lose ('win' :-) ).
+It's a very simple thing to do. Read the author's remarks for clues.
 
 This game crashes if it loses.
 
@@ -46,12 +61,6 @@ This is supposed to happen.  As is written in the
 ```
 That's not a bug, that's a feature.
 ```
-
-
-### Try:
-
-See if you can figure out how to make the computer always lose. It's a very
-simple thing to do. Read the author's remarks for clues.
 
 
 ## Judges' remarks:
@@ -100,6 +109,7 @@ can be captured.
 
 5. Castling is not allowed.
 
+
 #### Q: How do you use this program?
 
 A: The program is fairly straightforward.  When you start the program,
@@ -128,6 +138,7 @@ You can also specify a command line argument of a single digit to change
 the search depth of the program.  If no argument is specified, it
 defaults to a depth of 3.
 
+
 #### Q: Are there any limitations in your program?
 
 A: Yes.  The first of the limitations is that you can only play legal
@@ -140,6 +151,7 @@ It also does not detect the end of the game.  It can see sure wins or
 losses several moves ahead, but does not announce the end of a game or
 the winner.  Given the existing code it is easy to do this, but it was
 deemed unnecessary fluff.
+
 
 #### Q: What is the playing strength of this program?
 
@@ -163,14 +175,15 @@ In such positions, it will often just shuffle pieces around aimlessly
 until a tactical exchange presents itself.
 
 A small amount of randomness has been added to make the program a more
-interesting opponent.  To avoid a call to `srand()`, `rand()` and the
-extra code for the required include files, the `time()` function is used as
+interesting opponent.  To avoid a call to `srand(3)`, `rand(3)` and the
+extra code for the required include files, the `time(3)` function is used as
 the source of random data.  It is a slow function, and since it is
 executed inside the search loop, there is a significant performance
-decrease.  To make it faster, replace the `time()` call with `rand()` and add
+decrease.  To make it faster, replace the `time(3)` call with `rand(3)` and add
 the line `srand(time(0));` to the beginning of `main()`.  I used the more
-inefficient `time()` function to illustrate a different (and somewhat
+inefficient `time(3)` function to illustrate a different (and somewhat
 obfuscated?) way of generating random numbers.
+
 
 #### Q: Why is this program obfuscated?
 
@@ -200,7 +213,7 @@ hide the real purpose of strings.  These layers of obscurity cannot be
 penetrated by just preprocessing and beautifying the program.
 
 Fifth, various small obfuscations have been used in places all over the
-program.  Short circuit evaluation is used as a substitute for if()
+program.  Short circuit evaluation is used as a substitute for `if()`
 statements in some places.  The ternary operator is used.  In the
 author's opinion, use of the ternary operator is almost always a strong
 argument for employee turnover.
@@ -210,6 +223,7 @@ obfuscation, you are confronted by the fact that the game that it
 implements is an obscure game.  Casual inspection of the program might
 lead one to believe that it is an implementation of classic chess, but
 this is not so.
+
 
 #### Q: What about the compiler warnings?
 
@@ -226,7 +240,7 @@ value computed is not used
 
 The `value computed is not used` warning happens because I use the `&&`
 operator and take advantage of short circuit evaluation instead of using
-an if() statement.
+an `if()` statement.
 
 The `suggest parentheses...` warnings are given because of expressions
 that depend on operator precedence details in the C language.
@@ -234,6 +248,7 @@ Eliminating these warnings would reduce obfuscation.
 
 The other warnings are there because it would require more code to
 eliminate them and that can't be done given the size limit.
+
 
 #### Q: Why does this program crash when it loses?
 
@@ -245,12 +260,12 @@ obfuscated program.
 [Judge's note:  This was followed by a description of the bug, and
 the comment:]
 
-(Note, if this program wins, the author thinks it would be good to leave
+Note, if this program wins, the author thinks it would be good to leave
 this information out of the remarks and encourage others to try and
-figure it out for themselves)
+figure it out for themselves.
 
-[should you be too lazy to figure it out yourself, here's the author's
-fix.]
+[Should you be too lazy (or time-efficient or affected by 'real life' :-) ) to
+figure it out yourself, here's the author's fix.]
 
 This bug can be fixed in a number of ways, but there is a way that adds only one
 byte to the source code.  In the statement `s=(e=-V(n-1,o))>s?Y=G,e:s;` change

--- a/2001/dgbeards/dgbeards.alt.c
+++ b/2001/dgbeards/dgbeards.alt.c
@@ -132,7 +132,7 @@ P V(P n, P o) {
 	R s;
 }
 main(P db, F *bd[]){
-	srand(0);
+	srand(time(0));
 	N o[500];
 	F T[256];
 

--- a/2001/jason/README.md
+++ b/2001/jason/README.md
@@ -12,13 +12,6 @@ make
 ```
 
 
-### Try:
-
-```sh
-echo "Do or do not. There is no try."
-```
-
-
 ## Judges' remarks:
 
 You are in a maze of twisty little passages, all alike.
@@ -32,6 +25,11 @@ expect that from something this small.
 
 Of particular interest:  Go ahead, run it through the preprocessor.  You
 *still* won't see the words that are used in the game.
+
+If you run it through a beautifier you might cause a crash as most of the
+whitespace is significant. Also, if you attempt to change one character
+identifiers to longer names expect problems. Even swapping the `Y` and `Z` can
+cause problems. Go ahead, try it! :-)
 
 
 ## Author's remarks:
@@ -54,7 +52,7 @@ out by typing "`get lamp`", then use the direction words "`left`",
 "`right`", "`forward`", and "`back`" to explore the caves.  Note that
 these words can refer to different passages depending on which way
 you're facing.  "`back`" always takes you back the way you came.
-Type "quit" to quit.
+Type "`quit`" to quit.
 
 The maze is randomly generated each time you play.  The algorithm
 ensures that you start at least 6 hops away from the exit.  All
@@ -81,7 +79,7 @@ Why I think this program is obfuscated:
 * Where are all the messages?  The game is downright chatty for
   only having two string literals (`"%d \n"` and `"Y\n : ! ,.?>"`).
 
-* There is exactly one loop in the program, a for loop, and it is
+* There is exactly one loop in the program, a `for` loop, and it is
   clearly the product of a deranged mind.  Running the
   preprocessor only makes it worse.
 
@@ -117,6 +115,9 @@ the game entertaining, see if you can find
 ```
 
 in the source code.)
+
+
+
 
 
 

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -10,7 +10,7 @@ make
 The current status of this entry is:
 
 ```
-STATUS: known bug - please help us fix
+STATUS: INABIAF - please **DO NOT** fix
 ```
 
 For more detailed information see [2001 ollinger in bugs.md](/bugs.md#2001-ollinger).
@@ -49,6 +49,7 @@ Do get lost in the programs line of thought!  :-)
 
 ## Author's remarks:
 
+
 ### What's this?
 
 What do you see? On the left, you will see an enumeration of all successive
@@ -58,12 +59,14 @@ primes. The big diagonals from right to left are used to erase composed numbers.
 When no diagonal crosses a number, then the left cell take value 1 and the
 number is prime.
 
-The parallel version of this algorithm works in real time n. This C
+The parallel version of this algorithm works in real time `n`. This C
 sequential version is slower as it works in `O(n*log n)`. But you have some
 nice picture instead... the cost is a constant number of operation for each
 character printed on the screen.
 
+
 ### Why did I write this ?
+
 
 Let's just quote the [FAQ](/faq.md):
 
@@ -107,6 +110,7 @@ Unbeaten for 12 years and counting...
 I think this is enough motivation for trying to submit a program which uses
 some complex state machine/table to generate small primes and print them.
 
+
 ### The way it works
 
 This program simply prints the space-time diagram of some particular
@@ -116,7 +120,7 @@ It is an optimization of an old automaton for recognizing primes designed
 by [Fischer](http://richardallenfischer.com) in 1965.
 
 The table of the automaton is encoded into the string `e` and consists of
-345 transitions of the kind ff(left,middle,right)`. This encoding into `e`
+345 transitions of the kind `ff(left,middle,right)`. This encoding into `e`
 is obfuscated to reduce its size, restrict it to characters 32 to 127 and
 guarantee a constant time.
 

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -5,30 +5,10 @@ make
 ```
 
 
-### Bugs and (Mis)features:
-
-The current status of this entry is:
-
-```
-STATUS: INABIAF - please **DO NOT** fix
-```
-
-For more detailed information see [2001 ollinger in bugs.md](/bugs.md#2001-ollinger).
-
-
 ## To use:
 
 ```sh
 ./ollinger integer
-```
-
-This program will very likely crash or do something else without an arg.
-
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
 ```
 
 

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -41,9 +41,7 @@ That's not a bug, that's a feature.
 ### Try:
 
 ```sh
-./schweikh foo 'f??'; echo $?
-./schweikh 'best short program' '??st*o**p?*'; echo $?
-./schweikh bar 'f??'; echo $?
+./try.sh
 ```
 
 
@@ -64,7 +62,7 @@ the whole string, so you may want to use `*` at the beginning and end of the
 pattern if you are looking for something in the middle.
 
 You can use it for your shell scripting needs similar to a silent grep
-(and without stdout redirected to `/dev/null`):
+(and without `stdout` redirected to `/dev/null`):
 
 ```sh
 if prog "${VARIABLE}" '<glob>'; then
@@ -83,15 +81,15 @@ All obfuscation is obviously in the recursive `m()` function, an 86
 character glob pattern evaluator, returning nonzero for a match:
 
 * Just a single complex return expression.
-* Nested ternary operator `?:` to save on if/else verbosity.
-* Short circuiting `&&` and `||` to save even more on if/else verbosity.
+* Nested ternary operator `?:` to save on `if`/`else` verbosity.
+* Short circuiting `&&` and `||` to save even more on `if`/`else` verbosity.
 * Subtraction instead of an equality operator in `*t - 42`.
 * ASCII codes for `*` and `?`.
 * Careful use of blanks even though this year's rules have extended
   that resource limit.
 * The source is a complete preprocessed C program. Because it communicates
-  with the world out there by means of argv and the exit status, there
-  is no need for stdio bloat. An asm guru could surely squeeze this
+  with the world out there by means of `argv` and the exit status, there
+  is no need for `stdio.h` bloat. An asm guru could surely squeeze this
   program in less than a screenful.
 * `indent(1)` is probably not too helpful.
 
@@ -101,7 +99,7 @@ backtracking. I could tell you how it works but then I would have to
 inputs, it will be quite helpful and instructive. Handling of `?` is
 straightforward; for `*` start out with `*foo` and `foo*` against `foo`.
 How does it deal with sequences of adjacent `*`? How could this be
-improved? If all else fails, recode the `?:` operators with if/else and
+improved? If all else fails, recode the `?:` operators with `if`/`else` and
 try again. For extra credit implement character classes like `[a-z]`.
 
 

--- a/2001/schweikh/try.sh
+++ b/2001/schweikh/try.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2001/schweikh
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./schweikh foo 'f??'; echo \$?" 1>&2
+./schweikh foo 'f??'; echo $?
+
+echo "$ ./schweikh 'best short program' '??st*o**p?*'; echo \$?" 1>&2
+./schweikh 'best short program' '??st*o**p?*'; echo $?
+
+echo "$ ./schweikh bar 'f??'; echo \$?" 1>&2
+./schweikh bar 'f??'; echo $?

--- a/bugs.md
+++ b/bugs.md
@@ -302,7 +302,7 @@ NOTE: this does NOT apply to entries under the INABIAF status (though they're
 not mutually exclusive in some cases).
 
 
-## STATUS: uses gets() - change to fgets() if possible (in some cases getline() works)
+## STATUS: uses gets() - change to fgets() if possible
 
 NOTE: we're still locating entries and working on fixes with this status so we're not yet
 ready for help. We will remove this when we are.
@@ -347,6 +347,9 @@ _NOTE_: this status is _NOT necessarily mutually exclusive_ with the _INABIAF_
 (it's not a bug it's a feature) status. The reason for this is due to warnings
 during compiling, linking and/or runtime, sometimes causing confusing output (as
 noted above).
+
+Sometimes `getline(3)` will work but note that this function also stores the
+newline just like `fgets(3)`.
 
 
 ## STATUS: missing file(s) - please provide them
@@ -1427,8 +1430,6 @@ to /dev/null (`2>/dev/null`).
 ## 1996 jonth
 
 ### STATUS: INABIAF - please **DO NOT** fix
-
-### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1996/jonth/jonth.c](1996/jonth/jonth.c)
 ### Information: [1996/jonth/README.md](1996/jonth/README.md)
 
@@ -1926,7 +1927,7 @@ Although it is independent of endianness both systems need the same character
 set. In other words both have to be ASCII or EBCDIC - not one of each.
 
 
-## 2001 ollinger
+## 2001 schweikh
 
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2521,7 +2521,8 @@ the ANSI escape codes. This works with both linux and macOS.
 
 Cody fixed this so that it should always restore terminal sanity (echo enabled
 etc.) after exiting even if you don't press 'q', if you crash or if you kill the
-program prematurely.
+program prematurely. This was done by adding an explicit call to `e()` at the
+end of `main()`.
 
 Cody also added the [alt code](2001/ctk/README.md#alternate-code) that adds
 vi(m) movement keys.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -80,6 +80,16 @@ $ warning: this program uses gets(), which is unsafe.
 
 whereas without the warning it's much easier to see that it's a prompt.
 
+Another great example is:
+
+```sh
+$ cd 1990/cmills
+$ ./cmills
+Shuffle...
+warning: this program uses gets(), which is unsafe.
+Total $1000.  Wager?
+```
+
 In some entries this change is not possible, in one-liners it might make them
 too long (though it's also been possible to do it in some cases) and in some
 entries it's more complicated than others because of the annoying fact that for
@@ -93,6 +103,9 @@ fixes in that entry.
 
 In any case some of the entries have been updated this way for the reasons
 described above and in the [FAQ](/faq.md).
+
+Where possible `gets` has been redefined to be `fgets` with the appropriate arg.
+This is not always possible but if often is.
 
 See also [bugs.md](/bugs.md) for a further discussion on the matter.
 
@@ -408,9 +421,7 @@ commented out.
 
 ## [1986/hague](1986/hague/hague.c) ([README.md](1986/hague/README.md]))
 
-Cody made this use `fgets()` to avoid alarming and annoying messages about
-`gets()` being unsafe, sometimes interspersed with the output of the program.
-For more details about that see the [FAQ](/faq.md).
+Cody made this use `fgets()`.
 
 
 ## [1986/holloway](1986/holloway/holloway.c) ([README.md](1986/holloway/README.md]))
@@ -599,15 +610,7 @@ size constraints of the contest).
 
 ## [1987/wall](1987/wall/wall.c) ([README.md](1987/wall/README.md]))
 
-Cody made this safer by using `fgets()` instead of `gets()`. This prevents an
-annoying and potentially alarming warning at compiling, linking or runtime.
-Though this could be partly remedied through redirecting `stderr` to `/dev/null`
-this would not truly resolve the problem either and in order to avoid the
-warning one would have to always redirect `stderr` to `/dev/null`.
-
-Later Cody improved upon the `gets()`/`fgets()` change to make it more like the
-original by redefining `gets()` to use `fgets()` (with the correct args) so that
-the code can refer to `gets()` instead.
+Cody made this use `fgets(3)`.
 
 
 ## [1987/westley](1987/westley/westley.c) ([README.md](1987/westley/README.md]))
@@ -738,11 +741,7 @@ to itself and `pain()` does now.
 
 ## [1988/reddy](1988/reddy/reddy.c) ([README.md](1988/reddy/README.md))
 
-Cody made this use `fgets()` to prevent annoying warnings during compiling,
-linking and runtime, the latter of which being the most annoying.
-
-Cody also restored the name of the winner in the README.md file that was missing
-by some crazy chance.
+Cody made this use `fgets(3)`.
 
 
 ## [1988/spinellis](1988/spinellis/spinellis.c) ([README.md](1988/spinellis/README.md]))
@@ -981,17 +980,7 @@ judges was retained.
 Yusuke got this to work in modern systems (it previously resulted in a bus
 error).
 
-To prevent alarming warnings at linking or runtime Cody made the entry use
-`fgets()` rather than `gets()`. He notes that another option would have been to
-redirect `stderr` to `/dev/null` but he did not think of that at the time.
-
-Cody later improved upon the `gets()`/`fgets()` fix to make it more like the
-original where the code can refer to `gets()` in the way it originally did. This
-was done through a macro to redefine `gets`.
-
-BTW: Cody asks the following question: if the compiler compiles, the linker
-links and the user executes does that make the compiler the jury, the linker the
-judge and user the executioner? :-)
+Cody made this use `fgets(3)`.
 
 
 ## [1990/dds](1990/dds/dds.c) ([README.md](1990/dds/README.md]))
@@ -1008,16 +997,7 @@ Cody fixed another compiler error by removing the erroneous prototype to
 `fopen()`.  Cody also changed a `char *` used for file I/O to be a proper `FILE
 *` and fixed a typo in [LANDER.BAS](1990/dds/LANDER.BAS).
 
-Cody also made this use `fgets()` instead of `gets()` to make it safer and to
-prevent an annoying and potentially alarming warning at compiling and/or linking
-and/or runtime, the latter of which is unfortunately interspersed with the
-output of the program.
-
-Later Cody improved the `gets()`/`fgets()` fix by redefining `gets()` to use
-`fgets()`. Notice that the original entry used `fgets()` in one case as it has
-to read from another file and in this place nothing was changed.
-
-With these improvements the entry looks much more like the original!
+Cody also made this use `fgets(3)`.
 
 
 ## [1990/dg](1990/dg/dg.c) ([README.md](1990/dg/README.md]))
@@ -1074,21 +1054,12 @@ suggested `-trigraphs`. Both work but we used Yusuke's idea.
 ## [1990/tbr](1990/tbr/tbr.c) ([README.md](1990/tbr/README.md]))
 
 Cody fixed this to work with modern compilers; `exit(3)` returns void but the
-function was used in a binary expression so this wouldn't even compile. Cody
-also changed the code to use `fgets()` instead of `gets()` so one would not get
-a warning about the use of `gets()` at linking time or execution, the latter of
+function was used in a binary expression so this wouldn't even compile.
+
+Cody also changed the code to use `fgets()` instead of `gets()` so one would not get
+a warning about the use of `gets(3)` at linking time or execution, the latter of
 which was causing confusing output due to the warning being interspersed with
 the program's interactive output.
-
-Cody later improved his fix so that it looks more like the original. A problem
-that usually occurs with `gets()` to `fgets()` is for 'backwards compatibility'
-(so the man page once said) `fgets()` retains the newline and `gets()` does not.
-In this program if one does not remove the newline it breaks the program. This
-usually requires that one check that `fgets()` does not return NULL but with
-some experimenting this proved to seem to not be a problem here so by adding a
-couple macros that redefine `exit()` and `gets()` a whole binary expression
-could be removed (thus removing an extra `exit()` call) and it now almost looks
-like the same as the original.
 
 Additionally, Cody fixed the shortened version provided by the author in the
 same way as the original entry, first the compile fix and then later on making
@@ -1121,11 +1092,10 @@ if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;
 
 be changed to just test the value of `A` when `a` is argv and `A` is argc?
 
+Cody also changed the code to use `fgets(3)`.
 
-Finally Cody changed this program to use `fgets()` not `gets()` to make it safer
-and to prevent a warning about `gets()` at linking or runtime. Since this
-program is so incredible the extra fixes were deemed worth having and this is why
-it was done.
+Since this program is so incredible the extra fixes were deemed worth having and
+this is why it was done.
 
 Cody later disabled a warning in the Makefile that proved to be a problem only
 with clang in linux but which was defaulting to an error. This way was the
@@ -1256,8 +1226,8 @@ string. Thus the end of the string actually looks like:
 !.Xop.fssps!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!b/d
 ```
 
-But then there is the matter of getting the C to use `fgets()`. As can be seen
-above it's not as simple as changing `gets()` to `fgets()`. This was more magic
+But then there is the matter of getting the C to use `fgets(3)`. As can be seen
+above it's not as simple as changing `gets(3)` to `fgets(3)`. This was more magic
 characters that had to be updated and some added. The C code:
 
 ```c
@@ -1327,8 +1297,8 @@ It is hoped that this is the last time the string has to be updated to work with
 all versions of clang but if not the above is how it works.
 
 With these changes in place it will compile and work with both gcc and clang and
-the C code generated will use `fgets()`, not `gets()`, therefore removing the
-annoying warnings. Note that the array passed to `fgets()` is an int but that
+the C code generated will use `fgets(3)`, not `gets(3)`, therefore removing the
+annoying warnings. Note that the array passed to `fgets(3)` is an int but that
 was the same for `gets()` and is not necessary to update to a `char[]`.
 
 The key to the string is that it rotates the character by `+1`. This was not
@@ -1439,33 +1409,27 @@ Cody also restored a slightly more obscure line of code that had been changed:
 
 though it's questionable how much more (if at all) obscure that is :-)
 
-Cody also changed the location that it used `gets()` to be `fgets()` instead to
-make it safer and to prevent annoying warnings during compiling, linking or
-runtime (interspersed with the program's output). This was complicated because
-of how the other source files are generated (as above); simply changing the code
-could cause invalid output in the program which made other files fail to compile
-(for this example specifically, see below).
+Cody also changed the location that it used `gets()` to be `fgets(3)`.
+This was complicated because of how the other source files are generated (as
+above); simply changing the code could cause invalid output in the program which
+made other files fail to compile (for this example specifically, see below).
 
-One might think that simply changing the `gets()` to `fgets()` (with `stdin`)
-would work but it did not because `fgets()` stores the newline and `gets()` does
+One might think that simply changing the `gets(3)` to `fgets(3)` (with `stdin`)
+would work but it did not because `fgets(3)` stores the newline and `gets(3)` does
 not. That is well known but this code was relying on not having this newline in
 a different way (see also above).
 
-With `fgets()` the code `if(A(Y)) puts(Y);` ended up printing an extra line
+With `fgets(3)` the code `if(A(Y)) puts(Y);` ended up printing an extra line
 which made the generation of some files (like `adhead.c`) fail to compile. Why?
 There was a blank line after a `\` at the end of the first line of a _macro
 definition_! Thus the code now first trims off the last character of the buffer
 read to get the same correct functionality but in a safe and non obnoxious way.
 
-Later Cody improved the change to `fgets()` to make it slightly more like the
-original. This still requires the additional stripping of the newline inside the
-loop but now it uses what looks like before, just a call to `gets()`.
-
-But the improvement so that it uses `gets()` could not be changed to have the
-macro do the removal of the extra line (as in with a comma operator or a `&&`)
-as this, as might be expected from the above, caused compilation errors with
-another generated file (`adwc.c`)! Thus after the `gets()` call in the line that
-looks like:
+In this case the macro for `gets` could not be changed to have the macro do the
+removal of the extra line (as in with a comma operator or a `&&`) as this, as
+might be expected from the above, caused compilation errors with another
+generated file (`adwc.c`)! Thus after the `gets(3)` call in the line that looks
+like:
 
 ```c
 while( gets(Y) ){ Y[strlen(Y)-1]='\0'; if(A(Y)) puts(Y); }
@@ -1522,18 +1486,18 @@ commands that we suggested and some additional ones that provide for some fun.
 Cody fixed a crash that prevented this entry from working in some cases in some
 systems (like macOS) by disabling the optimiser in the Makefile.
 
-Cody also changed the buffer size in such a way that `gets()` should be safe
+Cody also changed the buffer size in such a way that `gets(3)` should be safe
 (theoretically) as it comes from the command line (though it can also read input
-from stdin after starting the program). Ideally `fgets()` would be used but this
+from stdin after starting the program). Ideally `fgets(3)` would be used but this
 is a more problematic.  Previously it had a buffer size of 256 which could
-easily overflow. In this entry `gets()` is used in a more complicated way:
+easily overflow. In this entry `gets(3)` is used in a more complicated way:
 first `m` is set to `*++p` in a for loop where `p` is argv. Later `m` is set to
-point to `h` which was of size 256. `gets()` is called as `m = gets(m)`) but
-trying to change it to use `fgets()` proved more a problem. Since the input must
+point to `h` which was of size 256. `gets(3)` is called as `m = gets(m)`) but
+trying to change it to use `fgets(3)` proved more a problem. Since the input must
 come from the command line Cody changed the buffer size to `ARG_MAX+1` which
 should be enough (again theoretically) especially since the command expects
 redirecting a dictionary file as part of the command line. This also makes it
-possible for longer strings to be read (in case the `gets()` was not used in a
+possible for longer strings to be read (in case the `gets(3)` was not used in a
 loop).
 
 Cody also added the [mkdict.sh](1992/gson/mkdict.sh) script that the author
@@ -1578,17 +1542,9 @@ Judges' remarks in the README.md file) this will not work with clang.
 Cody also provided the `runme.sh` script to demonstrate it as using make was
 problematic.
 
-Cody made it use `fgets()` instead of `gets()` to prevent annoying warnings
-getting in the way (in linux linking in a binary with `gets()` produces a
-warning that might get in the way with this entry and in macOS at runtime it
-prints a warning which often is interspersed with the output of the program
-which can be confusing).
+Cody made it use `fgets()` instead of `gets()`.
 
-Cody later improved the `fgets()` change to look more like the original i.e. it
-now uses a redefined `gets()`. This did require modifying the line number with
-`#line 1` under the macro `gets()`.
-
-Still this cannot work with clang due to different compiler messages. See
+NOTE: this entry cannot work with clang due to different compiler messages. See
 [bugs.md](/bugs.md) for details.
 
 
@@ -1718,12 +1674,7 @@ compile time. See the README.md for details.
 
 ## [1993/schnitzi](1993/schnitzi/schnitzi.c) ([README.md](1993/schnitzi/README.md]))
 
-Cody made this use `fgets()` not `gets()` to make it safer and to prevent an
-annoying warning with compiling and/or linking and/or runtime, the latter of
-which is unfortunately interspersed with the output of the program itself.
-
-Cody later improved the fix to use `gets()` via a macro so that it looks like
-the original code.
+Cody made this use `fgets(3)` not `gets(3)`.
 
 
 ## [1993/vanb](1993/vanb/vanb.c) ([README.md](1993/vanb/README.md]))
@@ -1808,12 +1759,10 @@ Cody also fixed it for clang under linux which objected to incompatible pointer
 type (because `time(2)` takes a `time_t *` which in some systems is a `long *`
 but what was being passed to it is an `int`).
 
-Cody also changed the entry to use `fgets()` instead of `gets()` to make it safe
-for lines greater than 231 in length and to prevent a warning at linking or at
-runtime, the latter of which can be interspersed with output of the program.
-Note that this now prints a newline after the output but this seems like a
-worthy compromise for preventing the interspersed output in macOS and at the
-same time it's safer (fixing it to not have the extra newline is more
+Cody also changed the entry to use `fgets(3)` instead of `gets(3)`. This one has
+a minor annoyance in that it now prints a newline after the output but this
+seems like a worthy compromise for preventing the interspersed output in macOS
+and at the same time it's safer (fixing it to not have the extra newline is more
 problematic than it's worth and in macOS another line of output would be shown
 without the change anyway and the difference is that now it's just a blank line
 rather than an annoying warning).
@@ -2257,13 +2206,8 @@ commands that we recommended.
 
 ## [2000/anderson](2000/anderson/anderson.c) ([README.md](2000/anderson/README.md]))
 
-Cody changed this entry to use `fgets()` instead of `gets()` to make it safer
-and to prevent annoying warnings from showing up at compiling, linking and/or
-runtime, the latter interspersed with the output of the program. This involved
+Cody changed this entry to use `fgets(3)` instead of `gets(3)`. This involved
 changing the `K` arg to `gets(3)` to `&K` in `fgets(3)`.
-
-Cody later improved the fix to use `gets()` by redefining `gets()` so that the
-code looks like before.
 
 Cody also added the [try.sh](2000/anderson/try.sh) script.
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2536,8 +2536,7 @@ that the idea of crashing on losing (see the README.md for details on why that
 might be) too good to get rid of so he kept that in.
 
 He also points out that there is a way to get the computer to automatically lose
-very quickly and he also points out that there is a flaw in the alternate
-version that the author did not note. Do you know what these are?
+very quickly. Do you know what it is?
 
 
 ## [2001/herrmann1](2001/herrmann1/herrmann1.c) ([README.md](2001/herrmann1/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2517,7 +2517,14 @@ sound devices in macOS).
 ## [2001/ctk](2001/ctk/ctk.c) ([README.md](2001/ctk/README.md]))
 
 The ANSI escape codes were no longer valid but Yusuke provided a patch to fix
-the ANSI escape codes. Cody tested this for macOS and it works fine.
+the ANSI escape codes. This works with both linux and macOS.
+
+Cody fixed this so that it should always restore terminal sanity (echo enabled
+etc.) after exiting even if you don't press 'q', if you crash or if you kill the
+program prematurely.
+
+Cody also added the [alt code](2001/ctk/README.md#alternate-code) that adds
+vi(m) movement keys.
 
 
 ## [2001/dgbeards](2001/dgbeards/dgbeards.c) ([README.md](2001/dgbeards/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -146,7 +146,7 @@ they were not fixed as the problems were documented by the author or us.
 
 Of course it can be argued that by fixing these things it makes it more user
 friendly for modern enjoyment but even so it's very often the wrong way to go
-about it. If the author does not mention it t hen it can be considered a bug
+about it. If the author does not mention it then it can be considered a bug
 that can be fixed.
 
 See the [bugs.md](/bugs.md) for more information regarding this situation and

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -94,6 +94,14 @@ In some entries this change is not possible, in one-liners it might make them
 too long (though it's also been possible to do it in some cases) and in some
 entries it's more complicated than others because of the annoying fact that for
 '"compatibility" reasons' `fgets()` retains the newline and `gets()` does not.
+As the v7 man page used to say:
+
+```
+BUGS
+
+The fgets(3) function retains the newline while gets(3) does not, all in the
+name of backward compatibility.
+```
 
 Some entries like [1992/adrian](1992/adrian/README.md) were more complicated in
 other ways due to the code generating other output and because of how it works

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2587,6 +2587,8 @@ Cody fixed this to not crash if not enough args as this was not documented by
 the author. The other problems are documented so were not fixed. See
 README.md for details.
 
+Cody also added the [try.sh](2001/schweikh/try.sh) script.
+
 
 ## [2001/westley](2001/westley/westley.c) ([README.md](2001/westley/README.md]))
 


### PR DESCRIPTION

There was some inconsistency as far as whether or not the problem was a
bug or feature, where not enough args would result in a crash. At one
point it seems it was changed to a bug, not a feature, and it is then
that I must have fixed it. However the bugs.md file incorrectly labelled
another entry as ollinger and the README.md for ollinger referred to
something that did not exist or rather it existed but it was for another
entry.

A minor fix in bugs.md has been done as well: change the status name of
using fgets() to not refer to getline(3); rather the description does 
that. This is because no other place has that function in the status 
line. Doing this is how I found the problem this commit fixes as another
entry should have that status.