### PR TITLE
Add alt versions to 1991/cdupont

### DIFF
--- a/1991/cdupont/.gitignore
+++ b/1991/cdupont/.gitignore
@@ -1,3 +1,6 @@
 cdupont
+cdupont.alt
+cdupont.alt2
+cdupont.alt3
 cdupont.orig
 prog.orig

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -57,7 +57,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -Ds=\"cdupont.c\" -Dt=\"r\"
+CDEFINE= -Ds=__FILE__ -Dt=\"r\"
 
 # Include files that are needed to compile
 #
@@ -111,8 +111,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o ${PROG}.alt2.o ${PROG}.alt3.o
+ALT_TARGET= ${PROG}.alt ${PROG}.alt2 ${PROG}.alt3
 
 
 #################

--- a/1991/cdupont/README.md
+++ b/1991/cdupont/README.md
@@ -4,12 +4,48 @@
 make all
 ```
 
+There are three alt versions which demonstrate a problem that the code documents
+(as an obfuscation technique) and what the judges document so you can see what
+it looks like. See [alternate code](#alternate-code) below for more details.
+
 
 ## To use:
 
 ```sh
 ./cdupont
 ```
+
+
+## Alternate code:
+
+These three versions show what will happen if certain things are done that were
+warned against: if you remove a comment and more so an unused `goto` label or if
+you beautify it. The [cdupont.alt.c](cdupont.alt.c) is the one with both the
+unused `goto` label and comments removed, the [cdupont.alt2.c](cdupont.alt2.c)
+is the version that has these things removed and is also beautified and the
+[cdupont.alt3.c](cdupont.alt3.c) is just beautified. This required changing the
+`s` macro to be `__FILE__` as otherwise it would read in the original code which
+doesn't have the modifications.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+
+### Alternate try:
+
+
+```sh
+./cdupont.alt
+./cdupont.alt2
+./cdupont.alt3
+```
+
+Enjoy! :-)
 
 
 ## Judges' remarks:

--- a/1991/cdupont/cdupont.alt.c
+++ b/1991/cdupont/cdupont.alt.c
@@ -1,0 +1,61 @@
+   /* common sense  to nohonest programmer */
+#include <stdio.h>
+main ()
+{
+  int x, gi = 4, i, f, ri = 1, httxkbl = 1, m = 012;
+  long cd = 0x5765248d, n;
+  char u[0x50][032];
+  FILE *ind;
+  ind = fopen (s, t);
+  for (i = 0; i < 0x1a; i++)
+    {
+      goto daswjhkls;
+    vhjsgfdy1l1gjhd:;
+    }
+/*borntorun.*/ goto c0g0;
+cOgO:i = 0;
+  fclose (ind);
+c0gO:
+  x = u[gi][m];
+  if (m == gi)
+    {
+      x = 0x70;
+      f = 0x68;
+    }
+  else
+    goto cOg0;
+b:putchar (x);
+  if (!(n - httxkbl++))
+#define yank(x) putchar(x)
+    {
+      httxkbl = 1;
+      yank (' ');
+      goto hxi;
+    }
+  goto bl;
+daswjhkls:fgets (u[i], 0120, ind);
+  /*obfuscated, eh? */ goto
+    vhjsgfdy1l1gjhd;
+c0g0:n = cd & 0x40000000L >> 0x1e;
+  goto cOgO;
+g6w:
+  if (x != 0x2e)
+    {
+      i++;
+      goto c0gO;
+    }
+  else				/*
+				   injail */
+    yank ('\n');
+  goto vhjsgfdyl1lgjhd;
+cOg0:
+  f = u[m][gi];
+  goto b;
+bl:m = (i + 1) * (4 * x + 3 * f) % 032;
+  gi = (i + 1) * (x + 2 * f) % 0x1a;
+  goto g6w;
+hxi:cd ^= n = cd & (7 << 3 * (014 - ++ri));
+  n >>= 3 * (12 - ri);
+  goto bl;
+vhjsgfdyl1lgjhd:;
+}

--- a/1991/cdupont/cdupont.alt2.c
+++ b/1991/cdupont/cdupont.alt2.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+main(){int x  ,gi=4,i,f,ri=1,httxkbl=1,m=012;long cd=0x5765248d,n;
+   char u[0x50][032];FILE *ind;
+      ind=fopen(s,t); for(i=0; i<0x1a; i++){goto daswjhkls;vhjsgfdy1l1gjhd:;}
+/*borntorun.*/goto c0g0;cOgO:i=0;fclose(ind);c0gO:
+x=  u [gi][m];
+     if(  m==gi){x=0x70;f=0x68;}else goto cOg0 ; b:putchar(x); if(
+!(n-httxkbl++))
+#define yank(x) putchar(x)
+  {httxkbl=1;       yank(' ');goto
+   hxi;}goto bl;
+    daswjhkls:    fgets(u[i], 0120, ind);
+  /*obfuscated, eh? */goto
+    vhjsgfdy1l1gjhd;
+          c0g0 : n=cd&0x40000000L>>0x1e;
+ goto         cOgO;   g6w:
+                 if(x!=0x2e){i++;goto c0gO;}else /*
+injail*/yank('\n');goto vhjsgfdyl1lgjhd;
+cOg0 :
+f=u[m][gi];goto b;bl:m=(i+1)*(4*
+x+3*f)%032;gi=(i+1)*(x+2*f)%0x1a; goto g6w;
+  hxi:cd^=        n=  cd&(7<<3*(014-++ri));
+n >>=3*(12-ri); goto bl;vhjsgfdyl1lgjhd:;}

--- a/1991/cdupont/cdupont.alt3.c
+++ b/1991/cdupont/cdupont.alt3.c
@@ -1,0 +1,64 @@
+   /* common sense  to nohonest programmer */
+#include <stdio.h>
+main ()
+{
+  int x, gi = 4, i, f, ri = 1, httxkbl = 1, m = 012;
+  long cd = 0x5765248d, n;
+  char u[0x50][032];
+  FILE *ind;
+  ind = fopen (s, t);
+  for (i = 0; i < 0x1a; i++)
+    {
+      goto daswjhkls;
+    vhjsgfdy1l1gjhd:;
+    }
+/*borntorun.*/ goto c0g0;
+cOgO:i = 0;
+  fclose (ind);
+c0gO:
+  x = u[gi][m];
+sorryfor_this_unused_but_very_needed_label:
+  if (m == gi)
+    {
+      x = 0x70;
+      f = 0x68;
+    }
+  else
+    goto cOg0;
+b:putchar (x);
+  if (!(n - httxkbl++))
+#define yank(x) putchar(x)
+    {
+      httxkbl = 1;
+      yank (' ');
+      goto hxi;
+    }
+  goto bl;
+  /* hardlyundrstandable, but
+     likely to be missed if removed */
+daswjhkls:fgets (u[i], 0120, ind);
+  /*obfuscated, eh? */ goto
+    vhjsgfdy1l1gjhd;
+c0g0:n = cd & 0x40000000L >> 0x1e;
+  goto cOgO;
+g6w:
+  if (x != 0x2e)
+    {
+      i++;
+      goto c0gO;
+    }
+  else				/*
+				   injail */
+    yank ('\n');
+  goto vhjsgfdyl1lgjhd;
+cOg0:
+  f = u[m][gi];
+  goto b;
+bl:m = (i + 1) * (4 * x + 3 * f) % 032;
+  gi = (i + 1) * (x + 2 * f) % 0x1a;
+  goto g6w;
+hxi:cd ^= n = cd & (7 << 3 * (014 - ++ri));
+  n >>= 3 * (12 - ri);
+  goto bl;
+vhjsgfdyl1lgjhd:;
+}

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1096,6 +1096,19 @@ him): `k` for forward, `h` for left and `l` for right. This version also has a
 more useful way to exit, just entering `q` followed by enter.
 
 
+## [1991/cdupont](1991/cdupont/cdupont.c) ([README.md](1991/cdupont/README.md]))
+
+Cody provided [three alternate](1991/cdupont/README.md#alternate-code) versions
+that allow one to see what would happen if one were to beautify the program or
+remove a `goto` label or a comment that was in the original code. This required
+changing the `s` macro to be `__FILE__` (which is more reliable anyway) as
+otherwise it would read in the original code and not demonstrate the problem.
+[One version](1991/cdupont/cdupont.alt2.c) has the comments and unused `goto`
+label removed and [the other](1991/cdupont/cdupont.alt.c) has the comments and
+label removed and it is also beautified. The [third
+one](1991/cdupont/cdupont.alt3.c) is just beautified.
+
+
 ## [1991/davidguy](1991/davidguy/davidguy.c) ([README.md](1991/davidguy/README.md]))
 
 As some systems like macOS can be particular about not declaring functions Cody


### PR DESCRIPTION
There are three alt versions. One has a comment and an unused goto label removed that are warned against being removed; another has this done and is also beautified (which is also warned against) and the third is one that is just beautified.

This involved changing the 's' macro to be '__FILE__' because otherwise it would read in the original code and not show the problem.