### PR TITLE
Add bug status to 2001/williams

### DIFF
--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -68,7 +68,7 @@ CINCLUDE= -I ${X11_INCDIR} -I ${X11_INCDIR}/X11
 
 # Optimization
 #
-OPT= -O3
+OPT= -ggdb3
 
 # Default flags for ANSI C compilation
 #

--- a/2001/williams/README.md
+++ b/2001/williams/README.md
@@ -4,18 +4,22 @@
 make
 ```
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: known bug - please help us fix
+```
+
+For more detailed information see [2001 williams in bugs.md](/bugs.md#2001-williams).
+
+
 
 ## To use:
 
 ```sh
 ./williams
-```
-
-
-### Try:
-
-```sh
-echo "Do or do not. There is no try."
 ```
 
 

--- a/2001/williams/williams.c
+++ b/2001/williams/williams.c
@@ -52,7 +52,7 @@ A]; }Ne(l,30); Y==1){ E;K; } else    c=l.t=0;} Y==1&&h<H    -75&&!N(p*77)){ do{ 
                              dC(B++)); R Z|dL()){ Z&&!N(p)&&(Z--
                             ,nL(1+!N(p),N(W<<9), 0,N(W<<9),H<<9,1
                            ,0)); usleep(p*200); XCheckMaskEvent(d,
-                          4,&e)&&A&&--S&&nL(4,a[N(A)]<<9,H-10<<9,e.
+                          4,&e)&&A&&--S&&nL(4,a[N(7)]<<9,H-10<<9,e.
                          xbutton.x<<9,e.xbutton.y<<9,5,0);}S+=A*100;
                              B=sprintf(m,Q,v,S); XDrawString(d,w
                                      ,g,W/3,H/2,m,B); } }


### PR DESCRIPTION
There are two bugs that are known. First is that at the end of the game (when you lose) it appears to in (an infinite?) while loop call usleep(3). However you can still shoot your missiles at this point. The other bug is that it will eventually crash. It's easy to make it crash if you wait until everything is destroyed (that is when it starts printing the lines in a loop, sleeping over and over again) and only then start shooting your missiles, over and over again until it crashes. It appears that it's the 'Window *d' getting corrupted but I'm not sure why. These details have been added to bugs.md.

The README.md file has been format fixed.

There was a minor change to williams.c as well though this was only rolling back a change that should not have been committed yesterday.