### PR TITLE
Minor update to 2004/sds/README.md

### DIFF
--- a/2004/sds/README.md
+++ b/2004/sds/README.md
@@ -29,17 +29,6 @@ For more detailed information see [2004 sds in bugs.md](/bugs.md#2004-sds).
 ./try.sh
 ```
 
-The generated code will very likely crash or do something else if not given a
-proper command line, like a file that can be opened with `fopen(3)`. This is not
-a bug but a feature.
-
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
-```
-
 
 ## Judges' remarks:
 

--- a/2004/sds/README.md
+++ b/2004/sds/README.md
@@ -64,13 +64,13 @@ decoder.
 Try it out.  Compile the program, then type
 
 ```sh
-sds < sds.c
+./sds < sds.c
 ```
 
 You should see the encoder program displayed.  Now save it, like:
 
 ```sh
-sds < sds.c > encoder.c
+./sds < sds.c > encoder.c
 ```
 
 Then compile `encoder.c`.  You now have the complete system ready.


### PR DESCRIPTION
Let the bugs.md file speak for the feature itself rather than saying in the README.md that the program is is expected to crash if the generated code cannot open a file or there's some invalid command line.