### PR TITLE
Add try.sh and hint.md to 2012/hou + formatting

### DIFF
--- a/2012/hou/hint.md
+++ b/2012/hou/hint.md
@@ -1,46 +1,47 @@
-## To build:
+# Most useful obfuscation
 
-```sh
-make
-```
-
-
-## To use:
-
-```sh
-./hou syntax-file file-to-process
-```
+Qiming Hou  
+<hqm03ster@gmail.com>  
+<http://www.houqiming.net>  
 
 
-### Try:
+## Judges' comments:
 
-```sh
-./try.sh
-```
+### To build:
 
-View the `remarks.htm` file in your web browser.
+    make hou
 
-The result is best viewed in a 80x25 console with ANSI colors.
+### To run:
+
+    ./hou syntax-file file-to-process
+
+### Try (Unix):
+
+The results are best viewed in a 80x25 console with ANSI colors.
+
+    less hou.c
+
+    ./hou ansi.txt hou.c | less -r
+
+    ./hou chk.txt hou.c | wc
+
+    ./hou markdown.txt remarks.markdown > remarks.htm
+    your-browser remarks.htm
+
+### Try (Windows):
+
+    copy header.htm hou.htm /y
+    hou html.txt hou.c >> hou.htm
+    start hou.htm
+
+### Selected Judges Remarks:
+
+What a versatile entry! It can be used to check the size of IOCCC entries *and* to publish them as HTML.
+
+For extra credit: what is the meaning of the number 2321237?
 
 
-## Try (Windows):
-
-```
-copy header.htm hou.htm /y
-hou html.txt hou.c >> hou.htm
-start hou.htm
-```
-
-
-## Judges' remarks:
-
-What a versatile entry! It can be used to check the size of IOCCC entries *and*
-to publish them as HTML.
-
-For extra credit: what is the meaning of the number `2321237`?
-
-
-## Author's remarks:
+## Author's comments:
 
 ### Disclaimer
 
@@ -49,7 +50,7 @@ dense blob, which is discouraged by the contest rules. We wish to point out that
 a majority of state-of-art programming editors support syntax highlighting,
 which should be enabled when reading this entry. Anticipating that the
 reviewer's preferred color setting may produce a suboptimal visual effect, a few
-syntax files is provided to highlight the source code under an author-provided
+syntax files are provided to highlight the source code under an author-provided
 setting, using the submitted program itself. Syntax highlighting would also
 visually improve the 3rd page.
 
@@ -67,52 +68,41 @@ The syntax file consists of a number of rewriting rules. Each rule consists of a
 regular expression, a space, a format string, and a newline. All text matching
 the regular expression would be replaced by the format string. In case of a
 conflict, rules appearing earlier would take precedence. One can refer to the
-original text in the format string using `%s`. Other `%` characters in the
-format string must be escaped with another `%`. The space character can be used
-in the regular expression by escaping it with `[]` or `""`.
+original text in the format string using "%s". Other "%" characters in the
+format string must be escaped with another "%". The space character can be used
+in the regular expression by escaping it with [] or "".
 
 The following regular expression operators are supported:
 
-```
-() [] * + ? | ""
-```
+    () [] * + ? | ""
 
-For example, one can use the following expression to match a certain declaration
-statement in [hou.c](hou.c):
+For example, one can use the following expression to match a certain declaration statement in hou.c:
 
-```re
     "char"[ *]*[a-zA-Z_][0-9a-zA-Z_]*[ ]*((=[0-9a-zA-Z_ ]+)|(\[[0-9a-zA-Z_ ]*\]))?[ ]*(,[ *]*[a-zA-Z_][0-9a-zA-Z_]*[ ]*((=[0-9a-zA-Z_ ]+)|(\[[0-9a-zA-Z_ ]*\]))?[ ]*)*;
-```
 
 The regex engine is also algorithmically efficient. To illustrate the point,
-[ansi.txt](ansi.txt) contains a pathological expression [2] that guarantees a
-hang for the competing Perl engine while matching itself. Try to compare these
-two engines:
+ansi.txt contains a pathological expression [2] that guarantees a hang for the
+competing Perl engine while matching itself. Try to compare these two engines:
 
-```sh
-./hou ansi.txt ansi.txt
-perl patho.pl < ansi.txt
-```
-
-
-### Limitations
+    ./hou ansi.txt ansi.txt
+    perl patho.pl < ansi.txt
 
 Finally, there are a few limitations...
 
-- The only escape sequence supported is `\n` and it doesn't work in `[]`.
-- The maximum file/rule size is a linear function of the hard-coded constant `M`.
+
+- The only escape sequence supported is \n and it doesn't work in [].
+- The maximum file/rule size is a linear function of the hard-coded constant M.
 - Single-character matches at the end of file may be missed.
-- The operator `|` doesn't obey precedence rules and some extra `()`s may be required.
+- The operator | doesn't obey precedence rules and some extra ()s may be required.
 - Incorrect syntax files are not tolerated.
 - The program relies on ASCII.
-
 
 ### Why obfuscated
 
 The first layer of obfuscation comes from the challenge of embedding a large
 ASCII art in a dense blob. The entire art is composed using only keywords,
 strings and character constants. That results in a number of otherwise useless
-`#define`s and quite a number of unconventionally written constants. While the
+defines and quite a number of unconventionally written constants. While the
 preprocessor may remove the former, the later would remain regardless of
 beautification and preprocessing.
 
@@ -130,16 +120,15 @@ As an extra tweak, the text message actually does something useful. Remove the
 
 ### References
 
-[1][Russ Cox, Regular Expression Matching: the Virtual Machine Approach](http://swtch.com/~rsc/regexp/regexp2.html)
+[1] [Russ Cox, Regular Expression Matching: the Virtual Machine Approach](http://swtch.com/~rsc/regexp/regexp2.html)
 
-[2][Regular Expression Matching Can Be Simple And Fast (but is slow in Java, Perl, PHP, Python, Ruby, ...)](http://swtch.com/~rsc/regexp/regexp1.html)
+[2] [Regular Expression Matching Can Be Simple And Fast (but is slow in Java, Perl, PHP, Python, Ruby, ...)](http://swtch.com/~rsc/regexp/regexp1.html)
 
+--------------------------------------------------------------------------------
+<!--
+(c) Copyright 1984-2015, [Leo Broukhis, Simon Cooper, Landon Curt Noll][judges] - All rights reserved
+This work is licensed under a [Creative Commons Attribution-ShareAlike 3.0 Unported License][cc].
 
-## Copyright and CC BY-SA 4.0 License:
-
-This file is Copyright (c) 2023 by Landon Curt Noll.  All Rights Reserved.
-You are free to share and adapt this file under the terms of this license:
-
-    Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
-
-For more information, see: https://creativecommons.org/licenses/by-sa/4.0/
+[judges]: http://www.ioccc.org/judges.html
+[cc]: http://creativecommons.org/licenses/by-sa/3.0/
+-->

--- a/2012/hou/try.sh
+++ b/2012/hou/try.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2012/hou
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: less hou.c (space = next page, q = quit): "
+echo 1>&2
+less -X hou.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./hou ansi.txt hou.c | less -r (space = next page, q = quit): "
+echo 1>&2
+echo "$ ./hou ansi.txt hou.c | less -r"
+./hou ansi.txt hou.c | less -r
+echo 1>&2
+
+read -r -n 1 -p "Press any key to check size of hou.c: "
+echo 1>&2
+echo "$ ./hou chk.txt hou.c | wc" 1>&2
+./hou chk.txt hou.c | wc
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./hou markdown.txt hint.md > remarks.htm: "
+echo 1>&2
+./hou markdown.txt hint.md > remarks.htm
+echo 1>&2
+echo "Now open remarks.htm in your web browser of choice."

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3344,6 +3344,15 @@ Cody fixed a typo in the ruby script
 Cody restored the original code from the archive.
 
 
+## [2012/hou](2012/hou/hou.c) ([README.md](2012/hou/README.md]))
+
+Cody added the [try.sh](2012/hou/try.sh) script and restored the original [hint
+markdown file](2012/hou/hint.md) as the changes made when converting to a GitHub
+README.md made the generated html not look correct; it did not have a title, a
+stylesheet etc. due to the fact that there is no `#` header (which specified
+title and stylesheet) and other formatting changes.
+
+
 ## [2012/kang](2012/kang/kang.c) ([README.md](2012/kang/README.md]))
 
 Cody added alt code that fixes a problem where in German 'v' sounds like 'f'


### PR DESCRIPTION
The hint.md file is necessary as the '#' header in it specifies the title and stylesheet as part of the entry.

The try.sh script is as usual.

Format/typo check README.md file. The hint.md file formatting was not changed due to the regexp engine amongst other reasons. Just obvious spelling errors were updated.