### PR TITLE
Add helper scripts to 2018/endoh2 + formatting

### DIFF
--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -148,22 +148,11 @@ alt: data ${ALT_TARGET}
 data: ${DATA}
 	@${TRUE}
 
-python: ${PROG}
-	${RM} -f ${PROG}_next.c
-	${CC} ${CFLAGS} ${PROG}.c -o ${PROG} ${LDFLAGS}
-	while :; do \
-	    ./${PROG} | tee ${PROG}_next.c; \
-	    ${CC} ${CFLAGS} ${PROG}_next.c -o ./${PROG} ${LDFLAGS}; \
-	    sleep 1; \
-	done
+python: 
+	./python.sh
 
-python3: ${PROG}
-	${RM} -f ${PROG}_next.c
-	${CC} ${CFLAGS} ${PROG}.c -o ${PROG} ${LDFLAGS}
-	while :; do \
-	    ./${PROG} | tee ${PROG}_next.c; \
-	    ${CC} ${CFLAGS} ${PROG}_next.c -o ./${PROG} ${LDFLAGS}; \
-	done
+python3:
+	./python3.sh
 
 # both all and alt
 #

--- a/2018/endoh2/README.md
+++ b/2018/endoh2/README.md
@@ -15,18 +15,10 @@ make
 ### Try:
 
 ```sh
-./prog | tee prog_next.c
-make prog_next
-./prog_next | tee prog_next.c
-make prog_next
-./prog_next | tee prog_next.c
-
-make python
-
-make python3
+./try.sh
 ```
 
-NOTE: to interrupt the loop send intr (typically ctrl-C).
+NOTE: to interrupt the loops send intr (typically ctrl-C).
 
 
 ## Judges' remarks:
@@ -41,31 +33,30 @@ This is an EX-tremely obfuscated program!
 
 A high-context work that combines parrots that new hackers like and parrots that
 old hackers like. One is an internet meme called [Party
-Parrot](https://cultofthepartyparrot.com). The other is a
-sketch (comte) called ["Dead
+Parrot](https://cultofthepartyparrot.com) (WARNING: has flashing lights). The other is a
+sketch [comté](https://en.wikipedia.org/wiki/Comté_cheese) called ["Dead
 Parrot"](https://en.wikipedia.org/wiki/Dead_Parrot_sketch) from the British
-comedy TV show ["Monty Python's Flying Circus"](https://en.wikipedia.org/wiki/Monty_Python%27s_Flying_Circus)
+sitcom ["Monty Python's Flying Circus"](https://en.wikipedia.org/wiki/Monty_Python%27s_Flying_Circus)
 The "_Python_" in the award name refers to Monty Python, **not** the
-[programming language Python (the name of the programming language Python is
-derived from Monty
-Python)](https://en.wikipedia.org/wiki/Python_(programming_language).
+[programming language Python](https://en.wikipedia.org/wiki/Python_(programming_language)
+(the name of the programming language Python is derived from Monty Python).
 
-
-The shape of prog.c is "Undead Parrot" based on "dead parrot". The message that
-appears in the bottom line of the output source code is the subject of the
-dialogue that appears in "Dead Parrot" and explains in various expressions that
-the parrot died. Also, the second **__<-_Source_of_Parrots__** line from the bottom
-<http://cultofthepartyparrot.com/> has a hidden URL (hidden by the parrot's body).
+The shape of [prog.c](prog.c) is "Undead Parrot" based on "dead parrot". The
+message that appears in the bottom line of the output source code is the subject
+of the dialogue that appears in "Dead Parrot" and explains in various
+expressions that the parrot died. Also, the second **__<-_Source_of_Parrots__**
+line from the bottom of <http://cultofthepartyparrot.com/> (WARNING: has
+flashing lights) has a hidden URL (hidden by the parrot's body).
 
 Although it is a boring Quine story, it is quite difficult to have 10 parrot
 pictures and 10 lines of data. Only the outline data of the parrot picture is
 saved, and the body is filled in at runtime. These data are probably compressed
 with [byte pair encoding](https://en.wikipedia.org/wiki/Byte_pair_encoding).
 
-The parrot ASCII art below is the opening line of the Monty Python show. The judge's
-comment ["And now for something completely
-different"](https://en.wikipedia.org/wiki/And_Now_for_Something_Completely_Different) is also used in the
-opening.
+The parrot ASCII art below is the opening line of the Monty Python show. The
+judge's comment ["And now for something completely
+different"](https://en.wikipedia.org/wiki/And_Now_for_Something_Completely_Different)
+is also used in the opening.
 
 ```
                              ___-----__

--- a/2018/endoh2/python.sh
+++ b/2018/endoh2/python.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# python.sh - make python rule script of 2018/endoh2 so one can use this in
+# other scripts, allowing one to interrupt it but continue to the next script
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+CFLAGS="-Wno-strict-prototypes"
+LDFLAGS=
+
+# set up trap so one can go on to next script after interrupting this one in
+# case this script is being run from another
+EXIT=0
+trap 'EXIT=1' INT
+
+rm -f prog_next.c prog_next
+${CC} "${CFLAGS}" prog.c -o prog "${LDFLAGS}"
+while [[ "$EXIT" != 1 ]]; do
+    ./prog | tee prog_next.c;
+    cc prog_next.c -o ./prog "$CFLAGS" "$LDFLAGS"
+    sleep 1;
+done
+exit 0

--- a/2018/endoh2/python3.sh
+++ b/2018/endoh2/python3.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# python3.sh - make python3 rule script of 2018/endoh2 so one can use this in
+# other scripts, allowing one to interrupt it but continue to the next script
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+CFLAGS="-Wno-strict-prototypes"
+LDFLAGS=
+
+# set up trap so one can go on to next script after interrupting this one in
+# case this script is being run from another
+EXIT=0
+trap 'EXIT=1' INT
+
+rm -f prog_next.c prog_next
+${CC} "${CFLAGS}" prog.c -o prog "${LDFLAGS}"
+while [[ "$EXIT" != 1 ]]; do
+    ./prog | tee prog_next.c;
+    cc prog_next.c -o ./prog "$CFLAGS" "$LDFLAGS"
+done
+exit 0

--- a/2018/endoh2/run.sh
+++ b/2018/endoh2/run.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# Do the compile and run loop for 10 seconds
+#
+# run.sh - run 2018/endoh2 in a loop for 20 seconds
 
-transient_parrot=$(tempfile -s .c)
-cp prog.c "$transient_parrot"
+# set up trap so one can continue to next script if run from another script
+EXIT=0
+trap 'EXIT=1; rm -f prog_next.c prog_next' INT
 
-stop_dancing_deadline=$(($(date +"%s")+10))
-while [[ $(date +"%s") -lt "$stop_dancing_deadline" ]]; do
-  gcc "$transient_parrot" -o ./prog && ./prog | tee "$transient_parrot"
-  sleep 0.01
+transient_parrot=prog_next.c
+./prog | tee "$transient_parrot"
+
+stop_dancing_deadline=$(($(date +"%s")+20))
+while [[ $(date +"%s") -lt "$stop_dancing_deadline" && "$EXIT" != 1 ]]; do
+  cc "$transient_parrot" -o ./prog && ./prog | tee "$transient_parrot"
+  sleep 1 
 done
-
-rm -f "$transient_parrot"

--- a/2018/endoh2/try.sh
+++ b/2018/endoh2/try.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2018/endoh2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to continue (ctrl-c/intr = skip to next early, runs 20 seconds): "
+echo 1>&2
+./run.sh
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run a few times (ctrl-c/intr exits script): "
+echo 1>&2
+./prog | tee prog_next.c
+make prog_next
+./prog_next | tee prog_next.c
+make prog_next
+./prog_next | tee prog_next.c
+
+read -r -n 1 -p "Press any key to sleep 1 sec between runs (intr/ctrl-c to exit): "
+echo 1>&2
+./python.sh
+echo 1>&2
+
+read -r -n 1 -p "Press any key run without sleeping (intr/ctrl-c to exit): "
+echo 1>&2
+./python3.sh
+
+exit 0

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3968,9 +3968,10 @@ work for Windows, based on the author's remarks.
 Internet Wayback Machine.
 
 
+
 ## <a name="2018_endoh2"></a>[2018/endoh2](/2018/endoh2/prog.c) ([README.md](/2018/endoh2/README.md))
 
-Cody fixed the [run.sh](/2018/endoh2/run.sh) script (had commands that didn't
+[Cody](#cody) fixed the [run.sh](/2018/endoh2/run.sh) script (had commands that didn't
 exist and also didn't work even after that was addressed) and added the
 [try.sh](/2018/endoh2/try.sh), [python.sh](/2018/endoh2/python.sh) and
 [python3.sh](/2018/endoh2/python3.sh) scripts. The `try.sh` script runs all

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3968,6 +3968,18 @@ work for Windows, based on the author's remarks.
 Internet Wayback Machine.
 
 
+## <a name="2018_endoh2"></a>[2018/endoh2](/2018/endoh2/prog.c) ([README.md](/2018/endoh2/README.md))
+
+Cody fixed the [run.sh](/2018/endoh2/run.sh) script (had commands that didn't
+exist and also didn't work even after that was addressed) and added the
+[try.sh](/2018/endoh2/try.sh), [python.sh](/2018/endoh2/python.sh) and
+[python3.sh](/2018/endoh2/python3.sh) scripts. The `try.sh` script runs all
+three of the other scripts but each allows one to send an interrupt in the loops
+and still continue to the next script (if one does it when not in a loop it will
+exit the script). The `make python` and `make python3` rules in the Makefile now
+run the respective scripts.
+
+
 ## <a name="2018_ferguson"></a>[2018/ferguson](/2018/ferguson/prog.c) ([README.md](/2018/ferguson/README.md))
 
 [Cody](#cody), with irony well intended :-), fixed the [test.sh


### PR DESCRIPTION
The run.sh script was fixed to work. It did not work because it had a command that does not even exist ('tempfile') and even after that was resolved there was another problem to be resolved.

The Makefile rule make python runs the python.sh script but it sets a trap so one can exit that script but not exit everything (see below). The python3.sh script is what python.sh is but for the make rule python3 and it works in the same way. The try.sh script runs all of these scripts as well as the commands suggested by the judges.

The README.md file has been format/typo checked. For the link (twice referenced) that has flashing lights (and quite a few at that) I put a warning in parentheses for those who are (like me) sensitive to it (more important for some people with epilepsy, depending on how sensitive they are, maybe, but I hate flashing text and lights and so do many other people).