### PR TITLE
Fixes in 1987/lievaart

### DIFF
--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -69,7 +69,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We DISABLE the optimiser due to funny problems in different compilers and
+# systems. See compilers.md for more details on this problem.
+OPT= -O0
 
 # Default flags for ANSI C compilation
 #
@@ -132,8 +134,10 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE disable the optimiser due to funny problems in different compilers
+# and systems. See compilers.md for details.
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -4,6 +4,10 @@
 make all
 ```
 
+
+NOTE: we FORCE disable the optimiser due to a funny problem with different
+compilers and systems. See below and [compilers.md](compilers.md) for details.
+
 There is an [alternate version](#alternate-code). The reason is a funny problem:
 in modern systems, depending on the platform, compiler and the optimiser, it
 would work with one compiler with the optimiser but it would not work with the

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -66,7 +66,7 @@ CINCLUDE= -include stdio.h
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -14,8 +14,8 @@ bz,lv=60,*x,*y,m,t;S(d,v,f,a,b)l*v;{l c=0,*n=v+100,bw=d<u-1?a:-9000,w,z,i,zb,q=
 :t==q?50:0;return w;}H(z,0){if(GZ(v,z,f,100)){c++;w= -S(d+1,n,q,-b,-bw);if(w>bw
 ){zb=z;bw=w;if(w>=b||w>=8003)Y w;}}}if(!c){bz=0;C;Y-S(d+1,n,q,-b,-bw);}bz=zb;Y
 d>=u-1?bw+(c<<3):bw;}main(){R(;t<1100;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88
-||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((u
-=atoi(A))>10||u<0||!isdigit(*A))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
+||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((!
+isdigit(*A)||(u=atoi(A))>10||u<0))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
 }e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
 ;I("Value:%d\n",S(0,V,1,-9000,9000));I("move: %d\n",(lv-=GZ(V,bz,1,0),bz));}}GZ
 (v,z,f,o)l*v;{l*j,q=3-f,g=0,i,h,*k=v+z;if(*k==0)R(i=7;i>=0;i--){j=k+(h=r[i]);e(

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -19,7 +19,7 @@ t==q?50:0;Y w;}H(z,0){W(E(v,z,f,100)){c++;w= -S(d+1,n,q,0,-b,-j);W(w>j){g=bz=z;
 j=w;W(w>=b||w>=8003)Y w;}}}W(!c){g=0;W(_){H(x,v)c+= *x==f?1:*x==3-f?-1:0;Y c>0?
 8000+c:c-8000;}C;j= -S(d+1,n,q,1,-b,-j);}bz=g;Y d>=u-1?j+(c<<3):j;}main(){R(;t<
 1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;x:I("Level:");V[44]
-=V[55]=1;V[45]=V[54]=2;s(A);if(((u=atoi(A))>10)||u<0||!isdigit(*A))goto x;e(lv>0){Z
+=V[55]=1;V[45]=V[54]=2;s(A);if(!isdigit(*A)||((u=atoi(A))>10)||u<0)goto x;e(lv>0){Z
 do{I("You:");s(A);m=atoi(A);*A='\0';}e(!E(V,m,2,0)&&m!=99);
 W(m!=99)lv--;W(lv<15&&u<10)u+=2;U("Wait\n");I("Value:%d\n",S(0,V,1,0,-9000,9000
 ));I("move: %d\n",(lv-=E(V,bz,1,0),bz));}}E(v,z,f,o)l*v;{l*j,q=3-f,g=0,i,w,*k=v

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -65,7 +65,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We MUST DISABLE THE OPTIMISER AND ENABLE -g because the entry is A BACKTRACE
+# QUINE and NEEDS debugging symbols.
+OPT= -O0 -g
 
 # Default flags for ANSI C compilation
 #
@@ -129,6 +131,9 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE the use of -O0 -g even if someone overrides it because this entry is
+# a BACKTRACE QUINE and NEEDS DEBUGGING SYMBOLS.
+#
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} -g $< -o $@ ${LDFLAGS}
 

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+NOTE: we FORCE disable the optimiser and FORCE enable `-g` as this is a
+BACKTRACE QUINE and NEEDS debugging symbols.
+
 
 ### Bugs and (Mis)features:
 


### PR DESCRIPTION

The optimiser was left disabled by accident.

Check for !isdigit(*A) before using atoi(3) on A. This was part of the
bug fixes I made (infinite loop flooding the user with invalid input
which is frequent if one does not know how to play or if one makes a
typo). This is in both versions, the one with the board and the entry 
itself (the board being too big to fit in the contest size limits of the
time).