### PR TITLE
Add alt code to 2014/maffiodo2 + try.sh script

### DIFF
--- a/2014/birken/.gitignore
+++ b/2014/birken/.gitignore
@@ -1,2 +1,3 @@
 prog
+prog.alt
 prog.orig

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -115,8 +115,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -4,6 +4,10 @@
 make
 ```
 
+There is alternate code that lets you redefine the port to bind to, in case
+there is a firewall issue, and also lets you redefine the timing constant,
+`STARDATE`. See [Alternate code](#alternate code) below.
+
 
 ## To use:
 
@@ -40,6 +44,37 @@ But there's more! Try opening in a browser the same address and then see what
 happens. This is explained by the authors when explaining their inspiration.
 
 
+## Alternate code:
+
+This version allows you to redefine the port to bind to, should 1701 be a
+problem for some reason, and it also allows you to change the timing as
+described by the author. See [configuration](#configuration) below.
+
+
+### Alternate build:
+
+To specify the port to say, 31337, try:
+
+```sh
+make clobber CDEFINE="-DNCC=31337" alt
+```
+
+To change the `STARDATE` timing constant, try:
+
+```sh
+make clobber CDEFINE="-DSTARDATE=5000000" alt
+```
+
+You can combine them both of course.
+
+
+### Alternate use:
+
+
+Use `prog.alt` as you would `prog` above. Remember that ports < 1024 are
+privileged ports that unprivileged users cannot use.
+
+
 ## Judges' remarks:
 
 Port 1701?  Well this is not the l2f registered TCP/1701 protocol.
@@ -59,7 +94,7 @@ obfuscation awaits the reader of the source!
 ### Abstract
 
 When launched in web server mode, this application appears to deliver nothing
-more than a static HTML page.  But, in actuality, it provides covert file
+more than a static HTML page.  But, in actuality, it allows covert file
 transfer over the Internet.  This is demonstrated by starting the application as
 a client-side downloader.  The hidden transmitted data cannot be reconstructed
 or even detected from the binary content of the traffic between the client and
@@ -96,9 +131,11 @@ approximately 1 baud.
 The client-side downloader will automatically terminate if the web server is
 bounced.
 
+
 ### HTML content
 
 Plug the URL into a browser to view a static HTML page containing ASCII artwork.
+
 
 ### Exploration
 
@@ -111,35 +148,50 @@ mentioned in the abstract, the data is not transmitted within the binary content
 communicated between the client and the server.  A full explanation of the
 protocol appears below, but feel free to explore before reading further.
 
+
 ### Inspiration
 
-The inspiration for this program comes from _Star Trek VI: The Undiscovered
-Country_, specifically the final confrontation between the _Enterprise_ and the
-enhanced prototype Klingon Bird of Prey. The definitive feature of the
-prototype was its ability to fire while cloaked. But, perhaps even more
-impressive was its ability to keep an open communication channel with the
-_Enterprise_ throughout the battle, enabling the antagonist Chang to taunt
-Captain Kirk with Shakespearian quotes while he slowly pelted his ship with
-torpedoes.  Normally, cloaked vessels must maintain silent running to avoid
-detection.
+The inspiration for this program comes from [Star Trek VI: The Undiscovered
+Country](https://memory-alpha.fandom.com/wiki/Star_Trek_VI:_The_Undiscovered_Country),
+specifically the final confrontation between the
+[Enterprise](https://memory-alpha.fandom.com/wiki/USS_Enterprise_(NCC-1701)) and
+the enhanced prototype [Klingon Bird of
+Prey](https://memory-alpha.fandom.com/wiki/Klingon_Bird-of-Prey). The definitive
+feature of the prototype was its ability to fire while cloaked. But, perhaps
+even more impressive was its ability to keep an open communication channel with
+the Enterprise throughout the battle, enabling the antagonist
+[Chang](https://memory-alpha.fandom.com/wiki/Chang_(General)) to taunt [Captain
+Kirk](https://memory-alpha.fandom.com/wiki/James_T._Kirk) with
+[Shakespearian](https://en.wikipedia.org/wiki/William_Shakespeare) quotes while
+he slowly pelted his ship with torpedoes.  Normally, cloaked vessels must
+maintain silent running to avoid detection.
 
 The battle is commemorated in the form of ASCII artwork depicting the ships
 faced head-to-head in the page delivered by the web server.  Plus, the program
 source code is formatted in the shape of a Klingon Bird of Prey.  The code
 itself includes a number of Star Trek references: the registry number of the
-_Enterprise_ (NCC-1701) is defined as a constant; variable names spell out Cpt.
-James T. Kirk and Odo (the Deep Space 9 character was played by René Auberjonois
-who also appeared as Colonel West in _Star Trek VI_); the `STARDATE` constant
-makes timing configurable; and, the constant `k` stands for Khan (in the final
-engagement in _Star Trek II: The Wrath of Khan_, the damaged _Enterprise_
-managed to disable the USS _Reliant_’s shield generator by accessing its prefix
-code: 16309).
+Enterprise (NCC-1701) is defined as a constant; variable names spell out Cpt.
+James T. Kirk and [Odo](https://memory-alpha.fandom.com/wiki/Odo) (the [Deep
+Space 9](https://memory-alpha.fandom.com/wiki/Star_Trek:_Deep_Space_Nine)
+character was played by René Auberjonois who also appeared as [Colonel
+West](https://memory-alpha.fandom.com/wiki/West) in [Star Trek
+VI](https://memory-alpha.fandom.com/wiki/Star_Trek_VI:_The_Undiscovered_Country));
+the `STARDATE` constant makes timing configurable; and, the constant `k` stands
+for [Khan](https://memory-alpha.fandom.com/wiki/Khan_Noonien_Singh) (in the
+final engagement in [Star Trek II: The Wrath of
+Khan](https://memory-alpha.fandom.com/wiki/Star_Trek_II:_The_Wrath_of_Khan), the
+damaged Enterprise managed to disable the USS
+[Reliant](https://memory-alpha.fandom.com/wiki/USS_Reliant_(NCC-1864))'s shield
+generator by accessing its prefix code: 16309).
+
 
 ### Secondary size limit
 
 As obligated by a program that employs 23rd century cloaking technology, when
-the source is fed as input to IOCCC size tool version 2014-09-23-v19, and the
-`-i` command line option is used, the value printed is 0.
+the source is fed as input to [IOCCC size tool version
+2014-09-23-v19](../iocccsize.c), and the `-i` command line option is used, the
+value printed is 0.
+
 
 ### Transmission protocol revealed
 
@@ -163,6 +215,7 @@ the assumption that the bit value does not affect transmission time.
 The server relies on the cookie to identify each client uniquely, enabling it to
 transfer the sequence independently to each client.
 
+
 ### Configuration
 
 As with all network communication, accurate transmission of data relies on the
@@ -173,6 +226,7 @@ value in the event of transmission errors.  Decrease the value to download
 faster and less reliably.
 
 The NCC constant is the web server port number.
+
 
 ### Obfuscations
 
@@ -186,6 +240,7 @@ referenced via pointers.
 * `O` and `l` were selected for their resemblance to `0` and `1` respectively.
 * Standard constants and ASCII characters were replaced with their respective
 numerical values.
+
 
 ### Compiler warnings
 

--- a/2014/birken/prog.alt.c
+++ b/2014/birken/prog.alt.c
@@ -1,0 +1,64 @@
+/**??/
+/
+#include<netdb.h>
+#include<stdio.h>
+#include<sys/time.h>
+#ifndef NCC
+#define NCC 1701
+#endif
+#ifndef STARDATE
+#define STARDATE 500000
+#endif
+#define k 16309
+
+                      int C,p,t,J,a,m,e,s,T,K,i,r[k],_[k][2],c[k][2],f=NCC;
+                    fd_set O,d,o;char g[8][k],*h,j[]="0\1&me\1&t&e\1TFTTJPO>"
+                 "\1&t\\_<\16\v^\1&+\\_;^&o;&e\1TFU.DPPLJF;\1iuuq;00&92:2\\_0^&"
+               "o\1&tDppljf;!tfttjpo>&t\16\v\16\v\1HFU!&t!IUUQ02/1\16\vIptu;!"""
+            "&t\16\v\1IUUQ02/1!311!PL\16\vDpoufou.uzqf;!ufyu0iunm\16\vFyqjsft;!1"""
+          "\16\vTfu.Dppljf;!tfttjpo>&t\16\vDpoufou.Mfohui;!&me\16\v\16\v&t\1=iunm?=c"                                 "pez!chdpmps>#cmbdl"
+       "#?=ejw!tuzmf>(qptjujpo;bctpmvuf<upq;61&&<mfgu;61&&<usbotgpsn;usbotmbufY).61&&*u"                        "sbotmbufZ).61&&*<(?=gpou!dpm"
+     "ps>#xijuf#?=qsf?&t=0qsf?=0gpou?=0ejw?=0cpez?=0iunm?\1T`K!`.`[!G!G`\v]C`)K>0`>`0!E`/"                  "D.(D.aD./E`D!C`p`K!F`0F`}\vM!]`!]E!"
+   "]E./J`/E.0C!G>I`0L.0\vO!]!]D!0C!0E!a.`.(K!)E`0I!]G`E!}\vK!C`-C.a/a.(//(.`[!N!]C!+!]\vJ!0E`K!}}[!K!C`0E`0C`\vO!aC./E`-.([!K!|K`|";struct sockad\
+dr_in l;struct timeval n,q;struct hostent*u;long w;void x(int y){close(y);FD_CLR(y,&O);if(y>=m)while(--m)if(FD_ISSET(m,&O))break;}vo\
+id z(char*A,char*B){char*D,*E=A,*F=A;for(0[0[g]]=0;*E;E++)if(*E==10){if(E-F==(*(E-1)-13?1:2))break;*E=0;if(!strncmp(F,B,strlen(B))&&(D=strstr(F,j+\
+11))){sscanf(D+8,j+20,0[g]);break;}F=E+1;}else*E=toupper(*E);}int main(int G,char**H){h=j;while(*h)(*h)--,h++;h=j+414;do{t=*h++;e=1;if(t>=65&&t<=90)e
+=t-64,t=*h++;while(e--)6[g][i++]=t;}while(t);sprintf(7[g],j+229,6[g]);l.sin_family=2;if(G>1){sscanf(1[H],j+53,4[g],&K);sprintf(2[g],j+97,*(1[H]+K)?1[
+H]+K:j,4[g]);sscanf(4[g],j+29,&i,&f);i[4[g]]=0;u=gethostbyname(4[g]);memcpy(&l.sin_addr.s_addr,0[u->h_addr_list],u->h_length);l.sin_port=htons(f);\
+for(;;close(G))if(!connect(G=socket(2,1,0),&l,sizeof l))for(;;){strcpy(1[g],0[g]);s=sprintf(5[g],j+72,2[g],0[g]);if(write(G,5[g],s)<0)break;gett\
+imeofday(&n,0);0[3[g]]=0;e=read(G,3[g],k);if(e<0)break;else if(e&&*3[g]==72){gettimeofday(&q,0);3[g][k-1]=0;z(3[g],j+41);if(0[1[g]])if(!strnc\
+mp(1[g],0[g],strlen(1[g]))){t=0;if((q.tv_sec-n.tv_sec)*1000000+q.tv_usec-n.
+tv_usec<STARDATE-1000){t=p<15?1:16;p+=t;C+=t;}else p=p<15?15:255;if(p==2\
+55){putchar(C);fflush(stdout);C=p=0;}}else{T=1;goto l;}}}}else{for(f=0;
+f<k;f++){if((i=fgetc(stdin))<0)break;f[r]=i;}for(i=0;i<k;i++){0[i[_]]
+=1[i[_]]=-1;0[i[c]]=1[i[c]]=0;}gettimeofday(&n,0);p=sprintf(5[g],j+2
+,n.tv_sec);n.tv_sec=0;n.tv_usec=STARDATE;FD_ZERO(&d);FD_ZERO(&O);F\
+D_ZERO(&o);l.sin_addr.s_addr=0;l.sin_port=htons(NCC);bind(G=sock\
+et(2,1,0),&l,sizeof l);listen(G,10);FD_SET(m=G,&O);for(i=1,t=0;;
+){d=O;C=select(m+1,&d,0,0,0);if(C<=0){if(!i&&t)x(t);goto l;}fo\
+r(J=t;C&&J<=m;J++)if(FD_ISSET(J,&d)){C--;if(J==G){t=accept(G,
+0,0);FD_SET(t,&O);FD_CLR(t,&d);FD_SET(t,&o);if(t>m)m=t;t=0;
+}else if(!i||FD_ISSET(J,&o)){e=read(J,2[g],k);K=0;if(e>0){
+2[g][k-1]=0;if(*2[g]==71){a=0;strcpy(1[g],0[g]);z(2[g],j+
+45);if(!strncmp(0[g],5[g],strlen(5[g]))&&!strncmp(1[g],
+0[g],strlen(1[g]))){K=atoi(0[g]+p);}if(K){if(0[K[_]]<f
+){if(a=(1[K[_]]<15?1[K[_]]:1[K[_]]>>4)>=(1[K[_]]<15?
+0[K[_]][r]&15:0[K[_]][r]>>4))1[K[_]]=1[K[_]]<15?1\
+5:255;else 1[K[_]]+=1[K[_]]<16?1:16;if(_[K][1]==\
+255){0[K[_]]++;1[K[_]]=0;}}else{write(1[K[c]],_[
+K],sizeof(_[K]));close(1[K[c]]);K=0;}}else fo\
+r(s=1;s<k;s++)if(0[s[_]]==-1){0[s[_]]=1[s[_]]
+=0;K=s;break;}if(K)sprintf(0[g],j+6,5[g],K)
+;else 0[0[g]]=0;w=sprintf(3[g],j+125,0[g],
+strlen(7[g]),7[g]);if(i){pipe(c[K]);if(!
+(i=fork())){close(0[K[c]]);FD_ZERO(&O);
+FD_SET(t=m=J,&O);}}if(i<0){T=1;goto l;
+}if(i){close(1[K[c]]);FD_SET(0[K[c]]
+,&O);if(0[K[c]]>m)m=0[K[c]];x(J);\
+break;}else{if(a){n.tv_sec=0;n.t\
+v_usec=STARDATE;select(0,0,0,0,&
+n);}write(J,3[g],w);if(!K){close(J);return 0;}}}}else if(i){
+close(J);FD_CLR(J,&o);x(J);}else{write(1[K[c]],K[_],sizeof(K[_
+]));close(1[K[c]]);close(J);return 0;}}else{for(K=0;K<=m;K++)if(
+0[K[c]]==J){read(J,K[_],sizeof(K[_]));x(J);if(_[K][0]>=f){0[K[_]
+]=1[K[_]]=-1;0[K[c]]=1[K[c]]=0;}break;}}}}}l:close(G);return T;}

--- a/2014/deak/README.md
+++ b/2014/deak/README.md
@@ -5,7 +5,9 @@ make
 ```
 
 There is an alternate version that the author provided but fixed in 2023 to
-compile. See [alternate code](#alternate-code) below.
+compile with modern systems and to allow one to reconfigure the constants `X1`,
+`X2`, `Y1` and `Y2` (which were magic numbers). See [Alternate
+code](#alternate-code) below.
 
 
 ## To use:
@@ -29,16 +31,30 @@ various regions of the fractal.
 
 The alternate code is included as [prog.alt.c](prog.alt.c) so you can more
 easily see the difference in what it might look like if the C was more
-recognisable. To use, try:
+recognisable and also to let you reconfigure the coordinates.
+
+
+### Alternate build:
 
 ```sh
 make alt
 ```
 
-Use `prog.alt` as you would `prog`.
+If you wish to redefine the coordinates you can do so by defining `X1`, `X2`,
+`Y1` and/or `Y2`, which default to: `-2`, `1`, `-1.3` and `1.3` respectively.
+For instance:
 
-Bonus: the author explains how to configure the program but can you figure out
-how to do it in the alternate code?
+
+```sh
+make clobber CDEFINE="-DX1=-3 -DX2=2 -DY1=-2.3 -DY2=2.3" alt
+```
+
+You may pick and choose which ones to redefine.
+
+
+### Alternate use:
+
+Use `prog.alt` as you would `prog`.
 
 
 ## Judges' remarks:
@@ -51,19 +67,21 @@ We liked the use of unary notation facilitated by variadic macros.
 
 ## Author's remarks:
 
+
 ### Portability
 
 The application was written on a standard Ubuntu 14.04 and tested with
-gcc 4.9.1 and clang 3.5 on 64 bit system (though this should not matter).
+gcc 4.9.1 and clang 3.5 on a 64 bit system (though this should not matter).
 The application makes no assumption regarding any system specific settings,
 and it only needs a console to run. The provided Makefile is just to have
 an easy compilation. I don't see any problems porting it to different
 compiler/system as long as it supports the C99 standard.
 
+
 ### The application
 
 The purpose of the application is mainly to illustrate the weird possibilities
-of the C preprocessor, than to be a full featured console mode Mandelbrot
+of the C preprocessor, rather than to be a full featured console mode Mandelbrot
 drawer. There are tools much better suited for drawing fractals.
 
 The usage of recognizable elements from the C programming language in the
@@ -97,6 +115,7 @@ is to modify the source code at the indicated location: the line
 `/* <-- Configure here: X1, X2, Y1, Y2 */` is intentionally not obfuscated so
 that the adventurous programmer can manually modify the coordinates of the
 fractal to be drawn on the screen.
+
 
 ### Compiler warnings
 

--- a/2014/deak/prog.alt.c
+++ b/2014/deak/prog.alt.c
@@ -1,6 +1,18 @@
 #include <stdio.h>
-double                                 _[]={-2
-,1,-1.3                ,1.3,  0,         0,0,0
+#ifndef X1
+#define X1 -2
+#endif
+#ifndef X2
+#define X2 1
+#endif
+#ifndef Y1
+#define Y1 -1.3
+#endif
+#ifndef Y2
+#define Y2 1.3
+#endif
+double                                 _[]={X1
+,X2,Y1                ,Y2,  0,           0,0,0
 ,0               ,0,50, 80,     0,0,0     ,255
 ,               8,0};    int      main       (
 	       int j) {if (j==  1 ){ if(

--- a/2014/endoh1/README.md
+++ b/2014/endoh1/README.md
@@ -15,25 +15,18 @@ make
 ### Try:
 
 ```sh
-./prog > main.c
-
-make main
-./main Hello
+./try.sh
 ```
 
-Also try:
-
-```sh
-make rake
-```
-
-which will run the [rake.sh](rake.sh) script and then `prog` if all is built
-okay. If `rake` is not installed then it will check that `gem` is installed. If
-`gem` is not installed it will tell you where to get it and then tell you how to
-install `rake`. Otherwise, if `rake` is installed it will try running `rake `
-and if that fails to run it will tell you to run a `gem` command as either root
-or via sudo and then to try running `make rake` or `./rake.sh` again. If `rake`
-succeeds it will run `./prog` which can be used to build `main.c`.
+The script will ask you if you wish to run `make rake` but this is not necessary
+to fully enjoy the entry. `make rake` will run the [rake.sh](rake.sh) script and
+then `prog` if all is built okay. If `rake` is not installed then it will check
+that `gem` is installed. If `gem` is not installed it will tell you where to get
+it and then tell you how to install `rake`. Otherwise, if `rake` is installed it
+will try running `rake ` and if that fails to run it will tell you to run a
+`gem` command as either root or via sudo and then to try running `make rake` or
+`./rake.sh` again. If `rake` succeeds it will run `./prog` which can be used to
+build `main.c`.
 
 What is the difference between running `./prog` and `main`?
 
@@ -64,9 +57,11 @@ more than 1000 words.
 
 ## Author's remarks:
 
+
 ### Remarks
 
-You may want to use a large display with a very small-font terminal.
+You may want to use a large display with a very small terminal font.
+
 
 ### Spoiler
 

--- a/2014/endoh1/rake.sh
+++ b/2014/endoh1/rake.sh
@@ -20,7 +20,7 @@ if ! type -P rake >/dev/null 2>&1; then
     else
 	echo "Please run the following command as root or via sudo:" 1>&2
 	echo ""
-	echo "	   gem install rake" 1>2
+	echo "	   gem install rake" 1>&2
 	echo "" 1>&2
 	echo "and then try running make rake or running $0 again" 1>&2
     fi

--- a/2014/endoh1/spoilers.md
+++ b/2014/endoh1/spoilers.md
@@ -7,8 +7,8 @@ requires a bit stream, Reed-Solomon codes, BCH codes, data relocation, big (and
 irregular!) numerical tables, human-oriented pattern arrangement (difficult to
 implement by a small program), etc.
 
-On the other hand, a quine has a big restriction:
-it needs to have two copies of the program!
+On the other hand, a quine has a big restriction: it needs to have two copies of
+the program!
 
 Do you think that it is possible to write QR code encoder in C within *1kB*?
 
@@ -18,7 +18,9 @@ Do you think that it is possible to write QR code encoder in C within *1kB*?
 It is known that we can mitigate the quine restriction by `eval`.
 For example, this is a quine written in Ruby:
 
-    eval s="print 'eval s='; p s"
+```ruby
+eval s="print 'eval s='; p s"
+```
 
 Note that `print` appears just once in the program.
 
@@ -29,8 +31,10 @@ char s[]="<main code>int main() { <VM code> }";
 int main() { <VM code>; }
 ```
 
-* `<VM code>` : An own VM implementation (written in C) that executes the main code
-* `<main code>` : An object code of quine and QR code encoder (written in the assembly language of the VM)
+* `<VM code>` : An own VM implementation (written in C) that executes the main
+code.
+* `<main code>` : An object code of quine and QR code encoder (written in the
+assembly language of the VM).
 
 `<main code>` (about 1100 bytes) appears once and `<VM code>` (about 450 bytes)
 appears twice.  So the whole code is about 1100 + 450 * 2 = 2000 bytes.  Hooray!
@@ -45,7 +49,7 @@ code>` and `<VM code>`.
 * 21 integer registers access
   * read, write, inc-and-read, dec-and-read
 * Binary operations
-  * add, sub, mul, div, mod, xor, less than, equal, rshift
+  * add, sub, mul, div, mod, xor, less than, equal, right shift
 * Stack operation
   * push (an immediate value)
 * Heap access
@@ -55,10 +59,11 @@ code>` and `<VM code>`.
 * Misc.
   * putchar, exit
 
-The instructions have variable length, but many of them are represented as one
-printable character.  (See `machine.rb` and `assemble.rb` in detail.) The
-mapping between instructions and characters is also carefully designed to
-minimize `<VM code>`, which makes the resulted program non-human-readable.
+The instructions have variable lengths, but many of them are represented as one
+printable character.  (See [machine.rb](machine.rb) and
+[assemble.rb](assemble.rb) in detail.) The mapping between instructions and
+characters is also carefully designed to minimize `<VM code>`, which makes the
+resulted program non-human-readable.
 
 
 ## How did I create the main code?
@@ -126,30 +131,34 @@ $ rake
 
 I checked that the following QR code readers can read the output of my program.
 
-* Linux: [ZBar bar code reader][1]
+* Linux: [ZBar bar code reader][1].
 
-### 2023 note from the judges:
 
-The author also tested an Android app called Barcode Scanner] which used to be
+### A note from the judges in 2023:
+
+The author also tested an Android app called Barcode Scanner which used to be
 found at
 `https://play.google.com/store/apps/details?id=com.google.zxing.client.android`
 but it appears to no longer exist.
 
 [1]: http://zbar.sourceforge.net/
 
-You can use `tool.rb` to convert the output to a png file.
+You can use [tool.rb](tool.rb) to convert the output to a png file.
 
-    $ ./main Hello | ruby tool.rb > hello.png
+```sh
+./main Hello | ruby tool.rb > hello.png
 
-    $ zbarimg -q hello.png
-    QR-Code:Hello
+$ zbarimg -q hello.png
+QR-Code:Hello
 
-    $ ruby tool.rb prog.c
-    $ ruby tool.rb prog.c | ruby tool.rb
+$ ruby tool.rb prog.c
+$ ruby tool.rb prog.c | ruby tool.rb
+```
+
 
 ## Limitations
 
 * QR code error correction level is fixed to L (Low).
-* It supports only byte mode (not numeric, alphanumeric, kanji mode...)
+* It supports only byte mode (not numeric, alphanumeric, kanji mode...).
 * The mask pattern is fixed to 4.
 * The mask is not applied to the remained bits.

--- a/2014/endoh1/try.sh
+++ b/2014/endoh1/try.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/endoh1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to show prog.c (space = next page, q = quit): "
+echo 1>&2
+less -EXF prog.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog: "
+echo 1>&2
+./prog
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog > main.c: "
+echo 1>&2
+./prog > main.c
+read -r -n 1 -p "Press any key to run: make main: "
+echo 1>&2
+make main
+
+read -r -n 1 -p "Press any key to run: ./main IOCCC: "
+echo 1>&2
+./main IOCCC
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./main Hello: "
+echo 1>&2
+./main Hello
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog IOCCC: "
+echo 1>&2
+./prog IOCCC
+
+echo 1>&2
+
+read -r -p "Do you want to run make rake (Y/N)? "
+if [[ "$REPLY" == "y" || "$REPLY" == "Y" ]]; then
+    make rake 2>/dev/null
+fi

--- a/2014/endoh2/.gitignore
+++ b/2014/endoh2/.gitignore
@@ -1,2 +1,6 @@
 prog
 prog.orig
+hello.c
+hello
+ioccc.c
+ioccc

--- a/2014/endoh2/README.md
+++ b/2014/endoh2/README.md
@@ -32,6 +32,7 @@ in the DNA code of the code? Perhaps there are 23 reasons? :-)
 
 ## Author's remarks:
 
+
 ### Remarks
 
 This chromosome program synthesizes a double helix.
@@ -39,14 +40,16 @@ The helix can also be compiled as a C program.
 
 Enjoy DNA programming!
 
-### For more information / backgroud reading:
+
+### For more information / background reading:
 
 * This program was inspired by Acme::DoubleHelix:
-  http://search.cpan.org/~xern/Acme-DoubleHelix-0.01/
+  <http://search.cpan.org/~xern/Acme-DoubleHelix-0.01/>
 
 * The synthesized helix just includes the original program at the head.
-  Do you see how `prog.c` determines whether it was invoked as a standalone program or included as a header file?
-  Note that it does not use any gcc extension such as `__INCLUDE_LEVEL__`.
+  Do you see how [prog.c](prog.c) determines whether it was invoked as a
+  standalone program or included as a header file? Note that it does not use any
+  gcc extension such as `__INCLUDE_LEVEL__`.
 
 * The synthesized helix of course follows the base-pairing rules for DNA:
   A is bonding only to T, and C is bonding only to G.

--- a/2014/endoh2/try.sh
+++ b/2014/endoh2/try.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/endoh2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: echo Hello | ./prog: "
+echo 1>&2
+echo Hello | ./prog
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo IOCCC | ./prog: "
+echo 1>&2
+echo IOCCC | ./prog
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo Hello | ./prog > hello.c: "
+echo 1>&2
+echo Hello | ./prog > hello.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to compile hello.c: "
+echo 1>&2
+make hello >/dev/null
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./hello: "
+./hello
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo IOCCC | ./prog > ioccc.c: "
+echo 1>&2
+echo IOCCC | ./prog > ioccc.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to compile ioccc.c: "
+echo 1>&2
+make ioccc >/dev/null
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./ioccc: "
+echo 1>&2
+./ioccc

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -1,30 +1,59 @@
 ## To build:
 
-This entry requires SDL to be installed. See the [faq.md](/faq.md) if you don't
-know how to do this for your system.
+This entry requires SDL to be installed. See [FAQ 3.8](/faq.md#faq3_8) if you
+don't know how to do this for your system.
+
 
 ```sh
 make
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2014 maffiodo1 in bugs.md](/bugs.md#2014-maffiodo1).
+
+
+
 ## To use:
 
 ```sh
-cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679
+cat game.level | ./prog 320 200 800 300 128 144 game.rgba game.wav 10343679
 ```
+
+The parameters to the program are:
+
+1. Window width.
+2. Window height.
+3. Level width.
+4. Level height.
+5. Sprites image width.
+6. Sprites image height.
+7. Filename of the sprites image (raw RGBA image).
+8. Filename of the music (WAVE 8000 Hz 8bit Mono).
+9. Sky color. This number depends on the system where you run the program. See
+note on macOS.
+
 
 
 ### Try:
 
 ```sh
-cat giana.level | ./prog 320 200 1000 300 192 168 giana.rgba giana8.wav 5459393
+./giana.sh
 
-cat mario.level | ./prog 320 200 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet telehack.com 23
+./mario.sh
 
 ```
 
-If you end up telnetting to the server you can try:
+If you end up telnetting to the server (feature of [mario.sh](mario.sh)) you can
+try:
+
 
 ```
 ls # show files including games
@@ -33,18 +62,14 @@ advent.gam # you know what this is! :-)
 starwars # animated Star Wars 'film'
 ```
 
-NOTE: the author stated that the sky colour is incorrect in some versions of
-macOS, offering a workaround. Others tested this out in the most recent macOS
-version and this does not seem to be a problem any more. As he played (and beat)
-the entire series many times years ago he can confirm that the sky is more or
-less correct though it's possible that because he's practically blind he might
-have missed something :-) He guesses that the problem might have been the
-version of `SDL1` but he does not know this either way.
+If you wish to change the width and height, defaulting at 640 x 480, say to
+800 x 800, try:
 
-Others notes ironically that the author stated that in Super Mario Bros one cannot
-go through walls but there are known glitches where you can in some areas (as he
-recalls this also applied to the arcade version, Mario Bros, but he cannot
-confirm this now) :-)
+```sh
+ROWS=800 COLS=800 ./mario.sh
+
+ROWS=800 COLS=800 ./giana.sh
+```
 
 
 ## Judges' remarks:
@@ -60,9 +85,9 @@ the code. In `vim` you can do:
 ```
 
 in command mode to see this effect. You don't need to modify your `.vimrc` file!
-You can also use `expand` as described below if your terminal has enough rows
-and you don't want to move about in the code. The vim command should immediately
-take effect.
+You can also use `expand` as described below by the author if your terminal has
+enough rows and you don't want to move about in the code. The vim command should
+immediately take effect.
 
 
 ## Author's remarks:
@@ -95,7 +120,7 @@ for free!
 
 In my two tests I tried to create one level of [Super Mario
 Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.) and one of [The Great
-Giana The Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters).
+Giana Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters).
 
 Both games are classic [platform
 games](https://en.wikipedia.org/wiki/Platform_game) and both share the same
@@ -109,8 +134,9 @@ character more or different powers or abilities!
 - There are walls, floors and ceilings. The character can move and jump over
 these type of obstacles but cannot walk through them.
 
-- There are enemies and; if the character collides with an enemy, the character
+- There are enemies and if the character collides with an enemy, the character
 dies or loses its powers.
+
 
 ###  Running under macOS
 
@@ -124,17 +150,19 @@ last parameter of the program:
 
 * GIANA LAST PARAMETER: `3243070463`
 
+
 ### Regarding how to compile
 
 The code requires `SDL1`.
 
-The build process will generate some warnings  (60~ on clang) about:
+The build process will generate some warnings (~60 with clang) about:
 
 - `incompatible pointer types`: because all pointers are declared to `int` or
 `char`, to save bytes.
 - `type specifier missing, defaults to 'int'`: because I need to save bytes.
 - `using the result of an assignment as a condition without parentheses`:
 because `while(c=getchar())` is not evil.
+
 
 ### How it works
 
@@ -193,6 +221,7 @@ Position          | Description
 
 All the others sprites can be used as you want, depending on the game you want
 to create.
+
 
 ## Levels
 
@@ -259,7 +288,7 @@ Each row has six columns:
 * `DESTROY` (`64`)
 
 	    When the player hits the object (e.g. the classic Mario coin) the
-	    object disappears but the engine does not counts the points, so,
+	    object disappears but the engine does not count the points, so,
 	    from the player point of view, this object is useless.
 
 * `DESTROYUP` (`128`)
@@ -271,6 +300,7 @@ If `CLASSFLAGS` is `0` the object only has an aesthetic function.
 
 The last row of the level descriptor must have all its columns set equal to
 `-1`.
+
 
 ### Limitations
 
@@ -306,12 +336,12 @@ only demonstrates the operation of the program. From my point of view this is a
 tribute to the legendary game [Super Mario
 Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.)!
 
-[The Great Giana The
+[The Great Giana
 Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters) is the game
 created by [Time Warp
 Productions](https://www.ign.com/games/producer/time-warp-productions) and my
 justification for the sprites for Mario are the same for this game. Long live
-[The Great Giana The
+[The Great Giana
 Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters) !! :)
 
 

--- a/2014/maffiodo1/giana.sh
+++ b/2014/maffiodo1/giana.sh
@@ -23,4 +23,6 @@ if [[ -z "$COLS" ]]; then
 	COLS="640"
 fi
 
+# ^---------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
 cat giana.level | ./prog "$COLS" "$ROWS" 1000 300 192 168 giana.rgba giana8.wav 5459393

--- a/2014/maffiodo1/giana.sh
+++ b/2014/maffiodo1/giana.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# giana.sh - demonstrate IOCCC winner 2014/maffiodo1 The Great Giana Sisters
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# see if the user wants to override width and height
+if [[ -z "$ROWS" ]]; then
+	ROWS="480"
+fi
+if [[ -z "$COLS" ]]; then
+	COLS="640"
+fi
+
+cat giana.level | ./prog "$COLS" "$ROWS" 1000 300 192 168 giana.rgba giana8.wav 5459393

--- a/2014/maffiodo1/mario.sh
+++ b/2014/maffiodo1/mario.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# mario.sh - demonstrate IOCCC winner 2014/maffiodo1 Super Mario Bros.
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# see if the user wants to override width and height
+if [[ -z "$ROWS" ]]; then
+	ROWS="480"
+fi
+if [[ -z "$COLS" ]]; then
+	COLS="640"
+fi
+
+cat mario.level | ./prog "$COLS" "$ROWS" 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet telehack.com 23

--- a/2014/maffiodo1/mario.sh
+++ b/2014/maffiodo1/mario.sh
@@ -23,4 +23,6 @@ if [[ -z "$COLS" ]]; then
 	COLS="640"
 fi
 
+# ^---------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
 cat mario.level | ./prog "$COLS" "$ROWS" 800 300 128 144 mario.rgba mario8.wav 10343679 && telnet telehack.com 23

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA= image.rgb
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -136,6 +136,10 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/2014/maffiodo2/README.md
+++ b/2014/maffiodo2/README.md
@@ -4,6 +4,21 @@
 make
 ```
 
+There is a 121 byte version provided by the author. See [Alternate
+code](#alternate-code) below.
+
+
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2014 maffiodo2 in bugs.md](/bugs.md#2014-maffiodo2).
+
+
 
 ## To use:
 
@@ -15,7 +30,28 @@ make
 ### Try:
 
 ```sh
-cat image.rgb | ./prog '  .,:;!$#@'
+./try.sh
+```
+
+
+## Alternate code:
+
+This shorter version is provided by the author. It has a fixed ramp and so not
+as fun but it's 121 bytes instead of 140.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+
+### Alternate use:
+
+```sh
+cat image.rgb | ./prog.alt
 ```
 
 
@@ -34,14 +70,15 @@ get?  And how many people will really understand the tweet?
 ### Remarks
 
 This program convert an image to an ASCII ART. The program reads a raw RGB image
-from **stdin** and print the ASCII ART to **stdout**.
+from `stdin` and print the ASCII ART to `stdout`.
 
 The build process will raise some warnings about:
 
 - declaration specifier missing, defaulting to 'int'
 - implicitly declaring library function
 
-The program crash if run without parameters.
+The program will crash if run without parameters.
+
 
 ### Screen size
 
@@ -60,13 +97,17 @@ Type this:
 cat image.rgb | ./prog "  .:;Y0"
 ```
 
-You can use your own image. Convert the image to a raw RGB image, using imagemagick it's very simple:
+You can use your own image. Convert the image to a raw RGB image. Using
+ImageMagick it's very simple:
 
 ```sh
 convert -geometry 80x source.jpg image.rgb
 ```
 
-This program require one parameter, or crash. The parameter of the program is the *convertion ramp*. You can use different ramps or create your own (for ex. using some letters of your name).
+This program require one parameter or it will crash. The parameter of the
+program is the *conversion ramp*. You can use different ramps or create your own
+(for example using some letters of your name).
+
 These are some ramps you can try:
 
 ```sh
@@ -74,7 +115,6 @@ These are some ramps you can try:
 ./prog "  .:;Y0"
 ./prog " .:-=+*#%@"
 ./prog "   .,:!-iots&8%#@$"
-./prog "$@B%8&WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/\|()1{}[]?-_+~<>i!lI;:,"^`'. "
 ```
 
 ### 121 byte version
@@ -85,7 +125,7 @@ An alternative version of this program is only 121bytes long:
 d=80,e,j;g(){j+=getchar();}main(){for(;;){j=0;g();if(j<0)break;g(g());putchar(" .:#@"[j/3*5>>8]);if(!(++e%d))puts("");}}
 ```
 
-This alternative version have a **fixed ramp**. It's smaller but it's not so fun to use...
+This alternative version has a **fixed ramp**. It's smaller but it's not so fun to use...
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2014/maffiodo2/prog.alt.c
+++ b/2014/maffiodo2/prog.alt.c
@@ -1,0 +1,1 @@
+d=80,e,j;g(){j+=getchar();}main(){for(;;){j=0;g();if(j<0)break;g(g());putchar(" .:#@"[j/3*5>>8]);if(!(++e%d))puts("");}}

--- a/2014/maffiodo2/try.sh
+++ b/2014/maffiodo2/try.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/maffiodo2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ cat image.rgb | ./prog '  .,:;!$#@'" 1>&2
+read -r -n 1 -p "Press any key to run command (space = next page, q = quit): "
+echo 1>&2
+# ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
+cat image.rgb | ./prog '  .,:;!$#@' | less -EXF
+
+echo "$ cat image.rgb | ./prog '  .:;Y0'" 1>&2
+read -r -n 1 -p "Press any key to run command (space = next page, q = quit): "
+echo 1>&2
+# ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
+cat image.rgb | ./prog "  .:;Y0" | less -EXF
+
+echo "$ cat image.rgb | ./prog ' :1'" 1>&2
+read -r -n 1 -p "Press any key to run command (space = next page, q = quit): "
+echo 1>&2
+# ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
+cat image.rgb | ./prog ' :1' | less -EXF
+
+echo "$ cat image.rgb | ./prog '  .:;Y0'" 1>&2
+read -r -n 1 -p "Press any key to run command (space = next page, q = quit): "
+echo 1>&2
+# ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
+cat image.rgb | ./prog '  .:;Y0' | less -EXF
+
+echo "$ cat image.rgb | ./prog ' .:-=+*#%@'" 1>&2
+read -r -n 1 -p "Press any key to run command (space = next page, q = quit): "
+echo 1>&2
+# ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
+cat image.rgb | ./prog ' .:-=+*#%@' | less -EXF
+
+echo "$ cat image.rgb | ./prog '   .,:!-iots&8%#@$'" 1>&2
+read -r -n 1 -p "Press any key to run command (space = next page, q = quit): "
+echo 1>&2
+# ^-------^ SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# shellcheck disable=SC2002
+cat image.rgb | ./prog '   .,:!-iots&8%#@$' | less -EXF

--- a/2014/morgan/README.md
+++ b/2014/morgan/README.md
@@ -15,20 +15,7 @@ make
 ### Try:
 
 ```sh
-make
-cp -f prog morgan
-./morgan clobber
-ls
-
-./morgan all install
-ls
-
-./prog love haste waste supernova
-ls
-
-make
-./prog magic
-ls
+./try.sh
 ```
 
 
@@ -36,19 +23,21 @@ ls
 
 Think of this as a Maker Faire's make.  :-)
 
-It works reasomably well.  While not super ultra-featured, it does fair well with the Makefile we supplied.
-Not only that, it helped uncover a bug we had in our special Makefile rules.
+It works reasonably well.  While not super ultra-featured, it does fair well
+with the Makefile we supplied.  Not only that, it helped uncover a bug we had in
+our special Makefile rules.
 
 
 ## Author's remarks:
 
 ### Remarks
 
-This program is a tiny `make` clone.
+This program is a tiny `make(1)` clone.
 
-It is able to parse a subset of the `make` syntax and will execute rules for
+It is able to parse a subset of the `make(1)` syntax and will execute rules for
 goals given in arguments if they need to (based on timestamp of dependencies
 of rule targets).
+
 
 ## Supported features
 
@@ -56,18 +45,19 @@ of rule targets).
 * Environment variables are available.
 * It is possible to specify variables in command line: `name=value`.
 * Variables given in command line will have precedence over variables defined
-  in makefile, which will have precedence over environment variables.
-* If no goal given in command line, the first target defined will be used.
+  in Makefile, which will have precedence over environment variables.
+* If no target given in command line, the first target defined will be used.
 * Comments, escaped comments, escaped new lines.
 
 It should be able to build programs of previous years with the provided `Makefile`
 found in previous contest archives. Simply use this program instead of `make`.
-It will recursively use itself for submake (the `MAKE=` assignment inside
+It will recursively use itself for sub-make (the `MAKE=` assignment inside
 `Makefile` will be ignored to continue using itself).
+
 
 ## Limitations / Known issues
 
-* There is a lot of memory leak (not a single free).
+* There are a lot of memory leaks (not a single free).
 * The opened file is not closed.
 * The input file shall be named `Makefile`.
 * No diagnostic message, but the exit status is non zero to indicates failure
@@ -82,13 +72,16 @@ It will recursively use itself for submake (the `MAKE=` assignment inside
 * No built-in variables (except the one from environment).
 * No conditional directives.
 
+
 ### Compilation warnings
 
-with gcc 4.8.2 on Linux Ubuntu 14.04 64-bit :
-* prog.c:22:15: warning: return makes integer from pointer without a cast [enabled by default]
-* prog.c:23:72: warning: signed and unsigned type in conditional expression [-Wsign-compare]
-* prog.c:12:11: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+With gcc 4.8.2 on Linux Ubuntu 14.04 64-bit :
 
+```
+prog.c:22:15: warning: return makes integer from pointer without a cast [enabled by default]
+prog.c:23:72: warning: signed and unsigned type in conditional expression [-Wsign-compare]
+prog.c:12:11: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+```
 
 ## Copyright and CC BY-SA 4.0 License:
 

--- a/2014/morgan/try.sh
+++ b/2014/morgan/try.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/morgan
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+echo "$ cp -f prog morgan" 1>&2
+cp -f prog morgan
+echo "$ ls" 1>&2
+ls
+
+read -r -n 1 -p "Press any key to run: ./morgan all install: "
+echo 1>&2
+./morgan all install
+echo 1>&2
+echo "$ ls" 1>&2
+ls
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog love haste waste supernova: "
+echo 1>&2
+./prog love haste waste supernova
+echo 1>&2
+echo "$ ls" 1>&2
+ls
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog magic: "
+echo 1>&2
+./prog magic
+echo 1>&2
+echo "$ ls" 1>&2
+ls

--- a/2014/sinon/.gitignore
+++ b/2014/sinon/.gitignore
@@ -1,3 +1,5 @@
 prog
 sinon.c
 prog.orig
+run
+run.c

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -4,6 +4,10 @@
 make
 ```
 
+There is an alternate version that will theoretically work with Windows
+compilers (if anything in Windows works :-) ). See the [Alternate
+code](#alternate-code) section below.
+
 
 ### Bugs and (Mis)features:
 
@@ -22,10 +26,6 @@ For more detailed information see [2014 vik in bugs.md](/bugs.md#2014-vik).
 ./prog > foo.c
 ```
 
-There is an alternate version that will theoretically work with Windows
-compilers (if anything in Windows works :-) ). See the [Alternate
-code](#alternate-code) section below.
-
 
 ### Try:
 
@@ -39,12 +39,18 @@ echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
 ## Alternate code:
 
 The alternate code, [prog.alt.c](prog.alt.c), is based on the author's
-instructions on how to get it to work with Windows. This has not been tested but
-in order to use it you can do:
+instructions on how to get it to work with Windows.
+
+
+### Alternate build:
+
 
 ```sh
 make alt
 ```
+
+
+### Alternate use:
 
 Use `prog.alt` as you would `prog` above as well as below.
 
@@ -70,15 +76,16 @@ might help? :-)
 
 ## Author's remarks:
 
+
 ### Remarks
 
-This program converts ascii text to Morse audio file and vice versa. As far as
+This program converts ASCII text to Morse audio file and vice versa. As far as
 I can tell, there are at least six chocolate references in this program.
 
 This program can convert text to Morse to a raw 44.1kHz stereo audio file.
-Via streaming to mplayer, you can listen to the Morse audio.
+Via streaming to `mplayer(1)`, you can listen to the Morse audio.
 
-Don't forget the last '`-`' as it makes mplayer read from stdin.
+Don't forget the last '`-`' as it makes `mplayer(1)` read from `stdin`.
 
 
 ## Convert audio file with Morse signals to text
@@ -92,20 +99,22 @@ or alternatively pass a .wav file as input.
 The preferred input format 44.1kHz stereo, but it does a decent job on mono
 input and different frequencies as well.
 
+
 ### Portability
 
 The program is portable to most platforms. The only system dependency is that
-the program relies on writing binary data to stdout.
+the program relies on writing binary data to `stdout`.
 
 Microsoft compilers add a carriage return to newlines, and to compile the
-program with this platform, the following line can be added after the main
-declaration in order for the program to run correctly:
+program with this platform, the following line can be added to `main()` before
+any code in order for the program to run correctly:
 
 ```c
 _setmode(_fileno(stdout), 0x8000);
 ```
 
 NOTE: see the [alternate code](prog.alt.c) for this.
+
 
 ### Known Issues
 

--- a/bugs.md
+++ b/bugs.md
@@ -2955,6 +2955,39 @@ it out as a known limitation it is not a bug but a feature.
 # 2014
 
 
+## 2014 maffiodo1
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2014/maffiodo1/prog.c](2014/maffiodo1/prog.c)
+### Information: [2014/maffiodo1/README.md](2014/maffiodo1/README.md)
+
+The author noted that in macOS the colours might be wrong. They gave a solution.
+However Cody didn't see any problem with it and he beat the series many times.
+Of course the game here is small and he's practically blind and it's been a
+while since he last played so it might be wrong. Nevertheless the author does
+give a way to reconfigure the colours.
+
+The author noted that the character cannot go through walls and the impression
+is that this is how it was believed but Cody ironically pointed out that there
+are known glitches where in some places you actually could go through walls.
+This might even have applied to the arcade version, Mario Bros, though that can
+no longer be confirmed by Cody. The point here is that in this game you cannot
+go through walls but it's not a bug.
+
+On the other hand, the author also stated:
+
+--
+
+When the `Super character` becomes bigger (`ZOOM` flag), the character can
+collide with blocks and get stuck inside them. This is a KNOWN BUG. When your
+player become bigger, stay away from blocks!
+
+
+--
+
+but since it's documented it's considered a feature, not a bug to fix.
+
+
 ## 2014 vik
 
 ### STATUS: known bug - please help us fix

--- a/bugs.md
+++ b/bugs.md
@@ -2988,6 +2988,15 @@ player become bigger, stay away from blocks!
 but since it's documented it's considered a feature, not a bug to fix.
 
 
+## 2014 maffiodo2
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2014/maffiodo2/prog.c](2014/maffiodo2/prog.c)
+### Information: [2014/maffiodo2/README.md](2014/maffiodo2/README.md)
+
+This program will very likely crash if no arg is given.
+
+
 ## 2014 vik
 
 ### STATUS: known bug - please help us fix

--- a/inc/README.md
+++ b/inc/README.md
@@ -13,8 +13,8 @@ will use files in this directory.
 ##  Why the name inc?
 
 We use inc because "include" would be misleading for both C and because
-the contents of HTML files under [inc](/inc) is not really included
-by the web server nor the browser.  Content of HTML files is
+the contents of HTML files under [inc](/inc) are not really included
+by the web server or the browser.  Content of HTML files is
 processed by tools in the [build-ioccc repo](https://github.com/ioccc-src/build-ioccc/tree/master).
 Processing can include substitution of strings of the form _%%CURDS%%_ with some command
 line supplied value by the tool in question.
@@ -24,7 +24,7 @@ line supplied value by the tool in question.
 
 Files under the [inc](/inc) directory contain HTML fragments that the
 [build-ioccc repo](https://github.com/ioccc-src/build-ioccc/tree/master)
-tools use to form HTML content for the official IOCCC web site](https://www.ioccc.org).
+tools use to form HTML content for the [official IOCCC web site](https://www.ioccc.org).
 
 The canonical way that HTML content is built uses, by default, files of the form:
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3688,18 +3688,21 @@ that was fixed and it also has `#include <stdio.h>` for `putchar(3)`. The
 
 ## [2014/endoh1](2014/endoh1/prog.c) ([README.md](2014/endoh1/README.md]))
 
-[Cody](#cody) added the [rake.sh](2014/endoh1/rake.sh) script and `make rake` rule that
-runs the script. This script will check that `rake` is installed and if it is
-not it will report this and then check that `gem` is installed. It checks that
-`gem` is installed in this case because `gem` is how you install `rake`. If
-`gem` is not installed it tells you to get it along with how to install `gem`.
-Then it tells you how to install `rake`. If `rake` fails to run then it tells
-you to install a specific gem and then to try again. Finally if `rake` succeeds
-it will verify that `prog` is executable and if it is it will run it.
+[Cody](#cody) added the [rake.sh](2014/endoh1/rake.sh) script and `make rake`
+rule that runs the script. This script will check that `rake` is installed and
+if it is not it will report this and then check that `gem` is installed. It
+checks that `gem` is installed in this case because `gem` is how you install
+`rake`. If `gem` is not installed it tells you to get it along with how to
+install `gem`.  Then it tells you how to install `rake`. If `rake` fails to run
+then it tells you to install a specific gem and then to try again. Finally if
+`rake` succeeds it will verify that `prog` is executable and if it is it will
+run it.
+
+Cody also added the [try.sh](2014/endoh1/try.sh) script.
 
 **_Barely_** worth noting but done nonetheless, Cody renamed the `read_me.md`
 file to [spoilers.md](2014/endoh1/spoilers.md) to be clearer in its purpose as
-it is a file with spoilers.
+it is a file with spoilers (and too close to README.md?).
 
 
 ## [2014/maffiodo1](2014/maffiodo1/prog.c) ([README.md](2014/maffiodo1/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3722,6 +3722,13 @@ Great Giana Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters), but
 which let one configure the width and height of the game.
 
 
+## [2014/maffiodo2](2014/maffiodo2/prog.c) ([README.md](2014/maffiodo2/README.md]))
+
+[Cody](#cody) added the [try.sh](2014/maffiodo2/try.sh) script and the
+[alternate code](2014/maffiodo2/README.md#alternate-code) provided by the
+author.
+
+
 ## [2014/morgan](2014/morgan/prog.c) ([README.md](2014/morgan/README.md))
 
 [Cody](#cody) added the [try.sh](2014/morgan/try.sh) script.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3715,6 +3715,12 @@ it is a file with spoilers (and too close to README.md?).
 [Cody](#cody) fixed the build for this entry: it does not require
 [SDL2](https://www.libsdl.org) but SDL1 so there were linking errors.
 
+Cody also added the [mario.sh](2014/maffiodo1/mario.sh) and
+[giana.sh](2014/maffiodo1/giana.sh) scripts which play, respectively, [Super
+Mario Bros](http://en.wikipedia.org/wiki/Super_Mario_Bros.) and one of [The
+Great Giana Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters), but
+which let one configure the width and height of the game.
+
 
 ## [2014/morgan](2014/morgan/prog.c) ([README.md](2014/morgan/README.md))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3716,6 +3716,11 @@ it is a file with spoilers (and too close to README.md?).
 [SDL2](https://www.libsdl.org) but SDL1 so there were linking errors.
 
 
+## [2014/morgan](2014/morgan/prog.c) ([README.md](2014/morgan/README.md))
+
+[Cody](#cody) added the [try.sh](2014/morgan/try.sh) script.
+
+
 ## [2014/sinon](2014/sinon/prog.c) ([README.md](2014/sinon/README.md))
 
 [Cody](#cody) fixed the code so that the game can play automatically like it

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3670,17 +3670,20 @@ details).
 
 ## [2014/deak](2014/deak/prog.c) ([README.md](2014/deak/README.md))
 
-[Cody](#cody) fixed the code that the author provided which would be what the program
-would look like if, as the author put it:
+[Cody](#cody) added [alt code](2014/deak/README.md#alternate-code) that lets one
+reconfigure the coordinates but instead of being a modified version of the entry
+it is the version the author provided which would be what the program would look
+like if, as the author put it:
 
 > The usage of recognizable elements from the C programming language in the
-application source code is intentionally kept to a bare minimum. If this phrase
-would not be true, the application would be the following:
+application source code is intentionally kept to a bare minimum.
 
-It did not compile because a value was left off the `return` statement.
+.. was not true.
 
-Cody added this as alternate code just for fun and so one can more easily see
-the difference to really appreciate the obfuscation.
+This alt version did not originally compile because a value was left off the
+`return` statement (this might have been fixed in the README.md file too) so
+that was fixed and it also has `#include <stdio.h>` for `putchar(3)`. The
+`#ifndef..#define..#endif` was not part of the original alt code, of course.
 
 
 ## [2014/endoh1](2014/endoh1/prog.c) ([README.md](2014/endoh1/README.md]))

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3705,6 +3705,11 @@ file to [spoilers.md](2014/endoh1/spoilers.md) to be clearer in its purpose as
 it is a file with spoilers (and too close to README.md?).
 
 
+## [2014/endoh2](2014/endoh2/prog.c) ([README.md](2014/endoh2/README.md]))
+
+[Cody](#cody) added the [try.sh](2014/endoh2/try.sh) script.
+
+
 ## [2014/maffiodo1](2014/maffiodo1/prog.c) ([README.md](2014/maffiodo1/README.md]))
 
 [Cody](#cody) fixed the build for this entry: it does not require

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3658,6 +3658,16 @@ implicitly (Linux doesn't seem to but macOS does).
 # <a name="2014"></a>2014
 
 
+## [2014/birken](2014/birken/prog.c) ([README.md](2014/birken/README.md))
+
+[Cody](#cody) provided the [alternate
+code](2014/birken/README.md#alternate-code) that lets one redefine the port to
+bind to in case there is a firewall issue or there is some other reason to not
+have the default port. Remember that ports < 1024 are privileged. It also lets
+you redefine the timing constant `STARDATE` (see the author's remarks for more
+details).
+
+
 ## [2014/deak](2014/deak/prog.c) ([README.md](2014/deak/README.md))
 
 [Cody](#cody) fixed the code that the author provided which would be what the program


### PR DESCRIPTION

The alt code is from the author.

The try.sh script has the example command provided by the judges as well
as some by the author. One was removed because of a syntax error 
(removed from the author's examples).

Format/typo check README.md file.

The only thing that has to be done is to update the references to 
twitter to note how the IOCCC no longer endorses twitter or whatever the
rocket destroyer wishes to call it (though certainly it won't be worded
like that :-) ).