### PR TITLE
Add second arg to main() in 1985/august

### DIFF
--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-array-bounds -Wno-error -Wno-implicit-function-declaration \
 	-Wno-keyword-macro -Wno-main-return-type -Wno-missing-field-initializers \
 	-Wno-unused-value -Wno-unused-variable -Wno-deprecated-non-prototype \
 	-Wno-empty-body -Wno-int-conversion -Wno-int-to-pointer-cast -Wno-main \
-	-Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label
+	-Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -88,7 +88,7 @@ CC= cc
 ifeq "$(findstring $(CLANG),${CC})" "$(CLANG)"
 #
 CSILENCE+= -Wno-comma -Wno-format-nonliteral -Wno-missing-variable-declarations \
-	-Wno-pedantic -Wno-poison-system-directories -Wno-strict-prototypes \
+	-Wno-pedantic -Wno-poison-system-directories \
 	-Wno-cast-function-type -Wno-float-conversion -Wno-padded \
 	-Wno-unreachable-code
 #

--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -5,17 +5,14 @@
 
 extern double floor(double);
 double (x1, y1) b;
-/*char x {sizeof(
-     double(%s,%D)(*)()) */
-int
-k['a'] = {sizeof(
-    int(*)())
+char x {sizeof(
+     double(%s,%D)(*)())
 ,};
 struct tag{int x0,*xO;};
 
-int dup, signal;
-*main(int i) {
+*main() {
 {
+  int i=1,signal, dup;
   for(signal=0;*k *= * __FILE__ *i;) do {
    (printf(&*"'\",x);	/*\n\\", (*((int(*)())&floor))(i)));
 	goto _0;

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-main \
-	-Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-non-prototype
+	-Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-non-prototype \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1985/august/august.c
+++ b/1985/august/august.c
@@ -10,5 +10,5 @@
 q{int a;p{q*(*a)();int b;p*c;}*b;};q*u n a=z(q);h=d;i=z(p);i->a=u;i->b=d+1;s
 v n c=b;do o,b=i;while(!(h%d));i=c;i->a=v;i->b=d;e=b;s
 w n o;c=i;i=b;i->a=w;e=z(p);e->a=v;e->b=h;e->c=c;s
-t n for(;;)o,main(-h),b=i;}main(b){p*a;if(b>0)a=z(p),h=w,a->c=z(p),a->c->a=u,
-a->c->b=2,t(0,a);putchar(b?main(b/2),-b%2+'0':10);}
+t n for(;;)o,main(-h,0),b=i;}main(b,f)char**f;{p*a;if(b>0)a=z(p),h=w,a->c=z(p),a->c->a=u,
+a->c->b=2,t(0,a);putchar(b?main(b/2,0),-b%2+'0':10);}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1,6 +1,15 @@
 # Thanks for all the fixes
 
-.. and thanks for all the fish.  :-)
+
+## .. and thanks for all the fish. :-)
+
+To avoid having to change numerous "_README.md_" files to add thank you notes,
+we centralize them below.
+
+The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
+important contributions to the IOCCC presentation of past IOCCC winners.
+We are pleased to note the many contributions, **made since 2021 Jan 01**,
+on a winner by winner basis.
 
 
 ## IOCCC thank you table of contents
@@ -13,7 +22,6 @@
 - [2012 winners](#2012)	|	[2013 winners](#2013)	|	[2014 winners](#2014)	|	[2015 winners](#2015)
 - [2018 winners](#2018)	|	[2019 winners](#2019)	|	[2020 winners](#2020)
 - [General thanks](#general_thanks)
-- [README and thanks](#readme_and_thanks)
 - [Makefile improvements](#makefile_improvements)
 - [Consistency improvements](#consistency_improvements)
 - [Thank you honor roll](#thank_you_honor_roll)
@@ -3624,17 +3632,6 @@ file) but probably a lot less :-)
 
 
 # <a name="general_thanks"></a>General thanks
-
-
-## <a name="readme_and_thanks"></a>README and thanks
-
-To avoid having to change numerous "_README.md_" files to add thank you notes,
-we centralize them below.
-
-The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
-important contributions to the IOCCC presentation of past IOCCC winners.
-We are pleased to note the many contributions, **made since 2021 Jan 01**,
-on a winner by winner basis.
 
 
 ## <a name="makefile_improvements"></a>Makefile improvements

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -78,18 +78,35 @@ original entry. Nevertheless those cannot be used.
 Later on Cody improved the fix to make it look rather more like the original by
 bringing back an extern declaration (slightly changing it to match the symbol
 that it is i.e. `extern double floor(double);` instead of `extern int floor;`)
-and `double (x1, y1) b;`, commenting out only the code:
+and also bringing back `double (x1, y1) b;` and even this funny code that could
+be kept in:
 
 ```c
+#define char k['a']
 char x {sizeof(
      double(%s,%D)(*)())
 ```
 
-and changing the type of `k` to be an `int`.
+This does mean that there cannot be a second arg to `main()`
+as clang requires that to be a `char **` and the `char` redefined would not
+allow this. Some versions of clang say that `main()` must have either 0, 2 or 3
+args but these versions do not object to 1 arg. However as the `char` macro
+seems more obscure and it is possible that a new version of clang will be even
+more strict the `int i` parameter in `main()` was moved to be inside `main()`,
+set to non-zero (setting `i` to 0 will not work). This way `main()` has zero
+args.
 
-Additionally, because of the `#define union static struct` there is no need to
-have in the code `static struct` as we can have it like the original code which
-has it as `union`.
+Observe how on line 29 there is a call to `main()` which does pass in a
+parameter. It has never been observed to be an error to pass in too many
+parameters to a function (`main()` or otherwise - it warns with other functions
+but does not appear to with `main()`) but only that `main()` itself has a
+certain number of args (in some versions) and that the first arg is an `int` and
+the others are `char **`s. This is why the arg was removed and the call to
+`main()` was not updated beyond what had to be done to fix it for compilers that
+do not support `-traditional-cpp`.
+
+If the ANSI C committee or a new version of clang messes this up (both of which
+seems possible) it is easy to fix but it is hoped that this won't happen.
 
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -178,10 +178,17 @@ returning to the shell. The original version does not have this change.
 
 ## [1985/august](1985/august/august.c) ([README.md](1985/august/README.md))
 
-Cody added the script [primes.sh](1985/august/primes.sh) which allows one to
-check the output for the first N prime numbers of the output, where N is either
-the default or user specified. The inspiration was the previous 'try' command he
-gave to have fun with finding primes that might seem unusual in a way.
+Cody, out of abundance of caution, added a second arg to `main()` because some
+versions of clang object to the number of args of `main()`, saying that it must
+be 0, 2 or 3. The version this has been observed in does not actually object to
+1 arg but it is entirely possible that this changes so a second arg (that's not
+needed and is unused) has been added just in case.
+
+Cody also added the script [primes.sh](1985/august/primes.sh) which allows one
+to check the output for the first N prime numbers of the output, where N is
+either the default or user specified. The inspiration was the previous 'try'
+command he gave to have fun with finding primes that might seem unusual in a
+way.
 
 
 ## [1985/lycklama](1985/lycklama/lycklama.c) ([README.md](1985/lycklama/README.md]))

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -8,7 +8,7 @@ This documentation is here to help define terms, files under `tmp/`
 and the format of those files.
 
 *NOTE*: The `terms` section may be moved to another file
-later on, after the contents
+later on, after the contents of this directory are removed.
 
 
 ## terms


### PR DESCRIPTION

Due to clang defect in number of args allowed in main(). Some versions 
will if you use, say, 4 args, object and report that main() can only 
have 0, 2 or 3 args. That same version does not appear to object to 1 
arg (bug?) but it's entirely possible that this changes so I have 
changed the number of args of main() to 2 even though it's unused just 
out of abundance of caution.

Updated CSILENCE for no implicit int. I have to test the unused 
parameter warning. That might need to be added to, 
-Wno-unused-parameter, but I have to find out which compilers will or 
will not object to it and that can come later on.