### PR TITLE
Fix synopsis in 2013/dlowe/README.md file

### DIFF
--- a/2000/primenum/.gitignore
+++ b/2000/primenum/.gitignore
@@ -1,3 +1,4 @@
 primenum
 primenum.orig
 prog.orig
+try.sh.txt

--- a/2000/primenum/try.sh
+++ b/2000/primenum/try.sh
@@ -28,7 +28,7 @@ rm -f try.sh.txt
 echo "$ ./primenum 101 < try.sh | ./primenum n > try.sh.txt" 1>&2
 ./primenum 101 < try.sh | ./primenum n > try.sh.txt
 echo "$ diff try.sh try.sh.txt"
-read -r -n 1 -p "Press any key to see diff (through less): " 1>&2
-diff try.sh try.sh.txt|less
+read -r -n 1 -p "Press any key to see diff (space = next page, q = quit): " 1>&2
+diff try.sh try.sh.txt|less -EXF
 
-
+rm -f try.sh.txt

--- a/2000/rince/try.sh
+++ b/2000/rince/try.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2000/rince
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" everything >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./rince" 1>&2
+./rince
+
+echo "$ ./rince 0.001 $(./dmy2jd 7.8 1 1610)" 1>&2
+./rince 0.001 $(./dmy2jd 7.8 1 1610)
+
+echo "$ ./rince 0.01" 1>&2
+./rince 0.01
+
+echo "$ ./rince 0 2441193.6" 1>&2
+./rince 0 2441193.6
+
+echo "$ ./rince 0.01 2441193.6" 1>&2
+./rince 0.01 2441193.6
+
+echo "$ ./rince 0 $(./dmy2jd 7.8 1 1610)" 1>&2
+./rince 0 $(./dmy2jd 7.8 1 1610)
+
+echo "$ ./rince 0 $(./dmy2jd 8.8 1 1610)" 1>&2
+./rince 0 $(./dmy2jd 8.8 1 1610)
+
+echo "$ ./rince 0 $(./dmy2jd 10.8 1 1610)" 1>&2
+./rince 0 $(./dmy2jd 10.8 1 1610)

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -19,10 +19,10 @@ For more detailed information see [2013 dlowe in bugs.md](/bugs.md#2013-dlowe).
 ## To use:
 
 ```sh
-./dlowe [word...]
+./dlowe [number...]
 ```
 
-where `[word...]` is one or more words including numbers or otherwise.
+where `[number...]` is one or more number, space separated.
 
 
 ### Try:


### PR DESCRIPTION

Although it appears to accept non digits I did not have time to test it
more and I see now it has no real purpose, showing the same thing, so I
have removed that and noted that it expects numbers.