### PR TITLE
Add 1998/schweikh3 alt code

### DIFF
--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -41,7 +41,8 @@ include ../../var.mk
 CSILENCE= -Wno-comment -Wno-deprecated-non-prototype -Wno-main -Wno-pedantic \
 	-Wno-return-type -Wno-strict-prototypes -Wno-unused-parameter -Wno-implicit-int \
 	-Wno-implicit-function-declaration -Wno-unused-value -Wno-multichar \
-	-Wno-uninitialized -Wno-unused-but-set-parameter
+	-Wno-uninitialized -Wno-unused-but-set-parameter -Wno-parentheses \
+	-Wno-int-conversion
 
 # Common C compiler warning flags
 #
@@ -136,7 +137,10 @@ ${PROG}: ${PROG}.c
 
 # alternative executable
 #
-alt: ${PROG}.alt.c
+alt: data ${ALT_TARGET}
+	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} -traditional-cpp $< -o $@ ${LDFLAGS}
 
 # data files

--- a/1985/sicherman/sicherman.c
+++ b/1985/sicherman/sicherman.c
@@ -2,25 +2,24 @@
 #define _C_C(_)('\b'b'\b'>=C_C>'\t'b'\n')
 #define C_C _|_
 #define b *
-#define c /b/
-#define v _C_C(
+#define C /**/
+#define V _C_C(
 char _,__;
-main(C,V)
-char **V;
+main(
 /*	C program. (If you don't
  *	understand it look it
- *	up.) (In the C Manual)*/
+ *	up.) (In the C*/ Manual)
 {
 	char _,__;
 	while (read(0,&__,1) & write((_=(_=C_C_(__),
-	('\b'b'\b'>=C_C>'\t'b'\n'))?__:__-_+'\b'b'\b'|
-	((_-52)%('\b'b'\b'+~' '&'\t'b'\n')+1),1),&_,1))_=V+subr(&V);
+	V))?__:__-_+'\b'b'\b'|((_-52)%('\b'b'\b'+~
+	' '&'\t'b'\n')+1),1),&_,1))_=C-V+subr(&V));
 }
 
-subr(C)
-char *C;
+subr(c)
+char *c;
 {
-	C="Lint says \"argument Manual isn't used.\" What's that\
-	mean?"; write((read(('"'-'/*"'/*"*/))?__:__-_+
-	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1);
+	c="Lint says \"argument Manual isn't used.\" What's that\
+	mean?"; while (write((read(('"'-'/*"'))?__:__-_+
+	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1));
 }

--- a/1998/schweikh3/.gitignore
+++ b/1998/schweikh3/.gitignore
@@ -1,4 +1,5 @@
 schweikh3
+schweikh3.alt
 file1
 file2
 file3

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA= samefile.1
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1998/schweikh3/README.md
+++ b/1998/schweikh3/README.md
@@ -13,15 +13,8 @@ the same size (on systems where `sizeof (char *) == 4`, or `4096` when
 31.
 ```
 
-so we changed the constant to be `SZ` defined in the Makefile. To change the
-value you can do something like:
-
-```sh
-make clobber CDEFINE="-DM0=sizeof -DM1=long -DM2=void \
-	-DM3=realloc -DM4=calloc -DM5=free -DSZ=55555" all
-```
-
-or whatever you wish to redefine it to.
+An alternate version allows one to fix this; see [alternate
+code](#alternate-code) below.
 
 
 ## To use:
@@ -46,6 +39,26 @@ If you're in this winning entry's directory:
 ```
 
 Notice that the tool finds some files that are duplicates.
+
+
+## Alternate code:
+
+If you run into the problem that the author described (above) you can redefine
+the size as described; this was done with the `SZ` macro defined in the Makefile
+which if (in the code) is unset will be set to the default, 32767.
+
+
+### Alternate build:
+
+If you wish to change the size to say, 55555:
+
+
+```sh
+make clobber CDEFINE="-DSZ=55555" alt
+```
+
+or whatever you wish to redefine it to. See [alternate code](#alternate-code)
+below.
 
 
 ## Judges' remarks:

--- a/1998/schweikh3/schweikh3.alt.c
+++ b/1998/schweikh3/schweikh3.alt.c
@@ -1,0 +1,85 @@
+%:define _POSIX_SOURCE
+#include<fcntl.h>
+#include<stdio.h>
+#include<unistd.h>
+#include<stdlib.h>
+#include<string.h>
+#include<sys/types.h>
+#include<sys/stat.h>
+#ifndef M0
+#define M0 sizeof
+#endif
+#ifndef M1
+#define M1 long
+#endif
+#ifndef M2
+#define M2 void
+#endif
+#ifndef M3
+#define M3 realloc
+#endif
+#ifndef M4
+#define M4 calloc
+#endif
+#ifndef M5
+#define M5 free
+#endif
+#ifndef SZ
+#define SZ 32767
+#elif SZ < 32767
+#undef SZ
+#define SZ 32767
+#endif
+#define D(N,t)Z t*N V<%t*z U M0*z); H z)u z; X}
+#define k(x,y)x<0||fstat(x,&y)||
+#define h(x)=open(x,O_RDONLY)
+#define b(x),(int)x.st_nlink
+#define B ;typedef g
+#define X exit (1);
+#define O .st_size
+#define U =malloc(
+#define Y S.st_ino
+#define v ;%>else
+#define W .st_dev
+#define o ||read(
+#define Z static
+#define g struct
+#define u return
+#define I char*
+#define V (M2)
+#define H if(
+#define _ ->
+
+/* HE WHO SAYS */
+
+Z I A<:   SZ/      M0(I )]; Z g     stat S,T; Z        size_t    y B f{
+I n ; g f *  x     ; dev_t d  ;    ino_t i; } f B      t{ M1     s,c; f
+*l; g t*L,*R; }    t; D(a,t)D(E    ,f)Z t*J(t*p,I      n){ H!   p){ p=
+a(); p    _ s =S      O; p _       c=1; p              _ L=p    _ R=0;
+p _ l=    E(); p      _ l  _       n=n; p              _ l _   x=0; p
+_ l  _    d=S W;      p _  l       _ i= Y              v H S   O==p _
+s){ f*    e; for      (e=p _       l; e; e=e _ x)      { H S W==e _ 
+d&&Y==    e _ i)      { u p;        } } e=E(); e _     x=p _ l; e _ 
+n=n; e    _ d =S      W; e _                i=Y; p     _ l=e;  ++p _ 
+c v  H    S O< p      _ s) {                p _ L=     J( p _  L,n)v{
+p _ R=    J (p _      R,n );                } u  p     ; }  Z   int Q(
+I G,I F){ int d    h(G),D h(F);    I m,*M; H k(d,S     )k(D,T   )(y =S 
+O)-T O){ y= 0;     goto d; } H!    (m U y))||!(M U     y))o d    ,m,y)-
+y o D,M,y)-y)      X y=!memcmp(     m,M,y); M5(m)      ; M5(M    ); d:V
+
+ close (d );V      close(D); u        y; } Z M2 C(M1       z,M1 N){ M1     i=N*(N-1)/2,
+j=1,s; I q,*e,*    p,*w,*l; e=q=     M4((size_t)i,1);     H!e) X p=q+i;    for(i=0; e-p
+; ++e){ H!*e&&Q    (A[i:>,A[j])){   V printf("%""l""d"   "\t""%" "s""\t"   "%""s"
+"??/t"             "%""c"   "\11"   "%""d"      "??/t"   "%""d"    "\n",   z,A[i]
+,A[j],             S W -T   W?'X'   :'='b(      S)b(T)   ); H j    -i-1)   { s=N-
+i-3; w             =e+s+1; l=q+N*   (j-1)-      j*(j-1   )/ 2 ;            do{ *w
+=1; H w==l)        break; w+= s;    } while( s-->0); }   } H++j            ==N){ j=i+++
+ 2; } } M5(q);     } Z M2 P(t*p     ){ H p){ P(p _ R);   H  p _            c>1){ M1 i=0
+         ; f*l=    p _ l;           for (;      i< p _   c; ++i            ){ A[i
+         ]= l _    n; l=l           _ x; }      C (p _   s, p _    c); }   P (p _ 
+         L) ; }    }  int           main V      { t*r=   0; I F    ; for   (; ; )
+{ H!(F U 1024))    )X H !           fgets(      F,1024   ,stdin) )break;   *(F+(y
+=strlen(F))-1)=    0; H!(          F=M3(F,      y)))X H   stat(F,&S)==0    &&S_ISREG(S.
+ st_mode)&&S O     )r=J(r          ,F ); }      H r)P(r    ); u 0; }/*     Obfuscated C
+
+IS FREE THINKS MONEY GROWS ON DIRECTORY TREE */

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2061,7 +2061,6 @@ done in modern systems) to be `_int`.
 
 
 ## [1998/dlowe](1998/dlowe/dlowe.c) ([README.md](1998/dlowe/README.md]))
-## [1998/dlowe](1998/dlowe/dlowe.c) ([README.md](1998/dlowe/README.md]))
 
 Cody made the program more portable by changing the void return type of `main()`
 to be `int` (in both versions).
@@ -2199,6 +2198,10 @@ README.md.
 
 
 ## [1998/schweikh3](1998/schweikh3/schweikh3.c) ([README.md](1998/schweikh3/README.md]))
+
+Cody added the [alternate code](1998/schweikh3/README.md#alternate-code) which allows one
+to reconfigure the size constant in the rare case that the author wrote about
+occurs.
 
 Cody added the [try.sh](1998/schweikh3/try.sh) script to make it easier to try
 the commands that we suggested. One command was not added, that of the to use

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -375,63 +375,83 @@ then compare it to [sicherman.c](1985/sicherman/sicherman.c) for some good old
 C-fashioned fun (alternatively, see below explanation)!
 
 Later on Cody improved the fix so that it looks much more like the [original
-entry](1985/sicherman/sicherman.c). He did this two more times and it's about as
-close to the original as one can get without causing a compilation error.
+entry](1985/sicherman/sicherman.c). He did this several more times and it's
+as close to the original as one can get without causing compiler errors.
 
 To get this to all work the following changes were made. If you really want to
-understand this you can do the following from the directory:
+understand this Cody provides the following. First run the following command
+from the directory:
 
 ```sh
 make diff_orig_prog
 ```
 
-and then read the following:
+and then read the following (you might also wish to look at the code in an
+editor with syntax highlighting):
 
-- The `C` macro, `#define C /b/`  was changed to `c`, so that in the function
-`subr()` we could assign to `C` (which there is a `char *` but with modern
-compilers would not work with the `C` macro changing the definition).
+- Because of the macros `C` and `V` in the original code, the args to `main()`
+were actually not what they appear: the only arg that existed in `main()` was
+`Manual`. Thus it now looks like:
+
+	```c
+	main(
+	/*	C program. (If you don't
+	 *	understand it look it
+	 *	up.) (In the C*/ Manual)
+	{
+	```
+
 - The code:
 
-
-	    C="Lint says "argument Manual isn't used."  What's that
-	    mean?"; while (write((read(C_C('"'-'/*"'/*"*/))?__:__-_+
-	    '\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1));
+	```c
+	C="Lint says "argument Manual isn't used."  What's that
+	mean?"; while (write((read(C_C('"'-'/*"'/*"*/))?__:__-_+
+	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1));
+	```
 
     had to be changed to:
 
-	C="Lint says \"argument Manual isn't used.\" What's that\
-	mean?"; write((read(('"'-'/*"'/*"*/))?__:__-_+
-	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1);
+	```c
+	c="Lint says \"argument Manual isn't used.\" What's that\
+	mean?"; while (write((read(('"'-'/*"'))?__:__-_+
+	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1));
+	```
 
-    because of the missing `"` at the end of the line. Observe how the while
-    loop was removed. It might be that this was once disabled but having it
-    there makes it impossible for `main()` to call it so it was removed.
+    because of the missing `"` at the end of the line and because `_|_` is not a
+    function call.
 
     The `\"` had to be done to keep the `"`s there though the string could be
-    broken up into multiple `"` pairs instead. Notice how the last line of code
-    in that function is the same as before!
+    broken up into multiple `"` pairs instead; that seemed less authentic,
+    however. Notice how the last line of code in that function is the same as
+    before and actually that there aren't that many changes in the function at
+    all!
 
-    Notice how in that function `subr()`, `C` could still stay the same in the
-    arg list (of `subr()`) since it is still a `char *C`! Since the `_` and `__`
-    were added at file scope (in addition to where it already was in `main()`),
-    the references to those variables could stay in the function.
+    Notice also that the parameter `C` had to be changed to `c` due to the macro.
 
-- The code in main `up.) (In the C Manual)` had to be commented out though
-another option would have been to close the comment earlier, opened a new one,
-and added `int C;` instead.
-- The code in `main()` is the significant change as the macros had to be
-replaced for actual code so that instead of having the while loop condition as:
+    The `char`s `_` and `__` were made file scope so the `subr()` could actually
+    compile but this does not affect the ones in `main()`. Why is this? You tell
+    us!
 
+- The code in `main()` is where there are significant changes, changing from:
+
+	    ```c
 	    while (read(0,&__,1) & write((_=(_=C_C_(__),C)),
 	    _C_,1)) _=C-V+subr(&V);
+	    ```
 
-    we have it as:
+	to:
 
+	    ```c
 	    while (read(0,&__,1) & write((_=(_=C_C_(__),
-	    ('\b'b'\b'>=C_C>'\t'b'\n'))?__:__-_+'\b'b'\b'|
-	    ((_-52)%('\b'b'\b'+~' '&'\t'b'\n')+1),1),&_,1))_=V+subr(&V);
+	    V))?__:__-_+'\b'b'\b'|((_-52)%('\b'b'\b'+~
+	    ' '&'\t'b'\n')+1),1),&_,1))_=C-V+subr(&V));
+	    ```
 
-    Note how numerous of the macros can still be used but some cannot.
+    Note how numerous of the macros can still be used but some cannot be. Can
+    you figure out why? Why too is it that the `subr()` function is called but
+    it appears that some of the code in that function is also in `main()` in the
+    `while` condition? What happens if you remove it from `main()`? What happens
+    if you remove it from `subr()` or don't even bother calling `subr()`?
 
 
 ## [1986/hague](1986/hague/hague.c) ([README.md](1986/hague/README.md]))


### PR DESCRIPTION

This is for the rare case that the author described where the size needs
to be increased: it can now be done when compiling without having to 
update the code. The original code is the recommended one try first; if
any of '-D' macros are not defined it will use the default, including 
the size one. This so to make it easier to redefine just one, rather 
than having to specify all the -D options.