### PR TITLE
Add alt code to 2012/omoikane + try + formatting

### DIFF
--- a/2012/omoikane/.gitignore
+++ b/2012/omoikane/.gitignore
@@ -3,7 +3,10 @@ data.c
 key
 key.c
 nyaruko
+nyaruko.alt
+nyaruko.alt2
 output
+output.2
 output.c
 regenerated.bin
 omoikane.orig

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -136,6 +136,17 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+
+alt2: data ${ALT_TARGET}2
+	@${TRUE}
+
+${PROG}.alt2: ${PROG}.alt2.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
 
 # data files
 #

--- a/2012/omoikane/README.md
+++ b/2012/omoikane/README.md
@@ -4,6 +4,11 @@
 make
 ```
 
+There is an alternate version that will read from the compiled file itself, in
+case you don't have a `/dev/urandom` file. There is also a version that should
+theoretically work with Windows which distinguishes binary and text. See
+[alternate code](#alternate-code) below. 
+
 
 ## To use:
 
@@ -14,21 +19,65 @@ perl output.c > data.c
 
 cat key.c data.c > output.c
 
-gcc output.c -o output
+cc output.c -o output
 ./output > regenerated.bin
 ```
+
+NOTE: if your OS does not have `/dev/urandom` then you should specify a seed
+file or use the [alternate version](#alternate-code) which reads in the compiled
+binary itself.
 
 
 ### Try:
 
 ```sh
-echo "A quick brown fox jumps over the lazy dog" | ./nyaruko > output.c
-perl output.c > data.c
-cc -o data data.c
-./data
-cc -o output output.c
-./output
+./try.sh
 ```
+
+The script [try.sh](try.sh) will check if you have perl before trying to use the
+perl parts of the script.
+
+
+## Alternate code:
+
+The alternate version will, if no file is specified, read in the compiled binary
+itself rather than trying to open `/dev/urandom`, which is the default for the
+original entry. This is useful if your system does not have a `/dev/urandom`
+file and you do not want to specify an extra file. The second alternate version
+is like the first except it also should theoretically work with Windows, setting
+binary mode on `stdin` and `stdout`.
+
+
+### Alternate build:
+
+For the first version:
+
+
+```sh
+make alt
+```
+
+For the second version:
+
+```sh
+make alt2
+```
+
+
+### Alternate use:
+
+Use `nyaruko.alt` or `nyaruko.alt2` as you would `nyaruko` above.
+
+
+### Alternate try:
+
+For the first alternate version:
+
+```sh
+./try.alt.sh
+```
+
+We have no way to test the second version, sorry (tm Canada :-) )!
 
 
 ## Judges' remarks:
@@ -41,8 +90,8 @@ The judges have nothing to add that has not already been written about in the
 
 ### Usage
 
-`Nyaruko` is a binary to text filter.  Given some input on stdin,
-`Nyaruko` will produce C code that reproduces this input on stdout:
+`Nyaruko` is a binary to text filter.  Given some input on `stdin`,
+`Nyaruko` will produce C code that reproduces this input on `stdout`:
 
 ```sh
 ./nyaruko < original.bin > output.c
@@ -54,20 +103,20 @@ Output is encrypted, but both key and data are included in the output.
 To separate the key from the data, run these commands:
 
 ```sh
-    bash output.c > key.c
-    perl output.c > data.c
+bash output.c > key.c
+perl output.c > data.c
 ```
 
 The key-less `data.c` still compiles, but produces a different message
-on stdout instead of the original input.  This message is a hint to
+on `stdout` instead of the original input.  This message is a hint to
 why the code is formatted the way it is.
 
 To combine the key and data, concatenate them together in either
 order:
 
 ```sh
-    cat key.c data.c > output.c
-    cat data.c key.c > output.c
+cat key.c data.c > output.c
+cat data.c key.c > output.c
 ```
 
 By default, `Nyaruko` generates a unique random key for every message,
@@ -78,10 +127,13 @@ argument, `Nyaruko` will seed using that file instead of `/dev/urandom`:
 ./nyaruko seed.txt < input.bin > output.c
 ```
 
-This makes the output key deterministic, allowing the same key to be
-shared across different files.  On operating systems that do not have
-`/dev/urandom`, users should always specify this extra seed argument to
-avoid deterministic keys.
+This makes the output key deterministic, allowing the same key to be shared
+across different files.  On operating systems that do not have `/dev/urandom`,
+users should always specify this extra seed argument to avoid indeterministic
+keys, or else use the alternate version which will by default read the compiled
+alternate version itself, which might or might not be deterministic, depending
+on where and how it's used.
+
 
 ### Features
 
@@ -109,7 +161,9 @@ Code layout is meant to resemble
 [Nyaruko](https://en.wikipedia.org/wiki/Nyarlathotep), also known as
 `Nyarlathotep`, the Crawling Chaos.  The most obvious thing to do with chaos is
 to make a random number generator, and the most obvious thing to do with a
-random number generator is to make one-time-pads for encryption.
+random number generator is to make
+[one-time-pads](https://en.wikipedia.org/wiki/One-time_pad) for encryption.
+
 
 ### Compatibility
 
@@ -135,8 +189,9 @@ combinations:
 * gcc 4.3.5 on JSLinux
 * tcc 0.9.25 on JSLinux
 
-Note that on MingW, stdin and stdout are not opened in binary mode by
+Note that on MingW, `stdin` and `stdout` are not opened in binary mode by
 default, this means `Nyaruko` may not faithfully encode files on MingW.
+
 
 ### Extra files
 

--- a/2012/omoikane/nyaruko.alt.c
+++ b/2012/omoikane/nyaruko.alt.c
@@ -1,0 +1,46 @@
+                                                      #include<stdio.h>
+                                                typedef unsigned int _;_ d,b,
+                                           #define i(I1,Il,lI)if(Il){lI;}else{I1;}
+                                         I[256],			n,y,a,r,u,k,o
+                                       ,L,l[					256],O,K[
+                                      /**/					    #define\
+                                      q(g)						g char\
+                                      *C,						   *Q,c[\
+                                      ]=						      "KfW"\
+                                      ""							"Ww|"\
+                                       /*							   'UU!\
+                                        %							     NYA!\
+                                        */							       "Z}"\
+                                 ";fRo?JtJaV<x4@*?R?&JV1"						 ".s"\
+                             "{Fyj2_;khB1xQ5oxm~mS@B|(pa>oRU"						  "Ro"\
+                          "nB}h@o?)d.X)NSTIUCz7@%",*s[]={c,"#en"					    "di"\
+                       "f/*}||1;\n__DATA__\40*/\n\n#ifndef\40q\n#d"					     "ef"\
+                      "ine\x20q\n#include<stdio.h>\ntypedef\40unsign"					       "e"\
+                    "d\x20int\x20_;_\x20K[]={\n#include\40__FILE__\n#u"						"n"\
+                   "def q","0},L,O,l[256],I[256],n,y,a,r,u,k,o;"#g"char"					 "*"\
+                 "S,s[]=\"",c,c,"\";int main(){X();for(S=s+*K;*S>37;){for"					 "(o"\
+                "=0;o<5;o++)r=r*85+(83+*S++)%89;r","^=*x();for(o=0;o<4;o++"					  ")"\
+                "{s[O++]=r&255;r>>=8;}}return!fwrite(s,O-*S%5,1,stdout);}\n"					   "#"\
+               "endif",c},S[256]="#ifdef/*\n'true'\40or\40q{\nexec\40head\40"					   "-"\
+              "8\40$0\n};for(open$O,$0;<$O>;print\40if$f){$f|=/^$/;}q{*/q",/*					    */z;
+              256];q(_*x(){if(!L--){y+=++a;for(o=0;o<256;y=l[o++]=I[255&(k>>10					    )]+u
+              ){n^=(o&1)?n>>(( o& 2)?16:6):n<<((o&2)?2:13);u=I[o];k=I[o]=I[255&					    (u>>
+             2)]+(n+=I[(o+128)  &   255]) +y;}L=255;}return&l[L];}_*X(){for(O=0					    ;256
+            >O;I[O++]=0);for(O   =     0;   sizeof(K)/sizeof( _)> O;O++)I[O&255]				    ^=K[
+            O];for(n=y=a=L=O=0 ;O<1<<24;++   O)x( );r=O=0x0; return&O;})int/*^^*/				    main
+           (int p,char**P){FILE* Z=fopen(p>    (+  1)?P[01   ]   :P[0],						    "rb"
+          );i(;,Z,O=fread(K,256  ,4,Z);/*P          */     fclose(Z))X();for(p=b=d				    =O=
+          0;O<256;K[O++]=0)*K=+  86;for(O                =1;12> O;K[O++]=*x());X();				    for
+         (C=Q=S;r-8;){i(*C++=34,  (r-4&&r               -5)||C- S ,;)z=Q[p++];i(;,z				    !=
+        32||r-3,i(i(C+=sprintf((    C),                 "%uU"    ",",K[b++]);i(d=1;C				   =S
+       ;i(d=02,b-12,;),b%6,;),r-1                       ,i(b=   fread(c,1,4,stdin);i				   (p
+       =O=0,b,for(d=O=0;O<04;O++)d                             +=(c[O]&255)<<(8*O);d				  ^=
+      *x();for(p=5;p;c[--p]=O<32?O+                            95:O+6){O=d%85;d/=85;}				 O=
+     5)i(d=0,b<4,c[O++]=b?b-1?b-2?36:      37:33:35           ;d=2)c[O]=0,r-4,i(i (d=				 2
+    |d,C!=S+6,*C++=(*x()%34)+93;p--),r      -5,*s=          C;d|=2)  )),z ,i(*C++ =92				,
+   z-63||C [-1]-63||C>S+76,;)*C++=z))i(                   ;,d>1,d=  d-2  ;Q=s[r]  ;i(			       ;
+  ,r<3||  r>5,d=1;i(;,r-1, *C=0)C=S)  i(;,            r-4, p=0)++   r)   i(*(C++ )=
+ 34,r    <4||r>5||   C<S+    78,;)i       (*C++=0;d=1; C=S   ,r<3       ||       r>
+5        ||C<S+     79,;      )i(;,d,                         puts               (
+        S);         d=0      )}  return
+                                      0;}

--- a/2012/omoikane/nyaruko.alt2.c
+++ b/2012/omoikane/nyaruko.alt2.c
@@ -1,0 +1,49 @@
+                                                      #include<stdio.h>
+						      #include<io.h>
+						      #include<fcntl.h>
+                                                typedef unsigned int _;_ d,b,
+                                           #define i(I1,Il,lI)if(Il){lI;}else{I1;}
+                                         I[256],			n,y,a,r,u,k,o
+                                       ,L,l[					256],O,K[
+                                      /**/					    #define\
+                                      q(g)						g char\
+                                      *C,						   *Q,c[\
+                                      ]=						      "KfW"\
+                                      ""							"Ww|"\
+                                       /*							   'UU!\
+                                        %							     NYA!\
+                                        */							       "Z}"\
+                                 ";fRo?JtJaV<x4@*?R?&JV1"						 ".s"\
+                             "{Fyj2_;khB1xQ5oxm~mS@B|(pa>oRU"						  "Ro"\
+                          "nB}h@o?)d.X)NSTIUCz7@%",*s[]={c,"#en"					    "di"\
+                       "f/*}||1;\n__DATA__\40*/\n\n#ifndef\40q\n#d"					     "ef"\
+                      "ine\x20q\n#include<stdio.h>\ntypedef\40unsign"					       "e"\
+                    "d\x20int\x20_;_\x20K[]={\n#include\40__FILE__\n#u"						"n"\
+                   "def q","0},L,O,l[256],I[256],n,y,a,r,u,k,o;"#g"char"					 "*"\
+                 "S,s[]=\"",c,c,"\";int main(){X();for(S=s+*K;*S>37;){for"					 "(o"\
+                "=0;o<5;o++)r=r*85+(83+*S++)%89;r","^=*x();for(o=0;o<4;o++"					  ")"\
+                "{s[O++]=r&255;r>>=8;}}return!fwrite(s,O-*S%5,1,stdout);}\n"					   "#"\
+               "endif",c},S[256]="#ifdef/*\n'true'\40or\40q{\nexec\40head\40"					   "-"\
+              "8\40$0\n};for(open$O,$0;<$O>;print\40if$f){$f|=/^$/;}q{*/q",/*					    */z;
+              256];q(_*x(){if(!L--){y+=++a;for(o=0;o<256;y=l[o++]=I[255&(k>>10					    )]+u
+              ){n^=(o&1)?n>>(( o& 2)?16:6):n<<((o&2)?2:13);u=I[o];k=I[o]=I[255&					    (u>>
+             2)]+(n+=I[(o+128)  &   255]) +y;}L=255;}return&l[L];}_*X(){for(O=0					    ;256
+            >O;I[O++]=0);for(O   =     0;   sizeof(K)/sizeof( _)> O;O++)I[O&255]				    ^=K[
+            O];for(n=y=a=L=O=0 ;O<1<<24;++   O)x( );r=O=0x0; return&O;})int/*^^*/				    main
+           (int p,char**P){FILE* Z=fopen(p>    (+  1)?P[01   ]   :P[0],						    "rb"
+          );_setmode(_fileno(stdout), 0x8000);_setmode(_fileno(stdin), 0x8000);i(
+	  ;,Z,O=fread(K,256  ,4,Z);/*P          */     fclose(Z))X();for(p=b=d				    =O=
+          0;O<256;K[O++]=0)*K=+  86;for(O                =1;12> O;K[O++]=*x());X();				    for
+         (C=Q=S;r-8;){i(*C++=34,  (r-4&&r               -5)||C- S ,;)z=Q[p++];i(;,z				    !=
+        32||r-3,i(i(C+=sprintf((    C),                 "%uU"    ",",K[b++]);i(d=1;C				   =S
+       ;i(d=02,b-12,;),b%6,;),r-1                       ,i(b=   fread(c,1,4,stdin);i				   (p
+       =O=0,b,for(d=O=0;O<04;O++)d                             +=(c[O]&255)<<(8*O);d				  ^=
+      *x();for(p=5;p;c[--p]=O<32?O+                            95:O+6){O=d%85;d/=85;}				 O=
+     5)i(d=0,b<4,c[O++]=b?b-1?b-2?36:      37:33:35           ;d=2)c[O]=0,r-4,i(i (d=				 2
+    |d,C!=S+6,*C++=(*x()%34)+93;p--),r      -5,*s=          C;d|=2)  )),z ,i(*C++ =92				,
+   z-63||C [-1]-63||C>S+76,;)*C++=z))i(                   ;,d>1,d=  d-2  ;Q=s[r]  ;i(			       ;
+  ,r<3||  r>5,d=1;i(;,r-1, *C=0)C=S)  i(;,            r-4, p=0)++   r)   i(*(C++ )=
+ 34,r    <4||r>5||   C<S+    78,;)i       (*C++=0;d=1; C=S   ,r<3       ||       r>
+5        ||C<S+     79,;      )i(;,d,                         puts               (
+        S);         d=0      )}  return
+                                      0;}

--- a/2012/omoikane/try.alt.sh
+++ b/2012/omoikane/try.alt.sh
@@ -10,7 +10,7 @@ if [[ -z "$CC" ]]; then
     CC="cc"
 fi
 
-make CC="$CC" all >/dev/null || exit 1
+make CC="$CC" everything >/dev/null || exit 1
 
 # clear screen after compilation so that only the entry is shown
 clear

--- a/2012/omoikane/try.alt.sh
+++ b/2012/omoikane/try.alt.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2012/omoikane alternate code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# remove temporary files before writing to them
+rm -f output output.2 output.c data data.c key.c
+
+# we need to find out if perl is installed
+PERL="$(type -P perl)"
+
+echo "$ echo \"A quick brown fox jumps over the lazy dog\" | ./nyaruko.alt > output.c" 1>&2
+echo "A quick brown fox jumps over the lazy dog" | ./nyaruko.alt > output.c
+read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+echo 1>&2
+less -EX output.c
+
+# perl specific stuff
+if [[ -n "$PERL" ]]; then
+    read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: " 1>&2
+    echo 1>&2
+    "${PERL}" output.c > data.c
+    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    echo 1>&2
+    less -EX data.c
+    echo "$ cc -o data data.c" 1>&2
+    cc -o data data.c
+    read -r -n 1 -p "Press any key to run: ./data: "
+    echo "$ ./data" 1>&2
+    echo 1>&2
+    ./data
+fi
+
+echo "$ cc -o output output.c" 1>&2
+cc -o output output.c
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+echo "$ ./output" 1>&2
+./output
+
+read -r -n 1 -p "Press any key to run: ./nyaruko.alt < output > output.c: "
+echo 1>&2
+./nyaruko.alt < output > output.c
+read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+echo 1>&2
+less -EX output.c
+
+read -r -n 1 -p "Press any key to run: bash output.c > key.c: "
+bash output.c > key.c
+echo 1>&2
+read -r -n 1 -p "Press any key to run: less -EX key.c (space = next page, q = quit): "
+less -EX key.c
+
+# more perl stuff
+if [[ -n "${PERL}" ]]; then
+    read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: "
+    echo 1>&2
+    "${PERL}" output.c > data.c
+    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    echo 1>&2
+    less -EX data.c
+    read -r -n 1 -p "Press any key to run: cat key.c data.c > output.c: "
+    echo 1>&2
+    cat key.c data.c > output.c
+    read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+    echo 1>&2
+    less -EX output.c
+    echo "$ cc output.c -o output" 1>&2
+    cc output.c -o output
+    read -r -n 1 -p "Press any key to run: ./output > output.2: "
+    echo 1>&2
+    ./output > output.2
+    echo "$ chmod +x output.2" 1>&2
+    chmod +x output.2
+    read -r -n 1 -p "Press any key to run: ./output.2: "
+    ./output.2
+fi

--- a/2012/omoikane/try.sh
+++ b/2012/omoikane/try.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2012/omoikane
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# remove temporary files before writing to them
+rm -f output output.2 output.c data data.c key.c
+
+# we need to find out if perl is installed
+PERL="$(type -P perl)"
+
+echo "$ echo \"A quick brown fox jumps over the lazy dog\" | ./nyaruko > output.c" 1>&2
+echo "A quick brown fox jumps over the lazy dog" | ./nyaruko > output.c
+read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+echo 1>&2
+less -EX output.c
+
+# perl specific stuff
+if [[ -n "$PERL" ]]; then
+    read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: " 1>&2
+    echo 1>&2
+    "${PERL}" output.c > data.c
+    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    echo 1>&2
+    less -EX data.c
+    echo "$ cc -o data data.c" 1>&2
+    cc -o data data.c
+    read -r -n 1 -p "Press any key to run: ./data: "
+    echo "$ ./data" 1>&2
+    echo 1>&2
+    ./data
+fi
+
+echo "$ cc -o output output.c" 1>&2
+cc -o output output.c
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+echo "$ ./output" 1>&2
+./output
+
+read -r -n 1 -p "Press any key to run: ./nyaruko < output > output.c: "
+echo 1>&2
+./nyaruko < output > output.c
+read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+echo 1>&2
+less -EX output.c
+
+read -r -n 1 -p "Press any key to run: bash output.c > key.c: "
+bash output.c > key.c
+echo 1>&2
+read -r -n 1 -p "Press any key to run: less -EX key.c (space = next page, q = quit): "
+less -EX key.c
+
+# more perl stuff
+if [[ -n "${PERL}" ]]; then
+    read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: "
+    echo 1>&2
+    "${PERL}" output.c > data.c
+    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    echo 1>&2
+    less -EX data.c
+    read -r -n 1 -p "Press any key to run: cat key.c data.c > output.c: "
+    echo 1>&2
+    cat key.c data.c > output.c
+    read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+    echo 1>&2
+    less -EX output.c
+    echo "$ cc output.c -o output" 1>&2
+    cc output.c -o output
+    read -r -n 1 -p "Press any key to run: ./output > output.2: "
+    echo 1>&2
+    ./output > output.2
+    echo "$ chmod +x output.2" 1>&2
+    chmod +x output.2
+    read -r -n 1 -p "Press any key to run: ./output.2: "
+    ./output.2
+fi

--- a/news.html
+++ b/news.html
@@ -10,7 +10,7 @@
 </HEAD>
 <BODY TEXT="#000000">
 
-<CENTER><a HREF="2011/zucker/hint.html"><IMG ALT="IOCCC" SRC="png/ioccc.png"></a><br><FONT SIZE="1">Logo by winner <a href="2011/zucker/hint.html">Matt Zucker</a></font></CENTER><BR>
+<CENTER><a HREF="2011/zucker/README.md"><IMG ALT="IOCCC" SRC="png/ioccc.png"></a><br><FONT SIZE="1">Logo by winner <a href="2011/zucker/README.md">Matt Zucker</a></font></CENTER><BR>
 <CENTER><FONT SIZE="6"><I>The International Obfuscated C Code
 Contest </I></FONT></CENTER><BR>
 
@@ -23,7 +23,7 @@ Please visit
 <A HREF="https://www.ioccc.org/index.html">www.ioccc.org</A>
 for the official IOCCC web.
 <P>
-Please do <B>NOT</B> bookmark nor link to this
+Please do <B>NOT</B> bookmark or link to this
 <A HREF="https://ioccc-src.github.io/temp-test-ioccc/">experimental web site</A>:
 <BLOCKQUOTE>
 <A HREF="https://ioccc-src.github.io/temp-test-ioccc/">https://ioccc-src.github.io/temp-test-ioccc/</A>
@@ -69,21 +69,21 @@ then consider making pull requests against the
 <LI TYPE=none><B>2023-05-22</B>
 <UL><LI TYPE=square>
 We have been busy preparing for an important / significant update to this web site.
-In the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>,
-we have made nearly 2000 changes to date.
+In the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>,
+we have made nearly 2645 changes to date.
 <BLOCKQUOTE>
-While you are free to look at the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>,
+While you are free to look at the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>,
 please <B>do not link to it</B> as this repo and related web site will disappear once the main
 <A HREF="https://github.com/ioccc-src/winner">IOCCC winner repo</A> has been updated.
 <P>
-Also be aware that the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>
+Also be aware that the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>
 is undergoing rapid changes.  There are broken links and other things in mid-change.
 <P>
 Once we are ready to update the <A HREF="https://github.com/ioccc-src/winner">IOCCC winner repo</A>
 and its associated <A HREF="https://www.ioccc.org/index.html">www.ioccc.org</A> web site,
 we will post a news article warning of the pending change that is about to arrive.
 </BLOCKQUOTE>
-These 2000+ changes in the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHiub repo</A>
+These 2645+ changes in the <A HREF="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</A>
 include diverse things such as:
 <P>
 <UL>

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3400,6 +3400,21 @@ show different languages and numbers.
 [Cody](#cody) added the [try.sh](2012/konno/try.sh) script.
 
 
+## [2012/omoikane](2012/omoikane/omoikane.c) ([README.md](2012/omoikane/README.md]))
+
+[Cody](#cody) added the [try.sh](2012/omoikane/try.sh) script.
+
+Cody also added the [alternate code](2012/omoikane/README.md#alternate-code)
+which will, if no arg is specified, read in the program itself, rather than
+`/dev/urandom`. This is mostly useful for those without a `/dev/urandom` device
+file (the default for the entry). The second alternate version is like the first
+except that it also sets binary mode on `stdin` and `stdout` which should
+theoretically make it work in Windows.
+
+Cody also added the [try.alt.sh](2012/omoikane/try.alt.sh) script that is like
+the `try.sh` script but which uses the (first version of the) alt code instead.
+
+
 ## [2012/tromp](2012/tromp/tromp.c) ([README.md](2012/tromp/README.md))
 
 [Cody](#cody) added the [try.sh](2012/tromp/try.sh) script.


### PR DESCRIPTION

There are two alt versions which should be useful for (respectively)
those who do not have /dev/urandom and those who use Windows. Both of 
these versions read from argv[0] instead of /dev/urandom but the second
one sets binary mode on stdin and stdout. This is to be consistent with
the fact that other entries also have this as an alt version.

The try.sh and try.alt.sh scripts work on the entry and the first
version of the alt code, the one that is not Windows specific. The
scripts consist of commands from both the to use section of the 
README.md (which is still there) and the try section (which now refers
to try.sh).

Format/typo checks in README.md file.