### PR TITLE
Fix 2020/endoh2/Makefile - DATA var out of date

### DIFF
--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -111,7 +111,7 @@ ENTRY= endoh2
 PROG= prog
 #
 OBJ= ${PROG}.o
-DATA= bear.txt hello.txt spoiler.zip yoda.txt
+DATA= bear.txt hello.txt yoda.txt
 TARGET= ${PROG}
 #
 ALT_OBJ=


### PR DESCRIPTION
This happened when I extracted the spoiler.zip into spoiler/ and forgot to update the Makefile.