### PR TITLE
Fix references to thanks-for-fixes -> help

### DIFF
--- a/inc/md2html.cfg
+++ b/inc/md2html.cfg
@@ -148,7 +148,7 @@
 /index.md				-H topnav=. -o inc/subst.default.sh
 /judges.md				-H topnav=. -o inc/subst.default.sh
 /news.md				-H topnav=. -o inc/subst.default.sh
-/thanks-for-fixes.md			-H topnav=. -o inc/subst.default.sh
+/thanks-for-help.md			-H topnav=. -o inc/subst.default.sh
 /winners.md				-H topnav=. -o inc/subst.default.sh
 /www-history.md				-H topnav=. -o inc/subst.default.sh
 /years.md				-H topnav=. -o inc/subst.default.sh

--- a/inc/sidenav.default.html
+++ b/inc/sidenav.default.html
@@ -21,7 +21,7 @@
       <a href="%%DOCROOT_URL_SLASH%%faq.html#fix_a_winner">Fixing IOCCC winners</a>
       <a href="%%DOCROOT_URL_SLASH%%faq.html#fix_web_site">Fixing the web site</a>
       <a href="%%DOCROOT_URL_SLASH%%faq.html#fix_author">Fixing winner info</a>
-      <a href="%%DOCROOT_URL_SLASH%%thanks-for-fixes.html">Thanks for the fixes</a>
+      <a href="%%DOCROOT_URL_SLASH%%thanks-for-help.html">Thanks for the help</a>
     </div>
     <div class="sidenav">
       <a href="%%DOCROOT_URL_SLASH%%judges.html">The IOCCC Judges</a>

--- a/tmp/template-header.html
+++ b/tmp/template-header.html
@@ -46,7 +46,7 @@
       <a href="%%DOCROOT_URL_SLASH%%faq.html#fix_a_winner">Fixing IOCCC winners</a>
       <a href="%%DOCROOT_URL_SLASH%%faq.html#fix_web_site">Fixing the web site</a>
       <a href="%%DOCROOT_URL_SLASH%%bugs.html">Bugs &amp; (mis)features</a>
-      <a href="%%DOCROOT_URL_SLASH%%thanks-for-fixes.html">Thanks for the fixes</a>
+      <a href="%%DOCROOT_URL_SLASH%%thanks-for-help.html">Thanks for the help</a>
     </div>
     <hr>
     <div class="sidenav">

--- a/tmp/test.html
+++ b/tmp/test.html
@@ -60,7 +60,7 @@
       <a href="../faq.html#fix_a_winner">Fixing IOCCC winners</a>
       <a href="../faq.html#fix_web_site">Fixing the web site</a>
       <a href="../bugs.html">Bugs &amp; (mis)features</a>
-      <a href="../thanks-for-fixes.html">Thanks for the fixes</a>
+      <a href="../thanks-for-help.html">Thanks for the help</a>
     </div>
     <hr>
     <div class="sidenav">

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -111,7 +111,7 @@ for links about the todo items wrt the [FAQ](/faq.md).
 website. I (Cody) would be seriously surprised if I did not make a typo
 somewhere (or some places!) in the many thousands of changes I made in the
 README.md files, the [bugs.md](/bugs.md) files and maybe even the
-[thanks-for-fixes.md](/thanks-for-fixes.md) file plus others that might be
+[thanks-for-help.md](/thanks-for-help.md) file plus others that might be
 there.
     * In the case of author URLs sometimes the Internet Wayback Machine is
     helpful (and has helped) but in other cases it has not. Note that sometimes


### PR DESCRIPTION
As the thanks-for-fixes.md file was renamed (at my suggestion) thanks-for-help.md I have made sure that the file referred to in the repo is thanks-for-help and that the text regarding it also refers to help and not fixes ('Thanks for the fixes' -> 'Thanks for the help').