### PR TITLE
Fixes and formatting/typo check 2005/vince

### DIFF
--- a/2005/vince/README.md
+++ b/2005/vince/README.md
@@ -14,21 +14,20 @@ make
 ./vince
 ```
 
-Under macOS run from within an console tab (whether xterm, the default or
-another) while the X11 server is running.
 
+## Try:
 
-### Try:
-
-```sh
-echo "Do or do not. There is no try."
-```
+When running this in the program's window try hitting space a few times and see
+what happens!
 
 
 ## Alternate code:
 
 The [vince.alt.c](vince.alt.c) code of the submission will run on SGI IRIX and
-also has the recursive CPP macro (which sneaked in accidentally) removed.
+also has the recursive `CPP` macro (which sneaked in accidentally) removed.
+
+
+### Alternate build:
 
 To compile this alternate version:
 
@@ -36,7 +35,14 @@ To compile this alternate version:
 make alt
 ```
 
+### Alternate use:
+
 Use `vince.alt` as you would `vince` above.
+
+
+### Alternate try:
+
+Try it just like `vince` as above.
 
 
 ## Judges' remarks:
@@ -53,6 +59,7 @@ Challenge: Try modifying the texture to something of your own design.
 
 ## Author's remarks:
 
+
 ### ABUSE OF RULES
 
 * The executable needs to read in its own source code in order to run. As
@@ -64,6 +71,7 @@ able to find it...
 * The program abuses severely the whitespace and `{ } ;` exceptions in the
 file size limits.
 
+
 ### Requirements
 
 * OpenGL. It works (slowly) with Mesa.
@@ -73,6 +81,7 @@ file size limits.
 * The original source needs to be in the same directory as the executable,
 and the source's name should be the same as the executable but with `.c` on the
 end.
+
 
 ### Background
 
@@ -84,6 +93,7 @@ So to one up them, I decided to use OpenGL. It's standard, and most Unix-like
 systems these days have either accelerated graphics or else software
 rendering.
 
+
 ### Obfuscation
 
 It was a challenge getting the source code below the 2k limit. OpenGL has way
@@ -94,17 +104,22 @@ size to fit under the limit while still having some semblance of a demo.
 
 There are some interesting abuses scattered about.
 
+
 ### Usage
 
 Try hitting the space bar when the program is running.
 
+
 ### For Fun
 
+
 Try modifying the texture to your own custom design...
+
 
 ### Thanks
 
 Many thanks to John Clemens for testing this on various machines for me.
+
 
 ### Errors you can get
 
@@ -112,8 +127,8 @@ Many thanks to John Clemens for testing this on various machines for me.
 - 1 =
 [X](https://en.wikipedia.org/wiki/X_Window_System_protocols_and_architecture)
 problem.
-- 2 = Can't open [glx](https://en.wikipedia.org/wiki/GLX).
-- 3 = Can't open 16bpp visual.
+- 2 = can't open [GLX](https://en.wikipedia.org/wiki/GLX).
+- 3 = can't open 16bpp visual.
 - 4 = can't open source file.
 
 

--- a/2005/vince/vince.alt.c
+++ b/2005/vince/vince.alt.c
@@ -57,7 +57,7 @@ void Q()
 ,N ) ) E( 2 ) ; v =  glXChooseVisual L , DefaultScreen (y              ),b
 ); s. colormap = XCreateColormap L , u = RootWindow ( y ,              v->
 screen),v->visual, AllocNone ); if ( !(r=glXCreateContext              L,v
-,N , 1 ) ) ) E ( 3 ) ; strcpy (f , * A) ; strcat (f, ".c"              ) ;
+,N , 1 ) ) ) E ( 3 ) ; strcpy (f , __FILE__);  ;
 F =  fopen ( f ,  "r" ) ; s . event_mask = KeyPressMask ;              w =
 XCreateWindow L,u, 0,0,640, 480,0,v -> depth, InputOutput              , v
 -> visual , CWBorderPixel  | CWColormap  | CWEventMask ,&              s);
@@ -72,9 +72,9 @@ GL_PROJECTION ) ; gluPerspective ( 60 , 1.333 , 1 ,  100)    	       ; J
 GL_MODELVIEW); u=glGenLists(1); glNewList (u,GL_COMPILE);	       H X
 ); while(a!=81)a=G; G;G;for(x=0;x<6;x++){glBegin(GL_QUADS              ) ;
 R(); glNormal3f(c,m,n); T(1,1); V T(1,0); V T(0,0); V T(0              ,1)
-; V glEnd(); } glEndList(); XMapWindow L, w) ; c=0; for(;              ; ) 
+; V glEnd(); } glEndList(); XMapWindow L, w) ; c=0; for(;              ; )
 { if (XPending L)){ XNextEvent L, &e); if ((XLookupKeysym              ( (
-XKeyEvent *)&e,0))&1<<5){ h=10; i[c] =!i[c]; c++; c&=3; }             else 
+XKeyEvent *)&e,0))&1<<5){ h=10; i[c] =!i[c]; c++; c&=3; }             els
 E(0) } glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT            ) ;
 glLoadIdentity (); gluLookAt ( -2 ,0 ,5 ,0,0 ,0,0 ,0 ,1 )          ; H
 GL_LIGHTING); H GL_LIGHT0 ); U GL_POSITION, i + 4 ); U O)        ; U

--- a/2005/vince/vince.c
+++ b/2005/vince/vince.c
@@ -58,8 +58,8 @@ void Q()
 glXQueryExtension L , N , N ) ) E (2); v=glXChooseVisual            L ,
 DefaultScreen (y ) , b  ) ; s.colormap = XCreateColormap            L ,
 RootWindow (y,v -> screen), v -> visual, AllocNone ); if            (!(
-r= glXCreateContext L, v, N, 1) ) ) E (3) ; strcpy(f, *A            ) ;  
-s.event_mask=KeyPressMask; strcat(f,".c"); F=fopen(f,"r"            ) ; 
+r= glXCreateContext L, v, N, 1) ) ) E (3) ; strcpy(f, __FILE__      ) ;  
+s.event_mask=KeyPressMask; ; F = fopen(f, "r"                       ) ; 
 w= XCreateWindow L, RootWindow( y, v -> screen ), M , M,            0,v
 ->depth,InputOutput, v->visual , CWColormap|CWEventMask,            &s)
 ;glXMakeCurrent L , w , r ); H GL_DEPTH_TEST ); if ( ! F            )E(

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3032,6 +3032,20 @@ another function that takes 4 args and which is what used to be `main()`.
 The alternate versions were also fixed.
 
 
+## [2005/vince](2005/vince/vince.c) ([README.md](2005/vince/README.md))
+
+Cody fixed this in the case that the program is compiled or linked/copies to
+another file name: the code constructed the source code file name in a clever
+and more obscure way by copying to the buffer `*argv` and then using `strcat(3)`
+to concatenate to it `.c`. But this assumes that the executable is the same name
+as the source file which isn't always be true. The author even stated: 'as long
+as the source is in the same directory as the executable it should be able to
+find it' but the source code file name is not always the same as the executable
+with the appropriate extension so this might be called a bug fix as well though
+if one runs it from another directory, specifying the directory, it'll not catch
+it.
+
+
 ## [2006/birken](2006/birken/birken.c) ([README.md](2006/birken/README.md]))
 
 Cody fixed a segfault in macOS with this entry. The problem was a missing `+1`


### PR DESCRIPTION
The code (both alt and entry) no longer assumes that the source code filename is the same as the running program with '.c' added. Instead it uses __FILE__. This does make it slightly less obscure (see next part) but it is also slightly less error prone at least in some cases. The way it worked before is that it copied to a buffer '*argv' and then used strcat(3) with the string ".c" to come up with the filename. The author actually stated:

    As long as the source is in the same directory as the executable it
    should be able to find it.

... but this was not strictly true. Now as long as the source file it was compiled as is in the directory it will find it even if the executable was copied/linked/renamed to something else.

Format/typo check README.md file.