### PR TITLE
Improve 1984/mullender alt code

### DIFF
--- a/1984/mullender/.gitignore
+++ b/1984/mullender/.gitignore
@@ -8,6 +8,5 @@ indent.c
 indent.o
 mullender
 mullender.alt
-mullender.alt2
 mullender.orig
 prog.orig

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -112,8 +112,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ= ${PROG}.alt.o ${PROG}.alt2.o
-ALT_TARGET= ${PROG}.alt ${PROG}.alt2
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -26,16 +26,18 @@ For more detailed information see [1984 mullender in bugs.md](/bugs.md#1984-mull
 
 ```sh
 ./mullender.alt [microseconds]
-
-./mullender.alt2 [microseconds] # starts over after it times out
 ```
 
-The default microseconds is 10000 and it is also the lowest it can be as any
-lower doesn't work very well. This feature is so you can experiment with
-different speeds in between writes. It can be useful if your CPU is too slow or
-too fast (:-) ).
+Hit ctrl-c/intr to exit the program.
 
-The author stated that the original version also had a delay.
+The default microseconds is 190000 as this is approximately how long it slept in
+the original entry but it can be no lower than 5000 as any lower doesn't work
+very well. This feature is so you can experiment with different speeds in
+between writes. It can be useful if your CPU is too fast :-)
+
+The author stated that the original version also had a delay but the difference
+is it required one to hit enter for it to print another line; the alt code will
+start over once it times out or if one hits a key.
 
 Note that the microseconds is argc and it uses `atoi()` which does NOT check for
 overflow!
@@ -49,15 +51,11 @@ which is probably not as uncommon as you think :-).
 ```sh
 ./mullender.alt
 
-./mullender.alt 5000
+./mullender.alt 5000	# wait for 5000 microseconds and see what happens
 
-./mullender.alt 500
+./mullender.alt 20000	# wait for 20000 microseconds and see what happens
 
-./mullender.alt 20000
-
-./mullender.alt 100000
-
-./mullender.alt2 500	# wait for 500 microseconds and see what happens
+./mullender.alt 100000	# wait for 100000 microseconds and see what happens
 ```
 
 What happens if you hit enter after it reaches the end of the line? Why? What

--- a/1984/mullender/mullender.alt.c
+++ b/1984/mullender/mullender.alt.c
@@ -1,1 +1,1 @@
-main(i,v)char**v;{i=v[1]?atoi(v[1]):10000;i=i<500?500:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);}
+main(i,v)char**v;{j:i=v[1]?atoi(v[1]):190000;i=i<5000?5000:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);goto j;}

--- a/1984/mullender/mullender.alt2.c
+++ b/1984/mullender/mullender.alt2.c
@@ -1,1 +1,0 @@
-main(i,v)char**v;{j:i=v[1]?atoi(v[1]):10000;i=i<500?500:i;do write(1,"  :-)\b\b\b\b",9),usleep(i);while(--i);write(1,"\n",1);goto j;}

--- a/2018/bellard/prog.alt.c
+++ b/2018/bellard/prog.alt.c
@@ -111,7 +111,7 @@ o[C?j*f+a:a*f+j]+=*i*(8-J)+i[1]*J+4>>3;
 K(b){
 putchar(b<0?0:b>255?255:b);
 }
-main(D){
+main(D,char**V){
 int a,l,L,M,g,N;
 _setmode(0, 32768); _setmode(1, 32768);
 s=D>1?256:1968;

--- a/2018/bellard/prog.c
+++ b/2018/bellard/prog.c
@@ -109,7 +109,7 @@ o[C?j*f+a:a*f+j]+=*i*(8-J)+i[1]*J+4>>3;
 K(b){
 putchar(b<0?0:b>255?255:b);
 }
-main(D){
+main(int D,char**V){
 int a,l,L,M,g,N;
 s=D>1?256:1968;
 Q();

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3965,11 +3965,19 @@ He also added the [try.sh](/2015/yang/try.sh) script.
 
 ## <a name="2018_bellard"></a>[2018/bellard](/2018/bellard/prog.c) ([README.md](/2018/bellard/README.md))
 
-[Cody](#cody) added explicit linking of libm (`-lm`) for systems that do not do this
+[Cody](#cody), out of abundance of caution, added a second arg to `main()`
+because some versions of clang object to the number of args of `main()`, saying
+that it must be 0, 2 or 3. The version this has been observed in does not
+actually object to 1 arg but it is entirely possible that this changes so a
+second arg (that's not needed and is unused) has been added just in case.
+
+Cody also added explicit linking of libm (`-lm`) for systems that do not do this
 (Linux doesn't seem to but macOS does).
 
 Cody also added [alt code](/2018/bellard/README.md#alternate-code) that should
-work for Windows, based on the author's remarks.
+work for Windows, based on the author's remarks. The same thing with the number
+of args to `main()` that was done in the original entry was done with this
+version as well.
 
 
 ## <a name="2018_burton1"></a>[2018/burton1](/2018/burton1/prog.c) ([README.md](/2018/burton1/README.md))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -130,15 +130,15 @@ This was fixed on 30 October 2023 after the bug status was changed from INABIAF
 
 ## <a name="1984_mullender"></a>[1984/mullender](/1984/mullender/mullender.c) ([README.md](/1984/mullender/README.md]))
 
-[Cody](#cody) provided an [alternate version](/1984/mullender/mullender.alt.c), an
-improved version of the judges, so that everyone can enjoy it with systems that
-are not VAX/PDP. We also refer you to the [FAQ](faq.md) as there are some
-winning entries that also let one enjoy it - with more to them of course!
-
-Cody further added the second alt version,
-[mullender.alt2.c](/1984/mullender/mullender.alt2.c) which is like the
-[1984/mullender/mullender.alt.c](/1984/mullender/mullender.alt.c) except that it
-starts over after it times out.
+[Cody](#cody) provided an [alternate version](/1984/mullender/mullender.alt.c),
+an improved version of the judges, so that everyone can enjoy it with systems
+that are not VAX/PDP. It moves at approximately the same speed as the original
+did. We also refer you to the [FAQ](faq.md) as there are some winning entries
+that also let one enjoy it (which through trial and error was how the right
+speed was discovered) - with more to them of course! The difference between the
+original is that it will start over after it times out but that might not happen
+with the original (might need you to press a key though this is not known for
+sure).
 
 Cody also added the [gentab.c](/1984/mullender/gentab.c) file, fixed to compile
 (and work, though see [bugs.md](#1984mullender-readmemd)) with modern systems


### PR DESCRIPTION

Using 2018/mills (an amazing entry) with trial and error I was able to 
determine the approximate speed that the :-) moved across the screen and
now the alt code moves at almost exactly (I believe, at least) that 
speed.

The mullender.alt2.c was deleted; instead that became mullender.alt.c. 
This is because (I believe but have not confirmed) that the original did
not exit after it timed out and there's no need to have two alt versions
when they're so similar. One is good enough and the obvious choice is 
the one that can keep going on.

.gitignore updated.