### PR TITLE
Remove 2013/cable3 from bugs.md

### DIFF
--- a/2013/cable3/README.md
+++ b/2013/cable3/README.md
@@ -8,17 +8,6 @@ An alternate version that should compile in Windows/MS Visual Studio is
 available. See the [Alternate code](#alternate-code) section below.
 
 
-### Bugs and (Mis)features:
-
-The current status of this entry is:
-
-```
-STATUS: missing files - please provide them
-```
-
-For more detailed information see [2013 cable3 in bugs.md](/bugs.md#2013-cable3).
-
-
 ## To use:
 
 ```sh
@@ -32,7 +21,19 @@ For more detailed information see [2013 cable3 in bugs.md](/bugs.md#2013-cable3)
 ./runme
 ```
 
-NOTE: to quit the program type `QUITEMU`.
+NOTE: to quit the program type `QUITEMU`. You might have to be at the top level
+directory of the drive, `A:` or `C:`.
+
+To send an `Alt+XXX` key combination, press (`^A` / `Ctrl+A`) then the key, so
+for example to type `Alt+F`, press (`^A` / `Ctrl+A`) then `F`.
+
+To send an `Fxx` key, press `^F` / `Ctrl+F` then a number key. For example, to
+get the `F4` key, press `^F` / `Ctrl+F` then `4`. To get `F10`, press `^F` /
+`Ctrl+F` then `0`.
+
+To send a `Page Down` key, press `^F` / `Ctrl+F` then `O` (letter O, not digit
+zero). To send a `Page Up` key, press `^F` / `Ctrl+F` then `E`. Other key
+combinations are left for the discovery of the user.
 
 
 ## Alternate code:
@@ -262,7 +263,7 @@ example, with non-QWERTY e.g. international keyboards.
 Most of the time you can just type normally, but there are special sequences to
 get `Alt+xxx` and `Fxxx`.
 
-To send an `Alt+XXX` key combination, press (`^A` or `Ctrl+A`) then the key, so
+To send an `Alt+XXX` key combination, press (`^A` / `Ctrl+A`) then the key, so
 for example to type `Alt+F`, press (`^A` / `Ctrl+A`) then `F`.
 
 To send an `Fxx` key, press `^F` / `Ctrl+F` then a number key. For example, to

--- a/2013/cable3/README.md
+++ b/2013/cable3/README.md
@@ -224,7 +224,7 @@ stty cooked echo
 ## To use the emulator - floppy + HD mode
 
 Easiest to start with is to try a ready-made 40MB hard disk image containing a
-whole bunch of software: <http://bitly.com/1bU8URK>
+whole bunch of software which is in the included file `hd.img`.
 
 For the more adventurous, you can start off with (for example) a blank 40MB
 image file called hd.img made using e.g. Makefile. Then use:

--- a/bugs.md
+++ b/bugs.md
@@ -2861,21 +2861,6 @@ antialiasing interferes with color detection in "color" mode.
 and endianness conversion would make the source too large for IOCCC rule 2).
 
 
-## 2013 cable3
-
-### STATUS: missing files - please provide them
-### Source code: [2013/cable3/cable3.c](2013/cable3/cable3.c)
-### Information: [2013/cable3/README.md](2013/cable3/README.md)
-
-Many fixes and improvements were made by Cody but he observed that the author
-referred to a file that is nowhere to be found: not in the directory or the
-archive.
-
-The file is `hd.img`.
-
-Do you have it? Please provide it!
-
-
 ## 2013 dlowe
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3532,7 +3532,7 @@ Finally Cody provided the [bios.asm](2013/cable3/bios.asm) that the author
 referred to, found at the [GitHub repo for the
 entry](https://github.com/adriancable/8086tiny/tree/master), and the 'ready-made
 40MB hard disk image containing a whole bunch of software' in `hd.img` that the
-author linked to at `http://bitly.com/1bU8URK`.
+author linked to at `https://bitly.com/1bU8URK`.
 
 
 ## [2013/dlowe](2013/dlowe/dlowe.c) ([README.md](2013/dlowe/README.md))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3530,7 +3530,9 @@ this will not link in Unix systems (including macOS).
 
 Finally Cody provided the [bios.asm](2013/cable3/bios.asm) that the author
 referred to, found at the [GitHub repo for the
-entry](https://github.com/adriancable/8086tiny/tree/master).
+entry](https://github.com/adriancable/8086tiny/tree/master), and the 'ready-made
+40MB hard disk image containing a whole bunch of software' in `hd.img` that the
+author linked to at `http://bitly.com/1bU8URK`.
 
 
 ## [2013/dlowe](2013/dlowe/dlowe.c) ([README.md](2013/dlowe/README.md))


### PR DESCRIPTION

As the bug status was a missing file and it was actually hd.img and as 
that was added to the repo the entry can be removed from the bugs.md 
file.

I also added some important points for the entry about quitting 
(elaborating) and also how to input certain keys like alt/ctrl 
combinations (amongst others) that the author had later on in the 
README.md file. The former might especially be important if someone did
it at the console and was not aware of how to open another console but
even so it can be annoying having to close a tab just to stop a program.

Now I can say that 2013/cable3 is almost certainly complete (review 
wise?).
