### PR TITLE
Add 2019/endoh/try.sh, helper program + formatting

### DIFF
--- a/1988/spinellis/.gitignore
+++ b/1988/spinellis/.gitignore
@@ -6,7 +6,6 @@ indent.c
 indent.o
 prog.c
 prog.orig
-runme
 spinellis
 spinellis.alt
 spinellis.orig

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -130,20 +130,21 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c input.txt
 	@${RM} -f $@
 	@echo
-	@echo "Hello, world!  To compile this IOCCC winner, we need you to take change."
+	@echo "Hello, world!  To compile this IOCCC winner, we need you to take charge."
 	@echo
-	@echo "IMPORTANT NOTE:"
+	@echo "IMPORTANT NOTE: this entry is likely to NOT compile with some compilers"
+	@echo "like clang, NOR will it likely compile under macOS. In particular the"
+	@echo "the compiler must accept reading in input from /dev/tty. Where this is"
+	@echo "not possible, try this instead: "
 	@echo
-	@echo "	This entry is likely to NOT compile with some compilers like clang, NOR will it likely"
-	@echo "	to compile under macOS.  For those situations, try this instead:"
+	@echo "    make clobber alt"
 	@echo
-	@echo "	make clobber alt"
+	@echo "For hosts with a true gcc compiler, manually run the following command:"
 	@echo
-	@echo "For non-macOS hosts with a true gcc compiler, manually run the following command:"
+	@echo "    ${GCC} ${CFLAGS} ${PROG}.c -o $@ ${LDFLAGS}"
 	@echo
-	@echo ${GCC} ${CFLAGS} ${PROG}.c -o $@ ${LDFLAGS}
-	@echo
-	@echo "Next copy and paste (on a non-macOS host) the folowwing as input to the above command:"
+	@echo "Next copy and paste (on a non-macOS host/host with true gcc)"
+	@echo "the folowwing as input to the above command:"
 	@echo
 	@${CAT} input.txt
 	@echo
@@ -151,7 +152,9 @@ ${PROG}: ${PROG}.c input.txt
 	@echo
 	@echo "Finally run the program you have just compiled:"
 	@echo
-	@echo "./$@"
+	@echo "    ./$@"
+	@echo
+	@echo "Of course you may provide other C code if you wish, even typing it manually."
 	@echo
 
 # alternative executable
@@ -163,11 +166,11 @@ ${PROG}.alt: ${PROG}.alt.c input.txt
 	@${RM} -f $@ runme
 	${CC} ${CFLAGS} ${PROG}.alt.c -o $@ ${LDFLAGS}
 	@echo
-	@echo "Hello, world!  To compile this IOCCC winner, we need you to take change."
+	@echo "Hello, world!  To compile this IOCCC winner, we need you to take charge."
 	@echo
 	@echo "Run the following command:"
 	@echo
-	@echo "./$@"
+	@echo "   ./$@"
 	@echo
 	@echo "Next copy and paste the folowwing as input to the above command:"
 	@echo
@@ -175,9 +178,11 @@ ${PROG}.alt: ${PROG}.alt.c input.txt
 	@echo
 	@echo "After pasing the above, end input by providing an EOF (usually control-D)."
 	@echo
-	@echo "Finally run the this progrqm:"
+	@echo "Finally run the program you have just compiled:"
 	@echo
-	@echo "./runme"
+	@echo "    ./$@"
+	@echo
+	@echo "Of course you may provide other C code if you wish, even typing it manually."
 	@echo
 
 # data files

--- a/1988/spinellis/README.md
+++ b/1988/spinellis/README.md
@@ -1,35 +1,58 @@
 ## To build:
 
 ```sh
-make all
+make clobber all
 ```
 
+and follow the instructions this will give you.
 
-### Try:
+If your compiler will not read from `/dev/tty` see the [Alternate
+code](#alternate-code) section below.
+
+
+### To use:
 
 ```sh
-rm -f spinellis ; cc spinellis.c -o spinellis < input.txt && ./spinellis
+./spinellis
 ```
 
-and try:
+Type in or copy paste some C code, perhaps from [input.txt](input.txt), and send
+EOF (typically ctrl-d).
+
+Now run again:
 
 ```sh
-rm -f spinellis ; cc spinellis.c -o spinellis < input2.txt && ./spinellis
+./spinellis
 ```
 
 
 ## Alternate code:
 
-For clang try the alt code like:
+For clang or compilers that won't read from `/dev/tty`, we provide this version.
+
+
+### Alternate build:
 
 ```sh
-cc spinellis.alt.c -o spinellis.alt < input.txt && ./spinellis.alt
+make clobber alt
 ```
 
-and try:
+and follow the instructions.
+
+
+### Alternate use:
 
 ```sh
-cc spinellis.alt.c -o spinellis.alt < input2.txt && ./spinellis.alt
+./spinellis.alt
+```
+
+Type in or copy paste some C code, perhaps from [input.txt](input.txt), and send
+EOF (typically ctrl-d).
+
+Now run again:
+
+```sh
+./spinellis.alt
 ```
 
 

--- a/1988/spinellis/input.txt
+++ b/1988/spinellis/input.txt
@@ -1,7 +1,7 @@
-#include <stdio.h>
-int
-main(void)
-{
-    printf("Hello, world!\n");
-    return 0;
-}
+    #include <stdio.h>
+    int
+    main(void)
+    {
+	printf("Hello, world!\n");
+	return 0;
+    }

--- a/1988/spinellis/spinellis.alt.c
+++ b/1988/spinellis/spinellis.alt.c
@@ -1,1 +1,2 @@
-int main(void){system("cc -x c -Wno-everything - -o runme");return 0;}
+#include <stdlib.h>
+int main(void){system("cc -x c -Wno-everything - -o spinellis.alt");return 0;}

--- a/1988/spinellis/try.alt.sh
+++ b/1988/spinellis/try.alt.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1988/spinellis alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ cat input.txt" 1>&2
+cat input.txt
+
+echo "$ cc -Wno-error spinellis.alt.c -o spinellis.alt && ./spinellis.alt < input.txt"
+cc -Wno-error spinellis.alt.c -o spinellis.alt && ./spinellis.alt < input.txt
+echo "$ ./spinellis.alt" 1>&2
+./spinellis.alt
+
+echo 1>&2
+
+echo "$ cat input2.txt" 1>&2
+cat input2.txt
+echo "$ cc -Wno-error spinellis.c -o spinellis.alt && ./spinellis" 1>&2
+cc -Wno-error spinellis.alt.c -o spinellis.alt && ./spinellis.alt < input2.txt
+echo "$ ./spinellis.alt" 1>&2
+./spinellis.alt

--- a/1988/spinellis/try.sh
+++ b/1988/spinellis/try.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1988/spinellis
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ cat input.txt" 1>&2
+cat input.txt
+
+echo "$ cc spinellis.c -o spinellis < input.txt && ./spinellis" 1>&2
+cc spinellis.c -o spinellis < input.txt && ./spinellis
+
+echo 1>&2
+
+echo "$ cat input2.txt" 1>&2
+cat input2.txt
+echo "$ cc spinellis.c -o spinellis < input2.txt && ./spinellis" 1>&2
+cc spinellis.c -o spinellis < input2.txt && ./spinellis

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -146,16 +146,8 @@ ${PROG}:
 check-os: check-os.sh
 	${SHELL} ./check-os.sh ${LINES} ${COLUMNS}
 
-error-stty:
-	@echo "No stty command here. Please manually specify size in the Makefile." >&2 ; false
-
-has-stty:
-	which stty >/dev/null || ${MAKE} error-stty
-
-fullscreen: has-stty
-	${MAKE} ${PROG} \
-	LINES=`stty size | sed -s 's/ .*$$//'` \
-	COLUMNS=`stty size | sed -s 's/^.* //'`
+fullscreen: fullscreen.sh
+	./$<
 
 Darwin: ${PROG}.c
 	${RM} -f $@

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+There is an alternate version, the original, which does not work well in macOS.
+See [Alternate code](#alternate-code) below if you are curious.
+
 
 ### Bugs and (Mis)features:
 
@@ -37,53 +40,69 @@ Open another window / terminal.
 
 Open more terminals and repeat...
 
+You might also wish to try a full screen size. For this try:
+
+```sh
+make clobber fullscreen
+```
+
+Alternatively, if you want to change the size, do something like:
+
+```sh
+make clobber LINES=20 COLUMNS=20 all
+```
+
+The author provided us with the following table for use:
+
+---
+
+* **Arrow keys**: move cursor.
+* `p` key: enter *pen* mode (type **p** again to return to the default *move*
+mode).
+* `l` key: enter *line* mode (type **l** again to validate the line and return
+to the *move* mode).
+* `c` key: cycle through a small set of different *colors*.
+* `q` key: quit the editor. The drawing is automatically saved.
+
+The mode and current color is indicated at the bottom left corner of
+the editor.
+
+After editing the file and quitting, try:
+
+```sh
+/tmp/drawing
+```
+
+i.e. execute the file.
+
+
+---
+
 WARNING: if the file is deleted it might lock any session still in use. These
-will have to be killed from another shell session or by closing the terminal
-tab.
-
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
-```
+will have to be killed from another shell session or by closing the terminal tab
+(in other words don't do this from the console!). If the file cannot be opened
+in the beginning this will also happen. This is discussed in [2019 duble in
+bugs.md](/bugs.md#2019-duble).
 
 NOTE: this entry might leave sockets lying about in the current working
-directory which you'll have to delete manually. Here's an example in macOS:
-
-```sh
-$ ls -al
-srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:19 .BDHFHALG
-srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:15 .CGGHAMGC
-srwxr-xr-x   1 ioccc  staff      0  6 Apr 08:16 .CMDGAELH
-...
-```
-
-To get a list of files with this glob try:
-
-```sh
-ls -al|awk '{print $NF}'|grep -E '^\.[A-Z]{2,}'
-```
-
-To delete them you can do:
-
-```sh
-find . -name '.[A-Z]*' -delete
-```
-
-though one might want to check that the program is not currently running. :-)
+directory which you'll have to delete manually. This is also discussed in [2019
+duble in bugs.md](/bugs.md#2019-duble).
 
 
 ## Alternate code:
 
-An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.  This alternate
-code might not work as well on macOS.
+An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.  This
+alternate code might not work as well in macOS.
 
-To compile this alternate version:
+
+### Alternate build:
 
 ```sh
 make alt
 ```
+
+
+### Alternate use:
 
 Use `prog.alt` as you would `prog` above.
 
@@ -96,6 +115,7 @@ or `l` (they toggle).
 
 ## Author's remarks:
 
+
 ### Introduction:
 
 This program is a **graphics editor**, running in the terminal.
@@ -103,10 +123,11 @@ This program is a **graphics editor**, running in the terminal.
 It provides **collaborative** features: one can join the drawing session
 of someone else by just opening the same file!
 
+
 ### Getting started:
 
 The program can run on Linux, FreeBSD, macOS, and in most terminals.
-See section 'Limits, Portability' for more info.
+See section [Limits, Portability](#limits-portability) for more info.
 
 To build, type `make` (assuming gcc) or `make CC=clang`.
 
@@ -116,14 +137,15 @@ Then you can start the program. It expects a file path as its first argument:
 ./prog /tmp/drawing
 ```
 
-(If not started this way, `prog` will refuse to start.)
+(If not started this way, with a file, `prog` will refuse to start.)
 
 If the file does not exist, you will start with a blank drawing.
 
 If someone else (or another *instance of yourself*, maybe?) is already
 editing this file, you will join the session!
 
-### Edition features:
+
+### Edit features:
 
 * **arrow keys**: move cursor.
 * `p` key: enter *pen* mode (type **p** again to return to the default *move* mode).
@@ -133,6 +155,7 @@ editing this file, you will join the session!
 
 The mode and current color is indicated at the bottom left corner of
 the editor.
+
 
 ### Bonus features:
 
@@ -152,7 +175,7 @@ You will probably have a hard time analyzing this entry, because:
 *   Code coverage of single vs multi-user sessions is more or less the same. :-)
 *   Code coverage when using *move*, *pen* or *line* modes is almost the same.
     (so, is there a Bresenham algorithm somewhere??)
-*   Some OS resource values and stdlib call results are inferred.
+*   Some OS resource values and `stdlib.h` call results are inferred.
 *   Whenever possible, variable names are reused.
 *   You might start analyzing escape code sequences right now, but warming up
     your brain is actually recommended. Start with a simple question such as:
@@ -166,6 +189,7 @@ variable, instead? (spoiler: <http://c-faq.com/ansi/constasconst.html>)
 
 If your keyboard has no arrow keys, you can probably find alternate keys by
 reading the source code.
+
 
 ### Limits, Portability:
 
@@ -184,7 +208,9 @@ inverse video mode, and movement escape codes, e.g. `xterm`, `gnome-terminal`,
 Note: the drawing files `prog` generates are probably even more portable than
 `prog` itself!
 
+
 ### Drawing area size:
+
 
 #### The drawing area size is set at compilation time:
 
@@ -203,28 +229,27 @@ IMPORTANT NOTES:
     so any peer reaching the session should have a terminal with the same
     size or larger.
 
-### prog.c vs prog.alt.c
+### [prog.c](prog.c) vs [prog.alt.c](prog.alt.c)
 
 The file [prog.alt.c](prog.alt.c) is the one I submitted.
 
-Judges proposed a small update: the program was using macro `FD_SET` inside an
+The judges proposed a small update: the program was using macro `FD_SET` inside an
 expression, which breaks compilation on macOS. Wrapping this macro into a
 function was enough to fix this compilation issue.
 
 However, that was not enough to make the program work on macOS. If you analyse
 the program you will see that it heavily relies on OS resources. And, for this
 first version of the program, you even needed to increase default `sysctl`
-parameters to make it work on FreeBSD (this was the purpose of file `check-os.sh`).
-I tried hard to tune macOS the same, but failed.
+parameters to make it work on FreeBSD (this was the purpose of file
+[check-os.sh](check-os.sh)). I tried hard to tune macOS the same, but failed.
 
-The simple fact Judges proposed this update meant they wish it could work on Mac.
-And if judges wish something, it **has to** be done. ;)
-So I refactored a little more the program to reduce OS resources consumption.
-Or maybe not reduce consumption, but consume them differently...
-And I obtained `prog.c`. With this version, no need to touch `sysctl` parameters,
-and it works on macOS too!
-I must confess it was challenging to remain below the size limit with this little
-change.
+The simple fact the Judges proposed this update meant they wish it could work on
+Mac.  And if the judges wish something, it **has to** be done. ;) So I
+refactored a little more the program to reduce OS resources consumption.  Or
+maybe not reduce consumption, but consume them differently...  And I obtained
+[prog.c](prog.c). With this version, no need to touch `sysctl` parameters, and
+it works on macOS too!  I must confess it was challenging to remain below the
+size limit with this little change.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2019/duble/fullscreen.sh
+++ b/2019/duble/fullscreen.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Try and determine full screen size for make fullscreen rule.
+#
+TPUT="$(type -P tput)"
+
+if [[ -z "$TPUT" ]]; then
+    echo "No tput found, try:" >&2
+    echo >&2
+    echo "  make clobber LINES=\$LINES COLUMNS=\$COLUMNS all" >&2
+    echo >&2
+    echo "or to specify a specific size:" >&2
+    echo >&2
+    echo "  make clobber LINES=20 COLUMNS=20 all" >&2
+    echo >&2
+    echo "or whatever you wish the lines and columns to be." >&2
+    exit 1
+else
+    make clobber all LINES="$($TPUT lines)" COLUMNS="$($TPUT cols)"
+fi

--- a/2019/endoh/.gitignore
+++ b/2019/endoh/.gitignore
@@ -1,6 +1,7 @@
 #
 # sort with: sort -d -u
 *.dSYM
+ascii
 indent
 indent.c
 indent.o

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -111,7 +111,7 @@ PROG= prog
 OBJ= ${PROG}.o
 CSRC= ${PROG}.o
 DATA=
-TARGET= ${PROG}
+TARGET= ${PROG} ascii
 #
 ALT_OBJ=
 ALT_TARGET=
@@ -131,6 +131,9 @@ all: data ${TARGET}
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} -g $< -o $@ ${LDFLAGS}
+
+ascii: ascii.c
+	${CC} $< -o $@
 
 # alternative executable
 #

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -25,9 +25,23 @@ For more detailed information see [2019 endoh in bugs.md](/bugs.md#2019-endoh).
 
 ### Try:
 
+If you have `gdb(1)` installed:
+
+```sh
+./try.sh
+```
+
+Note that in macOS installing `gdb(1)` takes multiple steps - it's not just a
+matter of installing `gdb(1)` and that's that. The [try.sh](try.sh) script has
+only been tested with linux.
+
+You might also wish to try:
+
 ```sh
 gdb ./prog || lldb ./prog
 ```
+
+and then type in `r` (to run program) and then `bt` (for backtrace).
 
 
 ## Judges' remarks:
@@ -37,6 +51,7 @@ ascii` when debugging it to reveal its purpose.
 
 
 ## Author's remarks:
+
 
 ### backtrace quine:
 

--- a/2019/endoh/ascii.c
+++ b/2019/endoh/ascii.c
@@ -1,0 +1,19 @@
+/*
+ * ascii.c - simple program that shows the character value of ASCII values, if
+ * isascii() is true, to help demonstrate IOCCC winner 2019/endoh.
+ *
+ * Will not do anything if no args specified. Use xargs(1) to pass args to
+ * program if it's a lot of characters.
+ */
+#include <stdio.h>
+#include <ctype.h>
+#include <stdlib.h>
+int main(int argc, char **argv)
+{
+    int i;
+    for (argc = 1; argv[argc]; ++argc)
+    {
+	i=atoi(argc[argv]);
+	if (isascii(i)) printf("%c", i);
+    }
+}

--- a/2019/endoh/try.sh
+++ b/2019/endoh/try.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2019/endoh
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# Before we do anything we have to make sure we have GDB available
+#
+GDB="$(type -P gdb)"
+
+if [[ -z "$GDB" ]]; then
+    echo "No gdb found, install gdb and try again." 1>&2
+    exit 1
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ $GDB -q -x prog.c ./prog | head -n 25" 1>&2
+read -r -n 1 -p "Press any key to use source code as GDB command file (first 25 lines): "
+echo >&2
+"$GDB" -q -x prog.c ./prog | head -n 25
+
+echo "$ $GDB -q -x prog.c ./prog | cat | grep : | cut -f 2 -d:|xargs ./ascii"
+read -r -n 1 -p "Press any key to use the backtrace to reconstruct prog.c (space = next page, q = quit): "
+echo 1>&2
+"$GDB" -q -x prog.c ./prog | cat | grep : | cut -f 2 -d: | xargs ./ascii | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to compare reconstructed code with original: "
+echo 1>&2
+echo "$ "$GDB" -q -x prog.c ./prog | cat | grep : | cut -f 2 -d: | xargs ./ascii > prog2.c" 1>&2
+"$GDB" -q -x prog.c ./prog | cat | grep : | cut -f 2 -d: | xargs ./ascii > prog2.c
+echo "$ diff -s prog.c prog2.c" 1>&2
+diff -s prog.c prog2.c

--- a/bugs.md
+++ b/bugs.md
@@ -3348,9 +3348,16 @@ ideal if this was not the case.
 ### Source code: [2019/duble/prog.c](2019/duble/prog.c)
 ### Information: [2019/duble/README.md](2019/duble/README.md)
 
-This program will very likely leave sockets lying about in the current working
-directory. For instance [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson)
-showed us this:
+There are two things to be aware of with this entry.
+
+If the file being used (to draw) is deleted it might lock any session still in
+use. These will have to be killed from another shell session or by closing the
+terminal tab. This will also happen if the file cannot be opened in the
+beginning.
+
+This program will also very likely leave sockets lying about in the current
+working directory. For instance [Cody Boone
+Ferguson](/winners.html#Cody_Boone_Ferguson) showed us this:
 
 ```sh
 $ ls -al |grep '^s'
@@ -3365,20 +3372,20 @@ This is NOT a bug and you'll have to (at least at this time?) delete the files
 manually. You shouldn't have to worry about these being added to git: it seems
 to ignore sockets (it did at least in macOS).
 
-NOTE: to get a list of files with this glob try:
+He provides the following tips on this situation. A simpler way to find sockets
+in the directory:
 
 ```sh
-ls -al |awk '{print $NF}' | grep -E '^\.[A-Z]+'
+file .*|grep socket|cut -f1 -d:
 ```
 
 To delete them you can do:
 
 ```sh
-find . -name '.[A-Z]*' -delete
+find . -exec file '{}' \;|grep socket|cut -f 1 -d: | xargs rm -f
 ```
 
 though one might want to check that the program is not currently running. :-)
-
 
 
 ## 2019 endoh

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4194,6 +4194,19 @@ was to only correct spelling and only some, not to change wording or anything
 else).
 
 
+## <a name="2019_duble"></a>[2019/duble](/2019/duble/prog.c) ([README.md](/2019/duble/README.md]))
+
+[Cody](#cody) made the `make fullscreen` more portable by not relying on
+`stty(1)` and `sed(1)` but rather it just uses `tput(1)`. He also made it so
+that if `tput(1)` is not found it tells the user an easier way to compile the full
+screen size rather than having to modify the Makefile. This done with a script,
+[fullscreen.sh](/2019/duble/fullscreen.sh), to simplify the Makefile and provide
+an easy way to tell the user how to compile it, assuming that the environmental
+variables `LINES` and `COLUMNS` are set. But even if they're not set it explains
+how to easily compile the program to a specific size. Note that `LINES` and
+`COLUMNS` is not available to scripts so it can't make use of them that way.
+
+
 ## <a name="2019_endoh"></a>[2019/endoh](/2019/endoh/prog.c) ([README.md](/2019/endoh/README.md]))
 
 As this is a backtrace quine having the optimiser enabled is not a good idea so

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4214,6 +4214,12 @@ As this is a backtrace quine having the optimiser enabled is not a good idea so
 compilation as debugging symbols might just be useful for an entry that's
 supposed to segfault :-)
 
+Cody also added the simple [ascii.c](/2019/endoh/ascii.c) that (while it has an
+arg) prints out the character of the ASCII value (uses `isascii(3)` first). This
+combined with the [try.sh](/2019/endoh/try.sh) script that he added allows one
+to easily reconstruct the source code through GDB by the fact it's a backtrace
+quine.
+
 
 ## <a name="2019_karns"></a>[2019/karns](/2019/karns/prog.c) ([README.md](/2019/karns/README.md]))
 


### PR DESCRIPTION

The helper program ascii.c converts args passed to it to char values (if
isascii() returns non-zero) which with try.sh allows one to reconstruct
the code with the backtrace rather than having to memorise ascii(7) (and
even if they did it would be hard to put it together). One should of 
course use xargs(1) and try.sh does.

The try.sh script checks that gdb is installed first, telling the user
to install it if they don't have it. The README.md file notes that for
macOS It's not a simple matter of just installing gdb - there are 
additional steps. 
