### PR TITLE
Minor improvements in thanks file

### DIFF
--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1,6 +1,15 @@
 # Thanks for all the fixes
 
-.. and thanks for all the fish.  :-)
+
+## .. and thanks for all the fish. :-)
+
+To avoid having to change numerous "_README.md_" files to add thank you notes,
+we centralize them below.
+
+The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
+important contributions to the IOCCC presentation of past IOCCC winners.
+We are pleased to note the many contributions, **made since 2021 Jan 01**,
+on a winner by winner basis.
 
 
 ## IOCCC thank you table of contents
@@ -13,7 +22,6 @@
 - [2012 winners](#2012)	|	[2013 winners](#2013)	|	[2014 winners](#2014)	|	[2015 winners](#2015)
 - [2018 winners](#2018)	|	[2019 winners](#2019)	|	[2020 winners](#2020)
 - [General thanks](#general_thanks)
-- [README and thanks](#readme_and_thanks)
 - [Makefile improvements](#makefile_improvements)
 - [Consistency improvements](#consistency_improvements)
 - [Thank you honor roll](#thank_you_honor_roll)
@@ -3624,17 +3632,6 @@ file) but probably a lot less :-)
 
 
 # <a name="general_thanks"></a>General thanks
-
-
-## <a name="readme_and_thanks"></a>README and thanks
-
-To avoid having to change numerous "_README.md_" files to add thank you notes,
-we centralize them below.
-
-The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
-important contributions to the IOCCC presentation of past IOCCC winners.
-We are pleased to note the many contributions, **made since 2021 Jan 01**,
-on a winner by winner basis.
 
 
 ## <a name="makefile_improvements"></a>Makefile improvements

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -8,7 +8,7 @@ This documentation is here to help define terms, files under `tmp/`
 and the format of those files.
 
 *NOTE*: The `terms` section may be moved to another file
-later on, after the contents
+later on, after the contents of this directory are removed.
 
 
 ## terms


### PR DESCRIPTION
 
Moved 'README and thanks' to top and made it '.. and thanks for all the
fish. :-)' instead.. This is because it talked about how the judges 
wish to thank the various people but at the bottom it would serve no 
purpose and yet it felt like it should still be in the file. The heading
or subheading title is an experiment but I think it is probably better 
than 'README and thanks'.