### PR TITLE
Improve how to redefine macros in 2012/endoh1 alt

### DIFF
--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -57,7 +57,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -DG="$G" -DP="$P" -DV="$V" -DS=12321 -DA=10
+CDEFINE= -DG="${GRAVITY}" -DP="${PRESSURE}" -DV="${VISCOSITY}"
 
 # Include files that are needed to compile
 #
@@ -120,15 +120,15 @@ ALT_TARGET= ${PROG}.alt ${PROG}_color.alt
 
 # The factor of gravity
 #
-G=1
+GRAVITY=1
 
 # The factor of pressure
 #
-P=4
+PRESSURE=4
 
 # The factor of viscosity
 #
-V=8
+VISCOSITY=8
 
 
 #################
@@ -154,13 +154,18 @@ ${PROG}_color: ${PROG}_color.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
+# Variables that control the alarm(3) timer and how much to sleep for alt code
+#
+TIMER= 10
+SLEEP= 12321
+
 ${PROG}.alt: ${PROG}.alt.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -DS=${SLEEP} -DA=${TIMER} $< -o $@ ${LDFLAGS}
 
 # this does NOT correspond to endoh1.alt2.c but rather endoh1.alt.c: it is NOT
 # deobfuscated.
 ${PROG}_color.alt: ${PROG}_color.alt.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -DS=${SLEEP} -DA=${TIMER} $< -o $@ ${LDFLAGS}
 
 alt2: ${PROG}.alt2
 	@${TRUE}

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -59,7 +59,7 @@ for fun. That is controlled by the variable `A`; 0 disables it.
 If you wish to change the speed you should do:
 
 ```sh
-make clobber CDEFINE="-DS=N" alt
+make clobber SLEEP=N alt
 ```
 
 where `N` is number or the letter `I`.
@@ -75,7 +75,7 @@ you wish to change the viscosity and pressure factors but leave the other macros
 alone:
 
 ```sh
-make clobber CDEFINE="-DV=X -DP=Y" alt
+make clobber VISCOSITY=X PRESSURE=Y alt
 ```
 
 where `X` and `Y` are numbers or the letter `I` and which are, respectively, the
@@ -88,7 +88,7 @@ it from being done.
 If you want to disable the alarm time, set `A` to 0:
 
 ```sh
-make clobber CDEFINE="-DA=0" alt
+make clobber TIMER=0 alt
 ```
 
 It cannot be < 0 or > 60 (arbitrarily selected).
@@ -97,7 +97,7 @@ Try slowing down the display by increasing the sleep time from `12321` to
 `50000`:
 
 ```sh
-make clobber CDEFINE="-DS=50000" alt
+make clobber SLEEP=50000 alt
 ```
 
 Now try using both `endoh1.alt` and `endoh1_color.alt` as you would `endoh1` above.
@@ -106,7 +106,7 @@ Also try speeding up the display by decreasing the sleep time from `12321` to
 `9999`:
 
 ```sh
-make clobber CDEFINE="-DS=9999" alt2
+make clobber SLEEP=9999 alt2
 ```
 
 WARNING: again, be careful with too low a value if you're sensitive to flashing
@@ -119,13 +119,13 @@ instance:
 
 
 ```sh
-make clobber CDEFINE="-DG=5 -DP=5 -DV=5" alt
+make clobber GRAVITY=5 PRESSURE=5 VISCOSITY=5 alt
 ```
 
 You might try even:
 
 ```sh
-make clobber CDEFINE="-DG=I" alt
+make clobber GRAVITY=I alt
 ```
 
 See the author's remarks for details on these macros.

--- a/2012/endoh1/try.alt.sh
+++ b/2012/endoh1/try.alt.sh
@@ -13,11 +13,11 @@ fi
 
 # unlike other try.sh/try.alt.sh scripts this one has two compiled binaries: one
 # which sets the gravity factor to I and the other that does not.
-make clobber CC="$CC" CDEFINE="-DA=10 -DG=I -DS=39000" alt >/dev/null || exit 1
+make clobber CC="$CC" TIMER=10 GRAVITY=I SLEEP=39000 alt >/dev/null || exit 1
 # we have to move the endoh1_color.alt to endoh1_color.alt3, not alt2, because
 # we have to use make clobber which would wipe out endoh1_color.alt2.
 mv endoh1_color.alt endoh1_color.alt3
-make clobber CC="$CC" CDEFINE="-DA=10 -DS=39000" alt >/dev/null || exit 1
+make clobber CC="$CC" TIMER=10 SLEEP=39000 alt >/dev/null || exit 1
 read -r -n 1 -p "Press any key run run slower fluid on endoh1_color.alt.c: "
 mv endoh1_color.alt3 endoh1_color.alt2
 # clear screen before continuing

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -57,7 +57,7 @@ ARCH=
 
 # Defines that are needed to compile
 #
-CDEFINE= -DZ=15000
+CDEFINE=
 
 # Include files that are needed to compile
 #
@@ -139,12 +139,17 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
-${PROG}.alt: ${PROG}.alt.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+# Variable to control how to redefine sleep time in alt code
+#
+SLEEP= 15000
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} -DZ=${SLEEP} $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/2013/birken/README.md
+++ b/2013/birken/README.md
@@ -40,7 +40,7 @@ compile time. If you wish to speed it up by 100% you can instead do:
 
 
 ```sh
-make clobber CDEFINE=-DZ=7500 alt
+make clobber SLEEP=7500 alt
 ```
 
 and then try `birken.alt` as above.

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -139,6 +139,14 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
+# Variables to control port and timing constant in alt code
+#
+PORT= 1701
+TIME= 500000
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} -DNCC=${PORT} -DSTARDATE=${TIME} $< -o $@ ${LDFLAGS}
+
 # data files
 #
 data: ${DATA}

--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -56,13 +56,13 @@ described by the author. See [configuration](#configuration) below.
 To specify the port to say, 31337, try:
 
 ```sh
-make clobber CDEFINE="-DNCC=31337" alt
+make clobber PORT=31337 alt
 ```
 
-To change the `STARDATE` timing constant, try:
+To change the timing constant, `STARDATE`, try:
 
 ```sh
-make clobber CDEFINE="-DSTARDATE=5000000" alt
+make clobber TIME=5000000 alt
 ```
 
 You can combine them both of course.

--- a/2018/poikola/README.md
+++ b/2018/poikola/README.md
@@ -14,10 +14,11 @@ make
 
 ### Try:
 
-On terminal supports 24 bit color, has black background, and size at least 125x38, try:
+On a terminal that supports 24 bit color, has black background, and size at
+least 125x38, try:
 
 ```sh
-./prog
+./try.sh
 ```
 
 
@@ -54,16 +55,17 @@ make
 You can generate an A3 sized poster by _make docs_. This command creates a pdf
 file _poikola.pdf_.
 
-### What this entry does:
 
-#### Introduction:
+### Introduction:
+
 It was a starry night when my wife pointed her finger up and asked: "What is
 this star and may I have some Easter eggs?"
 
 So I had to sit down and solve those tricky questions with Nano and a C
 compiler.
 
-#### Little spoilers:
+
+### Little spoilers:
 
 Basically, the program draws animated ASCII art of the Big Dipper using Annie
 Jump Cannon's spectral classification system of stars and I think the colors of
@@ -74,7 +76,9 @@ some Easter eggs.
 
 The program has also at least three other functions, obvious and not so obvious.
 
-#### Technical jargon
+
+### Technical jargon
+
 This program has been tested on xterm and Konsole and also Linux virtual
 terminal. Color support in the terminal is not necessary, but the effect is
 better with it.
@@ -83,12 +87,14 @@ This entry has partial support for terminals with a white background but the
 best viewing experience is achieved when the terminal in use supports 24-bit
 colors, has a black background and the size is at least 125x38.
 
-Special note for Mac users: __Terminal__ does not work as expected; you might
-need xterm from XQuartz or some other working terminal. Thanks to [Dave
-Burton](/winners.html#Dave_Burton) for spotting this problem.
+Special note for Mac users: `Terminal.app` does not work as expected; you might
+need xterm from XQuartz (see [FAQ 3.7: How do I compile and use on macOS, an
+IOCCC winner that requires X11?](/faq.md#X11macos)) or some other working
+terminal. Thanks to [Dave Burton](/winners.html#Dave_Burton) for spotting this
+problem.
 
-The main reason for the header `unistd.h` is `getdelim()` but once I included it
-I also abused other functions and defines. This header is mutually exclusive
+The main reason for the header `unistd.h` is `getdelim(3)` but once I included it
+I also abused other functions and `#define`s. This header is mutually exclusive
 with _-std=c11_.
 
 The program was developed with little-endian machines; I tried to support
@@ -102,21 +108,32 @@ This program has been compiled with:
 4. Lego Mindstorms EV3 Intelligent Brick (Debian Jessie) with gcc and clang (in
 this case, compiling time with clang-3.5 12 seconds and with gcc 27 seconds)
 
+
+### Extra notes from the judges on the macOS Terminal.app problems:
+
+Depending on the settings of the terminal in Terminal.app the program might not
+show anything at all. In other cases it won't show all the colours right but
+mostly is okay. YMMV, as they say.
+
+
 ### Warnings and restrictions required by law:
+
 Please do not feed little babies chocolate.
 
-### Major spoilers:
-<div style="margin-bottom:61em;">&nbsp;</div>
 
-I incorporated the Fletcher 16 checksum algorithm into the source for security
-reasons; it might be challenging to make changes without breaking the main
-functionality of the code.
+### Major spoilers:
+
+I incorporated the [Fletcher 16 checksum
+algorithm](https://en.wikipedia.org/wiki/Fletcher%27s_checksum) into the source
+for security reasons; it might be challenging to make changes without breaking
+the main functionality of the code.
 
 The space after `#define p return` is necessary.
 
 The computus (method to determine the date of Easter) uses an algorithm
 described in the journal Nature in 1876. It should be valid for Gregorian
 calendars.
+
 
 ### Some obfuscation techniques used:
 
@@ -144,10 +161,22 @@ questions:
 ### Rot18 part
 
 Because the rot13 is too easy to decode with the plain eyes, I decided to use
-the Caesar cipher with the key 18.
+the [Caesar cipher](https://en.wikipedia.org/wiki/Caesar_cipher) with the key
+18:
 
     Lzw xajkl tsffwj ak wfugvwv mkafy AWWW 754 xdgslk gf dafw 47. Al ak hjaflwv
     gfdq gf dalldw-wfvasf esuzafwk.
+
+If you want to or must know and don't know how to decipher this, you might look
+at the [Caesar cipher decoder](https://www.dcode.fr/caesar-cipher). Find the
+text that says:
+
+```
+Manual decryption and parameters
+Shift/Key (number)
+```
+
+and enter 18 and then click the button that says: `DECRYPT (BRUTEFORCE)`.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2018/poikola/try.sh
+++ b/2018/poikola/try.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2018/poikola
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+clear
+read -r -n 1 -p "Press any key to show code (space = next page, q = quit): "
+echo 1>&2
+less -EXF prog.c
+read -r -n 1 -p "Press any key to run program: "
+echo 1>&2
+./prog

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4037,7 +4037,15 @@ supposed to segfault :-)
 
 ## <a name="2019_poikola"></a>[2019/poikola](/2019/poikola/prog.c) ([README.md[(/2019/poikola/README.md))
 
-[Cody](#cody) added a missing rule to the Makefile.
+[Cody](#cody) added the `docs` rule to the Makefile that forms a PDF file. The
+rule requires the tool `pdflatex`.
+
+Cody also added the [try.sh](/2019/poikola/try.sh) script.
+
+[Dave Burton](/winners.html#Dave_Burton), during the preview period, noticed a
+problem where the macOS `Terminal.app` does not work properly for this program.
+We added some additional notes on what might happen (it varies depending on
+configuration).
 
 
 ## <a name="2019_karns"></a>[2019/karns](/2019/karns/prog.c) ([README.md](/2019/karns/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3677,7 +3677,8 @@ code](/2014/birken/README.md#alternate-code) that lets one redefine the port to
 bind to in case there is a firewall issue or there is some other reason to not
 have the default port. Remember that ports < 1024 are privileged. It also lets
 you redefine the timing constant `STARDATE` (see the author's remarks for more
-details).
+details on this macro). The Makefile was made to use variables so it's easier to
+redefine the port and timing constant.
 
 
 ## <a name="2014_deak"></a>[2014/deak](/2014/deak/prog.c) ([README.md](/2014/deak/README.md))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3491,11 +3491,13 @@ pairs though that should be obvious) and also some that are correct including
 system("reset");` (via redefining `exit(3)` so that the column ending would be
 the same) so that as long as it runs to completion the terminal will be sane and
 the cursor will be visible. Using `atexit(3)` will not work if the program is
-killed and signals are ugly so this was not done.
+killed, signals are ugly and these would be messing with the entry too much so
+these were not done.
 
 Cody also added the alt version that lets one control how fast the painting is
 done, based on the author's recommendations, except that Cody made it
-configurable at compile time.
+configurable at compile time. The Makefile was modified in such a way as to make
+it very easy to redefine them at compile time.
 
 Cody also added the [try.sh](/2013/birken/try.sh) script for the entry and the
 [try.alt.sh](/2013/birken/try.alt.sh) script for the alt code.

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3359,13 +3359,16 @@ Cody also added two [alt versions](/2012/endoh1/README.md#alternate-code) that
 let one control how fast the fluid moves (how long to sleep in between writes)
 and also the gravity factor, the pressure factor and the viscosity factor as
 well as an alarm that lets one run it in a loop without having to hit
-ctrl-c/intr in between (the alarm can be disabled, however). The two different
-versions is because there are two versions: the original and the colour version
-added by the author, [Yusuke](#yusuke), at the request of the judges.
+ctrl-c/intr in between (the alarm can be disabled, however). The Makefile allows
+one to easily do this with variable names rather than redefining `CDEFINE`.
 
-Cody also added the [try.alt.sh](/2012/endoh1/try.alt.sh) script compiles the alt
-code in two ways, one with setting the gravity factor to `I` and another with
-the default, and which is run on the source file and each of the text files
+The two different alt versions is because there are two versions: the original
+and the colour version added by the author, [Yusuke](#yusuke), at the request of
+the judges.
+
+Cody also added the [try.alt.sh](/2012/endoh1/try.alt.sh) script that compiles
+the alt code in two ways, one with setting the gravity factor to `I` and another
+with the default, and which is run on the source file and each of the text files
 supplied by the author. This code has an alarm set at 10 seconds so that one
 need not hit ctrl-c/intr in between .. say to make it more fluid :-)
 


### PR DESCRIPTION

Now one can use variables SLEEP, TIMER, GRAVITY, PRESSURE and VISCOSITY,
rather than single letter variables. This is like other commits where
instead of having to redefine CDEFINE one can do something like

    make clobber SLEEP=50 GRAVITY=I TIMER=15 alt

Notice that some can be set to I rather than a number. See the author's
remarks for details.

The try.alt.sh script was updated for this improvement.