### PR TITLE
Make 1992/marangon main() return int, not void

### DIFF
--- a/1991/cdupont/.gitignore
+++ b/1991/cdupont/.gitignore
@@ -1,3 +1,6 @@
 cdupont
+cdupont.alt
+cdupont.alt2
+cdupont.alt3
 cdupont.orig
 prog.orig

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -57,7 +57,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -Ds=\"cdupont.c\" -Dt=\"r\"
+CDEFINE= -Ds=__FILE__ -Dt=\"r\"
 
 # Include files that are needed to compile
 #
@@ -111,8 +111,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o ${PROG}.alt2.o ${PROG}.alt3.o
+ALT_TARGET= ${PROG}.alt ${PROG}.alt2 ${PROG}.alt3
 
 
 #################

--- a/1991/cdupont/README.md
+++ b/1991/cdupont/README.md
@@ -4,12 +4,48 @@
 make all
 ```
 
+There are three alt versions which demonstrate a problem that the code documents
+(as an obfuscation technique) and what the judges document so you can see what
+it looks like. See [alternate code](#alternate-code) below for more details.
+
 
 ## To use:
 
 ```sh
 ./cdupont
 ```
+
+
+## Alternate code:
+
+These three versions show what will happen if certain things are done that were
+warned against: if you remove a comment and more so an unused `goto` label or if
+you beautify it. The [cdupont.alt.c](cdupont.alt.c) is the one with both the
+unused `goto` label and comments removed, the [cdupont.alt2.c](cdupont.alt2.c)
+is the version that has these things removed and is also beautified and the
+[cdupont.alt3.c](cdupont.alt3.c) is just beautified. This required changing the
+`s` macro to be `__FILE__` as otherwise it would read in the original code which
+doesn't have the modifications.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+
+### Alternate try:
+
+
+```sh
+./cdupont.alt
+./cdupont.alt2
+./cdupont.alt3
+```
+
+Enjoy! :-)
 
 
 ## Judges' remarks:

--- a/1991/cdupont/cdupont.alt.c
+++ b/1991/cdupont/cdupont.alt.c
@@ -1,0 +1,61 @@
+   /* common sense  to nohonest programmer */
+#include <stdio.h>
+main ()
+{
+  int x, gi = 4, i, f, ri = 1, httxkbl = 1, m = 012;
+  long cd = 0x5765248d, n;
+  char u[0x50][032];
+  FILE *ind;
+  ind = fopen (s, t);
+  for (i = 0; i < 0x1a; i++)
+    {
+      goto daswjhkls;
+    vhjsgfdy1l1gjhd:;
+    }
+/*borntorun.*/ goto c0g0;
+cOgO:i = 0;
+  fclose (ind);
+c0gO:
+  x = u[gi][m];
+  if (m == gi)
+    {
+      x = 0x70;
+      f = 0x68;
+    }
+  else
+    goto cOg0;
+b:putchar (x);
+  if (!(n - httxkbl++))
+#define yank(x) putchar(x)
+    {
+      httxkbl = 1;
+      yank (' ');
+      goto hxi;
+    }
+  goto bl;
+daswjhkls:fgets (u[i], 0120, ind);
+  /*obfuscated, eh? */ goto
+    vhjsgfdy1l1gjhd;
+c0g0:n = cd & 0x40000000L >> 0x1e;
+  goto cOgO;
+g6w:
+  if (x != 0x2e)
+    {
+      i++;
+      goto c0gO;
+    }
+  else				/*
+				   injail */
+    yank ('\n');
+  goto vhjsgfdyl1lgjhd;
+cOg0:
+  f = u[m][gi];
+  goto b;
+bl:m = (i + 1) * (4 * x + 3 * f) % 032;
+  gi = (i + 1) * (x + 2 * f) % 0x1a;
+  goto g6w;
+hxi:cd ^= n = cd & (7 << 3 * (014 - ++ri));
+  n >>= 3 * (12 - ri);
+  goto bl;
+vhjsgfdyl1lgjhd:;
+}

--- a/1991/cdupont/cdupont.alt2.c
+++ b/1991/cdupont/cdupont.alt2.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+main(){int x  ,gi=4,i,f,ri=1,httxkbl=1,m=012;long cd=0x5765248d,n;
+   char u[0x50][032];FILE *ind;
+      ind=fopen(s,t); for(i=0; i<0x1a; i++){goto daswjhkls;vhjsgfdy1l1gjhd:;}
+/*borntorun.*/goto c0g0;cOgO:i=0;fclose(ind);c0gO:
+x=  u [gi][m];
+     if(  m==gi){x=0x70;f=0x68;}else goto cOg0 ; b:putchar(x); if(
+!(n-httxkbl++))
+#define yank(x) putchar(x)
+  {httxkbl=1;       yank(' ');goto
+   hxi;}goto bl;
+    daswjhkls:    fgets(u[i], 0120, ind);
+  /*obfuscated, eh? */goto
+    vhjsgfdy1l1gjhd;
+          c0g0 : n=cd&0x40000000L>>0x1e;
+ goto         cOgO;   g6w:
+                 if(x!=0x2e){i++;goto c0gO;}else /*
+injail*/yank('\n');goto vhjsgfdyl1lgjhd;
+cOg0 :
+f=u[m][gi];goto b;bl:m=(i+1)*(4*
+x+3*f)%032;gi=(i+1)*(x+2*f)%0x1a; goto g6w;
+  hxi:cd^=        n=  cd&(7<<3*(014-++ri));
+n >>=3*(12-ri); goto bl;vhjsgfdyl1lgjhd:;}

--- a/1991/cdupont/cdupont.alt3.c
+++ b/1991/cdupont/cdupont.alt3.c
@@ -1,0 +1,64 @@
+   /* common sense  to nohonest programmer */
+#include <stdio.h>
+main ()
+{
+  int x, gi = 4, i, f, ri = 1, httxkbl = 1, m = 012;
+  long cd = 0x5765248d, n;
+  char u[0x50][032];
+  FILE *ind;
+  ind = fopen (s, t);
+  for (i = 0; i < 0x1a; i++)
+    {
+      goto daswjhkls;
+    vhjsgfdy1l1gjhd:;
+    }
+/*borntorun.*/ goto c0g0;
+cOgO:i = 0;
+  fclose (ind);
+c0gO:
+  x = u[gi][m];
+sorryfor_this_unused_but_very_needed_label:
+  if (m == gi)
+    {
+      x = 0x70;
+      f = 0x68;
+    }
+  else
+    goto cOg0;
+b:putchar (x);
+  if (!(n - httxkbl++))
+#define yank(x) putchar(x)
+    {
+      httxkbl = 1;
+      yank (' ');
+      goto hxi;
+    }
+  goto bl;
+  /* hardlyundrstandable, but
+     likely to be missed if removed */
+daswjhkls:fgets (u[i], 0120, ind);
+  /*obfuscated, eh? */ goto
+    vhjsgfdy1l1gjhd;
+c0g0:n = cd & 0x40000000L >> 0x1e;
+  goto cOgO;
+g6w:
+  if (x != 0x2e)
+    {
+      i++;
+      goto c0gO;
+    }
+  else				/*
+				   injail */
+    yank ('\n');
+  goto vhjsgfdyl1lgjhd;
+cOg0:
+  f = u[m][gi];
+  goto b;
+bl:m = (i + 1) * (4 * x + 3 * f) % 032;
+  gi = (i + 1) * (x + 2 * f) % 0x1a;
+  goto g6w;
+hxi:cd ^= n = cd & (7 << 3 * (014 - ++ri));
+  n >>= 3 * (12 - ri);
+  goto bl;
+vhjsgfdyl1lgjhd:;
+}

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
-	-Wno-logical-op-parentheses -Wno-main -Wno-variadic-macros -Wno-deprecated-non-prototype
+	-Wno-logical-op-parentheses -Wno-main -Wno-variadic-macros -Wno-deprecated-non-prototype \
+	-Wno-unused-parameter
 
 # Common C compiler warning flags
 #

--- a/1992/kivinen/kivinen.alt.c
+++ b/1992/kivinen/kivinen.alt.c
@@ -11,7 +11,7 @@
 #	  define	     R			    BlackPixel(d,D)
 #	   define	     S			    r.xvisibility
 
-	      int main(a)int a;{Window s[53];int w,u,i,c,y,l=0
+          int main(a,b)int a;char**b;{Window s[53];int w,u,i,c,y,l=0
 	  ,q,e=32,t,k,j=~0,z=(a+1)/2,x=a&1,v=z&1;XEvent r;Display*
 	d=XOpenDisplay("");s[0]=A(d,DefaultRootWindow(d),200,200,(x&
        v?330:120)*z,215*z,2,R,R);I(N(c=0),_);for(;c<(x?32:52);c++){s[

--- a/1992/kivinen/kivinen.c
+++ b/1992/kivinen/kivinen.c
@@ -11,7 +11,7 @@
 #	  define	     R			    BlackPixel(d,D)
 #	   define	     S			    r.xvisibility
 
-	      int main(a)int a;{Window s[53];int w,u,i,c,y,l=0
+	  int main(a,b)int a;char**b;{Window s[53];int w,u,i,c,y,l=0
 	  ,q,e=32,t,k,j=~0,z=(a+1)/2,x=a&1,v=z&1;XEvent r;Display*
 	d=XOpenDisplay("");s[0]=A(d,DefaultRootWindow(d),200,200,(x&
        v?330:120)*z,215*z,2,R,R);I(N(c=0),_);for(;c<(x?32:52);c++){s[

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -41,7 +41,8 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
 	-Wno-logical-op-parentheses -Wno-main-return-type -Wno-missing-braces \
 	-Wno-parentheses -Wno-return-type -Wno-tautological-bitwise-compare \
-	-Wno-unsequenced -Wno-deprecated-non-prototype -Wno-strict-prototypes
+	-Wno-unsequenced -Wno-deprecated-non-prototype -Wno-strict-prototypes \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1992/marangon/marangon.c
+++ b/1992/marangon/marangon.c
@@ -48,7 +48,7 @@ I (;y<6;++y)
 I(x=0;x<6;++x)
 mvwaddch(r,X(y),Y(x),z[x][y]+'0'); Q(0);
 }
-void main()
+int main()
 {
 char *ST();
 i a=0,b=0,c,q,t,s,x,sc=0;

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1491,6 +1491,11 @@ NOTE: this entry cannot work with clang due to different compiler messages. See
 [bugs.md](/bugs.md) for details.
 
 
+## [1992/marangon](1992/marangon/marangon.c) ([README.md](1992/marangon/README.md))
+
+Cody made this more portable by changing the `void main()` to be `int main()`.
+
+
 ## [1992/nathan](1992/nathan/nathan.c) ([README.md](1992/nathan/README.md))
 
 Cody added the original file back as it was deemed that the export restrictions

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1096,6 +1096,19 @@ him): `k` for forward, `h` for left and `l` for right. This version also has a
 more useful way to exit, just entering `q` followed by enter.
 
 
+## [1991/cdupont](1991/cdupont/cdupont.c) ([README.md](1991/cdupont/README.md]))
+
+Cody provided [three alternate](1991/cdupont/README.md#alternate-code) versions
+that allow one to see what would happen if one were to beautify the program or
+remove a `goto` label or a comment that was in the original code. This required
+changing the `s` macro to be `__FILE__` (which is more reliable anyway) as
+otherwise it would read in the original code and not demonstrate the problem.
+[One version](1991/cdupont/cdupont.alt2.c) has the comments and unused `goto`
+label removed and [the other](1991/cdupont/cdupont.alt.c) has the comments and
+label removed and it is also beautified. The [third
+one](1991/cdupont/cdupont.alt3.c) is just beautified.
+
+
 ## [1991/davidguy](1991/davidguy/davidguy.c) ([README.md](1991/davidguy/README.md]))
 
 As some systems like macOS can be particular about not declaring functions Cody

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1278,10 +1278,10 @@ original entry Cody left the message before ending curses in and printed another
 message of the same kind after `endwin()` was called with the exception that he
 added a newline at the end of the screen to be more user friendly.
 
-Cody also added two alt versions, one to remove the maximum number of moves you
-may make and another to let you configure the maximum number of moves, even if
-that is making it harder to win. Naturally the above fix was applied to these
-versions too.
+Cody also added [two alt versions](1991/rince/README.md#alternate-code), one to
+remove the maximum number of moves you may make and another to let you configure
+the maximum number of moves, even if that is making it harder to win. Naturally
+the above fix was applied to these versions too.
 
 
 ## [1991/westley](1991/westley/westley.c) ([README.md](1991/westley/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1467,6 +1467,12 @@ line lengths match the original code, at least as best as possible (if not
 perfectly), including start and end columns, often (if not all) with the same
 start and end character.
 
+Cody made `main()` have two args, not one, as some versions of clang have a
+defect with the number of args to `main()` though when it comes to 1 arg it is
+only in an error message if say 4 args are used. This is out of an abundance of
+caution as it's quite possible that clang or the ANSI C committee end up further
+changing this.
+
 Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back.
 


### PR DESCRIPTION

Due to the fact that void main() will not work in some systems, of 
course.