### PR TITLE
Typo fixes in news.html

### DIFF
--- a/news.html
+++ b/news.html
@@ -10,7 +10,7 @@
 </HEAD>
 <BODY TEXT="#000000">
 
-<CENTER><a HREF="2011/zucker/hint.html"><IMG ALT="IOCCC" SRC="png/ioccc.png"></a><br><FONT SIZE="1">Logo by winner <a href="2011/zucker/hint.html">Matt Zucker</a></font></CENTER><BR>
+<CENTER><a HREF="2011/zucker/README.md"><IMG ALT="IOCCC" SRC="png/ioccc.png"></a><br><FONT SIZE="1">Logo by winner <a href="2011/zucker/README.md">Matt Zucker</a></font></CENTER><BR>
 <CENTER><FONT SIZE="6"><I>The International Obfuscated C Code
 Contest </I></FONT></CENTER><BR>
 
@@ -23,7 +23,7 @@ Please visit
 <A HREF="https://www.ioccc.org/index.html">www.ioccc.org</A>
 for the official IOCCC web.
 <P>
-Please do <B>NOT</B> bookmark nor link to this
+Please do <B>NOT</B> bookmark or link to this
 <A HREF="https://ioccc-src.github.io/temp-test-ioccc/">experimental web site</A>:
 <BLOCKQUOTE>
 <A HREF="https://ioccc-src.github.io/temp-test-ioccc/">https://ioccc-src.github.io/temp-test-ioccc/</A>
@@ -69,21 +69,21 @@ then consider making pull requests against the
 <LI TYPE=none><B>2023-05-22</B>
 <UL><LI TYPE=square>
 We have been busy preparing for an important / significant update to this web site.
-In the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>,
-we have made nearly 2000 changes to date.
+In the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>,
+we have made nearly 2645 changes to date.
 <BLOCKQUOTE>
-While you are free to look at the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>,
+While you are free to look at the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>,
 please <B>do not link to it</B> as this repo and related web site will disappear once the main
 <A HREF="https://github.com/ioccc-src/winner">IOCCC winner repo</A> has been updated.
 <P>
-Also be aware that the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>
+Also be aware that the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>
 is undergoing rapid changes.  There are broken links and other things in mid-change.
 <P>
 Once we are ready to update the <A HREF="https://github.com/ioccc-src/winner">IOCCC winner repo</A>
 and its associated <A HREF="https://www.ioccc.org/index.html">www.ioccc.org</A> web site,
 we will post a news article warning of the pending change that is about to arrive.
 </BLOCKQUOTE>
-These 2000+ changes in the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>
+These 2645+ changes in the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>
 include diverse things such as:
 <P>
 <UL>


### PR DESCRIPTION
There were references to hint.html which were changed to README.md files. Later on I presume they'll be index.html files on the main website but for now these do not exist as such.

The number of changes in the repo include over 2600 now. I kept the word nearly (next to 2645) because there have been some changes that were reverted or decided against, for example.

There was a typo in references to GitHub too.