### PR TITLE
Make my fix to 1984/decot more like original

### DIFF
--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-array-bounds -Wno-error -Wno-implicit-function-declaration \
 	-Wno-keyword-macro -Wno-main-return-type -Wno-missing-field-initializers \
 	-Wno-unused-value -Wno-unused-variable -Wno-deprecated-non-prototype \
 	-Wno-empty-body -Wno-int-conversion -Wno-int-to-pointer-cast -Wno-main \
-	-Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label
+	-Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -88,7 +88,7 @@ CC= cc
 ifeq "$(findstring $(CLANG),${CC})" "$(CLANG)"
 #
 CSILENCE+= -Wno-comma -Wno-format-nonliteral -Wno-missing-variable-declarations \
-	-Wno-pedantic -Wno-poison-system-directories -Wno-strict-prototypes \
+	-Wno-pedantic -Wno-poison-system-directories \
 	-Wno-cast-function-type -Wno-float-conversion -Wno-padded \
 	-Wno-unreachable-code
 #

--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -5,17 +5,14 @@
 
 extern double floor(double);
 double (x1, y1) b;
-/*char x {sizeof(
-     double(%s,%D)(*)()) */
-int
-k['a'] = {sizeof(
-    int(*)())
+char x {sizeof(
+     double(%s,%D)(*)())
 ,};
 struct tag{int x0,*xO;};
 
-int dup, signal;
-*main(int i) {
+*main() {
 {
+  int i=1,signal, dup;
   for(signal=0;*k *= * __FILE__ *i;) do {
    (printf(&*"'\",x);	/*\n\\", (*((int(*)())&floor))(i)));
 	goto _0;

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1,6 +1,15 @@
 # Thanks for all the fixes
 
-.. and thanks for all the fish.  :-)
+
+## .. and thanks for all the fish. :-)
+
+To avoid having to change numerous "_README.md_" files to add thank you notes,
+we centralize them below.
+
+The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
+important contributions to the IOCCC presentation of past IOCCC winners.
+We are pleased to note the many contributions, **made since 2021 Jan 01**,
+on a winner by winner basis.
 
 
 ## IOCCC thank you table of contents
@@ -13,7 +22,6 @@
 - [2012 winners](#2012)	|	[2013 winners](#2013)	|	[2014 winners](#2014)	|	[2015 winners](#2015)
 - [2018 winners](#2018)	|	[2019 winners](#2019)	|	[2020 winners](#2020)
 - [General thanks](#general_thanks)
-- [README and thanks](#readme_and_thanks)
 - [Makefile improvements](#makefile_improvements)
 - [Consistency improvements](#consistency_improvements)
 - [Thank you honor roll](#thank_you_honor_roll)
@@ -3624,17 +3632,6 @@ file) but probably a lot less :-)
 
 
 # <a name="general_thanks"></a>General thanks
-
-
-## <a name="readme_and_thanks"></a>README and thanks
-
-To avoid having to change numerous "_README.md_" files to add thank you notes,
-we centralize them below.
-
-The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
-important contributions to the IOCCC presentation of past IOCCC winners.
-We are pleased to note the many contributions, **made since 2021 Jan 01**,
-on a winner by winner basis.
 
 
 ## <a name="makefile_improvements"></a>Makefile improvements

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -78,18 +78,35 @@ original entry. Nevertheless those cannot be used.
 Later on Cody improved the fix to make it look rather more like the original by
 bringing back an extern declaration (slightly changing it to match the symbol
 that it is i.e. `extern double floor(double);` instead of `extern int floor;`)
-and `double (x1, y1) b;`, commenting out only the code:
+and also bringing back `double (x1, y1) b;` and even this funny code that could
+be kept in:
 
 ```c
+#define char k['a']
 char x {sizeof(
      double(%s,%D)(*)())
 ```
 
-and changing the type of `k` to be an `int`.
+This does mean that there cannot be a second arg to `main()`
+as clang requires that to be a `char **` and the `char` redefined would not
+allow this. Some versions of clang say that `main()` must have either 0, 2 or 3
+args but these versions do not object to 1 arg. However as the `char` macro
+seems more obscure and it is possible that a new version of clang will be even
+more strict the `int i` parameter in `main()` was moved to be inside `main()`,
+set to non-zero (setting `i` to 0 will not work). This way `main()` has zero
+args.
 
-Additionally, because of the `#define union static struct` there is no need to
-have in the code `static struct` as we can have it like the original code which
-has it as `union`.
+Observe how on line 29 there is a call to `main()` which does pass in a
+parameter. It has never been observed to be an error to pass in too many
+parameters to a function (`main()` or otherwise - it warns with other functions
+but does not appear to with `main()`) but only that `main()` itself has a
+certain number of args (in some versions) and that the first arg is an `int` and
+the others are `char **`s. This is why the arg was removed and the call to
+`main()` was not updated beyond what had to be done to fix it for compilers that
+do not support `-traditional-cpp`.
+
+If the ANSI C committee or a new version of clang messes this up (both of which
+seems possible) it is easy to fix but it is hoped that this won't happen.
 
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -8,7 +8,7 @@ This documentation is here to help define terms, files under `tmp/`
 and the format of those files.
 
 *NOTE*: The `terms` section may be moved to another file
-later on, after the contents
+later on, after the contents of this directory are removed.
 
 
 ## terms


### PR DESCRIPTION
The #define char can be used as long as main() does not have two args
which it does not need to work. But since some versions have an
additional defect that main() can only have 0, 2 or 3 args (but see
below) it was made so that main() no longer has any args: instead the
'int i' was moved to be inside main() and set to 1 (it cannot be 0).

The version where I noticed that clang whines about the number of args
to main() will whine if it has, say, 4 args, but it will not if it has
1 and it has never whined (as an error) about passing too many args to a
function. Thus on line 29 the call to main() still passes the same
variable to main().

If clang or the ANSI C committee ruin more perfectly fun programs (both
of which seem possible) then the #define char could be renamed say to
shar or else commented out with an adjustment to 'k' (see the diff for
this commit below for where I originally had it to what it is now) or
alternatively (at the expense of making it even less like the original
in obscurity) one could remove the parameter to main() on line 29.
 
The way 'k' changed in this commit:
 
```diff
 #define char k['a']
 #define union static struct

 extern double floor(double);
 double (x1, y1) b;
-/*char x {sizeof(
-     double(%s,%D)(*)()) */
-int
-k['a'] = {sizeof(
-    int(*)())
+char x {sizeof(
+     double(%s,%D)(*)())
 ,};
 struct tag{int x0,*xO;};
```

but now it's improved upon.
