### PR TITLE
Add 2020/burton/try.sh, improve make test

### DIFF
--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -152,8 +152,8 @@ ${PROG}_be: ${PROG}.c
 	${CC} ${CFLAGS} -DB=${_B} -DI=${_I} -DT=${_T} -DS=${_S} $< -o $@ ${LDFLAGS}
 
 test: check_le.sh check_be.sh prog_le prog_be correct
-	./check_le.sh ./prog_le | ${DIFF} -bw - correct
-	./check_be.sh ./prog_be | ${DIFF} -bw - correct
+	./check_le.sh ./prog_le | ${DIFF} -sbw - correct
+	./check_be.sh ./prog_be | ${DIFF} -sbw - correct
 
 # alternative executable
 #

--- a/2020/burton/README.md
+++ b/2020/burton/README.md
@@ -26,25 +26,22 @@ For more detailed information see [2020 burton in bugs.md](/bugs.md#2020-burton)
 ### Try:
 
 ```sh
-./prog 128
-
-./prog_le 128
-./prog_be 128
-
-./prog 170
-
-./prog 85
-
-./prog 128 128
-./prog 128 128 128
-./prog 128 128 128 128
+./try.sh
 ```
 
 
 ## Alternate code:
 
-By default, this code compiles for Little Endian machines.
-An alternate version is also compiled for Big Endian machines.
+By default, the program works for Little Endian machines. This alternate build
+is for Big Endian machines (that works whether you have LE or BE).
+
+
+### Alternate build:
+
+Running `make` builds the alternate code by default.
+
+
+### Alternate use:
 
 Use `prog_be` as you would `prog` above.
 
@@ -80,11 +77,13 @@ make test
 Invoke this with a single non-negative integer less than 256, and a useful
 transformation occurs.
 
+
 ### Rule 2-ish:
 
 Exporting the constants `B`,`I`,`T`,`S` to the [Makefile](Makefile) allows the
 code to be compiled for either LE (little-endian) or BE (big-endian)
 machines(!!), so they are truly configuration parameters, not logic.
+
 
 ### Notes:
 
@@ -94,16 +93,17 @@ display strange results with more than one argument.
 Small, non-negative integers only.  Useful range is `0 .. 511`, sorta, for LE; `0
 .. 255` for BE.  Bonus points if you can explain why the limits work this way.
 
-ASCII character set, 64-bit long longs are required.
+ASCII character set, 64-bit `long long`s are required.
 
 v,a,r,i,a,b,l,e,s\_NAME the operation.
 
 No loops, no branches?!?
 
+
 #### Compilation:
 
 Compiles cleanly under `clang -Wall -Weverything -pedantic`, but you need to add
-`--include stdio.h --include stdlib.h` for the `printf`(3) and `atoi`(3).
+`--include stdio.h --include stdlib.h` for the `printf(3)` and `atoi(3)`.
 
 On a little-endian machine:
 

--- a/2020/burton/try.sh
+++ b/2020/burton/try.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2020/burton
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ make test" 1>&2
+make test
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./check_be.sh (Big Endian) (space = next page, q = quit): "
+echo 1>&2
+./check_be.sh | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./check_le.sh (Little Endian) (space = next page, q = quit): "
+echo 1>&2
+./check_le.sh | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 128: "
+echo 1>&2
+./prog 128
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog_le 128: "
+echo 1>&2
+./prog_le 128
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog_be 128: "
+echo 1>&2
+./prog_be 128
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 170: "
+echo 1>&2
+./prog 170
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 85: "
+echo 1>&2
+./prog 85
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 128 128: "
+echo 1>&2
+./prog 128 128
+echo 1>&2
+echo "Why did that print strange output?"
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 128 128 128: "
+echo 1>&2
+./prog 128 128 128
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 128 128 128 128: "
+echo 1>&2
+./prog 128 128 128 128
+echo "Why did that print strange output?"
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog 1; ./prog_be 1: "
+echo 1>&2
+./prog 1; ./prog_be 1

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4278,6 +4278,19 @@ shouldn't) and adding the [ioccc.txt](/2019/yang/ioccc.txt) file.
 # <a name="2020"></a>2020
 
 
+## <a name="2020_burton"></a>[2020/burton](/2020/burton/prog.c) ([README.md](/2020/burton/README.md))
+
+[Cody](#cody) fixed the script [check_be.sh](/2020/burton/check_be.sh): it
+assumed that `prog_be` was in `PATH` which is unlikely so it was changed to
+`./prog_be`.
+
+Cody also improved the `make test` rule (which uses `check_be.sh` and the Little
+Endian counterpart) so that it shows that the files are identical rather than
+showing nothing at all.
+
+Cody also added the [try.sh](/2020/burton/try.sh) script.
+
+
 ## <a name="2020_endoh2"></a>[2020/endoh2](/2020/endoh2/prog.c) ([README.md](/2020/endoh2/README.md))
 
 [Cody](#cody) copied the files from the spoiler.zip file that was password protected with


### PR DESCRIPTION
The make test now uses option -s to show that the output is the same (as it should be), for better demonstration.

Format/typo check README.md.