### PR TITLE
Swap alt and alt2 of 2012/endoh1

### DIFF
--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -115,8 +115,8 @@ DATA= column.txt column2.txt column3.txt corners.txt dripping-pan.txt \
 	funnel3.txt leidenfrost.txt logo.txt pour-out.txt tanada.txt
 TARGET= ${PROG} ${PROG}_color
 #
-ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_OBJ= ${PROG}.alt.o ${PROG}_color.alt.o
+ALT_TARGET= ${PROG}.alt ${PROG}_color.alt
 
 # The factor of gravity
 #
@@ -151,19 +151,21 @@ ${PROG}_color: ${PROG}_color.c
 
 # alternative executable
 #
-alt: data ${ALT_TARGET}
-	@${TRUE}
-
-alt2: ${ALT_TARGET}2 ${PROG}_color.alt
+alt: data ${ALT_TARGET} ${PROG}.alt2
 	@${TRUE}
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
-${PROG}.alt2: ${PROG}.alt2.c
+# this does NOT correspond to endoh1.alt2.c but rather endoh1.alt.c: it is NOT
+# deobfuscated.
+${PROG}_color.alt: ${PROG}_color.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
-${PROG}_color.alt: ${PROG}_color.alt.c
+alt2: ${PROG}.alt2
+	@${TRUE}
+
+${PROG}.alt2: ${PROG}.alt2.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 
@@ -231,7 +233,7 @@ clean:
 	fi
 
 clobber: clean
-	${RM} -f ${TARGET} ${ALT_TARGET} ${ALT_TARGET}2 ${PROG}_color.alt
+	${RM} -f ${TARGET} ${ALT_TARGET} ${ALT_TARGET}2 ${PROG}_color.alt ${PROG}.alt2
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -1,12 +1,14 @@
-## To build:
 
 ```sh
 make
 ```
 
-There is a deobfuscated version of this entry. There are two other versions, one
-black and white and one coloured, as well that let you slow or speed up the
-display. See [alternate code](#alternate-code) below for more details.
+There are two alt versions that let you control the compile time variables that
+control the fluid behaviour and the added variable to speed up or slow down the
+fluid: one for the original black and white and the colour one added by the
+author at the request of the judges. Another version is the deobfuscated version
+provided by the author as well.  See [alternate code](#alternate-code) below for
+more details.
 
 
 ## To use:
@@ -32,40 +34,70 @@ this by default.
 
 ## Alternate code:
 
-The file [endoh1.alt.c](endoh1.alt.c) is deobfuscated.
-The file [endoh1_color.alt.c](endoh1_color.alt.c) is like
-[endoh1_color.c](endoh1_color.c) except that you can control how long to sleep
-between writes. The file [endoh1.alt2.c](endoh1.alt2.c) is like
-[endoh1.c](endoh1.c) except you can control how long to sleep between writes.
+The files [endoh1.alt.c](endoh1.alt.c) and
+[endoh1_color.alt.c](endoh1_color.alt.c) correspond to [endoh1.c](endoh1.c) and
+[endoh1_color.c](endoh1_color.c) but which allow you to speed up or slow down
+the fluid and change the behaviour of the fluid. The file
+[endoh1.alt2.c](endoh1.alt.c) is deobfuscated and was provided by the author.
 
 
 ### Alternate build:
 
+For the default values, try:
 
 ```sh
 make alt alt2
 ```
 
+The `alt2` is only necessary if you wish to compile the deobfuscated version but
+it is equivalent in function to the original entry, [endoh1.c](endoh1.c).
+
+If you wish to change the speed you should do:
+
+```sh
+make clobber CDEFINE="-DS=N" alt
+```
+
+where `N` is number or the letter `I`.
+
+WARNING: if you're sensitive to flashing colours or any flashing at all do make
+sure you don't decrease the value of `S`, the sleep time passed to `usleep(3)`,
+too much.
+
+If however you wish to change the gravity factor, pressure factor and/or
+viscosity factor, you should redefine the values `G`, `P` and/or `V` macros,
+respectively, with the same caveat about numbers for `S` above. For instance if
+you wish to change the viscosity and pressure factors but leave the other macros
+alone:
+
+```sh
+make clobber CDEFINE="-DV=X -DP=Y" alt
+```
+
+where `X` and `Y` are numbers or the letter `I` and which are, respectively, the
+viscosity and pressure factors.
+
+There is no restriction on what the number is because doing so prevents the
+macros from being defined to `I` which would prevent the author's remarks about
+it from being done.
+
 
 ### Alternate use:
 
-Use `endoh1.alt`, `endoh1.alt2` and `endoh1_color.alt` as you would `endoh1`
-above.
+Use `endoh1.alt`, `endoh1_color.alt` and `endoh1.alt2` as you would `endoh1`
+and `endoh1_color` above.
 
 
 ### Alternate try:
-
-WARNING: if you're sensitive to flashing colours do make sure you don't decrease
-the value too much.
 
 Try slowing down the display by increasing the sleep time from `12321` to
 `50000`:
 
 ```sh
-make clobber CDEFINE="-DS=50000" alt2
+make clobber CDEFINE="-DS=50000" alt
 ```
 
-Now try using both `endoh1.alt2` and `endoh1_color.alt` as you would `endoh1` above.
+Now try using both `endoh1.alt` and `endoh1_color.alt` as you would `endoh1` above.
 
 Also try speeding up the display by decreasing the sleep time from `12321` to
 `9999`:
@@ -74,20 +106,29 @@ Also try speeding up the display by decreasing the sleep time from `12321` to
 make clobber CDEFINE="-DS=9999" alt2
 ```
 
-Try using both `endoh1.alt2` and `endoh1_color.alt` as you would `endoh1` above.
+WARNING: again, be careful with too low a value if you're sensitive to flashing
+colours or anything at all.
+
+Now try using both `endoh1.alt` and `endoh1_color.alt` as you would `endoh1` above.
 
 You might also wish to try redefining the macros `G`, `P` and/or `V`. For
 instance:
 
 
 ```sh
-make clobber CDEFINE="-DG=5 -DP=5 -DV=5" alt2
+make clobber CDEFINE="-DG=5 -DP=5 -DV=5" alt
 ```
 
 You might try even:
 
 ```sh
-make clobber CDEFINE="-DG=I" alt2
+make clobber CDEFINE="-DG=I" alt
+```
+
+and even:
+
+```sh
+make clobber CDEFINE="-DG=I -DV=I" alt
 ```
 
 See the author's remarks for details on these macros.

--- a/2012/endoh1/endoh1.alt.c
+++ b/2012/endoh1/endoh1.alt.c
@@ -1,31 +1,40 @@
-#include <stdio.h>//  .IOCCC                                         Fluid-  #
-#include <unistd.h>  //2012                                         _Sim!_  #
-#include <complex.h>  //||||                     ,____.              IOCCC-  #
-double complex	a[97687], *p, *q, *r = a, w = 0, d;
-int		x         , y;
-char		b         [6856] = "\x1b[2J" "\x1b" "[1;1H     ", *o = b, *t;
-int
-main()
-{
+#  include<stdio.h>//  .IOCCC                                         Fluid-  #
+#  include <unistd.h>  //2012                                         _Sim!_  #
+#  include<complex.h>  //||||                     ,____.              IOCCC-  #
+#  ifndef	       S
+#  define              S 12321
+#  elif                S < 1
+#  undef               S
+#  define              S 12321
+#  endif
+#  ifndef              G
+#  define              G 1
+#  endif
+#  ifndef              P
+#  define              P 4
+#  endif
+#  ifndef              V
+#  define              V 8
+#  endif
 
-	for (; 0 < (x = getc(stdin));)
-		w = x > 10 ? 32 < x ? 4[*r++ = w, r] = w + 1, *r = r[5] = x == 35, r += 9 : 0, w - I : (x = w + 2);;
-	for (;; puts(o), o = b + 4) {
-		for (p = a; p[2] = p[1] * 9, p < r; p += 5)
-			for (q = a; w = cabs(d = *p - *q) / 2 - 1, q < r; q += 5)
-				if (0 < (x = 1 - w))
-					p[2] += w * w;
-		for (p = a; p[3] = G, p < r; p += 5)
-			for (q = a; w = cabs(d = *p - *q) / 2 - 1, q < r; q += 5)
-				if (0 < (x = 1 - w))
-					p[3] += w * (d * (3 - p[2] - q[2]) * P + p[4] * V - q[4] * V) / p[2];
-		for (x = 011; 2012 - 1 > x++;)
-			b[x] = 0;
-		for (p = a; (t = b + 10 + (x = *p * I) + 80 * (y = *p / 2), *p += p[4] += p[3] / 10 * !p[1]), p < r; p += 5)
-			x = 0 <= x && x < 79 && 0 <= y && y < 23 ? 1[1[*t |= 8, t] |= 4, t += 80] = 1, *t |= 2 : 0;
-		for (x = 011; 2012 - 1 > x++;)
-			b[x] = " '`-.|//,\\" "|\\_" "\\/\x23\n"[x % 80 - 9 ? x[b] : 16];;
 
-		usleep(12321);
-	} return 0;
-}
+#  define              h for(                     x=011;              2012/*  #
+#  */-1>x              ++;)b[                     x]//-'              winner  #
+#  define              f(p,e)                                         for(/*  #
+#  */p=a;              e,p<r;                                        p+=5)//  #
+#  define              z(e,i)                                        f(p,p/*  #
+## */[i]=e)f(q,w=cabs  (d=*p-  *q)/2-     1)if(0  <(x=1-      w))p[i]+=w*/// ##
+   double complex a [  97687]  ,*p,*q     ,*r=a,  w=0,d;    int x,y;char b/* ##
+## */[6856]="\x1b[2J"  "\x1b"  "[1;1H     ", *o=  b, *t;   int main   (){/** ##
+## */for(              ;0<(x=  getc (     stdin)  );)w=x  >10?32<     x?4[/* ##
+## */*r++              =w,r]=  w+1,*r     =r[5]=  x==35,  r+=9:0      ,w-I/* ##
+## */:(x=              w+2);;  for(;;     puts(o  ),o=b+  4){z(p      [1]*/* ##
+## */9,2)              w;z(G,  3)(d*(     3-p[2]  -q[2])  *P+p[4      ]*V-/* ##
+## */q[4]              *V)/p[  2];h=0     ;f(p,(  t=b+10  +(x=*p      *I)+/* ##
+## */80*(              y=*p/2  ),*p+=p    [4]+=p  [3]/10  *!p[1])     )x=0/* ##
+## */ <=x              &&x<79   &&0<=y&&y<23?1[1  [*t|=8   ,t]|=4,t+=80]=1/* ##
+## */, *t              |=2:0;    h=" '`-.|//,\\"  "|\\_"    "\\/\x23\n"[x/** ##
+## */%80-              9?x[b]      :16];;usleep(      S)      ;}return 0;}/* ##
+####                                                                       ####
+###############################################################################
+**###########################################################################*/

--- a/2012/endoh1/endoh1.alt2.c
+++ b/2012/endoh1/endoh1.alt2.c
@@ -1,49 +1,31 @@
-#  include<stdio.h>//  .IOCCC                                         Fluid-  #
-#  include <unistd.h>  //2012                                         _Sim!_  #
-#  include<complex.h>  //||||                     ,____.              IOCCC-  #
-#  ifndef	       S
-#  define              S 12321
-#  elif                S < 1
-#  undef               S
-#  define              S 12321
-#  endif
-#  ifndef              G
-#  define              G 1
-#  elif                G < 1
-#  undef               G
-#  define              G 1
-#  endif
-#  ifndef              P
-#  define              P 4
-#  elif                P < 1
-#  undef               P
-#  define              P 4
-#  endif
-#  ifndef              V
-#  define              V 8
-#  elif                V < 1
-#  undef               V
-#  define              V 8
-#  endif
+#include <stdio.h>//  .IOCCC                                         Fluid-  #
+#include <unistd.h>  //2012                                         _Sim!_  #
+#include <complex.h>  //||||                     ,____.              IOCCC-  #
+double complex	a[97687], *p, *q, *r = a, w = 0, d;
+int		x         , y;
+char		b         [6856] = "\x1b[2J" "\x1b" "[1;1H     ", *o = b, *t;
+int
+main()
+{
 
+	for (; 0 < (x = getc(stdin));)
+		w = x > 10 ? 32 < x ? 4[*r++ = w, r] = w + 1, *r = r[5] = x == 35, r += 9 : 0, w - I : (x = w + 2);;
+	for (;; puts(o), o = b + 4) {
+		for (p = a; p[2] = p[1] * 9, p < r; p += 5)
+			for (q = a; w = cabs(d = *p - *q) / 2 - 1, q < r; q += 5)
+				if (0 < (x = 1 - w))
+					p[2] += w * w;
+		for (p = a; p[3] = G, p < r; p += 5)
+			for (q = a; w = cabs(d = *p - *q) / 2 - 1, q < r; q += 5)
+				if (0 < (x = 1 - w))
+					p[3] += w * (d * (3 - p[2] - q[2]) * P + p[4] * V - q[4] * V) / p[2];
+		for (x = 011; 2012 - 1 > x++;)
+			b[x] = 0;
+		for (p = a; (t = b + 10 + (x = *p * I) + 80 * (y = *p / 2), *p += p[4] += p[3] / 10 * !p[1]), p < r; p += 5)
+			x = 0 <= x && x < 79 && 0 <= y && y < 23 ? 1[1[*t |= 8, t] |= 4, t += 80] = 1, *t |= 2 : 0;
+		for (x = 011; 2012 - 1 > x++;)
+			b[x] = " '`-.|//,\\" "|\\_" "\\/\x23\n"[x % 80 - 9 ? x[b] : 16];;
 
-#  define              h for(                     x=011;              2012/*  #
-#  */-1>x              ++;)b[                     x]//-'              winner  #
-#  define              f(p,e)                                         for(/*  #
-#  */p=a;              e,p<r;                                        p+=5)//  #
-#  define              z(e,i)                                        f(p,p/*  #
-## */[i]=e)f(q,w=cabs  (d=*p-  *q)/2-     1)if(0  <(x=1-      w))p[i]+=w*/// ##
-   double complex a [  97687]  ,*p,*q     ,*r=a,  w=0,d;    int x,y;char b/* ##
-## */[6856]="\x1b[2J"  "\x1b"  "[1;1H     ", *o=  b, *t;   int main   (){/** ##
-## */for(              ;0<(x=  getc (     stdin)  );)w=x  >10?32<     x?4[/* ##
-## */*r++              =w,r]=  w+1,*r     =r[5]=  x==35,  r+=9:0      ,w-I/* ##
-## */:(x=              w+2);;  for(;;     puts(o  ),o=b+  4){z(p      [1]*/* ##
-## */9,2)              w;z(G,  3)(d*(     3-p[2]  -q[2])  *P+p[4      ]*V-/* ##
-## */q[4]              *V)/p[  2];h=0     ;f(p,(  t=b+10  +(x=*p      *I)+/* ##
-## */80*(              y=*p/2  ),*p+=p    [4]+=p  [3]/10  *!p[1])     )x=0/* ##
-## */ <=x              &&x<79   &&0<=y&&y<23?1[1  [*t|=8   ,t]|=4,t+=80]=1/* ##
-## */, *t              |=2:0;    h=" '`-.|//,\\"  "|\\_"    "\\/\x23\n"[x/** ##
-## */%80-              9?x[b]      :16];;usleep(      S)      ;}return 0;}/* ##
-####                                                                       ####
-###############################################################################
-**###########################################################################*/
+		usleep(12321);
+	} return 0;
+}

--- a/2012/endoh1/endoh1_color.alt.c
+++ b/2012/endoh1/endoh1_color.alt.c
@@ -9,20 +9,11 @@
 #  endif
 #  ifndef              G
 #  define              G 1
-#  elif                G < 1
-#  undef               G
-#  define              G 1
 #  endif
 #  ifndef              P
 #  define              P 4
-#  elif                P < 1
-#  undef               P
-#  define              P 4
 #  endif
 #  ifndef              V
-#  define              V 8
-#  elif                V < 1
-#  undef               V
 #  define              V 8
 #  endif
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3344,10 +3344,12 @@ Cody also added the [try.sh](2012/blakely/try.sh) script.
 implicitly (Linux doesn't seem to but macOS does).
 
 Cody also added two [alt versions](2012/endoh1/README.md#alternate-code) that
-let one control how fast to display (how long to sleep in between writes) the
-fluid, one an alt of the colour version (that Yusuke added at the request of the
-judges) and an alt of the original. The [endoh1.alt.c](2012/endoh1/endoh1.alt.c)
-was provided by Yusuke as a de-obfuscated version.
+let one control how fast the fluid moves (how long to sleep in between writes)
+and also the gravity factor, the pressure factor and the viscosity factor, one
+for the original entry and one for the alternate colour version that was added
+by the author, [Yusuke](#yusuke), at the request of the judges.
+The [endoh1.alt2.c](2012/endoh1/endoh1.alt.c) was provided by Yusuke as a
+de-obfuscated version.
 
 
 ## [2012/endoh2](2012/endoh2/endoh2.c) ([README.md](2012/endoh2/README.md))


### PR DESCRIPTION
The alt2 is the deobfuscated version; the alt one is the one with the ability to slow down/speed up the fluid and control the gravity factor, the pressure factor and/or the viscosity factor.

The alt version no longer imposes a lower limit on the factors because doing so prevents the ability to define them to 'I' which the author noted is a functional difference.