### PR TITLE
Make alt code variables in Makefiles consistent

### DIFF
--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -137,8 +137,9 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control amount of time to sleep between writes for alt code.
-SLEEP=500
+# Variable to control amount of time to sleep between writes for alt code.
+#
+SLEEP= 500
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} -DZ=${SLEEP} $< -o $@ ${LDFLAGS}

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -136,7 +136,8 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control size of maze for alt code
+# Variable to control size of maze for alt code
+#
 SIZE= 39
 
 ${PROG}.alt: ${PROG}.alt.c

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -137,8 +137,10 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control max number of moves
+# Variable to control max number of moves for alt code
+#
 MAXMOVES= 484
+
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -138,8 +138,10 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control amount of time to sleep between writes for alt code.
+# Variable to control amount of time to sleep between writes for alt code.
+#
 SLEEP= 20000
+
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} -DZ=${SLEEP} $< -o $@ ${LDFLAGS}
 

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -141,7 +141,8 @@ chris: ${PROG}
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control how long to sleep in alt version between updates
+# Variable to control amount of time to sleep between updates for alt code.
+#
 SLEEP= 100
 
 ${PROG}.alt: ${PROG}.alt.c

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -138,8 +138,10 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control how long to sleep in alt version
+# Variable to control amount of time to sleep between writes for alt code.
+#
 SLEEP= 200
+
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} -DZ=${SLEEP} $< -o $@ ${LDFLAGS}
 

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -143,7 +143,9 @@ jkb: ${PROG}
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to control how long to sleep in alt version
+
+# Variable to control amount of time to sleep between writes for alt code.
+#
 SLEEP= 17
 
 ${PROG}.alt: ${PROG}.alt.c

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -138,7 +138,8 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variable to allow overriding how many arrows to start with
+# Variable to set amount of arrows to start with for alt code
+#
 ARROWS= 3
 
 ${PROG}.alt: ${PROG}.alt.c

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -57,8 +57,8 @@ CSTD= -std=gnu90
 #
 ARCH=
 
-# variables that control the control keys
-
+# Variables that control the control keys and time step
+#
 IT= XK_Page_Up
 DT= XK_Page_Down
 UP= XK_Up
@@ -67,6 +67,7 @@ LT= XK_Left
 RT= XK_Right
 CS= XK_Return
 dt= 0.02
+
 # Defines that are needed to compile
 #
 CDEFINE= -DIT=${IT} -DDT=${DT} \

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -55,9 +55,6 @@ CSTD= -std=gnu90
 #
 ARCH=
 
-# variable for size, primarily for alt code
-#
-SIZE=32767
 # Defines that are needed to compile
 #
 CDEFINE= -DM0=sizeof -DM1=long -DM2=void \
@@ -141,6 +138,9 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
+# Variable to control size for alt code
+#
+SIZE=32767
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -56,7 +56,7 @@ CSTD= -std=gnu99
 #
 ARCH=
 
-# variables for redefining the time to sleep, primarily for alt code
+# Variable to control amount of time to sleep between updates for alt code.
 #
 SLEEP= 30
 SDL_SLEEP= 150000

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -57,7 +57,7 @@ CSTD= -std=gnu99
 #
 ARCH=
 
-# variables for the macros for easier redefining
+# Variables that control the port, speed and socket(2) call
 #
 PORT= 5455
 SPEED= 100

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -56,10 +56,6 @@ CSTD= -std=gnu99
 #
 ARCH=
 
-# variables for the macros for easier redefining
-XX= 1024
-YY= 768
-AA= 3
 # Defines that are needed to compile
 #
 CDEFINE= -DXX=${XX} -DYY=${YY} -DAA=${AA}
@@ -145,6 +141,11 @@ alt: data ${ALT_TARGET}
 # alternative executable for Windows
 alt2: ${PROG}.alt2
 	@${TRUE}
+
+# Variables to control the size and anti-aliasing factor for alt code
+XX= 1024
+YY= 768
+AA= 3
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -56,9 +56,6 @@ CSTD= -ansi
 #
 ARCH=
 
-# variable for redefining macro Ag
-#
-Ag= 11
 # Defines that are needed to compile
 #
 CDEFINE= -DAg=${Ag}
@@ -143,6 +140,10 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+# Variable to control how many numbers to print on a line for alt code
+#
+Ag= 11
 
 ${PROG}.alt: ${PROG}.alt.c
 	@${RM} -f ${PROG}2.alt.c $@

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -143,7 +143,7 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-# variables to help redefine width, height or iterations in alt version
+# Variables to control width, height and iterations in alt code
 #
 WIDTH= 400
 HEIGHT= 300

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -57,9 +57,6 @@ CSTD= -std=gnu99
 #
 ARCH=
 
-# variable to simplify redefining sleep duration for alt code
-#
-SLEEP= 75000
 # Defines that are needed to compile
 #
 CDEFINE= -DS=${SLEEP}
@@ -143,6 +140,9 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
+# Variable to control amount of time to sleep between writes for alt code.
+#
+SLEEP= 75000
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1979,12 +1979,17 @@ Later Cody made the entry look more like the original, removing the `argc` in
 
 ## <a name="1998_banks"></a>[1998/banks](/1998/banks/banks.c) ([README.md](/1998/banks/README.md]))
 
-[Cody](#cody) set up the Makefile to have an alt build (using the same code) for those
+[Cody](#cody) improved the Makefile to allow for easier redefining the control
+keys and time step that the author set up.
+
+Cody also set up the Makefile to have an alt build (using the same code) for those
 who do not have a page up or page down key and added the
 [keysym.h](/1998/banks/keysym.h) header file as a reference for other keys one
 can use if they wish to modify the controls. One can certainly do this even if
 they do have page up and page down but this gives a default for those who don't
-have them like with Macs.
+have them like with Macs. The alt build hard codes the page up and page down
+alternatives because not doing so would overly complicate both builds and since
+you can configure them all in both builds it shouldn't matter.
 
 
 ## <a name="1998_bas1"></a>[1998/bas1](/1998/bas1/bas1.c) ([README.md](/1998/bas1/README.md]))
@@ -2599,7 +2604,10 @@ added to `.gitignore` by accident) but Cody restored it from the archive.
 
 ## <a name="2001_kev"></a>[2001/kev](/2001/kev/kev.c) ([README.md](/2001/kev/README.md]))
 
-[Cody](#cody) slowed down the ball just a tad (it was already a `-D` macro that was used
+[Cody](#cody) improved the Makefile to allow one to more easily set up the port,
+speed and `socket(2)` call that the author had set up.
+
+Cody also slowed down the ball just a tad (it was already a `-D` macro that was used
 in the code) as it went too fast for the speed at which the paddles move even
 when holding down the movement keys (but see below).
 
@@ -2608,7 +2616,8 @@ the arrow keys on your keyboard instead of the more awkward '`,`' and '`.`'.
 
 He updated both versions to have `#ifndef..#endif` pairs for the macros so one
 can more easily configure different settings without having to specify all of
-them. The speed, `SPEED`, will be set to 50 if it's not defined at the compiler
+them (though this change became unnecessary with an improvement on how it was
+done). The speed, `SPEED`, will be set to 50 if it's not defined at the compiler
 line as 50 is what it used to be set to. This way it's more to the original but
 without having to sacrifice playability by running `make`.
 

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Thu 07 Dec 2023 19:12:36 UTC*
+*Last updated: Fri 08 Dec 2023 12:46:49 UTC*
 
 This document is primarily for [Cody Boone
 Ferguson](/winners.html#Cody_Boone_Ferguson) as he (that is I :-) ) wanted a way
@@ -192,9 +192,5 @@ too. The entries done as of 7 Dec 2023 are:
 	- 1991/rince
 	- 1985/shapiro
 	- 1985/lycklama
-    ... and at least one of them needs to have the thanks file updated as it
-    helps with the original entry itself. This one is 1998/banks but there might
-    be more (and there is at least one not done yet that this will apply I
-    believe).
-
-
+    ... and a couple or few involved updating the thanks file as it helps with
+    the entry itself. Ones not yet done might also have this need.


### PR DESCRIPTION
That is the comments have a general form and if they're for the alt code they're defined in the alt code section. If they're for the entry and the alt code they're above the CDEFINE variable.

The thanks file has been updated where it was needed.

Now only entries that have not been done need this improvement.