### PR TITLE
Minor fixes and formatting to 2001/coupard

### DIFF
--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -38,7 +38,7 @@ include ../../var.mk
 
 # Common C compiler warnings to silence
 #
-CSILENCE= -Wno-empty-body -Wno-pointer-sign -Wno-return-type -Wno-deprecated-non-prototype -Wno-implicit-int
+CSILENCE= -Wno-empty-body -Wno-pointer-sign -Wno-deprecated-non-prototype -Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/2001/coupard/README.md
+++ b/2001/coupard/README.md
@@ -14,15 +14,16 @@ make
 
 ### Try:
 
+If you have access to `/dev/audio` or `/dev/sound/dsp`:
+
 ```sh
 ./coupard > /dev/audio
 ./coupard > /dev/sound/dsp
 ```
 
-If you're using macOS then you won't have these devices. If however you install
-[sox](https://en.wikipedia.org/wiki/SoX) from
-[MacPorts](https://www.macports.org) or [Homebrew](https://brew.sh) you can do
-something like:
+If you do not, first install [sox](https://en.wikipedia.org/wiki/SoX). If you
+use macOS you might install it from [MacPorts](https://www.macports.org) or
+[Homebrew](https://brew.sh). Then you can try:
 
 ```sh
 ./coupard | sox -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
@@ -68,33 +69,36 @@ To listen to what the program says directly, invoke
 
 The program then speaks out something like
 
-  "The time is HH hours MM minutes SS seconds"
+> The time is HH hours MM minutes SS seconds
 
 in military time (24 hours). Of course, you need to have permissions
 to write to `/dev/audio`, have your sound card enabled, the volume up,
 the speakers connected ... :-)
 
 If you want to convert the audio output of the program into another audio
-format, you can pipe it to [sox](https://en.wikipedia.org/wiki/SoX) for example
-(`sox` is the Swiss army knife of Unix audio tools): the command:
+format, you can pipe it to [SoX](https://en.wikipedia.org/wiki/SoX) for example
+(`sox` is the Swiss army knife of Unix audio tools). The command:
 
 ```sh
 ./coupard | sox -c1 -r8000 -tub - -c2 -r44100 -twav test.wav
 ```
 
 converts the output of the program into a 44.1KHz stereo .WAV
-file and saves it into "test.wav".
+file and saves it into `test.wav`.
 
 The output format of the program is 8KHz, unsigned 8-bit samples.
 
 NOTE: the program's return code is meaningless.
 
+
 ### Audio quality
 
 The quality of the sound produced by the program is cross between a
-yogurt-pot-and-string telephone and a bad gramophone, i.e. the S/N ratio is very
-low and the signal's top frequency is very low as well.  This is because the
-audio is stored internally at a sampling rate of 4KHz (the [Nyquist
+[yogurt-pot-and-string
+telephone](https://en.wikipedia.org/wiki/Tin_can_telephone) and a bad
+[gramophone](https://en.wikipedia.org/wiki/Phonograph), i.e. the S/N ratio is
+very low and the signal's top frequency is very low as well.  This is because
+the audio is stored internally at a sampling rate of 4KHz (the [Nyquist
 frequency](https://en.wikipedia.org/wiki/Nyquist_frequency) is only 2KHz) with
 only 4-bit samples (adding 24db of quantization noise to an already poor
 signal).
@@ -103,12 +107,13 @@ In short, you might have to listen twice to understand what the
 program is saying. 2048 bytes including the sound generation program
 doesn't leave much room for audio quality ;-)
 
+
 ### Speech generation
 
 Only 9 phonemes are used to generate the speech. Beside the limited
 number of words the program has to generate (66 words), the low sound
 quality is actually exploited to take liberties with certain
-consonants (for example, "s" and "f" sound very much the same at 4KHz,
+consonants (for example, `s` and `f` sound very much the same at 4KHz,
 so they can be merged into one phoneme). Because the
 [psychoacoustic](https://en.wikipedia.org/wiki/Psychoacoustics)
 context around those phonemes is just sufficient, the words can be
@@ -118,6 +123,7 @@ pronounced quite wrongly.
 Internally, a table is used to generate most of the words, and
 composite words such as "thirty-five" are made up by the C code
 externally.
+
 
 ### Data compression
 
@@ -138,6 +144,7 @@ pairs of printable ASCII characters: the raw data is compressed to
 characters, which leaves just enough room for the decompressor with a
 hard-coded Huffman tree, and the code that plays the phonemes in the
 right order.
+
 
 ### Note on compiler warnings and lint
 

--- a/2001/coupard/coupard.c
+++ b/2001/coupard/coupard.c
@@ -39,4 +39,4 @@ int main(){
  for(;i<8476;j[p]=k>=0?j<*o?k-2:(p[j+1]=k<<4):0,j+=k>=0?1+(j>=*o):0,
  l=-k*(k<0),i++);e(21,4);x(hour)e(22,1);x(min)e(23,1);e(25,0);x(sec)e(24,0);
 
- return;}
+ return 0;}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2503,6 +2503,8 @@ He also fixed it to check the number of args.
 
 ## [2001/coupard](2001/coupard/coupard.c) ([README.md](2001/coupard/README.md]))
 
+Cody added a value to `return` in `main()` to make it more portable.
+
 Cody fixed this to compile with clang in linux. The problem was C99 does not
 support implicit int:
 
@@ -2516,11 +2518,11 @@ void e(n,h){
 
 ```
 
-The easiest fix is to just disable the warning which is what was done.
-Originally the code was changed to use `int` but to make it more like the
-original this was undone.
+This was not really worth a thanks per se but it was originally done by adding
+`int`. The better solution is to disable the warning which is what was done
+later on to make it more like the original.
 
-Yusuke for providing a proper command line for macOS (to do with sound; see his
+Yusuke provided a proper command line for macOS (to do with sound; see his
 [/2013/endoh3/README.md](2013/endoh3/README.md) entry where he also refers to
 sound devices in macOS).
 


### PR DESCRIPTION
main() now returns a value rather than just 'return' to be more portable.

Format/typo check README.md file.

I believe this completes the review of this entry.