### PR TITLE
Force use of -O0 -g in 2019/endoh

### DIFF
--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -65,7 +65,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We disable the optimiser and we enable -g because the entry is A BACKTRACE
+# QUINE and NEEDS debugging symbols.
+OPT= -O0 -g
 
 # Default flags for ANSI C compilation
 #
@@ -129,8 +131,11 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE the use of -O0 -g even if someone overrides it because this entry is
+# a BACKTRACE QUINE and NEEDS debugging symbols.
+#
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} -g $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 -g $< -o $@ ${LDFLAGS}
 
 ascii: ascii.c
 	${CC} $< -o $@

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+NOTE: the use of the C compiler optimiser was disabled and `-g` was enabled for
+this entry because it is SUPPOSED to crash and it needs debugging symbols.
+
 
 ### Bugs and (Mis)features:
 


### PR DESCRIPTION
Previously only -g was after ${CFLAGS} but it needs to have -O0 in case someone decides to run something like

    make clobber OPT= all

Use of OPT+= in the Makefile will not fix that problem. Thus if someone does NOT mess with OPT or any other variables that are added to CFLAGS it will look like:

     -O0 -g -O0 -g prog.c -o prog

Previously it was just '-g' and no '-O0' but if someone were to do instead

    make clobber OPT=-O3 all

it would have messed that up.