### PR TITLE
Fix 2014/sinon + add try.sh + formatting

### DIFF
--- a/2000/primenum/.gitignore
+++ b/2000/primenum/.gitignore
@@ -1,3 +1,4 @@
 primenum
 primenum.orig
 prog.orig
+try.sh.txt

--- a/2000/primenum/try.sh
+++ b/2000/primenum/try.sh
@@ -28,7 +28,7 @@ rm -f try.sh.txt
 echo "$ ./primenum 101 < try.sh | ./primenum n > try.sh.txt" 1>&2
 ./primenum 101 < try.sh | ./primenum n > try.sh.txt
 echo "$ diff try.sh try.sh.txt"
-read -r -n 1 -p "Press any key to see diff (through less): " 1>&2
-diff try.sh try.sh.txt|less
+read -r -n 1 -p "Press any key to see diff (space = next page, q = quit): " 1>&2
+diff try.sh try.sh.txt|less -EXF
 
-
+rm -f try.sh.txt

--- a/2000/rince/try.sh
+++ b/2000/rince/try.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2000/rince
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" everything >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./rince" 1>&2
+./rince
+
+echo "$ ./rince 0.001 $(./dmy2jd 7.8 1 1610)" 1>&2
+./rince 0.001 $(./dmy2jd 7.8 1 1610)
+
+echo "$ ./rince 0.01" 1>&2
+./rince 0.01
+
+echo "$ ./rince 0 2441193.6" 1>&2
+./rince 0 2441193.6
+
+echo "$ ./rince 0.01 2441193.6" 1>&2
+./rince 0.01 2441193.6
+
+echo "$ ./rince 0 $(./dmy2jd 7.8 1 1610)" 1>&2
+./rince 0 $(./dmy2jd 7.8 1 1610)
+
+echo "$ ./rince 0 $(./dmy2jd 8.8 1 1610)" 1>&2
+./rince 0 $(./dmy2jd 8.8 1 1610)
+
+echo "$ ./rince 0 $(./dmy2jd 10.8 1 1610)" 1>&2
+./rince 0 $(./dmy2jd 10.8 1 1610)

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -19,10 +19,10 @@ For more detailed information see [2013 dlowe in bugs.md](/bugs.md#2013-dlowe).
 ## To use:
 
 ```sh
-./dlowe [word...]
+./dlowe [number...]
 ```
 
-where `[word...]` is one or more words including numbers or otherwise.
+where `[number...]` is one or more number, space separated.
 
 
 ### Try:

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -227,7 +227,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -225,7 +225,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -245,7 +245,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -224,7 +224,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -232,7 +232,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -225,7 +225,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -226,7 +226,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -224,7 +224,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/sinon/README.md
+++ b/2014/sinon/README.md
@@ -8,15 +8,18 @@ make
 ## To use:
 
 ```sh
-cp -f sinon.c run.c; ./hecate.sh
+cp -f prog.c run.c; ./hecate.sh
 ```
 
 
 ### Try:
 
 ```sh
-cp -f sinon.c run.c; ./hecate.sh; ./glock.sh; sleep 3; ./glock.sh; sleep 1; ./hecate.sh
+./try.sh
 ```
+
+This script will ask you if you wish to try again after each run. Type in any
+character other than `y` or `Y` to exit at this point.
 
 
 ## Judges' remarks:
@@ -37,7 +40,7 @@ To start, compile and run the program.  To resume, compile and run the
 output repeatedly until you have won/lost the game.  For example:
 
 ```sh
-cp sinon.c run.c
+cp prog.c run.c
 gcc -O0 run.c -o run && ./run | tee run.c
 gcc -O2 run.c -o run && ./run | tee run.c
 ...
@@ -74,6 +77,7 @@ need to be more precise.  This is effectively playing the game on
 "hard" mode.  It is worth trying this mode even if you have the right
 compilers.
 
+
 ### Compatibility
 
 Sinon has been tested and verified to work on these platforms:
@@ -100,11 +104,13 @@ Sinon has a demo mode that plays the game automatically.  Make sure
 that there are no files named "run" and "run.c" in current directory
 (they will be overwritten) and run:
 
-    perl sinon.c | bash
+```sh
+perl prog.c | bash
+```
 
-File size and CRC32 of sinon.c are embedded in line 7.
+File size and CRC32 of [prog.c](prog.c) are embedded in line 7.
 
-Process for making Sinon is included in spoiler.html.
+Process for making Sinon is included in [spoiler.html](spoiler.html).
 
 Layout of this code is based on Asada Shino, also known as "Sinon",
 from Sword Art Online.

--- a/2014/sinon/prog.c
+++ b/2014/sinon/prog.c
@@ -14,7 +14,7 @@
                 "CYOUQWIN!]Q=;of8BQQ)88bc]QA98P'Qo]8>oQQ_8CP;QQ98b`_8@P8(Q`]'^Q=`']QB)88"
               "bQQ]`8J;QQ`88bc99bd(`8iQ@''QQo^8E'`8c;QQ'Q``8?QQ`'kQ<o]8B9PQQ`';_Q<`_8<cbQ"
             "<o_Q<o_QBdo`QQ';`Q=9`]8=bobQ_o_Q<o]8=';bQC(88cQ`bcgQ>oP']8<;cQ>98)^Q?''oc`Q>"
-           "oc']Q]8<;cQ>`8bbQA``QQ''`Q?88P;dQ=`)nQ?*/;;"/*}}=~/./;print"cp\40sinon.c\40r",
+           "oc']Q]8<;cQ>`8bbQA``QQ''`Q?88P;dQ=`)nQ?*/;;"/*}}=~/./;print"cp\40prog.c\40r",
                   "un.c\n";for($i=1;$i<21;$i++){for($j=0;$j<2;$j++){print"gcc\x20-O",$j*2,
                   "\40run.c\x20-o run&&./run|tee run.c\n"if!($i%(2+$j));}print"sleep $j\n";
                  } __DATA__ 8M*/;G(Z,60*(60*(10**s+s[1])+s[3]*10+s[4])+s[6]*10+s[7]-1933008

--- a/2014/sinon/try.sh
+++ b/2014/sinon/try.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/sinon
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+while :; do
+
+    cp -f prog.c run.c; ./hecate.sh; ./glock.sh; sleep 3; ./glock.sh; sleep 1; ./hecate.sh
+
+    read -r -p "Do you want to try again (Y/N)? "
+    if [[ "$REPLY" != "y" && "$REPLY" != "Y" ]]; then
+	exit 0
+    fi
+done
+

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -227,7 +227,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -225,7 +225,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -224,7 +224,7 @@ indent.c: ${PROG}.c
 	    echo "${INDENT} < $< > $@"; \
 	    ${INDENT} < $< > $@; \
 	else \
-	    echo "no indent tool found, ident $< yourself, sorry"; \
+	    echo "no indent tool found, indent $< yourself, sorry"; \
 	    echo "exit 17"; \
 	    exit 17; \
 	fi

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3695,6 +3695,17 @@ it is a file with spoilers.
 [SDL2](https://www.libsdl.org) but SDL1 so there were linking errors.
 
 
+## [2014/sinon](2014/sinon/prog.c) ([README.md](2014/sinon/README.md))
+
+[Cody](#cody) fixed the code so that the game can play automatically like it
+once did. The problem is that it expects a certain file name which was
+`sinon.c`. The code now refers to `prog.c`.
+
+Cody also added the [try.sh](2014/sinon/try.sh) script which is an improvement
+over what was once suggested in that when it's over it will ask you if you wish
+to try again, say because of a jam (see the README.md file for details).
+
+
 ## [2014/skeggs](2014/skeggs/prog.c) ([README.md](2014/skeggs/README.md))
 
 [Cody](#cody) fixed the Makefile to compile this entry in modern systems. The problem was


### PR DESCRIPTION

The mode where the game would play by itself did not work because the 
code had 'sinon.c' in it but this does not exist. Now the code refers to
'prog.c'.

Add try.sh script that is an improvement over the previous try command 
(or commands in a sequence) in that it loops, asking if you wish to try
again in case of a jam (or any other reason).

Format/typo check README.md.

This should complete the review of 2014/sinon.