### PR TITLE
Add alt versions to 2012/endoh1 + formatting

### DIFF
--- a/2012/endoh1/.gitignore
+++ b/2012/endoh1/.gitignore
@@ -1,6 +1,8 @@
 endoh1
 endoh1.alt
+endoh1.alt2
 endoh1_color
+endoh1_color.alt
 configuration.txt
 endoh1.orig
 prog.orig

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -57,7 +57,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -DG="$G" -DP="$P" -DV="$V"
+CDEFINE= -DG="$G" -DP="$P" -DV="$V" -DS=12321
 
 # Include files that are needed to compile
 #
@@ -154,8 +154,18 @@ ${PROG}_color: ${PROG}_color.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
+alt2: ${ALT_TARGET}2 ${PROG}_color.alt
+	@${TRUE}
+
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+${PROG}.alt2: ${PROG}.alt2.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+${PROG}_color.alt: ${PROG}_color.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
 
 # data files
 #
@@ -221,7 +231,7 @@ clean:
 	fi
 
 clobber: clean
-	${RM} -f ${TARGET} ${ALT_TARGET}
+	${RM} -f ${TARGET} ${ALT_TARGET} ${ALT_TARGET}2 ${PROG}_color.alt
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -4,6 +4,10 @@
 make
 ```
 
+There is a deobfuscated version of this entry. There are two other versions, one
+black and white and one coloured, as well that let you slow or speed up the
+display. See [alternate code](#alternate-code) below for more details.
+
 
 ## To use:
 
@@ -28,24 +32,73 @@ this by default.
 
 ## Alternate code:
 
-An alternate version of this entry, `endoh1.alt.c`, is provided.
-This alternate code is a de-obfuscated version of `endoh1.c`.
+The file [endoh1.alt.c](endoh1.alt.c) is deobfuscated.
+The file [endoh1_color.alt.c](endoh1_color.alt.c) is like
+[endoh1_color.c](endoh1_color.c) except that you can control how long to sleep
+between writes. The file [endoh1.alt2.c](endoh1.alt2.c) is like
+[endoh1.c](endoh1.c) except you can control how long to sleep between writes.
 
-To compile this alternate version:
+
+### Alternate build:
+
 
 ```sh
-make alt
+make alt alt2
 ```
 
-Use `endoh1.alt` as you would `endoh1` above.
+
+### Alternate use:
+
+Use `endoh1.alt`, `endoh1.alt2` and `endoh1_color.alt` as you would `endoh1`
+above.
+
+
+### Alternate try:
+
+WARNING: if you're sensitive to flashing colours do make sure you don't decrease
+the value too much.
+
+Try slowing down the display by increasing the sleep time from `12321` to
+`50000`:
+
+```sh
+make clobber CDEFINE="-DS=50000" alt2
+```
+
+Now try using both `endoh1.alt2` and `endoh1_color.alt` as you would `endoh1` above.
+
+Also try speeding up the display by decreasing the sleep time from `12321` to
+`9999`:
+
+```sh
+make clobber CDEFINE="-DS=9999" alt2
+```
+
+Try using both `endoh1.alt2` and `endoh1_color.alt` as you would `endoh1` above.
+
+You might also wish to try redefining the macros `G`, `P` and/or `V`. For
+instance:
+
+
+```sh
+make clobber CDEFINE="-DG=5 -DP=5 -DV=5" alt2
+```
+
+You might try even:
+
+```sh
+make clobber CDEFINE="-DG=I" alt2
+```
+
+See the author's remarks for details on these macros.
 
 
 ## Judges' remarks:
 
 Let's play [Jeopardy!](https://en.wikipedia.org/wiki/Jeopardy!)
 
-*   A: An obfuscated program that deals with complex numbers and produces animated ASCII graphics.
-*   Q: What is a Mandelbrot simulator?
+A: An obfuscated program that deals with complex numbers and produces animated ASCII graphics.
+Q: What is a Mandelbrot simulator?
 
 Bzzzt!
 
@@ -53,7 +106,8 @@ Such heavily squeezed fluid simulation (this is parsed uniquely
 as fluids are not squeezable) has a few quirks that the judges were
 happy to experiment with.
 
-One configuration file was inspired by an [XKCD what if? entry](http://whatif.xkcd.com/6/).
+One configuration file was inspired by an [XKCD what if?
+entry](https://web.archive.org/web/20230711134609/https://whatif.xkcd.com/6/).
 
 
 ## Author's remarks:
@@ -103,7 +157,7 @@ cc endoh1.c -DG=1 -DP=4 -DV=8 -D_BSD_SOURCE -o endoh1 -lm
 
 ```
 
-This program is a fluid simulator using [Smoothed-particle hydrodynamics
+This program is a fluid simulator using the [Smoothed-particle hydrodynamics
 (SPH)](http://en.wikipedia.org/wiki/Smoothed-particle_hydrodynamics) method.
 
 The SPH particles represent the fluid flow.  Particles have information about
@@ -111,8 +165,8 @@ the position, density, and velocity.  In every simulation step, they are
 changed by pressure force, viscosity force, and external force (i.e., gravity).
 
 This program reads a text from standard input, and uses it as an initial
-configuration of the particles.  The character `#` represents "wall particle" (a
-particle with fixed position), and any other non-space characters represent
+configuration of the particles.  The character `#` represents a "wall particle" (a
+particle with a fixed position), and any other non-space characters represent
 free particles.
 
 The compilation options `-DG=1 -DP=4 -DV=8` represent, respectively, the factor
@@ -122,10 +176,11 @@ different fluid behavior.
 [Marching square](http://en.wikipedia.org/wiki/Marching_squares)-like algorithm
 is used to render the particles.
 
+
 ### Portability
 
 The program requires a C99 compiler; it uses `complex` types and one-line
-comments.  It also uses `usleep`, which may require `-D_BSD_SOURCE` or so
+comments.  It also uses `usleep(3)`, which may require `-D_BSD_SOURCE` or so
 to build with no warning.  Under these conditions, it should be portable.
 At least, recent compilers with `-std=c99 -Wall -W -Wextra -pedantic` say
 nothing.
@@ -144,16 +199,17 @@ and gcc-4.5.3 and clang-3.1 on Cygwin.  On Cygwin, gcc and clang complain about
 a usage of `I` (complex's imaginary unit), but I bet this is cygwin's issue;
 it is surely a C99 feature.
 
+
 ### Obfuscation w/ Spoiler
 
 First of all, the source code itself serves as an initial configuration.
 Preprocessing directives (such as `#include`)'s `#` serve as walls.
 
 This program uses `double complex` to represent any 2D vector.  But, note that
-`x-axis` and `y-axis` is swapped (real axis = y-axis, imaginary axis = x-axis).
-The purpose of swapping is not only obfuscation, but also short coding: for
-example, to add gravity to total force, `force += G` suffices, rather than
-`force += G*I`.
+the `x-axis` and `y-axis` are swapped (real axis = y-axis, imaginary axis =
+x-axis).  The purpose of swapping is not only obfuscation, but also short
+coding: for example, to add gravity to total force, `force += G` suffices,
+rather than `force += G*I`.
 
 (Incidentally, you can exert horizontal gravity by using for instance `-DG=I`)
 
@@ -163,9 +219,10 @@ position, wall-flag, density, force, and velocity, in turn.
 You can use `G`, `P`, and `V` as a guide to find the calculation code of
 gravity, pressure, and viscosity forces.
 
-Though some assignments may look meaningless, it is actually meaningful; it
-extracts "integer part of real part" from a complex value by assigning (and
+Though some assignments may look meaningless, they are actually meaningful; they
+extract "integer part of real part" from a complex value by assigning (and
 casting) it to an integer-type variable.
+
 
 ### Notes about Additional Files
 

--- a/2012/endoh1/endoh1.alt2.c
+++ b/2012/endoh1/endoh1.alt2.c
@@ -1,0 +1,49 @@
+#  include<stdio.h>//  .IOCCC                                         Fluid-  #
+#  include <unistd.h>  //2012                                         _Sim!_  #
+#  include<complex.h>  //||||                     ,____.              IOCCC-  #
+#  ifndef	       S
+#  define              S 12321
+#  elif                S < 1
+#  undef               S
+#  define              S 12321
+#  endif
+#  ifndef              G
+#  define              G 1
+#  elif                G < 1
+#  undef               G
+#  define              G 1
+#  endif
+#  ifndef              P
+#  define              P 4
+#  elif                P < 1
+#  undef               P
+#  define              P 4
+#  endif
+#  ifndef              V
+#  define              V 8
+#  elif                V < 1
+#  undef               V
+#  define              V 8
+#  endif
+
+
+#  define              h for(                     x=011;              2012/*  #
+#  */-1>x              ++;)b[                     x]//-'              winner  #
+#  define              f(p,e)                                         for(/*  #
+#  */p=a;              e,p<r;                                        p+=5)//  #
+#  define              z(e,i)                                        f(p,p/*  #
+## */[i]=e)f(q,w=cabs  (d=*p-  *q)/2-     1)if(0  <(x=1-      w))p[i]+=w*/// ##
+   double complex a [  97687]  ,*p,*q     ,*r=a,  w=0,d;    int x,y;char b/* ##
+## */[6856]="\x1b[2J"  "\x1b"  "[1;1H     ", *o=  b, *t;   int main   (){/** ##
+## */for(              ;0<(x=  getc (     stdin)  );)w=x  >10?32<     x?4[/* ##
+## */*r++              =w,r]=  w+1,*r     =r[5]=  x==35,  r+=9:0      ,w-I/* ##
+## */:(x=              w+2);;  for(;;     puts(o  ),o=b+  4){z(p      [1]*/* ##
+## */9,2)              w;z(G,  3)(d*(     3-p[2]  -q[2])  *P+p[4      ]*V-/* ##
+## */q[4]              *V)/p[  2];h=0     ;f(p,(  t=b+10  +(x=*p      *I)+/* ##
+## */80*(              y=*p/2  ),*p+=p    [4]+=p  [3]/10  *!p[1])     )x=0/* ##
+## */ <=x              &&x<79   &&0<=y&&y<23?1[1  [*t|=8   ,t]|=4,t+=80]=1/* ##
+## */, *t              |=2:0;    h=" '`-.|//,\\"  "|\\_"    "\\/\x23\n"[x/** ##
+## */%80-              9?x[b]      :16];;usleep(      S)      ;}return 0;}/* ##
+####                                                                       ####
+###############################################################################
+**###########################################################################*/

--- a/2012/endoh1/endoh1_color.alt.c
+++ b/2012/endoh1/endoh1_color.alt.c
@@ -1,0 +1,55 @@
+#  include<stdio.h>//  .IOCCC                                         Fluid-  #
+#  include <unistd.h>  //2012                                         _Sim!_  #
+#  include<complex.h>  //||||                     ,____.              ||||||  #
+#  ifndef	       S
+#  define              S 12321
+#  elif                S < 1
+#  undef               S
+#  define              S 12321
+#  endif
+#  ifndef              G
+#  define              G 1
+#  elif                G < 1
+#  undef               G
+#  define              G 1
+#  endif
+#  ifndef              P
+#  define              P 4
+#  elif                P < 1
+#  undef               P
+#  define              P 4
+#  endif
+#  ifndef              V
+#  define              V 8
+#  elif                V < 1
+#  undef               V
+#  define              V 8
+#  endif
+
+#  define              c y+=(                    x=ctanh(            -cabs/*  #
+#  */(4[t              ]-=20)                     /2+9)*             3+3)*//  #
+#  define              f(p,e)                                        for(p/*  #
+#  */=a;e              ,p<r;p                                        +=5)///  #
+#  define              z(e,i)                                        f(p,p/*  #
+## */[i]=e)f(q,w=cabs  (d=*p-  *q)/2-     1)if(0  <(x=1-      w))p[i]+=w*/// ##
+   double complex a [  97687]  ,*p,*q     ,*r=a,  w=0,d;    char b[97687]=/* ##
+## */"GO\x1b[2J\x1b["  "1;1H"  ,*o=b,     *t;int  x,y,j;   void h(int e){/** ##
+## */for(              t=b;b+  24045>     (t+=12  );c 6,  sprintf     (t,/** ##
+## */"%c"              "[48%"  "c5;%"     "03dm"  "%c",3  *9,e,c      36,e/* ##
+## */?(t-              b)%960  ?(15-t     [11])[  "\x23"  "/\\_"      "\\"/* ##
+## */"||"              ",//|"  ".-`'      "]:10:  0)) y=  0020,c      01;}/* ##
+## */void              g( int  i){7[t     +=i]|=  x/=2;*  t+=y=p      [2];/* ##
+## */}int              main()  {for(;(    x=getc  (stdin  ))>0;)w     =10</* ##
+## */x?32              <x?4[*   r++=w,r]=w+1,*r=  r[5]=x   ==35,r+=9:0,w-I/* ##
+## */:(x=              w+02);    for(;;puts(o),o  =b+6){    z(p[1]*9,2)w;z/* ##
+## */(G,3              )(d*(3      -p[2]-q[2])*P  +p[4]*      V-q[4]*V )/p/* ##
+####                                                                       ####
+###############################################################################
+**###########################################################################*/
+
+         [2];h(0       );f(p,*     p+=           p[4]+=p     [3]/10*!p
+       [1]     )(t   =b+     16+   (x=         *p*     I)*   12+     960
+       *(y           =*p     /2)   ,x=         0<=     x&&   79>     x&&
+       0<=           y&&     23>   y?x         =16     ,g(   0),g(12),
+       g(+     948   ),g     (12   ),0         :0)     ;h(   59)     ;;;
+         usleep(       S    );     }return 0;}   /*IOCCC     '12     **/

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3343,6 +3343,12 @@ Cody also added the [try.sh](2012/blakely/try.sh) script.
 [Cody](#cody) added explicit linking of libm (`-lm`) as not all systems do this
 implicitly (Linux doesn't seem to but macOS does).
 
+Cody also added two [alt versions](2012/endoh1/README.md#alternate-code) that
+let one control how fast to display (how long to sleep in between writes) the
+fluid, one an alt of the colour version (that Yusuke added at the request of the
+judges) and an alt of the original. The [endoh1.alt.c](2012/endoh1/endoh1.alt.c)
+was provided by Yusuke as a de-obfuscated version.
+
 
 ## [2012/endoh2](2012/endoh2/endoh2.c) ([README.md](2012/endoh2/README.md))
 


### PR DESCRIPTION
The alt versions let one control how long to sleep between writes as in modern systems it goes pretty fast. There are two, one for the colour version that was added by Yusuke at the request of the judges and one for the original. But the one for the original is called endoh1.alt2.c as Yusuke provided endoh1.alt.c as a deobfuscated version.

The new alt versions let one only redefine certain macros should they choose but they can define them all or not define them all because of the #ifndef..#endif guards. These macros include the sleep time (S) as well as the others that Yusuke suggested one might want to change.

The README.md file has been format/typo checked.