### PR TITLE
Add 2015/mills1/try.sh + format/typo checks

### DIFF
--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -5,8 +5,9 @@ make all
 ```
 
 
-There is an [alternate version](#alternate-code) that allows you to cheat,
-giving you a configurable amount of arrows at the start of the game.
+There is an alternate version that allows you to heat, giving you configurable
+amount of arrows at the start of the game. See [Alternate
+code](#alternate-code).
 
 
 ### Bugs and (Mis)features:
@@ -30,6 +31,9 @@ For more detailed information see [1994 dodsond2 in bugs.md](/bugs.md#1994-dodso
 
 This version allows you to choose how many arrows to start with, instead of the
 default 0. If one tried specifying a value < 0 it will set it to 0.
+
+Fun fact: this version helped uncover and fix a bug that prevented the entry
+from working on some cases.
 
 ### Alternate build:
 
@@ -59,6 +63,7 @@ Each year people find new ways to squeeze more and more out of the
 contest rules.  Next year, entries that use compression utilities
 to get around the size limit will find themselves squeezed out of
 the contest!
+
 
 ### A historical note:
 

--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -127,19 +127,19 @@ Floating point exception (core dumped) (or something to that effect)
 ### Examples:
 
 ```sh
-$ echo "12 13 14 15 16 + + + + f" | ./dlowe
+$ echo '12 13 14 15 16 + + + + f' | ./dlowe
 70
-$ echo "12 13 14 15 16 17 + - * / p" | ./dlowe
+$ echo '12 13 14 15 16 17 + - * / p' | ./dlowe
 -0.0515873015873016
-$ echo "+" | ./dlowe
+$ echo '+' | ./dlowe
 stack empty
-$ echo "999999999999999 1 + p" | ./dlowe
+$ echo '999999999999999 1 + p' | ./dlowe
 1e+15
-$ echo "99999999999999 1 + p" | ./dlowe
+$ echo '99999999999999 1 + p' | ./dlowe
 100000000000000
-$ echo "12.5 9 % 10 * 15 + f" | ./dlowe
+$ echo '12.5 9 % 10 * 15 + f' | ./dlowe
 50
-$ echo "7 P 6 d P P 8 p" | ./dlowe | tr 876 tpo
+$ echo '7 P 6 d P P 8 p' | ./dlowe | tr 876 tpo
 poot
 ```
 

--- a/2000/dlowe/try.sh
+++ b/2000/dlowe/try.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2000/dlowe
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ echo '13 14 15 16 17 + - * / p' | ./dlowe" 1>&2
+echo '13 14 15 16 17 + - * / p' | ./dlowe
+
+echo "$ echo '12 13 14 15 16 + + + + f' | ./dlowe" 1>&2
+echo '12 13 14 15 16 + + + + f' | ./dlowe
+
+echo "$ echo '12 13 14 15 16 17 + - * / p' | ./dlowe" 1>&2
+echo '12 13 14 15 16 17 + - * / p' | ./dlowe
+
+echo "$ echo '+' | ./dlowe" 1>&2
+echo '+' | ./dlowe
+
+echo "$ echo '999999999999999 1 + p' | ./dlowe" 1>&2
+echo '999999999999999 1 + p' | ./dlowe
+
+echo "$ echo '99999999999999 1 + p' | ./dlowe" 1>&2
+echo '99999999999999 1 + p' | ./dlowe
+
+echo "$ echo '12.5 9 % 10 * 15 + f' | ./dlowe" 1>&2
+echo '12.5 9 % 10 * 15 + f' | ./dlowe

--- a/2001/ctk/ctk.alt.c
+++ b/2001/ctk/ctk.alt.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <signal.h>
+#define m(b)a=b;z=*a;while(*++a){y=*a;*a=z;z=y;}
+#define h(u)G=u<<3;printf("\e[%uq",l[u])
+#define c(n,s)case n:s;continue
+char x[]="((((((((((((((((((((((",w[]=
+"\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b";char r[]={92,124,47},l[]={2,3,1
+,0};char*T[]={"  |","  |","%\\|/%"," %%%",""};char d=1,p=40,o=40,k=0,*a,y,z,g=
+-1,G,X,**P=&T[4],f=0;unsigned int s=0;void u(int i){int n;printf(
+"\x1b[H\x1b[L\x1b[;%uH%c\x1b[;%uH%c\x1b[;%uH%s\x1b[22;%uH@\x1b[23;%uH \n",*x-*w,r[d],*x+*w
+,r[d],X,*P,p+=k,o);if(abs(p-x[21])>=w[21])exit(0);if(g!=G){struct itimerval t=
+{0,0,0,0};g+=((g<G)<<1)-1;t.it_interval.tv_usec=t.it_value.tv_usec=72000/((g>>
+3)+1);setitimer(0,&t,0);f&&printf("\e[10;%u]",g+24);}f&&putchar(7);s+=(9-w[21]
+)*((g>>3)+1);o=p;m(x);m(w);(n=rand())&255||--*w||++*w;if(!(**P&&P++||n&7936)){
+while(abs((X=rand()%76)-*x+2)-*w<6);++X;P=T;}(n=rand()&31)<3&&(d=n);!d&&--*x<=
+*w&&(++*x,++d)||d==2&&++*x+*w>79&&(--*x,--d);signal(i,u);}void e(){signal(14,
+SIG_IGN);printf("\e[0q\ecScore: %u\n",s);system("stty echo -cbreak");}int main
+(int C,char**V){atexit(e);(C<2||*V[1]!=113)&&(f=(C=*(int*)getenv("TERM"))==(
+int)0x756E696C||C==(int)0x6C696E75);srand(getpid());system("stty -echo cbreak"
+);h(0);u(14);for(;;)switch(getchar()){case 113:return 0;case 91:case 98:case 104:c(44,k
+=-1);case 32:case 110:case 107:c(46,k=0);case 93:case 109:case 108:c(47,k=1);c(49,h(0));c(50,h(1
+));c(51,h(2));c(52,h(3));}e();}

--- a/2011/akari/.gitignore
+++ b/2011/akari/.gitignore
@@ -11,3 +11,4 @@ akari.orig
 prog.orig
 rot13.c
 expanded_and_rot13_output.txt
+expanded_output.txt

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -136,14 +136,14 @@ DA=100		# Acceleration due to gravity (scaled by 256).
 		# Smaller values make you glide slower.
 
 DI=-200		# Impulse velocity of a flap (scaled by 256).
-		# Make larger if you want an less intense tapping experience!
+		# Make larger if you want a less intense tapping experience!
 
 DB='"<o^="'	# Sprite for player when gliding.
-		# HINT: Try using various emoji.
+		# HINT: Try using various emojis.
 		# NOTE: The string MUST be enclosed inside double quotes.
 
 DF='"<ov="'	# Sprite for player when flapping.
-		# HINT: Try using various emoji.
+		# HINT: Try using various emojis.
 		# NOTE: The string MUST be enclosed inside double quotes.
 
 DG='"Tap to Flap!"'	# Instruction text.

--- a/2015/mills1/README.md
+++ b/2015/mills1/README.md
@@ -24,12 +24,20 @@ Press the up arrow and the down arrow at the right time.
 ## Judges' remarks:
 
 Did you find that mobile application game a bit frustrating?
-Well you can adjust the makefile parameters to make life a
+Well you can adjust the Makefile parameters to make life a
 bit easier for you:
 
 ```sh
-make clobber all DW=199999 DW=22 DH=16 DA=50 DI=-150
+./try.sh
 ```
+
+which runs:
+
+```sh
+make clobber all DW=199999 DW=22 DH=16 DA=50 DI=-150
+./prog
+```
+
 
 From the Makefile:
 
@@ -53,20 +61,26 @@ DA=100          # Acceleration due to gravity (scaled by 256).
 		# Smaller values make you glide slower.
 
 DI=-200         # Impulse velocity of a flap (scaled by 256).
-		# Make larger if you want an less intense tapping experience!
+		# Make larger if you want a less intense tapping experience!
 
 DB='"<o^="'     # Sprite for player when gliding.
-		# HINT: Try using various emoji.
+		# HINT: Try using various emojis.
 		# NOTE: The string MUST be enclosed inside double quotes.
 
 DF='"<ov="'     # Sprite for player when flapping.
-		# HINT: Try using various emoji.
+		# HINT: Try using various emojis.
 		# NOTE: The string MUST be enclosed inside double quotes.
 
 DG='"Tap to Flap!"'     # Instruction text.
 			# Change to your native tongue.
 		# NOTE: The string MUST be enclosed inside double quotes.
 ```
+
+WARNING: if you have good eye-hand coordination and too much time on your hands
+you might fall asleep while playing as you probably will never die in this mode.
+We only stopped when a reminder came through and we tried to mark it complete at
+the same time as playing and we almost managed to survive that. At that point we
+already scored over 90.
 
 Enjoy!
 
@@ -92,12 +106,14 @@ You can even make the game more challenging -- resize the terminal window to
 make the world taller or shorter.  You'll never be able to get through the
 pipes when they are four times as tall!
 
+
 ### Instructions
 
 The instructions are printed at the start of the game:  Tap to Flap!
 
 Hit any key to make your bird fly.  Navigate her between the gaps in the pipes.
 Your score is shown in the upper left, along with your current high-score.
+
 
 ### Customization options
 
@@ -115,18 +131,18 @@ command line:
  * `-DI`: Impulse velocity of a flap (scaled by 256).  Make this smaller
    if you want an intense tapping experience!
  * `-DB`: Sprite for player when gliding.
- * `-DF`: Sprite for player when flapping.\
+ * `-DF`: Sprite for player when flapping.
  * `-DG`: Instruction text.  Change to your native tongue.
 
 Feel free to try out physics or play field options to make the game more
 interesting.  Try setting the player sprites to change the game completely --
 maybe you can be a fish, or a pig -- the options are limitless!  Try using
-emoji -- you can be a flying beer mug!
+emojis -- you can be a flying beer mug!
 
 Note that since the `curses` library on POSIX doesn't natively support wide
-characters (needed for UTF-8 support, which is needed for emoji), you may need
-to make some changes to the `Makefile` to get emoji to work on your system.
-To help you get started, I've included some example substitutions for emoji
+characters (needed for UTF-8 support, which is needed for emojis), you may need
+to make some changes to the `Makefile` to get emojis to work on your system.
+To help you get started, I've included some example substitutions for emojis
 sprites and instruction text; for example, type
 
 ```sh
@@ -139,19 +155,20 @@ or
 make EMOJI=globe
 ```
 
-for some examples (the full list of options is in the `Makefile`).  Don't
-forget to `make clobber` first.  If the output doesn't look right, you may need
-to link with the "wide" version of `ncurses`.  On MacOSX 10.11, it should work
-with the current `-lcurses`; on Linux, you might need `-lncursesw`.
+for some examples (the full list of options is in the `Makefile`).  Don't forget
+to `make clobber` first (or use `make -B`).  If the output doesn't look right,
+you may need to link with the "wide" version of `ncurses`.  On MacOSX 10.11, it
+should work with the current `-lcurses`; on Linux, you might need `-lncursesw`.
 See the `Makefile` to make this change if you need to.  Or buy a Mac.
 
 You will also need a UTF-8 compatible terminal and an emoji font installed,
 and you will need to have your `LANG` environment variable set to use UTF-8.
 Again, if this is too complicated, maybe just go and get that Mac.
 
+
 ### Future additions
 
-Future versions of the game will include monitization via the freemium model
+Future versions of the game will include monetization via the freemium model
 with micropayments for customization options, play-to-win and of course
 live-streamed targeted video advertising.
 

--- a/2015/mills1/try.sh
+++ b/2015/mills1/try.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2015/mills1 - make it much easier
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+make CC="${CC}" clobber all DW=199999 DW=22 DH=16 DA=50 DI=-150 || exit 1
+
+read -r -n 1 -p "Press any key to play (send EOF to quit game): "
+./prog
+exit 0

--- a/2015/muth/README.md
+++ b/2015/muth/README.md
@@ -15,13 +15,7 @@ make -B [MACHINE=your_machine.h] [TAPE=your_tape.h] [X=[0|1|2|3|4|5|6|7|8|9]] [V
 ### Try:
 
 ```sh
-make -B V=2 run
-
-strings prog | grep '(,)'
-
-make -B MACHINE=machine_times2.h TAPE=tape_five.h V=1 run
-
-make -B MACHINE=machine_chaos_5_2.h X=5 run
+./try.sh
 ```
 
 
@@ -51,21 +45,28 @@ even without conditionals and recursive file inclusion as some kind of a
 - make target `run` runs `./prog` and filters a little statistics out of the verbose output
 - `X` (defaults to 3) sets the maximum number of steps: *M*(`X`) ~ 8<sup>`X`</sup>
 
+
 ### Limitations
 
-If the machine does not halt after *M*(`X`) steps, you will see unexpanded macros in the output.
+If the machine does not halt after *M*(`X`) steps, you will see unexpanded
+macros in the output.
+
 
 ### Compiler warnings
 
-If `V=1` or `V=2` is used, you may see "`warning: string length is greater than the length '4095' ISO C99 compilers are required to support`".
+If `V=1` or `V=2` is used, you may see "`warning: string length is greater than
+the length '4095' ISO C99 compilers are required to support`".
+
 
 ### Programming
 
-Implementing your own Turing machine is easy. Take a look at the supplied header files for examples.
+Implementing your own Turing machine is easy. Take a look at the supplied header
+files for examples.
+
 
 #### Tape Symbols
 
-Every symbol used (except "`_`") must be explicitly declared using
+Every symbol used (except `_`) must be explicitly declared using
 
 ```c
 #define sym_SYMBOL(sym, _SYMBOL) sym
@@ -77,9 +78,11 @@ Example:
 #define sym_1(sym, _1) sym
 ```
 
+
 #### Tape
 
-The initial content of the tape must be defined in the tape header using a triple like:
+The initial content of the tape must be defined in the tape header using a
+triple like:
 
 ```c
 #define tape ((((,),...l2), l1), c, (r1, (r2..., (,))))
@@ -89,26 +92,32 @@ The initial content of the tape must be defined in the tape header using a tripl
 - `c` is the symbol at the current position
 - `r1`, `r2`, ... are the symbols to the right
 
-The empty pairs "`(,)`" represent the continuations of the tape, filled with underscore symbols ("`_`"). They are expanded on demand.
+The empty pairs `(,)` represent the continuations of the tape, filled with
+underscore symbols (`_`). They are expanded on demand.
+
 
 #### State Machine
 
 All transitions are defined in the machine header using the syntax
 
-	#define CURRENT_SCANNED (WRITE, MOVEMENT, NEXT)
+```
+#define CURRENT_SCANNED (WRITE, MOVEMENT, NEXT)
+```
 
 where
 
-- `CURRENT` is the current state
-- `SCANNED` is the symbol at the current position
-- the whitespace before the parentheses is significant
-- `WRITE` is the symbol to be written to the tape
-- `MOVEMENT` is "`L`" for left, "`R`" for right, or nothing
-- `NEXT` is the next state
+- `CURRENT` is the current state.
+- `SCANNED` is the symbol at the current position.
+- The whitespace before the parentheses is significant.
+- `WRITE` is the symbol to be written to the tape.
+- `MOVEMENT` is `L` for left, `R` for right; don't specify anything if you
+want no movement.
+- `NEXT` is the next state.
 
-There must be a state "`A`" defined, which becomes the initial state of the machine.
+There must be a state `A` defined, which becomes the initial state of the
+machine.
 
-To halt the machine, use the keyword "`break`" as in
+To halt the machine, use the keyword `break` as in
 
 ```c
 #define A_1 (2, break)

--- a/2015/muth/try.sh
+++ b/2015/muth/try.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2015/muth
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+echo "$ make -B V=2 run" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+make CC="${CC}" -B V=2 run | less -EXF
+echo 1>&2
+echo 1>&2
+
+echo "$ strings prog | grep '(,)'" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+strings prog | grep '(,)' | less -EXF
+echo 1>&2
+echo 1>&2
+
+for h in machine*.h; do
+    for t in tape*.h; do
+	echo "$ make CC=\"\${CC}\" -B MACHINE=$h TAPE=$t V=1 run" 1>&2
+	read -r -n 1 -p "Press any key to continue (q to exit): "
+	if [[ "$REPLY" == "q" || "$REPLY" == "Q" ]]; then
+	    exit 0
+	fi
+	echo 1>&2
+	make -B MACHINE="$h" TAPE="$t" V=1 run
+	echo 1>&2
+	echo 1>&2
+    done
+done
+

--- a/2015/yang/README.md
+++ b/2015/yang/README.md
@@ -8,34 +8,15 @@ make
 ## To use:
 
 ```sh
-echo Some text | ./prog\
+echo Some text | ./prog
 ```
 
 
 ### Try:
 
 ```sh
-echo IOCCC 2015 | ./prog | tee output.c
-make output
-./output
-
-echo IOCCC 2015 | ./prog_c11 | tee output.c
-make output
-./output
-
-echo IOCCC 2015 | ./prog_c++98 | tee output.c
-make output
-./output
+./try.sh
 ```
-
-### Also try:
-
-```sh
-./prog
-
-```
-
-Keep pressing enter to see more output. Send EOF to terminate.
 
 
 ## Judges' remarks:
@@ -54,7 +35,7 @@ so you need not worry about this.
 ## Author's remarks:
 
 `Fuuko` is a [sea star](https://en.wikipedia.org/wiki/Starfish) generator.  Feed
-her some input through `stdin` to get lots of sea star patterns in `stdout`.
+her some input through `stdin` to get lots of sea star patterns on `stdout`.
 
 ```sh
 cc -O3 -std=c90 fuuko.c -lm -o fuuko_c90
@@ -70,7 +51,7 @@ echo IOCCC | ./fuuko_c99 > output_c99.c
 ```
 
 Don't like [sea stars](https://en.wikipedia.org/wiki/Starfish)?  Use a C++98
-compiler to get [dango](https://en.wikipedia.org/wiki/Dango) instead.
+compiler to get a [dango](https://en.wikipedia.org/wiki/Dango) instead.
 
 ```sh
 g++ -O3 -std=c++98 fuuko.c -lm -o fuuko_cpp98
@@ -102,6 +83,7 @@ filled with pointer dereferences (C stars).
 Next time people ask you for a few pointers on C, you can run their
 question through `Fuuko` and give them pointers all day long.
 
+
 ### Compatibility
 
 `Fuuko` has been tested under these environments:
@@ -116,6 +98,7 @@ question through `Fuuko` and give them pointers all day long.
 - clang 3.5.0 on Linux
 - clang 3.4.1 on Linux
 - tcc 0.9.25 on JS/Linux (C99 only)
+
 
 ### Features
 

--- a/2015/yang/try.sh
+++ b/2015/yang/try.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2015/yang
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" everything >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+echo "$ echo IOCCC 2015 | ./prog | tee output.c | less" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+echo IOCCC 2015 | ./prog | tee output.c | less -EXF
+echo "$ make CC=\"${CC}\" output" 1>&2
+make CC="${CC}" output 2>/dev/null
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+./output
+
+echo 1>&2
+echo "$ echo IOCCC 2015 | ./prog_c90 | tee output.c | less" 1>&2
+read -r -n 1 -p "Press any key to show sea star (space = next page, q = quit): "
+echo 1>&2
+echo IOCCC 2015 | ./prog_c90 | tee output.c | less -EXF
+echo "$ make CC=\"${CC}\" output" 1>&2
+make CC="${CC}" output 2>/dev/null
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+./output
+
+echo 1>&2
+echo "$ echo IOCCC 2015 | ./prog_c99 | tee output.c | less" 1>&2
+read -r -n 1 -p "Press any key to show sea star with eyes (space = next page, q = quit): "
+echo 1>&2
+echo IOCCC 2015 | ./prog_c99 | tee output.c | less -EXF
+echo "Did you notice the 'rabbit' in there?" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+echo "$ make CC=\"${CC}\" output" 1>&2
+make CC="${CC}" output 2>/dev/null
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+./output
+
+echo "$ echo IOCCC 2015 | ./prog_cpp98 | tee output.c | less" 1>&2
+read -r -n 1 -p "Press any key to show dango (space = next page, q = quit): "
+echo IOCCC 2015 | ./prog_cpp98 | tee output.c | less -EXF
+echo "$ make CC=\"${CC}\" output" 1>&2
+make CC="${CC}" output 2>/dev/null
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+./output
+
+echo "$ echo IOCCC 2015 | ./prog_cpp11 | tee output.c | less" 1>&2
+read -r -n 1 -p "Press any key to show circles/Swiss cheese (space = next page, q = quit): "
+echo IOCCC 2015 | ./prog_cpp11 | tee output.c | less -EXF
+echo "$ make CC=\"${CC}\" output" 1>&2
+make CC="${CC}" output 2>/dev/null
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+./output
+
+echo 1>&2
+echo "$ echo IOCCC 2015 | ./prog_c11 | tee output.c | less" 1>&2
+read -r -n 1 -p "Press any key to show no extra pattern (space = next page, q = quit): "
+echo 1>&2
+echo IOCCC 2015 | ./prog_c11 | tee output.c | less -EXF
+echo "$ make CC=\"${CC}\" output" 1>&2
+make CC="${CC}" output 2>/dev/null
+read -r -n 1 -p "Press any key to run: ./output: "
+echo 1>&2
+./output
+
+read -r -n 1 -p "Press enter key repeatedly to get more output (send EOF to quit): "
+./prog
+exit 0

--- a/bugs.md
+++ b/bugs.md
@@ -1565,19 +1565,60 @@ echo "7 P 6 d P P 8 p" | ./dlowe | tr 876 tpo
 ```
 
 which should print out `poot` but it doesn't, not in linux and not in macOS.
-This might in part be because `./dlowe` will show not a number with `876` but
-rather
-
-```sh
-$ echo "7 P 6 d P P 8 p" | ./dlowe
-7668
-```
 
 In linux it doesn't crash but it doesn't print anything out either.
 
 In macOS it crashes; it might appear to not crash in macOS but this is because
 of the pipeline. If you remove the `| tr 876 tpo` part of the command you will
 see that it does indeed crash!
+
+The reason for this not working is really strange.
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe     
+7668
+$ echo "7 P 6 d P P 8 p" | ./dlowe | grep 7
+$
+```
+
+Why? Is it writing to stdout? Let's try some other things:
+
+```sh
+$ echo 7668 | tr 876 tpo
+poot
+```
+
+Okay so we know that it SHOULD work. But we also know something funny is going on with stdout and the entry. Another experiment:
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe 1>&2 | grep 7
+7668
+```
+
+Okay so now it sees it, `grep`. But watch!
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe 2>foo 1>&1
+7668
+$ cat foo
+
+```
+
+.. so at this hour it does appear to be writing to stdout but yet somehow it doesn't? But watch:
+
+```sh
+$ echo "7 P 6 d P P 8 p" | ./dlowe 1>foo 1>&1
+$ cat foo
+$
+```
+
+Well this explains why the `tr` does not transliterate it to `poot` but why is
+this happening? Why can't it be redirected to another file even? 
+
+If it could be figured out why it's not writing to stdout and yet at the same
+time is writing to stdout one bug could be fixed. Maybe it's the perl messing
+with things but we don't know.
+
 
 Other commands do work, however, and give the appropriate output, such as:
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3811,6 +3811,8 @@ files from compiling properly, trying instead to compile already compiled code.
 He also added explicit linking of libm (`-lm`) for systems that do not do this
 (Linux seems to not but macOS does).
 
+He also added the [try.sh](2015/yang/try.sh) script.
+
 
 # <a name="2018"></a>2018
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -2255,6 +2255,8 @@ He also added the [try.sh](2000/dhyang/try.sh) script.
 `PL_na` was once `na`. He notes that this entry crashes under macOS but it works
 under Linux after this change.
 
+Cody also added the [try.sh](2000/dlowe/try.sh) script.
+
 
 ## [2000/jarijyrki](2000/jarijyrki/jarijyrki.c) ([README.md](2000/jarijyrki/README.md]))
 

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -1667,14 +1667,14 @@ this code. Other code is also described there.
 
 ## [1994/dodsond2](1994/dodsond2/dodsond2.c) ([README.md](1994/dodsond2/README.md))
 
-[Cody](#cody) fixed an infinite loop that could happen when you shoot an arrow and end up
-having no arrows, thus making one force quit the game. The problem was in a
-condition in the outer loop it would repeatedly get input (if `getchar()`
-returned `'\n'`),  only if one has more than one arrow, returning after that.
-But if there were 0 arrows left it did not return and so the loop started over,
-doing nothing. This fix also seems to have fixed a problem where if you shoot
-your last arrow it would not move you to the room you shoot into (whereas if you
-had more arrows it would).
+[Cody](#cody) fixed an infinite loop that could happen when you shoot an arrow
+and end up having no arrows, thus making one force quit the game. The problem
+was in a condition in the outer loop it would repeatedly get input (if
+`getchar()` returned `'\n'`),  only if one has more than one arrow, returning
+after that.  But if there were 0 arrows left it did not return and so the loop
+started over, doing nothing. This fix also seems to have fixed a problem where
+if you shoot your last arrow it would not move you to the room you shoot into
+(whereas if you had more arrows it would).
 
 Cody added an alt version that allows one to cheat by specifying how many arrows
 to start with (this was for fun but it turned out a good way to debug the above

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3803,6 +3803,16 @@ simply typing `make back_to` or `make mullender`.
 (Linux doesn't seem to but macOS does).
 
 
+## [2015/mills1](2015/mills1/prog.c) ([README.md](2015/mills1/README.md))
+
+[Cody](#cody) added the [try.sh](2015/mills1/try.sh) script which changes the
+parameters to what we had in the judges' remarks to make it easier (he only died
+when he tried to mark a reminder complete on the other side of the screen at the
+same time and he almost survived that, scoring at that point over 90 - but this
+also involves good eye-hand coordination and playing games like this in the
+past).
+
+
 ## [2015/muth](2015/muth/prog.c) ([README.md](2015/muth/README.md))
 
 [Cody](#cody) added the [try.sh](2015/muth/try.sh) script.

--- a/thanks-for-fixes.md
+++ b/thanks-for-fixes.md
@@ -3803,6 +3803,11 @@ simply typing `make back_to` or `make mullender`.
 (Linux doesn't seem to but macOS does).
 
 
+## [2015/muth](2015/muth/prog.c) ([README.md](2015/muth/README.md))
+
+[Cody](#cody) added the [try.sh](2015/muth/try.sh) script.
+
+
 ## [2015/yang](2015/yang/prog.c) ([README.md](2015/yang/README.md]))
 
 [Cody](#cody) fixed an unfortunate typo in the Makefile that was preventing some of the


### PR DESCRIPTION

The try.sh script runs the make command in the judges' remarks to make
it easier.

A warning is that if you have good eye-hand coordination and you're good
at games and you have too much time you might end up falling asleep
playing it as you'll probably never die. I only died because I was
trying to mark a reminder complete on the other side of the screen at
the same time as playing .. and I almost survived that .. and 'Cody's
also blind' as the joke goes in the family. That's probably why I ended
up dying. At that point I already had over 90 points. 

Still the purpose is to make it easier to play if the default settings 
are too frustrating. I contemplated playing with other settings but I
decided not to. An example where it might be improved is to let the user
pass in the environmental variables to override should they wish to but
it is not even clear to me how the variables should be sanitised so
that's an argument against it.
