### PR TITLE
Fix infinite loop in 1992/vern

### DIFF
--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -40,7 +40,8 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-dangling-else -Wno-error \
 	-Wno-implicit-function-declaration -Wno-parentheses -Wno-pedantic \
-	-Wno-return-type -Wno-shift-op-parentheses -Wno-deprecated-non-prototype
+	-Wno-return-type -Wno-shift-op-parentheses -Wno-deprecated-non-prototype \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -137,7 +138,7 @@ ${PROG}: ${PROG}.tmp.c
 ${PROG}.tmp.c: ${PROG}.c
 	${RM} -f $@
 	${SED} <${PROG}.c 's/{ /(/g;s/} /)/g;s/;	/#define /' | \
-	    ${SED} 's/}	/=/g;s/{	/i/g' >$@
+	    ${SED} 's/}	/=/g;s/{	/i/g;s/|	/ii/g' >$@
 
 # alternative executable
 #

--- a/1992/vern/README.md
+++ b/1992/vern/README.md
@@ -10,7 +10,6 @@ make all
 The current status of this entry is:
 
 ```
-STATUS: known bug - please help us fix
 STATUS: INABIAF - please **DO NOT** fix
 ```
 

--- a/1992/vern/vern.c
+++ b/1992/vern/vern.c
@@ -12,6 +12,7 @@
 ;	b else
 ;	u while
 ;	B if
+char ii[5],jj[5];
 U v,w,Y}	 -1,W,J,p,F,o}	f,M,N,K,X,YY,_,P[f],s{ } ;
 typedef U{ *L} { } ;
 L q[f];
@@ -174,10 +175,13 @@ V{ ; ; } {
 y{ } ; 
 o}	f; 
 do{
+ii[0]='\0';
+jj[0]='\0';
+i=j=0;
 H"\n%d %d %d %s ",X,T,C{ } ,s{ } ?"!":">"} ;
 fflush{ stdout} ; 
 }
-u{ scanf{ "%o%o",&{	,&j} !}	2||I{ {	,j,1} } ;
+u{ scanf{ "%4s%4s",|	,jj} !}	2||(i=strtol(ii,NULL,8))<0||i>077||(j=strtol(jj,NULL,8))<0||j>077||I{ {	,j,1} } ;
 O{ {	,j} ; 
 y{ } ; 
 X}	0; 

--- a/bugs.md
+++ b/bugs.md
@@ -946,22 +946,6 @@ it can 'rub your nose in defeat', as the author puts it. You will have to exit
 it yourself through ctrl-c or killing it in some other fashion.
 
 
-### STATUS: known bug - please help us fix
-
-If one enters a number out of range, that is < 00 or > 77, the program will
-enter an infinite loop, flooding the screen.
-
-You are welcome to try and fix this (mis)feature. It might help if you run the
-intermediate step in compilation like so:
-
-```sh
-sed <vern.c 's/{ /(/g;s/} /)/g;s/;       /#define /' | \
-    sed 's/}      /=/g;s/{        /i/g' >vern.tmp.c
-```
-
-and look at `vern.tmp.c` instead, to give you an idea of what is going on.
-
-
 ## 1992 westley
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -14,6 +14,7 @@ Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson) who is
 responsible for most of the improvements and fixes including many **EXTREMELY
 HARD bug fixes** like
 [1988/phillipps](/thanks-for-fixes.md#1988phillipps-readmemd),
+[1992/vern](/thanks-for-fixes.md#1992vern-readmemd),
 [2001/anonymous](/thanks-for-fixes.md#2001anonymous-readmemd) and
 [2004/burley](/thanks-for-fixes.md#2004burley-readmemd), making entries like
 [1985/sicherman](/thanks-for-fixes.md#1985sicherman-readmemd) and
@@ -27,7 +28,7 @@ entries to macOS (some being **EXTREMELY HARD** like
 [1998/schweikh1](/thanks-for-fixes.md#1998schweikh1-readmemd)), fixing code like
 [2001/herrmann2](/thanks-for-fixes.md#2001herrmann2-readmemd) to work in both
 32-bit/64-bit which *can be* **EXTREMELY HARD**, providing alternate code
-where useful/necessary, fixing where possible/removing dead links,
+where useful/necessary, fixing possible/removing dead links,
 typo/consistency fixes, improving **ALL _Makefiles_** and writing
 [sgit](https://github.com/xexyl/sgit) that we installed locally to easily run
 `sed` on files in the repo to help build the website. **THANK YOU VERY MUCH**
@@ -1595,6 +1596,20 @@ participates in the IOCCC, that it must be our fault! :-)
 
 Cody also added the [try.sh](1992/nathan/try.sh) script that runs a few commands
 that we suggested as well as one he provided.
+
+
+## [1992/vern](1992/vern/vern.c) ([README.md](1992/vern/README.md]))
+
+Cody fixed an infinite loop if one were to input numbers < `0` or > `077`. The
+problem was that it tried to use `scanf(3)` with the format specifier `"%o %o"` in a
+loop, reading again if `scanf(3)` did not return 2 (that was not a problem in
+that `scanf(2)` will not return until the number of specifiers have been
+processed or some error occurs) or a function it called returned non-zero.
+
+Instead the fix involves the `scanf(3)` specifiers being `"%4s %4s" on two
+new char arrays (always cleared in the beginning of the loop) and then using
+`strtol(3)` with a base of `8` (as it's octal), checking for `< 0 || > 077` on
+both numbers (using `"%o %o"` does not solve the problem).
 
 
 ## [1992/westley](1992/westley/westley.c) ([README.md](1992/westley/README.md]))


### PR DESCRIPTION
If one entered input < 0 || > 077 (octal) the program would enter an infinite loop that flooded the screen, forcing the user to terminate the program.

The problem was that scanf(3) (with "%o %o" specifier string) was in a loop checking for return value of 2 (this was not a problem because scanf(3) does not return until all the specifiers are processed or I suppose some error occurs) and not checking the values. Instead it just checked a function on the numbers. This fix involves using scanf(3) with the specifier "%4s %4s" and then using strtol(3) with base 8 and then checking for < 0 || > 077 (using "%o %o" will not work).

The game now functions as expected without flooding the terminal if invalid input is given. The judges' remarks about the range has been kept in as it's still invalid it just won't flood the screen.