### PR TITLE
Add 2019/poikola alt code, try, try.alt, others

### DIFF
--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -146,7 +146,7 @@ data: ${DATA}
 	@${TRUE}
 
 docs: ${DOCS}
-	pdflatex ${DOCS}
+	${PDFLATEX} ${DOCS}
 
 
 # both all and alt

--- a/2019/poikola/.gitignore
+++ b/2019/poikola/.gitignore
@@ -9,4 +9,5 @@ poikola.log
 poikola.pdf
 poikola.synctex.gz
 prog
+prog.alt
 prog.orig

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -47,7 +47,8 @@ CWARN= -Wall -Wextra -pedantic ${CSILENCE}
 
 # Compiler standard
 #
-CSTD= -std=gnu17
+# The author did not test gnu17 but did gnu11 so we set to gnu11.
+CSTD= -std=gnu11
 
 # Compiler bit architecture
 #
@@ -66,7 +67,10 @@ CINCLUDE=
 
 # Optimization
 #
-OPT= -O3
+# We disable the optimiser because the author stated that for GCC optimiser
+# level 0 gave correct output. With clang [0123s] works which suggests that
+# [123s] might or might not work with GCC.
+OPT= -O0
 
 # Default flags for ANSI C compilation
 #
@@ -116,8 +120,8 @@ CSRC= ${PROG}.o
 DATA= poikola.tex
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 DOCS= poikola.tex
 #################
@@ -132,13 +136,26 @@ all: data ${TARGET}
 	clean clobber install love haste waste maker easter_egg \
 	sandwich supernova deep_magic magic charon pluto
 
+# We disable the optimiser because the author stated that for GCC optimiser
+# level 0 gave correct output. With clang [0123s] works which suggests that
+# [123s] might or might not work with GCC. The author also stated that they did
+# not test gnu17 but for clang and GCC gnu11 does so we also set the standard to
+# gnu11.
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -O0 -std=gnu11 $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+# We disable the optimiser because the author stated that for GCC optimiser
+# level 0 gave correct output. With clang [0123s] works which suggests that
+# [123s] might or might not work with GCC. The author also stated that they did
+# not test gnu17 but for clang and GCC gnu11 does so we also set the standard to
+# gnu11.
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} -O0 -std=gnu11 $< -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -146,7 +146,7 @@ data: ${DATA}
 	@${TRUE}
 
 docs: ${DOCS}
-	pdflatex ${DOCS}
+	${PDFLATEX} ${DOCS}
 
 # both all and alt
 #

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -4,6 +4,14 @@
 make
 ```
 
+There is an alternate version of this program which changes the way the output
+is displayed. See [Alternate code](#alternate-code) below.
+
+NOTE: we disable the optimiser because the author stated that for GCC optimiser
+level 0 gave correct output. With clang [0123s] works which suggests that [123s]
+might or might not work with GCC. Likewise, we do similar for the standard,
+forcing `-std=gnu11`.
+
 
 ### Bugs and (Mis)features:
 
@@ -26,7 +34,16 @@ sleep 86400; make clobber prog
 
 sleep 86400; make clobber prog
 ./prog 512 ./prog
+
 ```
+
+If you wish for some documentation:
+
+```sh
+make docs
+```
+
+This will create the file `poikola.pdf` for your enjoyment.
 
 
 ### Try:
@@ -34,21 +51,35 @@ sleep 86400; make clobber prog
 If you don't have a few days, try:
 
 ```sh
-TZ=UTC24 make clobber prog
-./prog 512 ./prog
-
-TZ=UTC48 make clobber prog
-./prog 512 ./prog
+./try.sh
 ```
 
-This program will not validate input so it might fail or get stuck if invoked
-erroneously.
+As the [bugs.md](/bugs.md#2019-poikola) says, this program will not validate
+input so it might get stuck or fail if invoked erroneously.
 
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
 
+## Alternate code:
+
+This version prints a newline after each number for parsing in other ways than
+what can be done with the original entry.
+
+
+### Alternate build:
+
+```sh
+make alt
 ```
-That's not a bug, that's a feature.
+
+
+### Alternate use:
+
+Use `prog.alt` as you would `prog` above.
+
+
+### Alternate try:
+
+```sh
+./try.alt.sh
 ```
 
 
@@ -57,9 +88,12 @@ That's not a bug, that's a feature.
 Do you have the time to see what this program does?  Think again, come back and
 try again.
 
-Note that 2 can be said to be the least odd prime because it is the greatest
-even prime.  Moreover 2 can be also said to be the greatest odd prime because it
-is the least even prime.
+Note that [2](https://t5k.org/curios/page.php/2.html) can be said to be the
+least [odd](https://en.wikipedia.org/wiki/Parity_(mathematics))
+[prime](https://en.wikipedia.org/wiki/Prime_number) because it is the greatest
+[even](https://en.wikipedia.org/wiki/Parity_(mathematics)) prime.  Moreover `2`
+can be also said to be the greatest odd prime because it is the least even
+prime.
 
 The source code layout and some of the variable names honors the ski jumping
 accomplishments of [Matti
@@ -67,6 +101,7 @@ Nyk&auml;nen](https://en.wikipedia.org/wiki/Matti_Nyk%C3%A4nen).
 
 
 ## Author's remarks:
+
 
 ### How to build:
 
@@ -86,11 +121,13 @@ e.g.:
 clang -O1 -o prog prog.c
 ```
 
+
 ### Poster:
 
 You can generate an A3 sized poster by `make docs`. This command creates a pdf
 file `poikola.pdf`. This requires the
 [pdfTeX](https://en.wikipedia.org/wiki/PdfTeX) tool.
+
 
 ### What this entry does:
 
@@ -111,19 +148,20 @@ jumper](https://en.wikipedia.org/wiki/Matti_Nyk%C3%A4nen) and [amateur
 philosopher](http://telefinn.blogspot.com/2011/11/matti-nykanen-quotes.html),
 who passed away on fourth of February 2019.
 
+
 ### Oh boys:
 
 So, I followed the rules given by [Gandalf the
 White](https://www.glyphweb.com/arda/g/gandalf.html) and the [Judges of
-IOCCC](/judges.html).
+the IOCCC](/judges.html).
 
 Output of `iocccsize`, using the [2019 version of
 iocccsize](https://www.ioccc.org/2019/iocccsize.c), is carefully selected.  For
 the sake of clarity, I used single letter variables in the code. I also avoided
 unnecessary use of functions.  Like a
-[tripundra](https://en.wikipedia.org/wiki/Tripundra), this program has three levels.
-In order to reveal all of them, you have to compile this program on three
-consecutive days.
+[tripundra](https://en.wikipedia.org/wiki/Tripundra), this program has three
+levels.  In order to reveal all of them, you have to compile this program on
+three consecutive days.
 
 As this is a contest for obfuscated code, the program does not perform
 unnecessary checks, but either fails or gets stuck if invoked erroneously. The
@@ -142,6 +180,7 @@ input in any way.  These same parameters should be given in calculating a
 numbers](https://en.wikipedia.org/wiki/Prime_number). *Please note that maximum
 file size is one gigabyte*!
 
+
 ### Obfuscation:
 
 *Matti Nyk&auml;nen*: Every time I jump, and I get that feeling of _bon voyage_,
@@ -150,10 +189,11 @@ the feeling that I've been here before.
 *Matti Nyk&auml;nen*: When you are about to jump, you are all alone and have to
 make your own decisions. Up there, it's all _up yours_.
 
-This code has some jumping too. I used some `goto`s instead of `longjmp()`. Some
+This code has some jumping too. I used some `goto`s instead of `longjmp(3)`. Some
 Finnish [ski jumping](https://en.wikipedia.org/wiki/Ski_jumping) sites are used
 as labels, however, there is `lahti` instead of <tt style="font-family: Monaco,
 Courier New, monospace;font-size: 12px;">salpausselk&auml;</tt>.
+
 
 ### SHA-3-512 Compatibility chart ###
 
@@ -167,10 +207,12 @@ and iso9899:2011 (argument of `-std=`).
 GCC-6: For optimization level 0, correct output using the C standards
 c11, c99, gnu11, gnu1x, gnu89, gnu90, gnu99, iso9899:1999 and iso9899:2011.
 
+
 ### Missing a prime
 
 For obvious reason, the [oddest
 prime](https://mathworld.wolfram.com/OddPrime.html) is missing from output.
+
 
 ### Observations
 
@@ -178,6 +220,7 @@ prime](https://mathworld.wolfram.com/OddPrime.html) is missing from output.
 achieve exactly the same output from different optimization levels and
 compilers. Small change in code can produce really unexpected results, i.e. the
 compiler can skip a few expressions or statements without obvious reason.
+
 
 ### Major spoilers
 
@@ -193,7 +236,7 @@ that `(23*m/9+(m<3?y--:y-2)+d+4+y/4-y/100+y/400)%7` is one character shorter. In
 my solution, `m<3?y--:y-2` is used directly, instead of assigning a value to
 `d`.
 
-Q is pronounced in Finnish exactly like "kuu", a word for
+`Q` is pronounced in Finnish exactly like `kuu`, a word for
 [month](https://en.wikipedia.org/wiki/Month) or the
 [Moon](https://en.wikipedia.org/wiki/Moon). So, `Q = k` is intended.
 
@@ -207,22 +250,23 @@ code from my high school C-programming course. Originally, I wrote it over 20
 years ago. My teacher said that it is (too) complicated to use bits stored in
 arrays, so I did it.
 
+
 ### Other stuff
 
 [Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson): I really like that you enjoyed my
 previous entry. I hope that you will like this entry too.  Because I did not
 want to give too many clues to [the Judges](/judges.html), I tried to write this
-entry in a different way than [Most Stellar](/2018/poikola/prog.c), but in this
+entry in a different way than [Most Stellar](/2018/poikola/README.md), but in this
 code there is at least one recycled thing from it. By the way, the answers to
-the questions I posed: `(1)` 255. `(2)` Try to compare binary representations of
-those floats and binary representation of the string "`25th IOCCC!`". `(3)` I
+the questions I posed: (1) 255. (2) Try to compare binary representations of
+those `float`s and binary representation of the string "`25th IOCCC!`". (3) I
 don't know. I used standard [trigonometric
 functions](https://en.wikipedia.org/wiki/Trigonometric_functions) from
 [math.h](https://en.wikipedia.org/wiki/C_mathematical_functions#Overview_of_functions)
 for rotating the [Big Dipper](https://en.wikipedia.org/wiki/Big_Dipper) and
 later replaced those functions with my own implementations.  But there was a bug
 in my code and the effect was more beautiful than intended.  I did not even
-debug this bug and now it works as a feature. `(4)` It is not possible. If you
+debug this bug and now it works as a feature. (4) It is not possible. If you
 change a single bit, the [Fletcher's 16
 checksum](https://en.wikipedia.org/wiki/Fletcher%27s_checksum#Fletcher-16) does
 not match anymore and `goto` jumps to the end of the code.

--- a/2019/poikola/prog.alt.c
+++ b/2019/poikola/prog.alt.c
@@ -1,0 +1,71 @@
+#include    <stdio.h>
+#include   <string.h>
+#include    <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+#define 		W 48
+#define 		b '\b'
+#define 		q R[2]==
+#define			R __DATE__
+#define 		n 1073741824ul
+#define 		L (V) l[++S] << b * S
+#define 		D (R[7]-W)*1000+(R[b]-W)*100+(R[9]-W)*10+R[10]-W
+#define k q'p'?9:q'y'?5:q'n'?(R[1]=='u'?6:1):q'b'?2:q'r'?(*R=='M'?3:4):q'g'?8:q't'?10:q'v'?11:q'l'?7:12
+#define 		Z B |= (V) *l++ << u++ * b;
+#define 		g for(a=0;a<5;a++)
+#define			o     25
+#define 		G a+
+
+typedef unsigned long			       long V;V _=1ULL   <<               63;  V d=1UL<<037;                     unsigned int x[
+n/16]; V m,F,u,T,a,r,H			      ,B,I; int main(int P,               char *U[]){union{V                     K[o];  unsigned
+char E[1]; }c ;   const                      unsigned char *f, *l ;               V X,i,e,z,A,Q,M=-~9,                   Y; struct  stat
+J; void *p; r++ ;V t,y=                     0,v[5];const void*j[ ]=               {&&laajavuori,&&ruka,                  &&puijo,&&lahti
+,&&vuokatti,&&virpiniemi,                  &&ounasvaara};V N[o]={r,		  P,6,M,15,21, 28,36,45,                 55,2,14, 27,41,
+56,b,o,43, 62,18,39,61,20,                44};for(;U[r][a]; a++)T=T               *M+U[!u][a]-W; T >>=P ;                X=open(U[--P],F
+); V w[o]= {_|d|32776,d|r,               _|32896,_| d |32897,_|d|M,               32778,_+128,_ |32770,_ |		 32771,_ |32905,
+_ |139, d| 32907 ,   d|M,d|	         32777,136,138,_|32777,_|d|               32897,d|1,32907,_|d|32768	         ,_|32906,32898,
+r,_}; i=  fstat (X,&J); V O             [o ]={M,7,11,17,18,3,5,16,b               ,21,24,4,15,23,19,13, 12,P,	         20,14,22,9,6,r}
+; Y=H=J./*****/ st_size; p=            mmap(/*TODO: FIX THIS */NULL               ,H,r,r,X, u  ); memset(&c,0,	         200 ) ; z = b &
+7; r =  T/11     [O]; l=p ;           for(I=2; I<=  Y; x[I++>>4]|=(               1<<(I&4[N])) ); goto C; ruka:	         for(I=b*3; I--;
+) { g v[ a ] =c   .K[a]^c.K[G        b-3]^ c.K[G    M] ^ c.K[G 15]^               c.K[G M+M] ;  g  {t =  v[(G 4)         %5]^(v[(G   1)%
+5]<<1|v[(G 1  )   %5] >> '?') ;     for(A =0; A<    o; A+= 5)c.K[ G               A]^=t;}t=c  .K[   1] ; for  ( a        =0; a-24; a ++)
+A =O[a],*v =  c    .K[A],c.K[A]    =t<<N[a]|t>>     (0100-N[a]),t=*               v;for(A    =!o;    A^o; A += 5 )       {g v[a] = c.K[G
+A]; g c .K[G A]     ^= ~v[( G 1)   %5]&v[(G P)      %5];}c.K[!1] ^=               w[I];    } goto     *j[Q];C:for(       I=P; I   <=Y/P;
+y=I*P) {  while      ( y <= Y   ) x[y>>4]&=~(1      <<(y&O[12])), y               +=I; do    I++;      while(~x[I>>4     ]&(1<<(I&15)));
+}if(H<z){ while       (H-- )    Z goto $ ;  }       if (z){ H -= z;               Q= P; while(z--       )Z c.K[F]^=B;    B=u=i; if(o-r==
+++F){goto*j[!!b        ]; puijo:F=!o; } }m=H        /b; e=H - m*b ;               for(; i<m; l+=b        ){i++; V S=~    -!W; t=/*foob*/
+L|L|L|L|L|L|L|L         ;c.K[F] ^= t; if(++F        ==o-r) { Q=-~P;               goto * j [ !0];         lahti: F=!r ;  }}while  (e--)Z
+$: c.K[F]^=(B ^         ((V) ((V)(P | 1 <<          P)<< u* b) )) ;               Q^=Q; c.K[o-r-1          ]^=w[ ~ -o ]; goto*j[-~(P-P)]
+; laajavuori: f          =c.E; _= d=I =~-P          ; a = D; Q = k;               goto*j[4+(23*Q/           9+(Q>P?a-P:a --)+(R[4]==32?0
+:((R[4]-W)*M))+           R[5]-45+a  /4+a           /0620-a/0x64)%	          3]; ounasvaara:            for ( I = 2 ;  I<= Y; I ++)
+if (x[I>>4]& (1            <<(15& I) ) )            printf( "%llu\n"              , I);goto http;             virpiniemi:for( I= !I; I-T
+; ){ char s[30]             ={W,W,'\0'}             ;X=!!W;for(e=f[               I++]; e^0; e>>=              4)P = e & 15, s[X--]= P <
+M ? W | P : P +	            'W'; printf	            ( "%s"  , s); }               /*  addr(ioccc)               */ http://www.ioccc.org/
+return /******/				            puts(""); /***/               vuokatti:for(;I                ^'^';++I,printf("%llx\n"
+,_),t =_+d,_=d,                                     d = t) ;   goto               http;/*m=  o/i;                  v[a]=a+n;return 0;*/}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/2019/poikola/try.alt.sh
+++ b/2019/poikola/try.alt.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 2019/poikola alt code
+#
+# 'I will move to Copenhagen and apply for Swedish citizenship.'
+#
+# -- Matti Ensio Nykänen
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make clobber CC="$CC" alt >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./prog.alt 512 ./prog.alt" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./prog.alt 512 ./prog.alt | less -rEXF
+echo 1>&2
+
+echo "$ TZ=UTC24 make CC="$CC" clobber prog.alt" 1>&2
+TZ=UTC24 make CC="$CC" clobber prog.alt || exit 1
+read -r -n 1 -p "Press any key to run: ./prog.alt 512 ./prog.alt (space = next page, q = quit): "
+echo 1>&2
+./prog.alt 512 ./prog.alt | less -rEXF
+echo 1>&2
+
+echo "$ TZ=UTC48 make CC="$CC" clobber prog.alt" 1>&2
+TZ=UTC48 make CC="$CC" clobber prog.alt || exit 1
+read -r -n 1 -p "Press any key to run: ./prog.alt 512 ./prog.alt (space = next page, q = quit): "
+echo 1>&2
+./prog.alt 512 ./prog.alt | less -rEXF
+echo 1>&2

--- a/2019/poikola/try.sh
+++ b/2019/poikola/try.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2019/poikola
+#
+# 'When you are about to jump, you are all alone and have to make your own
+# decisions. Up there, it's all "up yours".'
+#
+# -- Matti Ensio Nykänen
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make clobber CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./prog 512 ./prog" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+./prog 512 ./prog
+echo 1>&2
+
+echo "$ TZ=UTC24 make CC="$CC" clobber prog" 1>&2
+TZ=UTC24 make CC="$CC" clobber prog || exit 1
+read -r -n 1 -p "Press any key to run: ./prog 512 ./prog: "
+echo 1>&2
+./prog 512 ./prog
+echo 1>&2
+
+echo "$ TZ=UTC48 make CC="$CC" clobber prog" 1>&2
+TZ=UTC48 make CC="$CC" clobber prog || exit 1
+read -r -n 1 -p "Press any key to run: ./prog 512 ./prog: "
+echo 1>&2
+./prog 512 ./prog
+echo 1>&2

--- a/bugs.md
+++ b/bugs.md
@@ -3513,6 +3513,7 @@ remarks in the sections [Syntax](/2019/lynn/README.md#syntax) and
 This program will not validate input so it might fail or get stuck if invoked
 erroneously.
 
+Also, the maximum file size is 1GB.
 
 ## 2019 yang
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4243,6 +4243,24 @@ Cody also added the [example-1.txt](/2019/lynn/example-1.txt) and
 entry existing.
 
 
+## <a name="2019_poikola"></a>[2019/poikola](/2019/poikola/prog.c) ([README.md[(/2019/poikola/README.md))
+
+[Cody](#cody) added the missing `docs` rule to the Makefile that forms a PDF
+file. The rule requires the tool
+[pdflatex](https://tug.org/applications/pdftex/index.html).
+
+Cody also added the [alternate code](/2019/poikola/README.md#alternate-code).
+
+Cody also added the [try.sh](/2019/poikola/try.sh) and
+[try.alt.sh](/2019/poikola/try.alt.sh) scripts.
+
+Cody also disabled the optimiser because the author stated that for clang the
+levels [0123s] work okay but with GCC (6) they only said level 0 works,
+suggesting that with some versions of GCC it might not be correct with levels !=
+0 and since 0 works with clang that's okay. Similarly, the same for C standards
+tested: `gnu17` was not tested but `gnu11` was so the standard was set to
+`gnu11`.
+
 
 ## <a name="2019_yang"></a>[2019/yang](/2019/yang/prog.c) ([README.md](/2019/yang/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4243,6 +4243,7 @@ Cody also added the [example-1.txt](/2019/lynn/example-1.txt) and
 entry existing.
 
 
+
 ## <a name="2019_yang"></a>[2019/yang](/2019/yang/prog.c) ([README.md](/2019/yang/README.md]))
 
 [Cody](#cody) added the [try.sh](/2019/yang/try.sh) script which also involved
@@ -4381,7 +4382,12 @@ fixed, a good example being [1986/marshall](#1986marshall-readmemd) (see the
 had to be done to fix it).
 
 There was a 'problem' where `${MAKE}` was `$(MAKE)`: this doesn't break anything
-but it is inconsistent with the rest of the `${foo}` tools.
+but it is inconsistent with the rest of the `${foo}` tools even if by tradition
+it is `$(MAKE)`.
+
+Cody also added missing variables like `BASH` and `PDFLATEX` to the
+[var.mk](/var.mk) file and removed another that was deemed problematic or
+undesired.
 
 A lot of the fixes with the Makefiles that Cody made were done with his [sgit
 tool](https://github.com/xexyl/sgit).

--- a/var.mk
+++ b/var.mk
@@ -145,6 +145,7 @@ PATCH= patch
 PATHCHK= pathchk
 PAX= pax
 PERL= perl
+PDFLATEX= pdflatex
 PICO= pico
 PR= pr
 PRINTENV= printenv


### PR DESCRIPTION

The alt code is so one can more easily filter the long output: it prints
a newline after each number is printed. The try.alt.sh script uses this.

Force -O0: the author stated that with clang they got correct output for
[0123s] but with GCC 6 they only got that with level 0. Since 0 works
with clang and since the author stated that the compilers used were
picky I changed it to level 0. Similarly and for the same reason I
changed the C standard to gnu11 from gnu17.

Format/typo check README.md file.

Updated bugs.md: noted that the max file size is 1GB.

I would like to give two quotes from the person this entry was dedicated
to:

    'When you are about to jump, you are all alone and have to make your own
     decisions. Up there, it's all "up yours".'

and

    'I will move to Copenhagen and apply for Swedish citizenship.'

simply because they're funny and ironic (and one is quoted by the 
author). These might be found somewhere in this commit.