### PR TITLE
Fix number of args in main() in 2018/bellard

### DIFF
--- a/2018/bellard/prog.alt.c
+++ b/2018/bellard/prog.alt.c
@@ -111,7 +111,7 @@ o[C?j*f+a:a*f+j]+=*i*(8-J)+i[1]*J+4>>3;
 K(b){
 putchar(b<0?0:b>255?255:b);
 }
-main(D){
+main(D,char**V){
 int a,l,L,M,g,N;
 _setmode(0, 32768); _setmode(1, 32768);
 s=D>1?256:1968;

--- a/2018/bellard/prog.c
+++ b/2018/bellard/prog.c
@@ -109,7 +109,7 @@ o[C?j*f+a:a*f+j]+=*i*(8-J)+i[1]*J+4>>3;
 K(b){
 putchar(b<0?0:b>255?255:b);
 }
-main(D){
+main(int D,char**V){
 int a,l,L,M,g,N;
 s=D>1?256:1968;
 Q();

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3965,11 +3965,19 @@ He also added the [try.sh](/2015/yang/try.sh) script.
 
 ## <a name="2018_bellard"></a>[2018/bellard](/2018/bellard/prog.c) ([README.md](/2018/bellard/README.md))
 
-[Cody](#cody) added explicit linking of libm (`-lm`) for systems that do not do this
+[Cody](#cody), out of abundance of caution, added a second arg to `main()`
+because some versions of clang object to the number of args of `main()`, saying
+that it must be 0, 2 or 3. The version this has been observed in does not
+actually object to 1 arg but it is entirely possible that this changes so a
+second arg (that's not needed and is unused) has been added just in case.
+
+Cody also added explicit linking of libm (`-lm`) for systems that do not do this
 (Linux doesn't seem to but macOS does).
 
 Cody also added [alt code](/2018/bellard/README.md#alternate-code) that should
-work for Windows, based on the author's remarks.
+work for Windows, based on the author's remarks. The same thing with the number
+of args to `main()` that was done in the original entry was done with this
+version as well.
 
 
 ## <a name="2018_burton1"></a>[2018/burton1](/2018/burton1/prog.c) ([README.md](/2018/burton1/README.md))


### PR DESCRIPTION
Out of an abundance of caution with clang defects / the ANSI C Committee I have added a second arg to main() in case they decide to enforce the rule that main() has 0, 2, 3 args.