### PR TITLE
Add 2014/wiedijk/try.sh + formatting/typo checks

### DIFF
--- a/2014/wiedijk/README.md
+++ b/2014/wiedijk/README.md
@@ -15,8 +15,19 @@ make
 ### Try:
 
 ```sh
-cc -E prog.c | indent | sed '1,/5.*prog/d'
+./try.sh
 ```
+
+By default that will use `indent(1)` found by the shell `type -P indent` and
+`sed(1)` found by the shell `type -P sed` but if you want to change these, say
+to try a different beautifier, you can do it like:
+
+```sh
+INDENT=bcpp ./try.sh
+```
+
+which would change it to use `bcpp(1)` instead of `indent(1)`. Do similar for
+`sed(1)` only use the name `SED`.
 
 
 ## Judges' remarks:
@@ -32,31 +43,32 @@ If you win a bet by demonstrating this entry, please let us know.
 
 ### Remarks
 
-- computes the factorial function
-- no loops, no explicit recursion
-- untyped C without any casts, using a `w` word datatype
-- varargs not essential, `w(*)(w,w*)` works just as well
-- conforming ISO C
-- no warnings when compiled with `-std=c99 -Wall -Wextra -pedantic`
-- comments in the code explain what this really is about
-- C as a functional programming language:
-  untyped lambda calculus compiled to executable C functions
-- untagged closures (just a function pointer followed by some values)
-- recursion implemented through Curry's paradoxical combinator `Y`
-- the readable implementation of `Y` is on lines 29-30:
+- Computes the factorial function.
+- No loops, no explicit recursion.
+- Untyped C without any casts, using a `w` word datatype.
+- Varargs not essential, `w(*)(w,w*)` works just as well.
+- Conforming to ISO C.
+- No warnings when compiled with `-std=c99 -Wall -Wextra -pedantic`.
+- Comments in the code explain what this really is about.
+- C as a functional programming language: untyped lambda calculus compiled to
+executable C functions.
+- Untagged closures (just a function pointer followed by some values).
+- Recursion implemented through Curry's paradoxical combinator `Y`.
+- The readable implementation of `Y` is on lines 29-30:
 
 ```
 W_f = \x.f(xx)
 Y = \f.W_f W_f
 ```
 
-- a mixture of strict and lazy evaluation, with a `_` force function
+- A mixture of strict and lazy evaluation, with a `_` force function
   (John Tromp notes that if Turing's fixed-point combinator
   `(\xy.y\z.xxyz)(\xy.y\z.xxyz)` had been used,
-  all applications could have been strict)
-- uses `Y` to implement factorial on native `int`s
-- 10! seconds = 6 weeks
-- answers the ultimate question of life, the universe and everything
+  all applications could have been strict).
+- Uses `Y` to implement factorial on native `int`s.
+- 10! seconds = 6 weeks.
+- Answers the [ultimate question of life, the universe and
+everything](https://hitchhikers.fandom.com/wiki/42).
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2014/wiedijk/try.sh
+++ b/2014/wiedijk/try.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/wiedijk
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+# Make sure that indent(1) and sed(1) are installed but let user override them
+# as well say for using a different beautifier. We assume less(1) is installed.
+
+if [[ -z "$INDENT" ]]; then
+    INDENT="$(type -P indent)"
+else
+    INDENT="$(type -P "$INDENT")"
+fi
+if [[ ! -x "$INDENT" ]]; then
+    echo "$0: cannot find indent, sorry." 1>&2
+    exit 1
+fi
+
+if [[ -z "$SED" ]]; then
+    SED="$(type -P sed)"
+else
+    SED="$(type -P "$SED")"
+fi
+if [[ ! -x "$SED" ]]; then
+    echo "$0: cannot find sed, sorry." 1>&2
+    exit 2
+fi
+
+echo "$ cc -E prog.c | "$INDENT" |
+    "$SED" '1,/5.*prog/d' | less -EXF"
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+cc -E prog.c | "$INDENT" | "$SED" '1,/5.*prog/d' | less -EXF

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3721,6 +3721,16 @@ theoretically work for Microsoft Windows compilers (if anything works in Windows
 that would break it we do not know.
 
 
+## [2014/wiedijk](2014/wiedijk/prog.c) ([README.md](2014/wiedijk/README.md))
+
+[Cody](#cody) added the [try.sh](2014/wiedijk/try.sh) script which is based on
+the command to try in the 'try' section but improved so one can more easily
+specify what ident tool they want to use and also change which sed to use,
+should they want to. It also checks that both of these two tools exist and are
+executable and it pipes it through less as it's longer than a page worth of
+output.
+
+
 # <a name="2015"></a>2015
 
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3692,7 +3692,7 @@ it is a file with spoilers.
 ## [2014/maffiodo1](2014/maffiodo1/prog.c) ([README.md](2014/maffiodo1/README.md]))
 
 [Cody](#cody) fixed the build for this entry: it does not require
-[SDL2[(https://www.libsdl.org) but SDL1 so there were linking errors.
+[SDL2](https://www.libsdl.org) but SDL1 so there were linking errors.
 
 
 ## [2014/skeggs](2014/skeggs/prog.c) ([README.md](2014/skeggs/README.md))


### PR DESCRIPTION

The try.sh allows one to override the default indent(1) and sed(1) tools
and also verifies that they are executable. This means one can use, for
example, bcpp, instead of indent, or if one wants to specify a different
path to sed(1) they can. The README.md file explains this more.

README.md file format/typo checked.

This should complete the review of this entry.