### PR TITLE
Remove redundancy in 2000/tomx/try.sh

### DIFF
--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -69,7 +69,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We DISABLE the optimiser due to funny problems in different compilers and
+# systems. See compilers.md for more details on this problem.
+OPT= -O0
 
 # Default flags for ANSI C compilation
 #
@@ -132,8 +134,10 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE disable the optimiser due to funny problems in different compilers
+# and systems. See compilers.md for details.
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -4,6 +4,10 @@
 make all
 ```
 
+
+NOTE: we FORCE disable the optimiser due to a funny problem with different
+compilers and systems. See below and [compilers.md](compilers.md) for details.
+
 There is an [alternate version](#alternate-code). The reason is a funny problem:
 in modern systems, depending on the platform, compiler and the optimiser, it
 would work with one compiler with the optimiser but it would not work with the

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -66,7 +66,7 @@ CINCLUDE= -include stdio.h
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -14,8 +14,8 @@ bz,lv=60,*x,*y,m,t;S(d,v,f,a,b)l*v;{l c=0,*n=v+100,bw=d<u-1?a:-9000,w,z,i,zb,q=
 :t==q?50:0;return w;}H(z,0){if(GZ(v,z,f,100)){c++;w= -S(d+1,n,q,-b,-bw);if(w>bw
 ){zb=z;bw=w;if(w>=b||w>=8003)Y w;}}}if(!c){bz=0;C;Y-S(d+1,n,q,-b,-bw);}bz=zb;Y
 d>=u-1?bw+(c<<3):bw;}main(){R(;t<1100;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88
-||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((u
-=atoi(A))>10||u<0||!isdigit(*A))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
+||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((!
+isdigit(*A)||(u=atoi(A))>10||u<0))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
 }e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
 ;I("Value:%d\n",S(0,V,1,-9000,9000));I("move: %d\n",(lv-=GZ(V,bz,1,0),bz));}}GZ
 (v,z,f,o)l*v;{l*j,q=3-f,g=0,i,h,*k=v+z;if(*k==0)R(i=7;i>=0;i--){j=k+(h=r[i]);e(

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -19,7 +19,7 @@ t==q?50:0;Y w;}H(z,0){W(E(v,z,f,100)){c++;w= -S(d+1,n,q,0,-b,-j);W(w>j){g=bz=z;
 j=w;W(w>=b||w>=8003)Y w;}}}W(!c){g=0;W(_){H(x,v)c+= *x==f?1:*x==3-f?-1:0;Y c>0?
 8000+c:c-8000;}C;j= -S(d+1,n,q,1,-b,-j);}bz=g;Y d>=u-1?j+(c<<3):j;}main(){R(;t<
 1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;x:I("Level:");V[44]
-=V[55]=1;V[45]=V[54]=2;s(A);if(((u=atoi(A))>10)||u<0||!isdigit(*A))goto x;e(lv>0){Z
+=V[55]=1;V[45]=V[54]=2;s(A);if(!isdigit(*A)||((u=atoi(A))>10)||u<0)goto x;e(lv>0){Z
 do{I("You:");s(A);m=atoi(A);*A='\0';}e(!E(V,m,2,0)&&m!=99);
 W(m!=99)lv--;W(lv<15&&u<10)u+=2;U("Wait\n");I("Value:%d\n",S(0,V,1,0,-9000,9000
 ));I("move: %d\n",(lv-=E(V,bz,1,0),bz));}}E(v,z,f,o)l*v;{l*j,q=3-f,g=0,i,w,*k=v

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -68,7 +68,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -22,11 +22,7 @@ by chance or is killed.
 ### Try:
 
 ```sh
-./ovdluhe < ./ovdluhe.c
-./ovdluhe < ./ovdluhe.c
-
-./ovdluhe < README.md
-./ovdluhe < README.md
+./try.sh ; sleep 2 ; ./try.sh
 ```
 
 

--- a/1989/ovdluhe/try.sh
+++ b/1989/ovdluhe/try.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1989/ovdluhe
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+i=0
+for ((i=0; i<4; ++i)); do
+    read -r -n 1 -p "Press any key to run: ./ovdluhe < ovdluhe.c: "
+    echo 1>&2
+    ./ovdluhe < ovdluhe.c
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./ovdluhe < README.md: "
+    echo 1>&2
+    ./ovdluhe < README.md
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./ovdluhe < Makefile: "
+    echo 1>&2
+    ./ovdluhe < Makefile
+    echo 1>&2
+done

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -67,7 +67,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1990/jaw/try.sh
+++ b/1990/jaw/try.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Running shark.sh:"
-./shark.sh shark.sh README.md jaw.c try.sh > receive || exit 1
+./shark.sh atob shark.sh README.md jaw.c try.sh > receive || exit 1
 echo "Done."
 
 

--- a/2000/tomx/try.sh
+++ b/2000/tomx/try.sh
@@ -15,11 +15,6 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-if [[ ! -f "tomx" || ! -e "tomx" ]]; then
-    echo "Compiling tomx.c:" 1>&2
-    make all || exit 1
-fi
-
 echo "Running tomx:" 1>&2
 echo "$ ./tomx" 1>&2
 ./tomx

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -65,7 +65,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We MUST DISABLE THE OPTIMISER AND ENABLE -g because the entry is A BACKTRACE
+# QUINE and NEEDS debugging symbols.
+OPT= -O0 -g
 
 # Default flags for ANSI C compilation
 #
@@ -129,6 +131,9 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE the use of -O0 -g even if someone overrides it because this entry is
+# a BACKTRACE QUINE and NEEDS DEBUGGING SYMBOLS.
+#
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} -g $< -o $@ ${LDFLAGS}
 

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+NOTE: we FORCE disable the optimiser and FORCE enable `-g` as this is a
+BACKTRACE QUINE and NEEDS debugging symbols.
+
 
 ### Bugs and (Mis)features:
 

--- a/bugs.md
+++ b/bugs.md
@@ -667,6 +667,60 @@ Enjoy! :-)
 # 1990
 
 
+## 1990 jaw
+
+### STATUS: known bug - please help us fix
+### Source code: [1990/jaw/jaw.c](1990/jaw/jaw.c)
+### Information: [1990/jaw/README.md](1990/jaw/README.md)
+
+[Cody Boone Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson)
+fixed some issues in this program and [Yusuke
+Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) provided the `btoa`
+script but it appears there is a bug in this entry. The judges wrote that to
+test the entry one can do:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
+```
+
+which should apply the identity transformation to a minimal holoalphabetic
+sentence.
+
+But doing this shows instead:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
+a얖?)V...?????777??hC??h??-?	)SSSSXXX????r?L=???*?-???ppp,,,?R
+?j
+111-)))? '..F@E
+               ???b111?
+..F..F.?n,,,,,L@E$
+```
+
+Notice how there's no newline at the end: that final `$` is the prompt.
+
+If one does, however:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw | ./jaw
+```
+
+they will get just
+
+```
+oops
+```
+
+which seems to be an error message (one of the fixes was to make it not use
+`perror(3)` - this fixed something else though it's no longer known what).
+
+The script [shark.sh](/1990/jaw/shark.sh) has some issues too in that due to
+path not having `.` (this and maybe some other things were fixed) and `tar` not
+wanting to accept reading from `stdin` (this in particular) even with the right
+options used, seemingly, it has to write to disk the tarball which seems to
+defeat the purpose. This would ideally be fixed.
+
+
 ## 1990 theorem
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -744,6 +744,12 @@ and over again, flooding the screen. The problem is that there was a `for` loop
 that by necessity had to not have an increment stage but only in the `if` path
 (in the loop itself) did the pointer get updated.
 
+Cody also provided the [try.sh](/1989/ovdluhe/try.sh) script which runs the
+program four times on three files to show the different output. It doesn't run
+the program on each file four times in a row but rather does it on each file
+and starts over, doing it four times, to help with hopefully allowing different
+output.
+
 Cody also provided an [alternate version](/1989/ovdluhe/ovdluhe.alt.c) based on the
 author's remarks. See the README.md for details. The fix described above was
 fixed in this version too, after it was discovered and fixed.


### PR DESCRIPTION

After doing make all || exit 1 it checked for the existence of tomx and
it being executable but that should not be necessary after compilation.