### PR TITLE
Improve 2019/karns/try.sh, force -O0

### DIFF
--- a/2019/giles/README.md
+++ b/2019/giles/README.md
@@ -51,10 +51,11 @@ under a free license.
 
 This program has also been successfully compiled on Windows, with both the [Tiny
 C Compiler](https://bellard.org/tcc/) and Microsoft's C/C++ compiler. However,
-the latter reports warnings about loss of information when converting floats,
+the latter reports warnings about loss of information when converting `float`s,
 and that `void (*)()` and `void (*)(void)` are not the same thing.
 
 Interesting fact: The size of the program from `./iocccsize -i` is 2019.
+
 
 #### How to use:
 
@@ -98,6 +99,7 @@ print `Bad input file` or `Wave file must be 16 bits,1-2 channels.` depending on
 what it thinks the problem is. If the output file cannot be opened, the program
 will print `Can't open output file`.
 
+
 ### Assumptions:
 
 1. The code is compiled using the C99 or C11 standard.
@@ -106,6 +108,7 @@ will print `Can't open output file`.
 represents the number zero.
 4. `int16_t` and `int32_t` are 2's-complement, `sizeof(int16_t) == 2` and
 `sizeof(int32_t) == 4`.
+
 
 ### Obfuscations
 
@@ -143,8 +146,8 @@ to decipher it.
 `#define`s are used to abbreviate the code, which has a side effect of making it
 very slightly harder to read.
 
-* `k` is just a general-purpose replacement for 16.
-* `i` is the number of delay-lines to allocate and use (currently 24).
+* `k` is just a general-purpose replacement for `16`.
+* `i` is the number of delay-lines to allocate and use (currently `24`).
 * `q` is an abbreviation for multiplying two elements of `w[]` together.
 * `u()` is used to display percentages with proper rounding.
 * `j()` imposes an upper limit on a floating-point value, and then negates it.
@@ -186,7 +189,7 @@ As many values as possible have been crammed into arrays. `float w[]` contains:
 
 All of the strings are concatenated together and "encrypted" by breaking the
 string into 4-byte chunks (by casting it to an `int32_t*`), and then XORing the
-sequence of ints with a known numeric sequence. The "decryption" is not done
+sequence of `int`s with a known numeric sequence. The "decryption" is not done
 in-place, to avoid writing over the string constant.
 
 `int32_t *c` is a pointer that points into `f[]`, except that it is often

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -68,7 +68,8 @@ CINCLUDE=
 
 # Optimization
 #
-OPT=
+# We disable the optimiser because the entry has problems with it enabled.
+OPT= -O0
 
 # Default flags for ANSI C compilation
 #
@@ -137,8 +138,11 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+
+# We FORCE the use of -O0 even if someone overrides it because this entry has
+# problems with it enabled.
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 $< -o $@ ${LDFLAGS}
 	${LN} -sf ${PROG} tbfs
 
 test: ${PROG}

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -4,6 +4,21 @@
 make
 ```
 
+NOTE: we disable the optimiser because this program has problems with it
+enabled.
+
+
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2019 karns in bugs.md](/bugs.md#2019-karns).
+
+
 
 ## To use:
 
@@ -11,22 +26,25 @@ make
 ./prog < textfile_that_fits_on_the_screen
 ```
 
+You might want to type:
+
+```sh
+reset
+```
+
+after running the program to restore the terminal to its previous state.
+
 
 ### Try:
 
 ```sh
-./prog < README.md
-
-./prog < prog.c
-
-./prog < maze
+./try.sh
 ```
 
-The last two can be done in a sequence, first showing the respective files at
-the terminal, like:
+If you have more time you might want to try:
 
 ```sh
-./try.sh
+./prog < README.md
 ```
 
 
@@ -37,10 +55,10 @@ not, YMMV -- teach you how to find your way in a maze. The algorithm is
 well-known but the drawing is amazing!
 
 Before running, make sure that your terminal can accommodate the whole file.
-Before running "make test", make it about 120x40 to be safe, ensuring that you
-see the @ sign as well as the exclamation mark.
+Before running `make test`, make it about 120x40 to be safe, ensuring that you
+see the `@` sign as well as the exclamation mark.
 
-...Oh, and the first M in YMMV stands for "mazing".
+...Oh, and the first `M` in YMMV stands for "mazing".
 
 A puzzle for the reader: Can you change the program to consider a diagonal
 movement as one step?
@@ -50,14 +68,16 @@ movement as one step?
 
 ### The Program:
 
-This program is pretty simple! It performs a breadth first search on the
-specified graph. The graph can be any ascii text file  that has an 'at'
-character, which is going to be the starting location, and a '!' character
+This program is pretty simple! It performs a [breadth first
+search](https://en.wikipedia.org/wiki/Breadth-first_search) on the
+specified graph. The graph can be any ASCII text file that has an 'at' (`@`)
+character, which is going to be the starting location, and a `!` character
 which will be the destination.
 
 The nodes on this graph that are spaces are connected with any directly
 adjacent nodes that are also spaces. Nodes that aren't spaces are not
 connected with anything.
+
 
 ### Compiling and Running:
 
@@ -67,7 +87,7 @@ This program usually compiles under both GCC and clang. Build with:
 $(CC) -std=c99 -o tbfs prog.c
 ```
 
-where $(CC) is cc, gcc, clang, or some other c compiler.
+where `$(CC)` is cc, gcc, clang, or some other C compiler.
 
 You can then run it with:
 

--- a/2019/karns/try.sh
+++ b/2019/karns/try.sh
@@ -20,13 +20,11 @@ clear
 # display prog.c to the user
 echo "$ cat prog.c"
 cat prog.c
-sleep 2
 
-# run the program on itself
-echo "$ ./prog < prog.c"
-sleep 2
+# run the program on its own source code
+read -r -n 1 -p "Press any key to run: ./prog < prog.c: "
+echo 1>&2
 ./prog < prog.c
-sleep 2
 
 # reset terminal for colours
 reset
@@ -34,13 +32,12 @@ reset
 # display maze
 echo "$ cat maze"
 cat maze
-sleep 2
 
 # run the program on maze
-echo "$ ./prog < maze"
-sleep 2
+read -r -n 1 -p "Press any key to run: ./prog < maze: "
+echo 1>&2
 ./prog < maze
 
-sleep 2
+read -r -n 1 -p "Press any key to exit: "
 # reset terminal
 reset

--- a/2019/karns/try.sh
+++ b/2019/karns/try.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #
-# Demo of IOCCC 26 (2019) 'Most in need of whitespace' entry by Joshua Karns.
-#
-# Doesn't run the program on README.md as it's longer and slower.
+# try.sh - demonstrate IOCCC winner 2019/karns
 #
 
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it

--- a/bugs.md
+++ b/bugs.md
@@ -3466,6 +3466,32 @@ As a backtrace quine this entry is **SUPPOSED to segfault** so this should not b
 touched either.
 
 
+## 2019 karns
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2019/karns/prog.c](2019/karns/prog.c)
+### Information: [2019/karns/README.md](2019/karns/README.md)
+
+The author stated the following:
+
+---
+
+- The program must be ran in a terminal that supports ANSI escape codes for
+moving the cursor and changing colors.
+- Segfaults happen sometimes.
+- I don't know what memory management there is, if any.
+- The program will not compile by an ANSI C compiler: it uses for loops, and
+it uses C++ style comments. It should compile cleanly using a C99 standard.
+- Breadth first search is slow (and very slow on certain maps), but my A star
+version of this program is too big.
+- Lots of extra whitespace may be needed if you want to feed in an arbitrary
+file.
+- It fails to compile on GCC sometimes (according to a friend of mine, I've
+not encountered this myself).
+- The program could be obfuscated much further.
+- The program contains some unused code and data.
+
+
 ## 2019 poikola
 
 ### STATUS: INABIAF - please **DO NOT** fix


### PR DESCRIPTION

The try.sh script now prompts for input rather than just sleep for 2 
seconds.

The README.md file has been format/typo checked.

Added issues reported by the author to bugs.md.

Force disable optimiser as the program doesn't work in some cases with 
it enabled. If I recall correctly it crashed in some cases, something 
the author noted happens sometimes (it is unknown if it is because they
had it enabled or if it was something else but I have not experienced a
crash since then).