### PR TITLE
Improve instructions/alt code for 1988/spinellis

### DIFF
--- a/1988/spinellis/.gitignore
+++ b/1988/spinellis/.gitignore
@@ -6,7 +6,6 @@ indent.c
 indent.o
 prog.c
 prog.orig
-runme
 spinellis
 spinellis.alt
 spinellis.orig

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -130,20 +130,21 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c input.txt
 	@${RM} -f $@
 	@echo
-	@echo "Hello, world!  To compile this IOCCC winner, we need you to take change."
+	@echo "Hello, world!  To compile this IOCCC winner, we need you to take charge."
 	@echo
-	@echo "IMPORTANT NOTE:"
+	@echo "IMPORTANT NOTE: this entry is likely to NOT compile with some compilers"
+	@echo "like clang, NOR will it likely compile under macOS. In particular the"
+	@echo "the compiler must accept reading in input from /dev/tty. Where this is"
+	@echo "not possible, try this instead: "
 	@echo
-	@echo "	This entry is likely to NOT compile with some compilers like clang, NOR will it likely"
-	@echo "	to compile under macOS.  For those situations, try this instead:"
+	@echo "    make clobber alt"
 	@echo
-	@echo "	make clobber alt"
+	@echo "For hosts with a true gcc compiler, manually run the following command:"
 	@echo
-	@echo "For non-macOS hosts with a true gcc compiler, manually run the following command:"
+	@echo "    ${GCC} ${CFLAGS} ${PROG}.c -o $@ ${LDFLAGS}"
 	@echo
-	@echo ${GCC} ${CFLAGS} ${PROG}.c -o $@ ${LDFLAGS}
-	@echo
-	@echo "Next copy and paste (on a non-macOS host) the folowwing as input to the above command:"
+	@echo "Next copy and paste (on a non-macOS host/host with true gcc)"
+	@echo "the folowwing as input to the above command:"
 	@echo
 	@${CAT} input.txt
 	@echo
@@ -151,7 +152,9 @@ ${PROG}: ${PROG}.c input.txt
 	@echo
 	@echo "Finally run the program you have just compiled:"
 	@echo
-	@echo "./$@"
+	@echo "    ./$@"
+	@echo
+	@echo "Of course you may provide other C code if you wish, even typing it manually."
 	@echo
 
 # alternative executable
@@ -163,11 +166,11 @@ ${PROG}.alt: ${PROG}.alt.c input.txt
 	@${RM} -f $@ runme
 	${CC} ${CFLAGS} ${PROG}.alt.c -o $@ ${LDFLAGS}
 	@echo
-	@echo "Hello, world!  To compile this IOCCC winner, we need you to take change."
+	@echo "Hello, world!  To compile this IOCCC winner, we need you to take charge."
 	@echo
 	@echo "Run the following command:"
 	@echo
-	@echo "./$@"
+	@echo "   ./$@"
 	@echo
 	@echo "Next copy and paste the folowwing as input to the above command:"
 	@echo
@@ -175,9 +178,11 @@ ${PROG}.alt: ${PROG}.alt.c input.txt
 	@echo
 	@echo "After pasing the above, end input by providing an EOF (usually control-D)."
 	@echo
-	@echo "Finally run the this progrqm:"
+	@echo "Finally run the program you have just compiled:"
 	@echo
-	@echo "./runme"
+	@echo "    ./$@"
+	@echo
+	@echo "Of course you may provide other C code if you wish, even typing it manually."
 	@echo
 
 # data files

--- a/1988/spinellis/README.md
+++ b/1988/spinellis/README.md
@@ -1,35 +1,58 @@
 ## To build:
 
 ```sh
-make all
+make clobber all
 ```
 
+and follow the instructions this will give you.
 
-### Try:
+If your compiler will not read from `/dev/tty` see the [Alternate
+code](#alternate-code) section below.
+
+
+### To use:
 
 ```sh
-rm -f spinellis ; cc spinellis.c -o spinellis < input.txt && ./spinellis
+./spinellis
 ```
 
-and try:
+Type in or copy paste some C code, perhaps from [input.txt](input.txt), and send
+EOF (typically ctrl-d).
+
+Now run again:
 
 ```sh
-rm -f spinellis ; cc spinellis.c -o spinellis < input2.txt && ./spinellis
+./spinellis
 ```
 
 
 ## Alternate code:
 
-For clang try the alt code like:
+For clang or compilers that won't read from `/dev/tty`, we provide this version.
+
+
+### Alternate build:
 
 ```sh
-cc spinellis.alt.c -o spinellis.alt < input.txt && ./spinellis.alt
+make clobber alt
 ```
 
-and try:
+and follow the instructions.
+
+
+### Alternate use:
 
 ```sh
-cc spinellis.alt.c -o spinellis.alt < input2.txt && ./spinellis.alt
+./spinellis.alt
+```
+
+Type in or copy paste some C code, perhaps from [input.txt](input.txt), and send
+EOF (typically ctrl-d).
+
+Now run again:
+
+```sh
+./spinellis.alt
 ```
 
 

--- a/1988/spinellis/input.txt
+++ b/1988/spinellis/input.txt
@@ -1,7 +1,7 @@
-#include <stdio.h>
-int
-main(void)
-{
-    printf("Hello, world!\n");
-    return 0;
-}
+    #include <stdio.h>
+    int
+    main(void)
+    {
+	printf("Hello, world!\n");
+	return 0;
+    }

--- a/1988/spinellis/spinellis.alt.c
+++ b/1988/spinellis/spinellis.alt.c
@@ -1,1 +1,2 @@
-int main(void){system("cc -x c -Wno-everything - -o runme");return 0;}
+#include <stdlib.h>
+int main(void){system("cc -x c -Wno-everything - -o spinellis.alt");return 0;}

--- a/1988/spinellis/try.alt.sh
+++ b/1988/spinellis/try.alt.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1988/spinellis alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ cat input.txt" 1>&2
+cat input.txt
+
+echo "$ cc -Wno-error spinellis.alt.c -o spinellis.alt && ./spinellis.alt < input.txt"
+cc -Wno-error spinellis.alt.c -o spinellis.alt && ./spinellis.alt < input.txt
+echo "$ ./spinellis.alt" 1>&2
+./spinellis.alt
+
+echo 1>&2
+
+echo "$ cat input2.txt" 1>&2
+cat input2.txt
+echo "$ cc -Wno-error spinellis.c -o spinellis.alt && ./spinellis" 1>&2
+cc -Wno-error spinellis.alt.c -o spinellis.alt && ./spinellis.alt < input2.txt
+echo "$ ./spinellis.alt" 1>&2
+./spinellis.alt

--- a/1988/spinellis/try.sh
+++ b/1988/spinellis/try.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1988/spinellis
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ cat input.txt" 1>&2
+cat input.txt
+
+echo "$ cc spinellis.c -o spinellis < input.txt && ./spinellis" 1>&2
+cc spinellis.c -o spinellis < input.txt && ./spinellis
+
+echo 1>&2
+
+echo "$ cat input2.txt" 1>&2
+cat input2.txt
+echo "$ cc spinellis.c -o spinellis < input2.txt && ./spinellis" 1>&2
+cc spinellis.c -o spinellis < input2.txt && ./spinellis


### PR DESCRIPTION
There is no need to compile to 'runme': the way I designed the alt code is so that it can be compiled and used exactly like the original entry. Since the original entry need not compile to another file neither does the alt version. It just compiles to spinellis.alt instead. (Perhaps both should compile to something else though?)

The instructions of how to build/how to use in the README.md file have been fixed and improved (it referred to the old way). The alt code subsections have been added as well.

I also added to spinellis.alt.c #include <stdlib.h> as it's not a one-liner anyway and this way system(3) is available without worrying about warnings. The -Wno-everything still remains there in the system(3) call in case there is a problem with the code that is typed in (though that's not been tested either way).