### PR TITLE
Second alt version added to 1985/sicherman

### DIFF
--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-array-bounds -Wno-error -Wno-implicit-function-declaration \
 	-Wno-keyword-macro -Wno-main-return-type -Wno-missing-field-initializers \
 	-Wno-unused-value -Wno-unused-variable -Wno-deprecated-non-prototype \
 	-Wno-empty-body -Wno-int-conversion -Wno-int-to-pointer-cast -Wno-main \
-	-Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label
+	-Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -88,7 +88,7 @@ CC= cc
 ifeq "$(findstring $(CLANG),${CC})" "$(CLANG)"
 #
 CSILENCE+= -Wno-comma -Wno-format-nonliteral -Wno-missing-variable-declarations \
-	-Wno-pedantic -Wno-poison-system-directories -Wno-strict-prototypes \
+	-Wno-pedantic -Wno-poison-system-directories \
 	-Wno-cast-function-type -Wno-float-conversion -Wno-padded \
 	-Wno-unreachable-code
 #

--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -5,17 +5,14 @@
 
 extern double floor(double);
 double (x1, y1) b;
-/*char x {sizeof(
-     double(%s,%D)(*)()) */
-int
-k['a'] = {sizeof(
-    int(*)())
+char x {sizeof(
+     double(%s,%D)(*)())
 ,};
 struct tag{int x0,*xO;};
 
-int dup, signal;
-*main(int i) {
+*main() {
 {
+  int i=1,signal, dup;
   for(signal=0;*k *= * __FILE__ *i;) do {
    (printf(&*"'\",x);	/*\n\\", (*((int(*)())&floor))(i)));
 	goto _0;

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-main \
-	-Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-non-prototype
+	-Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-non-prototype \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1985/august/august.c
+++ b/1985/august/august.c
@@ -10,5 +10,5 @@
 q{int a;p{q*(*a)();int b;p*c;}*b;};q*u n a=z(q);h=d;i=z(p);i->a=u;i->b=d+1;s
 v n c=b;do o,b=i;while(!(h%d));i=c;i->a=v;i->b=d;e=b;s
 w n o;c=i;i=b;i->a=w;e=z(p);e->a=v;e->b=h;e->c=c;s
-t n for(;;)o,main(-h),b=i;}main(b){p*a;if(b>0)a=z(p),h=w,a->c=z(p),a->c->a=u,
-a->c->b=2,t(0,a);putchar(b?main(b/2),-b%2+'0':10);}
+t n for(;;)o,main(-h,0),b=i;}main(b,f)char**f;{p*a;if(b>0)a=z(p),h=w,a->c=z(p),a->c->a=u,
+a->c->b=2,t(0,a);putchar(b?main(b/2,0),-b%2+'0':10);}

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -132,16 +132,15 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
-${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+${PROG}: ${PROG}.c ${PROG}.alt2.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} || \
+	    ${CC} ${CFLAGS} ${PROG}.alt2.c -o $@ ${LDFLAGS}
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-${PROG}.alt: ${PROG}.alt.c
-	${CC} ${CFLAGS} -traditional-cpp $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -6,6 +6,11 @@ make all
 
 NOTE: there is an [alternate version](#alternate-code) for those who have an old
 enough compiler or have a compiler that supports the option `-traditional-cpp`.
+There is also an alternate version that is meant to work in the case that your
+version of clang fails to compile it due to the wrong number of args to `main()`
+should that ever happen (a compiler error of some versions of clang if `main()`
+has four args is that `main()` can only have 0, 2 or 3 args but it does
+currently accept 1 arg to `main()` nonetheless).
 
 
 ## To use:

--- a/1985/sicherman/sicherman.alt2.c
+++ b/1985/sicherman/sicherman.alt2.c
@@ -8,7 +8,8 @@ char _,__;
 main(
 /*	C program. (If you don't
  *	understand it look it
- *	up.) (In the C*/Manual)
+ *	up.) (In the */C, Manual)
+char **Manual;
 {
 	char _,__;
 	while (read(0,&__,1) & write((_=(_=C_C_(__),

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1,6 +1,15 @@
 # Thanks for all the fixes
 
-.. and thanks for all the fish.  :-)
+
+## .. and thanks for all the fish. :-)
+
+To avoid having to change numerous "_README.md_" files to add thank you notes,
+we centralize them below.
+
+The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
+important contributions to the IOCCC presentation of past IOCCC winners.
+We are pleased to note the many contributions, **made since 2021 Jan 01**,
+on a winner by winner basis.
 
 
 ## IOCCC thank you table of contents
@@ -13,7 +22,6 @@
 - [2012 winners](#2012)	|	[2013 winners](#2013)	|	[2014 winners](#2014)	|	[2015 winners](#2015)
 - [2018 winners](#2018)	|	[2019 winners](#2019)	|	[2020 winners](#2020)
 - [General thanks](#general_thanks)
-- [README and thanks](#readme_and_thanks)
 - [Makefile improvements](#makefile_improvements)
 - [Consistency improvements](#consistency_improvements)
 - [Thank you honor roll](#thank_you_honor_roll)
@@ -3624,17 +3632,6 @@ file) but probably a lot less :-)
 
 
 # <a name="general_thanks"></a>General thanks
-
-
-## <a name="readme_and_thanks"></a>README and thanks
-
-To avoid having to change numerous "_README.md_" files to add thank you notes,
-we centralize them below.
-
-The [IOCCC judges](https://www.ioccc.org/judges.html) wish to recognize the many
-important contributions to the IOCCC presentation of past IOCCC winners.
-We are pleased to note the many contributions, **made since 2021 Jan 01**,
-on a winner by winner basis.
 
 
 ## <a name="makefile_improvements"></a>Makefile improvements

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -250,11 +250,13 @@ were actually not what they appear: the only arg that existed in `main()` was
 
 - The macros `C` and `V` were changed to lower case. This is because it felt
 like the `C=" ..`' part in `subr()` would be better to be upper case as it talks
-about the language. Also in the second alternate version (the first being the
+about the language. Also in the second [alternate
+version](1985/sicherman/sicherman.alt2.c) (the first being the
 original code) which is in case a new version of clang ever objects to only one
 arg in `main()` (which is not out of the realm of possibility), `main()` can
 have `C` as `argc` to `main()` so it would read like it once did: `C manual`
-albeit with a `,` separating the two. The second alternate version is compiled
+albeit with a `,` separating the two. The [second
+alternate](1985/sicherman/sicherman.alt2.c) version is compiled
 in case the first does not. Originally the macros were kept the same and the
 `C` in `subr()` was `c`. It feels better (in some ways) to make it so that the
 `C` for the language is upper case though, and since it actually translated to

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -78,18 +78,35 @@ original entry. Nevertheless those cannot be used.
 Later on Cody improved the fix to make it look rather more like the original by
 bringing back an extern declaration (slightly changing it to match the symbol
 that it is i.e. `extern double floor(double);` instead of `extern int floor;`)
-and `double (x1, y1) b;`, commenting out only the code:
+and also bringing back `double (x1, y1) b;` and even this funny code that could
+be kept in:
 
 ```c
+#define char k['a']
 char x {sizeof(
      double(%s,%D)(*)())
 ```
 
-and changing the type of `k` to be an `int`.
+This does mean that there cannot be a second arg to `main()`
+as clang requires that to be a `char **` and the `char` redefined would not
+allow this. Some versions of clang say that `main()` must have either 0, 2 or 3
+args but these versions do not object to 1 arg. However as the `char` macro
+seems more obscure and it is possible that a new version of clang will be even
+more strict the `int i` parameter in `main()` was moved to be inside `main()`,
+set to non-zero (setting `i` to 0 will not work). This way `main()` has zero
+args.
 
-Additionally, because of the `#define union static struct` there is no need to
-have in the code `static struct` as we can have it like the original code which
-has it as `union`.
+Observe how on line 29 there is a call to `main()` which does pass in a
+parameter. It has never been observed to be an error to pass in too many
+parameters to a function (`main()` or otherwise - it warns with other functions
+but does not appear to with `main()`) but only that `main()` itself has a
+certain number of args (in some versions) and that the first arg is an `int` and
+the others are `char **`s. This is why the arg was removed and the call to
+`main()` was not updated beyond what had to be done to fix it for compilers that
+do not support `-traditional-cpp`.
+
+If the ANSI C committee or a new version of clang messes this up (both of which
+seems possible) it is easy to fix but it is hoped that this won't happen.
 
 Originally Yusuke supplied a patch so that this entry would compile with gcc -
 but not clang - or at least some versions.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -56,7 +56,7 @@ Scovell](https://web.archive.org/web/20070120220721/https://thomasscovell.com/ta
 ## [1984/decot](1984/decot/decot.c) ([README.md](1984/decot/README.md]))
 
 Cody fixed this to not require `-traditional-cpp` which some compilers like
-clang do not support. Fixing `-traditional-cpp` is, as noted earlier, very
+clang do not support. Fixing `-traditional-cpp` is, as noted later on, very
 complicated, but we encourage you to look at the alternate code (which is the
 original code with a minor modification made by the judges) and the fixed
 code, to see what had to be done.
@@ -215,7 +215,7 @@ the default).
 ## [1985/sicherman](1985/sicherman/sicherman.c) ([README.md](1985/sicherman/README.md]))
 
 Cody fixed this _very twisted entry_ to not require `-traditional-cpp`.  Fixing
-`-traditional-cpp` is, as noted earlier, very complicated, but Cody would like
+`-traditional-cpp` is, as noted later on, very complicated, but Cody would like
 to refer you to the original file
 [sicherman.orig.c](1985/sicherman/sicherman.orig.c) and he suggests that you
 then compare it to [sicherman.c](1985/sicherman/sicherman.c) for some good old
@@ -248,6 +248,19 @@ were actually not what they appear: the only arg that existed in `main()` was
 	{
 	```
 
+- The macros `C` and `V` were changed to lower case. This is because it felt
+like the `C=" ..`' part in `subr()` would be better to be upper case as it talks
+about the language. Also in the second alternate version (the first being the
+original code) which is in case a new version of clang ever objects to only one
+arg in `main()` (which is not out of the realm of possibility), `main()` can
+have `C` as `argc` to `main()` so it would read like it once did: `C manual`
+albeit with a `,` separating the two. The second alternate version is compiled
+in case the first does not. Originally the macros were kept the same and the
+`C` in `subr()` was `c`. It feels better (in some ways) to make it so that the
+`C` for the language is upper case though, and since it actually translated to
+`/**/` it can just be `c`, not `C`. The `V` was changed to `v` to be the same
+case as `c`.
+
 - The code:
 
 	```c
@@ -259,7 +272,7 @@ were actually not what they appear: the only arg that existed in `main()` was
     had to be changed to:
 
 	```c
-	c="Lint says \"argument Manual isn't used.\" What's that\
+	C="Lint says \"argument Manual isn't used.\" What's that\
 	mean?"; while (write((read(('"'-'/*"'))?__:__-_+
 	'\b'b'\b'|((_-52)%('\b'b'\b'+C_C_('\t'b'\n'))+1),1),&_,1));
 	```
@@ -273,11 +286,12 @@ were actually not what they appear: the only arg that existed in `main()` was
     before and actually that there aren't that many changes in the function at
     all!
 
-    Notice also that the parameter `C` had to be changed to `c` due to the macro.
+    Notice also that the parameter `C` remained the same due to the macro `C`
+    rename to `c`.
 
-    The `char`s `_` and `__` were made file scope so the `subr()` could actually
-    compile but this does not affect the ones in `main()`. Why is this? You tell
-    us!
+    The `char`s `_` and `__` in `main()` were copied to file scope so that
+    `subr()` could actually compile but this does not affect the ones in
+    `main()`. Why is this? You tell us!
 
 - The code in `main()` is where there are significant changes, changing from:
 
@@ -291,14 +305,15 @@ were actually not what they appear: the only arg that existed in `main()` was
 	    ```c
 	    while (read(0,&__,1) & write((_=(_=C_C_(__),
 	    V))?__:__-_+'\b'b'\b'|((_-52)%('\b'b'\b'+~
-	    ' '&'\t'b'\n')+1),1),&_,1))_=C-V+subr(&V));
+	    ' '&'\t'b'\n')+1),1),&_,1))_=c-v+subr(&v));
 	    ```
 
-    Note how numerous of the macros can still be used but some cannot be. Can
-    you figure out why? Why too is it that the `subr()` function is called but
-    it appears that some of the code in that function is also in `main()` in the
-    `while` condition? What happens if you remove it from `main()`? What happens
-    if you remove it from `subr()` or don't even bother calling `subr()`?
+    Note how numerous of the macros (though two changed in case) can still be
+    used but some cannot be. Can you figure out why? Why too is it that the
+    `subr()` function is called but it appears that some of the code in that
+    function is also in `main()` in the `while` condition? What happens if you
+    remove it from `main()`? What happens if you remove it from `subr()` or
+    don't even bother calling `subr()`?
 
 
 # <a name="1986"></a>1986
@@ -523,7 +538,7 @@ unlikely(?) but nevertheless suggested case that `putchar()` is not available.
 
 Cody fixed this twisted entry (as we called it :-) ) for modern compilers,
 including making it no longer require `-traditional-cpp`. Fixing
-`-traditional-cpp` is, as noted earlier, very complicated, but we encourage you
+`-traditional-cpp` is, as noted later on, very complicated, but we encourage you
 to compare the fix from the original entry. There was another problem to resolve
 as well, however.
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -178,10 +178,17 @@ returning to the shell. The original version does not have this change.
 
 ## [1985/august](1985/august/august.c) ([README.md](1985/august/README.md))
 
-Cody added the script [primes.sh](1985/august/primes.sh) which allows one to
-check the output for the first N prime numbers of the output, where N is either
-the default or user specified. The inspiration was the previous 'try' command he
-gave to have fun with finding primes that might seem unusual in a way.
+Cody, out of abundance of caution, added a second arg to `main()` because some
+versions of clang object to the number of args of `main()`, saying that it must
+be 0, 2 or 3. The version this has been observed in does not actually object to
+1 arg but it is entirely possible that this changes so a second arg (that's not
+needed and is unused) has been added just in case.
+
+Cody also added the script [primes.sh](1985/august/primes.sh) which allows one
+to check the output for the first N prime numbers of the output, where N is
+either the default or user specified. The inspiration was the previous 'try'
+command he gave to have fun with finding primes that might seem unusual in a
+way.
 
 
 ## [1985/lycklama](1985/lycklama/lycklama.c) ([README.md](1985/lycklama/README.md]))

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -8,7 +8,7 @@ This documentation is here to help define terms, files under `tmp/`
 and the format of those files.
 
 *NOTE*: The `terms` section may be moved to another file
-later on, after the contents
+later on, after the contents of this directory are removed.
 
 
 ## terms


### PR DESCRIPTION

Since some versions of clang object to the number of args to main() 
(requiring, supposedly, 0, 2 or 3[0] args) and in the case that it is 
enforced to not allow 1 I have added a second alt code that will be 
compiled IF sicherman.c fails to compile (and it'll compile into
sicherman, not sicherman.alt2 or something like that). This required 
another change which also is in sicherman.c.

The macros in the code that were C (which only translated to '/**/') and 
V were changed to lower case letters. Then the 'c' in 'subr()' was 
changed back to upper case. This also feels better since the 'C' (now 
'c') in main() is although used it is not necessary either since it just
is an empty comment. The primary reason for this change is that in the 
new version we obviously want the first arg of main() to be 'C' but with
the macro 'C' this would not be possible. The change to 'v' from 'V' is
simply to match case as both were in the original main() args (as ints).

I am not sure I like having to change the macro names to lower case but
at the same time the 'C="..."' in 'subr()' makes more sense to be upper
case as it's about the language and it also allows in the new version 
that main() can have upper case C. Of course I could have made that 
change in just the new version but it felt better to match style as much
as possible.

[0] The version that objects to this still seems to allow 1 arg even
though it claims that it requires 0, 2 or 3 args.
