### PR TITLE
Add 2005/sykes/try.sh and test.sh + make test rule

### DIFF
--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -137,6 +137,9 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
+test: ${PROG} test.sh
+	-./test.sh
+
 # alternative executable
 #
 alt: data ${ALT_TARGET}

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -15,18 +15,8 @@ make
 ### Try:
 
 ```sh
-./sykes pet.rom
-# type in the following for an old Easter egg:
-WAIT 6502,12
+./try.sh
 ```
-
-Also try:
-
-```
-./sykes chess
-```
-
-for some good [chess](https://en.wikipedia.org/wiki/Chess) fun.
 
 
 ## Judges' remarks:
@@ -57,7 +47,7 @@ dd bs=2k count=1 if=/dev/zero of=nullfill.bin
 ```
 
 For your convenience, we have added the above mentioned files to this entry directory.
-They are used to form the `pet.rom` file.
+They were used to form the `pet.rom` file.
 
 
 ## Author's remarks:
@@ -70,6 +60,7 @@ processor](https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_descripti
 This is the second version of the same entry, but this one takes care to
 not include any possibly copyrighted items in the info files, to be sure
 to not infringe the rules.
+
 
 ### Test
 
@@ -84,6 +75,7 @@ Compile the program, then test the
 A basic test is done for each instruction and addressing mode, all tests
 should pass. At the end of the tests, it loops forever - break out with
 control-C.
+
 
 ### PET EMULATION
 
@@ -180,8 +172,8 @@ WAIT 6502,12
 The program is basically a
 [6502](https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_description)
 [emulator](https://en.wikipedia.org/wiki/Emulator), and it does NOT need the
-[commodore](https://en.wikipedia.org/wiki/Commodore_PET)
-[rom](https://en.wikipedia.org/wiki/ROM_image) to work.
+[Commodore](https://en.wikipedia.org/wiki/Commodore_PET)
+[ROM](https://en.wikipedia.org/wiki/ROM_image) to work.
 
 Supplied as a demonstration is a
 compiled-for-[6502](https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_description)
@@ -222,9 +214,10 @@ In
 the screen understands normal
 [ASCII](https://en.wikipedia.org/wiki/ASCII#Character_set).
 
-Lastly, the before [emulation](https://en.wikipedia.org/wiki/Emulator) starts,
-the low byte from a `time()` call is placed at address 0 - this can be used as a
+Lastly, before [emulation](https://en.wikipedia.org/wiki/Emulator) starts,
+the low byte from a `time(3)` call is placed at address 0 - this can be used as a
 random seed.
+
 
 ### Technical description
 
@@ -241,7 +234,7 @@ the [PET](https://en.wikipedia.org/wiki/Commodore_PET) hardware for it to work.
 If the supplied file is exactly 16384 bytes, the
 [emulator](https://en.wikipedia.org/wiki/Emulator) assumes it is a
 [PET](https://en.wikipedia.org/wiki/Commodore_PET)
-[rom](https://en.wikipedia.org/wiki/ROM_image), and goes into PET emulation
+[ROM](https://en.wikipedia.org/wiki/ROM_image), and goes into PET emulation
 mode. Otherwise some PET specific features are skipped during normal
 [6502](https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_description)
 [emulation](https://en.wikipedia.org/wiki/Emulator).
@@ -254,6 +247,7 @@ instructions according to a table and executes them.
 
 The addressing mode is decoded in a similar expression starting on line
 53.
+
 
 ### Bugs
 
@@ -268,8 +262,8 @@ The parameter controls the speed of the 60Hz "jiffy clock", and not the
 processor speed. This means many games may run too fast to be usable -
 it really depends on the speed of your machine.
 
-Although the PET [emulator](https://en.wikipedia.org/wiki/Emulator) can do LOAD
-and SAVE, it cannot VERIFY or OPEN and CLOSE files.
+Although the PET [emulator](https://en.wikipedia.org/wiki/Emulator) can do `LOAD`
+and `SAVE`, it cannot `VERIFY` or `OPEN` and `CLOSE` files.
 
 The [PET](https://en.wikipedia.org/wiki/Commodore_PET) hardware
 [emulation](https://en.wikipedia.org/wiki/Emulator) is not at all complete -
@@ -281,6 +275,7 @@ The
 [emulation](https://en.wikipedia.org/wiki/Emulator) does not include the seldom
 used decimal mode, or any of the "undocumented" instructions.
 
+
 ### IMPORTANT NOTE
 
 I think it is great fun to run the
@@ -288,10 +283,11 @@ I think it is great fun to run the
 [emulation](https://en.wikipedia.org/wiki/Emulator) and mess around with
 [Microsoft](https://en.wikipedia.org/wiki/Microsoft)
 [BASIC](https://en.wikipedia.org/wiki/BASIC). However, this obviously needs the
-[rom](https://en.wikipedia.org/wiki/ROM_image) file to work. My
+[ROM](https://en.wikipedia.org/wiki/ROM_image) file to work. My
 program is original and completely free of any copyright, but, of
 course, the `pet.rom` is not my work. So I ask the user to download it
 from the Internet.  This is to avoid directly infringing any copyright.
+
 
 ### Finally
 

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -5,6 +5,17 @@ make
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2005 sykes in bugs.md](/bugs.md#2005-sykes).
+
+
 ## To use:
 
 ```sh
@@ -240,13 +251,14 @@ mode. Otherwise some PET specific features are skipped during normal
 [emulation](https://en.wikipedia.org/wiki/Emulator).
 
 The main processing all happens in a heroic expression containing no
-less than 64 ternary operators (after `cpp`) starting on line 56. This
-decodes the
+less than 64 ternary operators (after `cpp`) starting on [line
+56](https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c#L56).
+This decodes the
 [6502](https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_description)
 instructions according to a table and executes them.
 
-The addressing mode is decoded in a similar expression starting on line
-53.
+The addressing mode is decoded in a similar expression starting on [line
+53](https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c#L53).
 
 
 ### Bugs

--- a/2005/sykes/test.sh
+++ b/2005/sykes/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# 2005/sykes/test.sh - run the test suite
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "NOTE: you will have to hit ctrl-c to exit after the test." 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+
+./sykes 6502test 6 2>&1

--- a/2005/sykes/try.sh
+++ b/2005/sykes/try.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# try.sh - demonstrate IOCCC winner 2005/sykes
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+while true; do
+    echo "(0) Run demo" 1>&2
+    echo "(1) Show Easter egg" 1>&2
+    echo "(2) Play chess" 1>&2
+    echo "(3) Run test-suite" 1>&2
+    echo "(4) Run pet.rom with -1" 1>&2
+
+    echo "NOTE: you have to hit ctrl-c or whatever your interrupt combination is to" 1>&2
+    echo "exit the program to continue here." 1>&2
+
+    read -rp "Make your selection (0 - 4 or any other key to exit): " mode
+
+    echo 1>&2
+
+    case "${mode}" in
+	0)  # demo
+	    printf "LOAD \"DEMO\"\nRUN\n" | ./sykes pet.rom 6
+	    ;;
+	1)  # show old Easter egg
+	    echo "WAIT 6502,12" | ./sykes pet.rom 6
+	    ;;
+	2)  # chess
+	    ./sykes chess 6
+	    ;;
+	3)  # test mode
+	    make test
+	    ;;
+	4)  # -1
+	    ./sykes pet.rom -1
+	    ;;
+	*)
+	    exit 0
+    esac
+    read -r -n 1 -p "Do you want to continue? " ans
+
+    if [[ "$ans" != "y" && "$ans" != "Y" ]]; then
+	break;
+    fi
+    echo 1>&2
+done

--- a/2005/timwi/README.md
+++ b/2005/timwi/README.md
@@ -28,11 +28,9 @@ simple 3-character fix will make it slightly less so.
 
 Quite a few BF programs found on the Net expect byte-based memory, quite a few
 exceed the capacity of this interpreter, but there are many that work. Some
-small [quines][] work, some don't.
+small [quines](https://en.wikipedia.org/wiki/Quine_(computing)) work, some don't.
 
 Why?
-
-[quines]: https://en.wikipedia.org/wiki/Quine_(computing)
 
 
 ## Author's remarks:
@@ -45,6 +43,7 @@ separated by whitespace (this will be the input to the BF program), then a `:`
 (colon), then the BF program itself.
 
 You must not pass any command-line arguments.
+
 
 ### Features
 
@@ -60,20 +59,22 @@ Use this to obfuscate your BF programs!
 
 * Ignores all whitespace (newlines, spaces and tabs) in the input program.
 
+
 ### Limitations
 
-Since the program, naturally, uses ints, the calculations must not exceed the
-range of an int. (But then again, you can use the integer overflow to further
+Since the program, naturally, uses `int`s, the calculations must not exceed the
+range of an `int`. (But then again, you can use the integer overflow to further
 obfuscate your BF programs in creative ways!)
 
 You are limited to 3125 input integers and 3125 instructions. If you exceed
 one of these limits, the behaviour is undefined.
 
+
 ### Obfuscations
 
 Some of the superficial obfuscations are pretty obvious: I'm using `#define`s to
 make everything look nice and lineal, and the program is merely a recursive
-`main` function with only a single `return` statement which uses nested ternary
+`main()` function with only a single `return` statement which uses nested ternary
 operators to make even the pre-processed code unreadable.
 
 However, the more subtle obfuscations relate to the way the program works.

--- a/2005/timwi/try.sh
+++ b/2005/timwi/try.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2005/timwi
+#
+# This only does one thing and that is from the judges. This is because
+# brainfuck has too much potential to knacker the brain.
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ (echo \"20 : ,-->+.>+.<<[>[>>+>+<<<-]>[>>+>+<<<-]>"; \
+    echo "[<+>-]>[<<<+>>>-]>[-]<<<<.<-]\") | ./timwi" 1>&2
+
+(echo "20 : ,-->+.>+.<<[>[>>+>+<<<-]>[>>+>+<<<-]>"; echo "[<+>-]>[<<<+>>>-]>[-]<<<<.<-]") | ./timwi
+echo 1>&2
+echo "Now please go take better care of your brain. You only get one." 1>&2

--- a/2005/toledo/README.md
+++ b/2005/toledo/README.md
@@ -25,13 +25,18 @@ make
 Two alternate versions of this entry, [toledo2.c](toledo2.c) and
 [toledo3.c](toledo3.c) are provided.
 
-To compile these alternate versions:
+
+### Alternate build:
+
+To compile the alternate versions:
 
 ```sh
 make alt
 ```
 
-Use `toledo2` and `toledo3` as you would `toledo` above.
+### Alternate use:
+
+Use Use `toledo2` and `toledo3` as you would `toledo` above.
 
 
 ## Judges' remarks:
@@ -40,6 +45,13 @@ Challenge yourself with your ability to look 5, 6 or more moves ahead.
 Challenge your knowledge of C operator precedence.  The following is the
 move analysis via recursion while it executes moves.  All while playing
 by the rules of C and Chess within a single function!
+
+### Historical note:
+
+When this entry was submitted the code was a recursive call to `main()` - that
+was it. In 2023 due to problems with `clang` `main()` calls another function,
+`pain()`, which calls itself. But it might be said that the Chess is still a
+single function.
 
 
 ## Author's remarks:
@@ -74,20 +86,23 @@ And each successive argument will analyze one
 limit, but beyond 7 ply is very slow, try it at your own risk and computing
 time.
 
+
 ### Entering movements
 
-When is your turn, you can enter your move, by example, as `d2d4` and press the
-enter key. The computer will check move legality and will warn you of illegal
-moves. All legal chess moves are permitted.
+When it is your turn, you can enter your move, for example, as `d2d4` and press the
+enter key. This will move the pawn at `D2` to `D4`, assuming that a pawn is
+there (as it would be in the beginning). The computer will check move legality
+and will warn you of illegal moves. All legal chess moves are permitted.
 
 One special case is when you are doing promotion, you must enter the move with
 an extra letter indicating the desired piece.
 
-By example `f7f8n` (supposing you have a pawn on `F7`), will promote it to a
+For example `f7f8n` (supposing you have a pawn on `F7`), will promote it to a
 knight; substitute `n` for the desired piece (`N`/`Q`/`R`/`B`).
 
 Note that the program requires the piece letter; it will not select
 automatically a queen, so don't be surprised if it doesn't accept your move.
+
 
 ### Game status
 
@@ -95,9 +110,11 @@ The computer will check for checkmate and stalemate. Also, after each machine
 move, it will show the score of the position: a higher number is better for
 the computer, i.e. worse for you.
 
+
 ### Quirks
 
 None.
+
 
 ### Program operation
 
@@ -115,6 +132,7 @@ they are verified.
 It also sets a standard on ultra-mini-chess programs. The player and the
 computer can do all legal chess moves.
 
+
 ### Additional features
 
 Other features are:
@@ -125,6 +143,7 @@ Other features are:
 * Computer is tough (check
 7-[ply](https://en.wikipedia.org/wiki/Ply_(game_theory))) and even in 5 ply can give a surprise to
 amateur players.
+
 
 ### Obfuscation tricks
 

--- a/2005/vik/README.md
+++ b/2005/vik/README.md
@@ -39,6 +39,7 @@ through user configured [maps](https://en.wikipedia.org/wiki/Map). User defined
 worlds support up to 26 different wall textures that can even be animated. One
 example of a user defined world is submitted with the entry.
 
+
 ### Features
 
 This program is a complete 3D engine with
@@ -47,21 +48,27 @@ This program is a complete 3D engine with
 * Up to 26 different bitmap textures in a maze.
 * Support for animated bitmap textures.
 * Uses default bitmaps in case the configured bitmaps can't be found.
-* A default map in case no one is specified.
+* A default map in case none is specified.
 * Configurable window size.
 * Navigation using cursor keys (rotate left and right, move forward and
 backward).
 
+
 ### Build and Run
 
-Compile the source code and link [x
+Compile the source code and link in [X
 libraries](https://en.wikipedia.org/wiki/Xlib) if necessary. The program takes
 three options which have to be typed in a specific order as described below.
 
+```sh
+./vik [-w <width>] [mapfile]
 ```
-        Usage: ./vik [-w <width>] [mapfile]
-        width   - Specifies the width of the window
-        mapfile - Filename containing a map
+
+where:
+
+```
+width   - Specifies the width of the window
+mapfile - Filename containing a map
 ```
 
 #### Examples
@@ -91,30 +98,32 @@ located in the current directory.
 
 Use the cursor keys to navigate through the labyrinth.
 
+
 ### Creating mazes
 
-A maze consist of a map file and texture bitmap files. The map file is an
+A maze consists of a map file and texture bitmap files. The map file is an
 ASCII text file where lower case letters represent walls. The letter tells the
 engine what bitmap texture file to use. The `*` character lets the engine know
 where to position the user. The example below shows how a map file can look:
 
 ```
-       aaaaaaaaaaaaa
-       a           a
-       a      *    a
-       a    bbbb   cccccccc
-       c                  c
-       cccccccccccccccccccc
-
+aaaaaaaaaaaaa
+a           a
+a      *    a
+a    bbbb   cccccccc
+c                  c
+cccccccccccccccccccc
 ```
 
-The engine loads the map, and creates walls. When a character `a`-`z` is found,
-the engine will load the corresponding texture bitmap. The bitmap file must be
-named `*.bmp` where `*` is substituted with the letter of the wall in the map.
+The engine loads the map, and creates walls. When a character in the range `a-z`
+is found, the engine will load the corresponding texture bitmap. The bitmap file
+must be named `*.bmp` where `*` is substituted with the letter of the wall in
+the map (note that only `a`, `b` and `c` exist).
 
 So to load the map above, the files `a.bmp`, `b.bmp`, and `c.bmp` should be
 located in the same directory as the engine executable (or rather in the
 current directory).
+
 
 ### Obfuscation
 
@@ -123,15 +132,17 @@ The program is obfuscated in several ways:
 * Bad use of variables.
 * Use of the `?` operator.
 * Recursive calls to `main()`.
-* Bad use of for variables and the comma operator.
+* Bad use of `for` loops and the comma operator.
 * To make the final obfuscated touch I ran indent which really made the program
 unreadable (I guess that is not really the intent with indent ;) )
+
 
 ### Compiler warnings
 
 There are no compiler warnings when compiling with `-ansi` but there are quite
 a few warnings from `lclint`. Mainly because the program is very optimized for
 code size.
+
 
 ### Limitations
 

--- a/bugs.md
+++ b/bugs.md
@@ -2224,6 +2224,38 @@ bug but it's worth pointing out as it won't work on as many websites as it used
 to including the [IOCCC website](https://www.ioccc.org) itself.
 
 
+## 2005 sykes
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2005/sykes/sykes.c](2005/sykes/sykes.c)
+### Information: [2005/sykes/README.md](2005/sykes/README.md)
+
+The author stated the below points of interest.
+
+The machine emulated is an older 40 column one so 80 column programs will not
+show up correctly.
+
+There is no emulation of [PET](https://en.wikipedia.org/wiki/Commodore_PET)
+graphics characters.
+
+The parameter controls the speed of the 60Hz "jiffy clock", and not the
+processor speed. This means many games may run too fast to be usable -
+it really depends on the speed of your machine.
+
+Although the PET [emulator](https://en.wikipedia.org/wiki/Emulator) can do `LOAD`
+and `SAVE`, it cannot `VERIFY` or `OPEN` and `CLOSE` files.
+
+The [PET](https://en.wikipedia.org/wiki/Commodore_PET) hardware
+[emulation](https://en.wikipedia.org/wiki/Emulator) is not at all complete -
+features such as the hardware timers are completely missing. Some programs will
+not run correctly.
+
+The
+[6502](https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_description)
+[emulation](https://en.wikipedia.org/wiki/Emulator) does not include the seldom
+used decimal mode, or any of the "undocumented" instructions.
+
+
 # 2006
 
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3023,6 +3023,12 @@ how https is set up, in which case just enjoy it for what it was. But there
 might be some command line that will let it work that way.
 
 
+## [2005/timwi](2005/timwi/timwi.c) ([README.md](2005/timwi/README.md]))
+
+Cody added [try.sh](2005/timwi/try.sh). It only has one command as he doesn't
+want to knacker his brain any more than it might or might not already be.
+
+
 ## [2005/toledo](2005/toledo/toledo.c) ([README.md](2005/toledo/README.md))
 
 Cody fixed this to compile with some versions of clang which have an additional

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3023,6 +3023,19 @@ how https is set up, in which case just enjoy it for what it was. But there
 might be some command line that will let it work that way.
 
 
+## [2005/sykes](2005/sykes/sykes.c) ([README.md](2005/sykes/README.md]))
+
+Cody added the [try.sh](2005/sykes/try.sh) script which runs in a loop with a
+menu of things one might wish to try, asking if they wish to continue when done.
+
+Cody added the script [test.sh](2005/sykes/test.sh) and the make rule `test` to
+run the test suite. The program will enter an infinite loop after it runs so you
+have to hit ctrl-c to end it which the script tells you.
+
+The scripts note every time that one will have to send ctrl-c or whatever their
+interrupt is set to in order to exit the program.
+
+
 ## [2005/timwi](2005/timwi/timwi.c) ([README.md](2005/timwi/README.md]))
 
 Cody added [try.sh](2005/timwi/try.sh). It only has one command as he doesn't


### PR DESCRIPTION

The try.sh is different from others in that it is a loop showing a menu
with different options to use the emulator. It notes at the start of 
each iteration that one has to hit ctrl-c or whatever they have set 
their interrupt as.

The test.sh is run by make test. The exit status is ignored as it 
returns non-zero.

Format/typo check README.md.

I am not done with this entry as the bugs.md should probably be updated
to note some things the author noted. This will have to come another 
time.