### PR TITLE
Improve 1992/gson/try.sh

### DIFF
--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -69,7 +69,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We DISABLE the optimiser due to funny problems in different compilers and
+# systems. See compilers.md for more details on this problem.
+OPT= -O0
 
 # Default flags for ANSI C compilation
 #
@@ -132,8 +134,10 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE disable the optimiser due to funny problems in different compilers
+# and systems. See compilers.md for details.
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -4,6 +4,10 @@
 make all
 ```
 
+
+NOTE: we FORCE disable the optimiser due to a funny problem with different
+compilers and systems. See below and [compilers.md](compilers.md) for details.
+
 There is an [alternate version](#alternate-code). The reason is a funny problem:
 in modern systems, depending on the platform, compiler and the optimiser, it
 would work with one compiler with the optimiser but it would not work with the

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -66,7 +66,7 @@ CINCLUDE= -include stdio.h
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1987/lievaart/lievaart.c
+++ b/1987/lievaart/lievaart.c
@@ -14,8 +14,8 @@ bz,lv=60,*x,*y,m,t;S(d,v,f,a,b)l*v;{l c=0,*n=v+100,bw=d<u-1?a:-9000,w,z,i,zb,q=
 :t==q?50:0;return w;}H(z,0){if(GZ(v,z,f,100)){c++;w= -S(d+1,n,q,-b,-bw);if(w>bw
 ){zb=z;bw=w;if(w>=b||w>=8003)Y w;}}}if(!c){bz=0;C;Y-S(d+1,n,q,-b,-bw);}bz=zb;Y
 d>=u-1?bw+(c<<3):bw;}main(){R(;t<1100;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88
-||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((u
-=atoi(A))>10||u<0||!isdigit(*A))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
+||(m+1)%10<2?3:0;V[44]=V[55]=1;V[45]=V[54]=2;x:*A='\0';I("Level:");s(A);if((!
+isdigit(*A)||(u=atoi(A))>10||u<0))goto x;e(lv>0){do{I("You:");s(A);m=atoi(A);*A='\0';
 }e(!GZ(V,m,2,0)&&m!=99);if(m!=99)lv--;if(lv<15&&u<10)u+=2;I("Wait\n")
 ;I("Value:%d\n",S(0,V,1,-9000,9000));I("move: %d\n",(lv-=GZ(V,bz,1,0),bz));}}GZ
 (v,z,f,o)l*v;{l*j,q=3-f,g=0,i,h,*k=v+z;if(*k==0)R(i=7;i>=0;i--){j=k+(h=r[i]);e(

--- a/1987/lievaart/lievaart2.c
+++ b/1987/lievaart/lievaart2.c
@@ -19,7 +19,7 @@ t==q?50:0;Y w;}H(z,0){W(E(v,z,f,100)){c++;w= -S(d+1,n,q,0,-b,-j);W(w>j){g=bz=z;
 j=w;W(w>=b||w>=8003)Y w;}}}W(!c){g=0;W(_){H(x,v)c+= *x==f?1:*x==3-f?-1:0;Y c>0?
 8000+c:c-8000;}C;j= -S(d+1,n,q,1,-b,-j);}bz=g;Y d>=u-1?j+(c<<3):j;}main(){R(;t<
 1600;t+=100)R(m=0;m<100;m++)V[t+m]=m<11||m>88||(m+1)%10<2?3:0;x:I("Level:");V[44]
-=V[55]=1;V[45]=V[54]=2;s(A);if(((u=atoi(A))>10)||u<0||!isdigit(*A))goto x;e(lv>0){Z
+=V[55]=1;V[45]=V[54]=2;s(A);if(!isdigit(*A)||((u=atoi(A))>10)||u<0)goto x;e(lv>0){Z
 do{I("You:");s(A);m=atoi(A);*A='\0';}e(!E(V,m,2,0)&&m!=99);
 W(m!=99)lv--;W(lv<15&&u<10)u+=2;U("Wait\n");I("Value:%d\n",S(0,V,1,0,-9000,9000
 ));I("move: %d\n",(lv-=E(V,bz,1,0),bz));}}E(v,z,f,o)l*v;{l*j,q=3-f,g=0,i,w,*k=v

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -68,7 +68,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -22,11 +22,7 @@ by chance or is killed.
 ### Try:
 
 ```sh
-./ovdluhe < ./ovdluhe.c
-./ovdluhe < ./ovdluhe.c
-
-./ovdluhe < README.md
-./ovdluhe < README.md
+./try.sh ; sleep 2 ; ./try.sh
 ```
 
 

--- a/1989/ovdluhe/try.sh
+++ b/1989/ovdluhe/try.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1989/ovdluhe
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+i=0
+for ((i=0; i<4; ++i)); do
+    read -r -n 1 -p "Press any key to run: ./ovdluhe < ovdluhe.c: "
+    echo 1>&2
+    ./ovdluhe < ovdluhe.c
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./ovdluhe < README.md: "
+    echo 1>&2
+    ./ovdluhe < README.md
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./ovdluhe < Makefile: "
+    echo 1>&2
+    ./ovdluhe < Makefile
+    echo 1>&2
+done

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -67,7 +67,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/1990/jaw/try.sh
+++ b/1990/jaw/try.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Running shark.sh:"
-./shark.sh shark.sh README.md jaw.c try.sh > receive || exit 1
+./shark.sh atob shark.sh README.md jaw.c try.sh > receive || exit 1
 echo "Done."
 
 

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts \
 	-Wno-deprecated-declarations -Wno-empty-body -Wno-error \
 	-Wno-implicit-function-declaration -Wno-parentheses -Wno-pedantic \
 	-Wno-return-type -Wno-unused-parameter -Wno-unused-value \
-	-Wno-deprecated-non-prototype
+	-Wno-deprecated-non-prototype -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -69,7 +69,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We DISABLE the optimiser because having it enabled will cause a crash in some
+# invocations in some systems.
+OPT= -O0
 
 # Default flags for ANSI C compilation
 #
@@ -133,8 +135,11 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We DISABLE THE OPTIMISER because when it's enabled in some conditions it
+# crashes.
+#
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 $< -o $@ ${LDFLAGS}
 
 ag: ${PROG}
 	${RM} -f $@

--- a/1992/gson/README.md
+++ b/1992/gson/README.md
@@ -4,6 +4,10 @@
 make all
 ```
 
+NOTE: we DISABLE the optimiser because having it enabled causes some invocations
+to crash in some systems.
+
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:
@@ -127,13 +131,14 @@ Instead, it tries to achieve both its speed and its obscurity through a
 careful choice of algorithms.  Some of the finer points of those
 algorithms are outlined in the spoiler below.
 
+
 ### How it works:
 
 Here follows a description of some of the data structures and
 algorithms used by AG.  It is by no means complete, but it may help
 you get an idea about the general principles.
 
---
+---
 
 Internally, AG represents words and sentences as arrays of 32
 4-bit integer elements.  Each element represents the number of

--- a/1992/gson/try.sh
+++ b/1992/gson/try.sh
@@ -35,48 +35,42 @@ fi
 
 # safety check that DICT is not empty and is a readable file
 #
-if [[ -z "$DICT" || ! -f "$DICT" || ! -r "$DICT" ]]; then
-    echo "No dictionary file found, try specifying one like:" 1>&2
+if [[ -n "$DICT" && -f "$DICT" && -r "$DICT" ]]; then
+    echo "$ ./ag free software foundation < $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
     echo 1>&2
-    echo "  DICT=dict ./try.sh" 1>&2
+    ./ag free software foundation < "$DICT" 2>/dev/null | less -rEXF
+
+    echo "$ ./ag obfuscated c contest < $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
     echo 1>&2
-    exit 1
+    ./ag obfuscated c contest < "$DICT" 2>/dev/null | less -rEXF
+
+    echo "$ ./ag unix international	< $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+    echo 1>&2
+    ./ag unix international	< "$DICT" 2>/dev/null | less -rEXF
+
+    echo "$ ./ag george bush < $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+    echo 1>&2
+    ./ag george bush < "$DICT" 2>/dev/null | less -rEXF
+
+    echo "$ ./ag bill clinton < $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+    echo 1>&2
+    ./ag bill clinton < "$DICT" 2>/dev/null | less -rEXF
+
+    echo "$ ./ag ross perot	< $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+    echo 1>&2
+    ./ag ross perot	< "$DICT" 2>/dev/null | less -rEXF
+
+    echo "$ ./ag paul e tsongas < $DICT" 1>&2
+    read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+    echo 1>&2
+    ./ag paul e tsongas < "$DICT" 2>/dev/null | less -rEXF
 fi
-
-echo "$ ./ag free software foundation < $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag free software foundation < "$DICT" 2>/dev/null | less -rEXF
-
-echo "$ ./ag obfuscated c contest < $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag obfuscated c contest < "$DICT" 2>/dev/null | less -rEXF
-
-echo "$ ./ag unix international	< $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag unix international	< "$DICT" 2>/dev/null | less -rEXF
-
-echo "$ ./ag george bush < $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag george bush < "$DICT" 2>/dev/null | less -rEXF
-
-echo "$ ./ag bill clinton < $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag bill clinton < "$DICT" 2>/dev/null | less -rEXF
-
-echo "$ ./ag ross perot	< $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag ross perot	< "$DICT" 2>/dev/null | less -rEXF
-
-echo "$ ./ag paul e tsongas < $DICT" 1>&2
-read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
-echo 1>&2
-./ag paul e tsongas < "$DICT" 2>/dev/null | less -rEXF
 
 # now try making our own dictionary with mkdict.sh:
 #

--- a/1992/gson/try.sh
+++ b/1992/gson/try.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1992/gson
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# attempt to find a dictionary file if DICT unset or not a regular readable file
+#
+if [[ -z "$DICT" || ! -f "$DICT" || ! -r "$DICT" ]]; then
+    DICT="/usr/share/dict/words"
+
+    if [[ ! -r "$DICT" ]]; then
+	DICT="/usr/share/lib/spell/words"
+
+	if [[ ! -r "$DICT" ]]; then
+	    DICT="/usr/ucblib/dict/words"
+	    
+	    if [[ ! -r "$DICT" ]]; then
+		DICT="/dev/null"
+	    fi
+	fi
+    fi
+fi
+
+# safety check that DICT is not empty and is a readable file
+#
+if [[ -z "$DICT" || ! -f "$DICT" || ! -r "$DICT" ]]; then
+    echo "No dictionary file found, try specifying one like:" 1>&2
+    echo 1>&2
+    echo "  DICT=dict ./try.sh" 1>&2
+    echo 1>&2
+    exit 1
+fi
+
+echo "$ ./ag free software foundation < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag free software foundation < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag obfuscated c contest < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag obfuscated c contest < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag unix international	< $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag unix international	< "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag george bush < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag george bush < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag bill clinton < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag bill clinton < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag ross perot	< $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag ross perot	< "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag paul e tsongas < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag paul e tsongas < "$DICT" 2>/dev/null | less -rEXF
+
+# now try making our own dictionary with mkdict.sh:
+#
+rm -f words
+cat README.md try.sh Makefile | ./mkdict.sh > words
+DICT="words"
+
+read -r -n 1 -p "Press any key to use our own dict from mkdict.sh: "
+echo 1>&2
+
+echo "$ ./ag free software foundation < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag free software foundation < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag obfuscated c contest < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag obfuscated c contest < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag unix international	< $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag unix international	< "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag george bush < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag george bush < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag bill clinton < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag bill clinton < "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag ross perot	< $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag ross perot	< "$DICT" 2>/dev/null | less -rEXF
+
+echo "$ ./ag paul e tsongas < $DICT" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./ag paul e tsongas < "$DICT" 2>/dev/null | less -rEXF

--- a/2000/tomx/try.sh
+++ b/2000/tomx/try.sh
@@ -15,11 +15,6 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-if [[ ! -f "tomx" || ! -e "tomx" ]]; then
-    echo "Compiling tomx.c:" 1>&2
-    make all || exit 1
-fi
-
 echo "Running tomx:" 1>&2
 echo "$ ./tomx" 1>&2
 ./tomx

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -71,7 +71,7 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+OPT= -O3
 
 # Default flags for ANSI C compilation
 #

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -65,7 +65,9 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We MUST DISABLE THE OPTIMISER AND ENABLE -g because the entry is A BACKTRACE
+# QUINE and NEEDS debugging symbols.
+OPT= -O0 -g
 
 # Default flags for ANSI C compilation
 #
@@ -129,6 +131,9 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We FORCE the use of -O0 -g even if someone overrides it because this entry is
+# a BACKTRACE QUINE and NEEDS DEBUGGING SYMBOLS.
+#
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} -g $< -o $@ ${LDFLAGS}
 

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -4,6 +4,9 @@
 make
 ```
 
+NOTE: we FORCE disable the optimiser and FORCE enable `-g` as this is a
+BACKTRACE QUINE and NEEDS debugging symbols.
+
 
 ### Bugs and (Mis)features:
 

--- a/bugs.md
+++ b/bugs.md
@@ -667,6 +667,60 @@ Enjoy! :-)
 # 1990
 
 
+## 1990 jaw
+
+### STATUS: known bug - please help us fix
+### Source code: [1990/jaw/jaw.c](1990/jaw/jaw.c)
+### Information: [1990/jaw/README.md](1990/jaw/README.md)
+
+[Cody Boone Ferguson](https://www.ioccc.org/winners.html#Cody_Boone_Ferguson)
+fixed some issues in this program and [Yusuke
+Endoh](https://www.ioccc.org/winners.html#Yusuke_Endoh) provided the `btoa`
+script but it appears there is a bug in this entry. The judges wrote that to
+test the entry one can do:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
+```
+
+which should apply the identity transformation to a minimal holoalphabetic
+sentence.
+
+But doing this shows instead:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw
+a얖?)V...?????777??hC??h??-?	)SSSSXXX????r?L=???*?-???ppp,,,?R
+?j
+111-)))? '..F@E
+               ???b111?
+..F..F.?n,,,,,L@E$
+```
+
+Notice how there's no newline at the end: that final `$` is the prompt.
+
+If one does, however:
+
+```sh
+echo "Quartz glyph jocks vend, fix, BMW." | compress | ./btoa | ./jaw | ./jaw
+```
+
+they will get just
+
+```
+oops
+```
+
+which seems to be an error message (one of the fixes was to make it not use
+`perror(3)` - this fixed something else though it's no longer known what).
+
+The script [shark.sh](/1990/jaw/shark.sh) has some issues too in that due to
+path not having `.` (this and maybe some other things were fixed) and `tar` not
+wanting to accept reading from `stdin` (this in particular) even with the right
+options used, seemingly, it has to write to disk the tarball which seems to
+defeat the purpose. This would ideally be fixed.
+
+
 ## 1990 theorem
 
 ### STATUS: INABIAF - please **DO NOT** fix

--- a/bugs.md
+++ b/bugs.md
@@ -893,7 +893,18 @@ problem of `gets()` being used in a more complex way.
 
 It would be ideal if it were to use `fgets()` though. This will probably be
 looked at later but you're welcome to try and fix this too! A tip on how
-`gets()` is being used is in the [FAQ](/faq.md#gets) file.
+`gets()` is being used from Cody:
+
+Previously it had a buffer size of 256 which could easily overflow. In this
+entry `gets(3)` is used in a more complicated way: first `m` is set to `*++p` in
+a for loop where `p` is argv. Later `m` is set to point to `h` which was of size
+256. `gets(3)` is called as `m = gets(m)`) but trying to change it to use
+`fgets(3)` proved more a problem. Since the input must come from the command
+line Cody changed the buffer size to `ARG_MAX+1` which should be enough (again
+theoretically) especially since the command expects redirecting a dictionary
+file as part of the command line. This also makes it possible for longer strings
+to be read (in case the `gets(3)` was not used in a loop).
+
 
 
 ## 1992 kivinen

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1420,25 +1420,19 @@ commands that we suggested and some additional ones that provide for some fun.
 [Cody](#cody) fixed a crash that prevented this entry from working in some cases in some
 systems (like macOS) by disabling the optimiser in the Makefile.
 
-Cody also changed the buffer size in such a way that `gets(3)` should be safe
-(theoretically) as it comes from the command line (though it can also read input
-from stdin after starting the program). Ideally `fgets(3)` would be used but this
-is a more problematic.  Previously it had a buffer size of 256 which could
-easily overflow. In this entry `gets(3)` is used in a more complicated way:
-first `m` is set to `*++p` in a for loop where `p` is argv. Later `m` is set to
-point to `h` which was of size 256. `gets(3)` is called as `m = gets(m)`) but
-trying to change it to use `fgets(3)` proved more a problem. Since the input must
-come from the command line Cody changed the buffer size to `ARG_MAX+1` which
-should be enough (again theoretically) especially since the command expects
-redirecting a dictionary file as part of the command line. This also makes it
-possible for longer strings to be read (in case the `gets(3)` was not used in a
-loop).
+Cody also added the [try.sh](/1992/gson/try.sh) script.
 
 Cody also added the [mkdict.sh](/1992/gson/mkdict.sh) script that the author
 included in their remarks. See the README.md for its purpose. It was NOT fixed
 for [ShellCheck](https://github.com/koalaman/shellcheck)
-because the author deliberately obfuscated it so **PLEASE DO NOT
-FIX THIS**.
+because the author deliberately obfuscated it so **PLEASE *DO NOT* FIX THIS OR
+MODERNISE IT**.
+
+Cody also changed the buffer size in such a way that `gets(3)` should be safe
+(well, theoretically) as it comes from the command line (though it can also read input
+from `stdin` after starting the program). Ideally `fgets(3)` would be used but this
+is a more problematic. See [1992/gson in bugs.md](/bugs.md#1992-gson) for more
+details if you're interested in trying to understand it (or fix?).
 
 
 ## <a name="1992_imc"></a>[1992/imc](/1992/imc/imc.c) ([README.md](/1992/imc/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -744,6 +744,12 @@ and over again, flooding the screen. The problem is that there was a `for` loop
 that by necessity had to not have an increment stage but only in the `if` path
 (in the loop itself) did the pointer get updated.
 
+Cody also provided the [try.sh](/1989/ovdluhe/try.sh) script which runs the
+program four times on three files to show the different output. It doesn't run
+the program on each file four times in a row but rather does it on each file
+and starts over, doing it four times, to help with hopefully allowing different
+output.
+
 Cody also provided an [alternate version](/1989/ovdluhe/ovdluhe.alt.c) based on the
 author's remarks. See the README.md for details. The fix described above was
 fixed in this version too, after it was discovered and fixed.


### PR DESCRIPTION

Don't exit if it can't find a 'normal' dictionary file, skipping the 
creation of one from mkdict.sh. Just use the one generated from 
mkdict.sh if no other file can be opened (which most likely won't happen
but it can happen as not all systems have /usr/share/dict/words and the
others are unlikely in modern systems).