### PR TITLE
Add alt code to 2020/ferguson2

### DIFF
--- a/2020/ferguson2/.gitignore
+++ b/2020/ferguson2/.gitignore
@@ -8,5 +8,6 @@ indent
 indent.c
 indent.o
 prog
+prog.alt
 prog.orig
 recode

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -115,8 +115,8 @@ DATA= chocolate-cake.md enigma.1 input.txt obfuscation.key \
 	try.this.txt
 TARGET= ${PROG} recode
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -142,6 +142,11 @@ recode: recode.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
+# Variable to control how long to sleep for alt code
+#
+SLEEP= 400000
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} -Dh=${SLEEP} $< -o $@ ${LDFLAGS}
 # data files
 #
 data: ${DATA}

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -4,6 +4,10 @@
 make
 ```
 
+The author provided alternate code that prints the output one character at a
+time to make it a bit more like the real thing in that it isn't dumped out all
+at once. See [Alternate code](#alternate-code) below.
+
 
 ## To use:
 
@@ -85,6 +89,50 @@ echo | ./recode -v
 ```
 
 do?
+
+
+## Alternate code:
+
+This version, [prog.alt.c](prog.alt.c), writes a character at a time, sleeping
+after each character, so that one can read it more easily (for longer output)
+and to make it a bit more like the real thing.
+
+
+### Alternate build:
+
+
+```sh
+make alt
+```
+
+The default time to sleep is 400000 microseconds but you can change this by
+doing:
+
+```sh
+make clobber SLEEP=600000 alt
+```
+
+to change it to 600000 microseconds. It guards against negative numbers.
+
+
+### Alternate use:
+
+Use `prog.alt` as you would `prog` above.
+
+
+### Alternate try:
+
+
+```sh
+# encipher input.txt with default settings:
+cat input.txt | ./prog.alt
+
+# decipher enciphered input.txt with default settings:
+cat input.txt | ./prog| ./prog.alt
+```
+
+Notice how only the last part should use the `prog.alt`. Why? Try it and find
+out! Can you figure out why this works this way?
 
 
 ## Judges' remarks:

--- a/2020/ferguson2/prog.alt.c
+++ b/2020/ferguson2/prog.alt.c
@@ -1,0 +1,61 @@
+%:include					    <stdio.h>
+%:include					    <ctype.h>
+%:include					   <string.h>
+%:include					   <stdlib.h>
+%:include					   <unistd.h>
+%:define J(x)		  do(*x)=getchar(); while((*x)=='\n')
+
+%:define A(y)				  *(&Y<:7:><:1:>+(y))
+%:define D					      strchr(
+%:define q(s,x)					D(s),(x))-(s)
+
+%:define n					      isalpha
+%:define V(k)				    E = q(Y<:8:>,(k))
+%:define K				      fprintf(stderr,
+%:define l(c)				     (c)=toupper((c))
+%:define W(a,b)			 (a)<:(q((a),(b)) + 1) % 26:>
+%:define O(a)		      k = Y<:8:><:(E - (a) + 26)%26:>
+%:define d(a,b)                           v=(a)<:(E+(b))%26:>
+char*M,*R<:3:>,Y<:20:><:27:>=<% "EKMFLGDQVZNTOWYHXUSPAIBRCJ",
+"AJDKSIRUXBLHWTMCQGZNPYFVOE"  , "BDFHJLCPRTXVZNYEIWGAKMUSQO",
+"ESOVPZJAYQUIRHXLNFTGKDCMWB"  , "VZBRGITYUPSDNHLXAWMJQOFECK",
+"YRUHQSLDPXNGOKMIEBFZCWVJAT"  , "FVPJIAOYEDRZXWGCTKUQSBNMHL",
+"ABBBCCQEVJZ","ABCDEFGHIJKLMNOPQRSTUVWXYZ", "Mjqq", "Lcxvago"
+,"Huwfnbgt","Hdoqhmket fbvy","Mcromlhxo"} ,*S,*r; int *z=(int
+<:13:>){ 0} ,*e,*g,*P; size_t L; char Z(char x){ for(*g=0; *g
+<10;++*g) {r<:-2:>=Y<:14:><:*(e+1):>; r<:-3:>=Y<:15:><:1<:e:>
+:>; if(r<:-3:> && r<:-2:> == r<:-1:>)return r<:-3:>; if (r<:-
+2:>&&r<:-3:>==r<:-1:>)return r<:-2:>; }return x; } void  w  (
+char *s, int k, int v) {  for(e<:2:> = 0; s<:*P:>; ++e<:2:>){
+v = s<:e<:2:>:>; if(v > 64 && v < 91) s<:e<:2:>:> = (((v - 65
++k) % 26) + 65); } } void Q(void) { for(*g = 0; *g < 3; ++*g)
+{ *Y<:16+e<:1:>:>=S<:e<:e<:1:>-3:>:>;R<:e<:1:>:>=Y<:e<:-3+e<:
+1:>:>:>; w(R[*g],*(e+e<:1:>-6)=q(Y<:8:>,*Y<:7:>),*g); } }void
+m(char*x){ char*p=x,a=A(0),b=A(2),c=A(4); int f,E; for( ; *p;
+++p) { int u = islower(*p); if(n(l(*p))){char k=*p, v; f = 0;
+c == *Y<:18:> && (f = 1) ; c=W(Y<:8:>,c); if (f) {f = 0; b ==
+*Y<:17:> && (f = 1); b = W(Y<:8:>,b); f &&(f = 0 && (a= W(Y<:
+8:>,a))); }else if(b==*Y<:17:>){ b = W(Y<:8:>,b); a= W(Y<:8:>
+,a); } k = Z(r<:-1:> =k); e<:-6:> = q (Y<:8:>,a); e<:-5:> = q
+(Y<:8:>,b); e<:-4:>=q( Y<:8:>,c); V(k); d(R<:2:>,e<:-4:>); V(
+v); O(e<:-4:>); V(k); d(R<:1:>,e<:-5:>); V(v); O(e<:-5:>); V(
+k); d(*R,e<:-6:>); V(v) ; O(e<:-6:>);(Y<:e<:-10:>+ 5:><:k-'A'
+:>)&&(k=Y<:e<:-10:>+5:><:k-'A':>); V(k); d(Y<:8:>,e<:-6:>); E
+=q(*R,v); O(e<:-6:>); V(k); d(Y<:8:>,e<:-5:>); E= q (R<:1:>,v
+); O(e<:-5:>); V(k); d(Y <:8:>,e<:-4:>); E = q(R<:2:>,v); O(e
+<:-4:>); k = Z(r<:-1:>=k); *p = u? tolower(k):k; } } } void E
+(char*x, int s, int i){ if (n(l(s))) x<:i:>=s; } int p(char x
+) {return D 14<:Y:>,x)||D Y<:15:>,x); }int main(int i, char**
+v) { int j; e = z + 10; S = Y<:7:> + 6; r = S + 10 ; g = e +1
+; P=g+1; for (j=-3; j < 0; ++j) e<:j:> = j+3; Q(); for (j +=9
+; j < 14; ++j) m(Y<:j:>); if (!(v<:1:> && *v<:1:>=='-')) goto
+k; for (i = 0; i < 3; ++i) { K"%s %d: ",Y<:9:>, i+1); J(&j) ;
+j = j - '0'; e<:i-3:>=(j <1 ?  1 : (j>5?5:j))-1; K"%s %d: ",Y
+<:10:>,i+1); J(&j); E(Y<:7:>, j, i+i%3); K"%s %d: ",Y<:11:>,i
++1); J(&j); E(Y<:7:>, j,i+i+1); }K"%s: ",Y<:13:>); J(&j); e<:
+-10:> = (j < 1 ? 1:(j>1?2:j))-1; for (i = 0; i<10; ++i) { int
+a, b; K"%s %d: " , Y<:12:>,i+1); J(&a); J (&b);if  (n(l(a))&&
+n(l(b))&&a!=b&&!p(b)&&!p(a)) { Y<:14:><:i:> = a; 15<:Y:><:i:>
+= b; } %>k: Q(); if(getdelim(&M, &L, EOF, stdin) > 0) <%m(M);
+for(int i=0;i[M];putchar(i[M]),fflush(stdout),usleep(0<h?h:4\
+00000), ++i); free	(M)        ;}%>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3147,12 +3147,13 @@ Curiously, although clang requires the types of args to be strictly correct,
 some versions do allow only one arg. This was done at first because it's not
 used but Cody discovered that later versions of clang have an additional defect
 where it does not allow only one arg so the second arg to `main()` was added
-back. This was an unfortunate problem for the alt code as he has been using Z
-for alt code `usleep()` (for sleep) but
-in this case unfortunately the original entry used `Z` in `main()` (though
-unused) so to make it more like the original Cody renamed the macro `Z` for
-`usleep()` to `S` instead which can stand for sleep and also it is kind of like
-a backwards `Z`. That way `Z` could be in `main()`.
+back.
+
+This was an unfortunate problem for the alt code as he has been using Z for alt
+code `usleep()` (for sleep) but in this case unfortunately the original entry
+used `Z` in `main()` (though unused) so to make it more like the original Cody
+renamed the macro `Z` for `usleep()` to `S` instead which can stand for sleep
+and also it is kind of like a backwards `Z`. That way `Z` could be in `main()`.
 
 Cody also made sure that the Makefile links in `libm` as not all systems do this
 by default.
@@ -3795,9 +3796,24 @@ output.
 # <a name="2015"></a>2015
 
 
+## <a name="2015_dogon"></a>[2015/endoh3](/2015/dogon/prog.c) ([README.md](/2015/dogon/README.md]))
+
+[Cody](#cody) improved the Makefile so that one can easily change the dimensions
+at compilation time via `make(1)`.
+
+Cody also added alt code that is based on the author's remarks, suggesting that
+one change the value of `q` to a different number, in order to see a bug that
+they avoided.
+
+
 ## <a name="2015_duble"></a>[2015/endoh3](/2015/duble/prog.c) ([README.md](/2015/duble/README.md]))
 
 [Cody](#cody) added the [try.sh](/2015/duble/try.sh) script.
+
+
+## <a name="2015_endoh2"></a>[2015/endoh2](/2015/endoh2/prog.c) ([README.md](/2015/endoh2/README.md]))
+
+[Cody](#cody) added the [try.sh](2015/endoh2/try.sh) script.
 
 
 ## <a name="2015_endoh3"></a>[2015/endoh3](/2015/endoh3/prog.c) ([README.md](/2015/endoh3/README.md]))
@@ -3806,9 +3822,16 @@ output.
 symbols of `main()`. The fix is through the compiler option `-fcommon` which
 will let it compile like it does with macOS.
 
-Cody also made it easier to enjoy the theme of [Back to the
+Cody also added the [try.sh](/2015/endoh3/try.sh) script which makes use of the
+make rule he added (to enjoy the theme of the entry, [Back to the
 Future](https://en.wikipedia.org/wiki/Back_to_the_Future) using this entry by
-simply typing `make back_to` or `make mullender`.
+simply typing `make back_to` or `make mullender`) and then runs the famous
+[1984/mullender.c](/1984/mullender/mullender.c).
+
+
+## <a name="2015_endoh4"></a>[2015/endoh4](/2015/endoh4/prog.c) ([README.md](/2015/endoh4/README.md]))
+
+[Cody](#cody) added the [try.sh](/2015/endoh4/try.sh) script.
 
 
 ## <a name="2015_hou"></a>[2015/hou](/2015/hou/prog.c) ([README.md](/2015/hou/README.md))
@@ -3816,18 +3839,21 @@ simply typing `make back_to` or `make mullender`.
 [Cody](#cody) added explicit linking of libm (`-lm`) for systems that do not do this
 (Linux doesn't seem to but macOS does).
 
+Cody also added the [try.sh](/2015/hou/try.sh) script and the large file `large`
+which the `try.sh` script uses.
+
+Cody also added the RFC 1321 text file, [rfc1321.txt](/2015/hou/rfc1321.txt) to
+the directory, to make it so one need not download it, and which the README.md
+file now links to.
+
 
 ## <a name="2015_howe"></a>[2015/howe](/2015/howe/prog.c) ([README.md](/2015/howe/README.md))
 
-[Cody](#cody) added the [try.sh](2015/howe/try.sh) script, downloaded the War
-and Peace text file, fixed the [avgtime.sh](2015/howe/avgtime.sh) script (it
+[Cody](#cody) added the [try.sh](/2015/howe/try.sh) script, downloaded the War
+and Peace text file, fixed the [avgtime.sh](/2015/howe/avgtime.sh) script (it
 resulted in standard input errors in piping to `bc(1)`) and added the
-[cc.1](2015/howe/cc.1) man page as not all systems have it (in fact it's
+[cc.1](/2015/howe/cc.1) man page as not all systems have it (in fact it's
 `gcc(1)` from Rocky Linux).
-
-Cody also added the RFC 1321 text file, [rfc1321.txt](2015/hou/rfc1321.txt) to
-the directory, to make it so one need not download it, and which the README.md
-file now links to.
 
 
 ## <a name="2015_mills1"></a>[2015/mills1](/2015/mills1/prog.c) ([README.md](/2015/mills1/README.md))


### PR DESCRIPTION

This alt code prints out the text one character at a time to make it
easier to read and more generally so it's not dumped out at once. This
also makes it a bit more like the original thing (at least as I recall
it :-) ).

The default sleep time is 400000 microseconds but one can change it
like:

    make clobber SLEEP=0 alt

which would disable the delay, making it like the original.

If it's < 0 then it's set to the default.

I did not yet add a try.sh script. That'll likely come later when 
working on 2020. I only did this now as I thought of this idea and 
didn't want to forget it.
