### PR TITLE
Rename and improve 2006/sykes2/sykes2.sh -> try.sh

### DIFF
--- a/2006/sykes2/README.md
+++ b/2006/sykes2/README.md
@@ -15,7 +15,7 @@ make
 ### Try:
 
 ```sh
-./sykes2.sh
+./try.sh
 ```
 
 This will repeatedly remake the program and run it then sleep for one second for

--- a/2006/sykes2/sykes2.sh
+++ b/2006/sykes2/sykes2.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-while :; do
-    clear
-    rm -f sykes2
-    make sykes2 2>/dev/null 1>&2
-    ./sykes2
-    sleep 1
-done

--- a/2006/sykes2/try.sh
+++ b/2006/sykes2/try.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2006/sykes2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" sykes2 || exit 1
+
+while :; do
+    clear
+    rm -f sykes2
+    make sykes2 2>/dev/null 1>&2 || exit 1
+    ./sykes2
+    sleep 1
+done

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3026,6 +3026,12 @@ The video was also no longer available but Cody found an alternative and added
 it to the repo as well.
 
 
+## [2006/sykes2](2006/sykes2/sykes2.c) ([README.md](2006/sykes2/README.md]))
+
+Cody added the [try.sh](2006/sykes2/try.sh) script for easier use of the entry
+to show the clock update in real time.
+
+
 ## [2006/toledo2](2006/toledo2/toledo2.c) ([README.md](2006/toledo2/README.md]))
 
 Cody fixed a segfault in this program which was making it fail to work under


### PR DESCRIPTION
The README.md did not need anything done other than changing it to refer to try.sh instead of sykes2.sh.