### PR TITLE
Add 2000/dlowe/try.sh, update bugs.md, format

### DIFF
--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -5,8 +5,9 @@ make all
 ```
 
 
-There is an [alternate version](#alternate-code) that allows you to cheat,
-giving you a configurable amount of arrows at the start of the game.
+There is an alternate version that allows you to heat, giving you configurable
+amount of arrows at the start of the game. See [Alternate
+code](#alternate-code).
 
 
 ### Bugs and (Mis)features:
@@ -30,6 +31,9 @@ For more detailed information see [1994 dodsond2 in bugs.md](/bugs.md#1994-dodso
 
 This version allows you to choose how many arrows to start with, instead of the
 default 0. If one tried specifying a value < 0 it will set it to 0.
+
+Fun fact: this version helped uncover and fix a bug that prevented the entry
+from working on some cases.
 
 ### Alternate build:
 
@@ -59,6 +63,7 @@ Each year people find new ways to squeeze more and more out of the
 contest rules.  Next year, entries that use compression utilities
 to get around the size limit will find themselves squeezed out of
 the contest!
+
 
 ### A historical note:
 

--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -127,19 +127,19 @@ Floating point exception (core dumped) (or something to that effect)
 ### Examples:
 
 ```sh
-$ echo "12 13 14 15 16 + + + + f" | ./dlowe
+$ echo '12 13 14 15 16 + + + + f' | ./dlowe
 70
-$ echo "12 13 14 15 16 17 + - * / p" | ./dlowe
+$ echo '12 13 14 15 16 17 + - * / p' | ./dlowe
 -0.0515873015873016
-$ echo "+" | ./dlowe
+$ echo '+' | ./dlowe
 stack empty
-$ echo "999999999999999 1 + p" | ./dlowe
+$ echo '999999999999999 1 + p' | ./dlowe
 1e+15
-$ echo "99999999999999 1 + p" | ./dlowe
+$ echo '99999999999999 1 + p' | ./dlowe
 100000000000000
-$ echo "12.5 9 % 10 * 15 + f" | ./dlowe
+$ echo '12.5 9 % 10 * 15 + f' | ./dlowe
 50
-$ echo "7 P 6 d P P 8 p" | ./dlowe | tr 876 tpo
+$ echo '7 P 6 d P P 8 p' | ./dlowe | tr 876 tpo
 poot
 ```
 

--- a/2000/dlowe/try.sh
+++ b/2000/dlowe/try.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2000/dlowe
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ echo '13 14 15 16 17 + - * / p' | ./dlowe" 1>&2
+echo '13 14 15 16 17 + - * / p' | ./dlowe
+
+echo "$ echo '12 13 14 15 16 + + + + f' | ./dlowe" 1>&2
+echo '12 13 14 15 16 + + + + f' | ./dlowe
+
+echo "$ echo '12 13 14 15 16 17 + - * / p' | ./dlowe" 1>&2
+echo '12 13 14 15 16 17 + - * / p' | ./dlowe
+
+echo "$ echo '+' | ./dlowe" 1>&2
+echo '+' | ./dlowe
+
+echo "$ echo '999999999999999 1 + p' | ./dlowe" 1>&2
+echo '999999999999999 1 + p' | ./dlowe
+
+echo "$ echo '99999999999999 1 + p' | ./dlowe" 1>&2
+echo '99999999999999 1 + p' | ./dlowe
+
+echo "$ echo '12.5 9 % 10 * 15 + f' | ./dlowe" 1>&2
+echo '12.5 9 % 10 * 15 + f' | ./dlowe

--- a/2001/ctk/ctk.alt.c
+++ b/2001/ctk/ctk.alt.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <signal.h>
+#define m(b)a=b;z=*a;while(*++a){y=*a;*a=z;z=y;}
+#define h(u)G=u<<3;printf("\e[%uq",l[u])
+#define c(n,s)case n:s;continue
+char x[]="((((((((((((((((((((((",w[]=
+"\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b";char r[]={92,124,47},l[]={2,3,1
+,0};char*T[]={"  |","  |","%\\|/%"," %%%",""};char d=1,p=40,o=40,k=0,*a,y,z,g=
+-1,G,X,**P=&T[4],f=0;unsigned int s=0;void u(int i){int n;printf(
+"\x1b[H\x1b[L\x1b[;%uH%c\x1b[;%uH%c\x1b[;%uH%s\x1b[22;%uH@\x1b[23;%uH \n",*x-*w,r[d],*x+*w
+,r[d],X,*P,p+=k,o);if(abs(p-x[21])>=w[21])exit(0);if(g!=G){struct itimerval t=
+{0,0,0,0};g+=((g<G)<<1)-1;t.it_interval.tv_usec=t.it_value.tv_usec=72000/((g>>
+3)+1);setitimer(0,&t,0);f&&printf("\e[10;%u]",g+24);}f&&putchar(7);s+=(9-w[21]
+)*((g>>3)+1);o=p;m(x);m(w);(n=rand())&255||--*w||++*w;if(!(**P&&P++||n&7936)){
+while(abs((X=rand()%76)-*x+2)-*w<6);++X;P=T;}(n=rand()&31)<3&&(d=n);!d&&--*x<=
+*w&&(++*x,++d)||d==2&&++*x+*w>79&&(--*x,--d);signal(i,u);}void e(){signal(14,
+SIG_IGN);printf("\e[0q\ecScore: %u\n",s);system("stty echo -cbreak");}int main
+(int C,char**V){atexit(e);(C<2||*V[1]!=113)&&(f=(C=*(int*)getenv("TERM"))==(
+int)0x756E696C||C==(int)0x6C696E75);srand(getpid());system("stty -echo cbreak"
+);h(0);u(14);for(;;)switch(getchar()){case 113:return 0;case 91:case 98:case 104:c(44,k
+=-1);case 32:case 110:case 107:c(46,k=0);case 93:case 109:case 108:c(47,k=1);c(49,h(0));c(50,h(1
+));c(51,h(2));c(52,h(3));}e();}

--- a/2011/akari/.gitignore
+++ b/2011/akari/.gitignore
@@ -11,3 +11,4 @@ akari.orig
 prog.orig
 rot13.c
 expanded_and_rot13_output.txt
+expanded_output.txt

--- a/bugs.md
+++ b/bugs.md
@@ -1565,19 +1565,60 @@ echo "7 P 6 d P P 8 p" | ./dlowe | tr 876 tpo
 ```
 
 which should print out `poot` but it doesn't, not in linux and not in macOS.
-This might in part be because `./dlowe` will show not a number with `876` but
-rather
-
-```sh
-$ echo "7 P 6 d P P 8 p" | ./dlowe
-7668
-```
 
 In linux it doesn't crash but it doesn't print anything out either.
 
 In macOS it crashes; it might appear to not crash in macOS but this is because
 of the pipeline. If you remove the `| tr 876 tpo` part of the command you will
 see that it does indeed crash!
+
+The reason for this not working is really strange.
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe     
+7668
+$ echo "7 P 6 d P P 8 p" | ./dlowe | grep 7
+$
+```
+
+Why? Is it writing to stdout? Let's try some other things:
+
+```sh
+$ echo 7668 | tr 876 tpo
+poot
+```
+
+Okay so we know that it SHOULD work. But we also know something funny is going on with stdout and the entry. Another experiment:
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe 1>&2 | grep 7
+7668
+```
+
+Okay so now it sees it, `grep`. But watch!
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe 2>foo 1>&1
+7668
+$ cat foo
+
+```
+
+.. so at this hour it does appear to be writing to stdout but yet somehow it doesn't? But watch:
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe 1>foo 1>&1
+$ cat foo
+$
+```
+
+Well this explains why the `tr` does not transliterate it to `poot` but why is
+this happening? Why can't it be redirected to another file even? 
+
+If it could be figured out why it's not writing to stdout and yet at the same
+time is writing to stdout one bug could be fixed. Maybe it's the perl messing
+with things but we don't know.
+
 
 Other commands do work, however, and give the appropriate output, such as:
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2255,6 +2255,8 @@ He also added the [try.sh](2000/dhyang/try.sh) script.
 `PL_na` was once `na`. He notes that this entry crashes under macOS but it works
 under Linux after this change.
 
+Cody also added the [try.sh](2000/dlowe/try.sh) script.
+
 
 ## [2000/jarijyrki](2000/jarijyrki/jarijyrki.c) ([README.md](2000/jarijyrki/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1667,14 +1667,14 @@ this code. Other code is also described there.
 
 ## [1994/dodsond2](1994/dodsond2/dodsond2.c) ([README.md](1994/dodsond2/README.md))
 
-[Cody](#cody) fixed an infinite loop that could happen when you shoot an arrow and end up
-having no arrows, thus making one force quit the game. The problem was in a
-condition in the outer loop it would repeatedly get input (if `getchar()`
-returned `'\n'`),  only if one has more than one arrow, returning after that.
-But if there were 0 arrows left it did not return and so the loop started over,
-doing nothing. This fix also seems to have fixed a problem where if you shoot
-your last arrow it would not move you to the room you shoot into (whereas if you
-had more arrows it would).
+[Cody](#cody) fixed an infinite loop that could happen when you shoot an arrow
+and end up having no arrows, thus making one force quit the game. The problem
+was in a condition in the outer loop it would repeatedly get input (if
+`getchar()` returned `'\n'`),  only if one has more than one arrow, returning
+after that.  But if there were 0 arrows left it did not return and so the loop
+started over, doing nothing. This fix also seems to have fixed a problem where
+if you shoot your last arrow it would not move you to the room you shoot into
+(whereas if you had more arrows it would).
 
 Cody added an alt version that allows one to cheat by specifying how many arrows
 to start with (this was for fun but it turned out a good way to debug the above


### PR DESCRIPTION

The try.sh script also has some fixes in the author's remarks (as in
they were fixed in the author's remarks) - it had "s in the command line
rather than single quotes but some of these command lines had * which
would expand to the files in the directory, causing errors.

The bugs.md has been updated with the issue of not printing 'poot' when
it should. I did some debugging and removed some (obviously nonsense) 
ideas I had put in before (without thinking, being too tired, whatever
other reason or reasons). The real issue is a very strange one to be 
sure.

I am pretty sure the reason it does not work with macOS (this was 
already noted but worth repeating) is the version of perl as the author
noted this as an issue. We still have it as a known bug (some platforms)
but I don't think it's possible to fix without a higher perl version and 
neither MacPorts nor Homebrew seem to have this.