### PR TITLE
Add 2020/kurdyukov1/try.sh + format/typo checks

### DIFF
--- a/2020/giles/.gitignore
+++ b/2020/giles/.gitignore
@@ -4,5 +4,7 @@
 indent
 indent.c
 indent.o
+ioccc28.wav
+jenny.wav
 prog
 prog.orig

--- a/2020/giles/README.md
+++ b/2020/giles/README.md
@@ -5,44 +5,83 @@ make
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2020 giles in bugs.md](/bugs.md#2020-giles).
+
+
+
+
 ## To use:
 
 ```sh
-./prog
+./prog < dtmf.wav
+
+./prog [digits] > digits.wav
 ```
+
+where `dtmf.wav` is a WAV file of the dialling of a number being dialled with
+[DTMF (Dual-tone multi
+frequency)](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling)
+(more commonly known as Touch-Tone) and `[digits]` is a sequence of digits that
+will be converted to the DTMF sound!
 
 
 ### Try:
 
 ```sh
+./try.sh
 ./prog < pi.wav
 
-# [https://en.wikipedia.org/wiki/867-5309/Jenny]
+# See 
 ./prog 867-5309 > jenny.wav
 
-# Use an audio player to play jenny.wav
 ```
+
+If the script [try.sh](try.sh) did not play a WAV file, it means you do not have
+SoX installed; see [FAQ 3.10: How do I compile and use an IOCCC winner that
+requires sound?](/faq.md#faq3_10)). In this case install it and try it again or
+play the files `jenny.wav` and `ioccc28.wav` in a program that can play WAV
+files.
+
+NOTE: the phone number of `jenny.wav` comes from
+<https://en.wikipedia.org/wiki/867-5309/Jenny>.
 
 
 ## Judges' remarks:
 
-A cross platform utility for both encoding and decoding tones.
+A cross platform utility for both encoding and decoding touch tones.
 
 
 ## Author's remarks:
 
 ### Introduction and Usage
 
-This program encodes and decodes [dual-tone multiple frequency](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling) signals used in telephone systems, more commonly known as Touch-Tones.
+This program encodes and decodes [dual-tone multiple
+frequency](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling)
+signals used in telephone systems, more commonly known as Touch-Tones.
 
-If the program is executed with no arguments, it will read a WAV file from standard input, decode the touch-tones in the file, and output the corresponding digits to standard output. This program only supports WAV files that have exactly 16 bits per sample, but it allows any sample rate and any number of audio channels.
+If the program is executed with no arguments, it will read a WAV file from
+standard input, decode the touch-tones in the file, and output the corresponding
+digits to standard output. This program only supports WAV files that have
+exactly 16 bits per sample, but it allows any sample rate and any number of
+audio channels.
+
 
 ```sh
 $ ./prog < pi.wav
 31415926
 ```
 
-If the program is executed with a command-line argument, it will generate the tones corresponding to the specified characters, writing them to standard output as a WAV file.
+If the program is executed with a command-line argument, it will generate the
+tones corresponding to the specified characters, writing them to standard output
+as a WAV file.
 
 ```sh
 $ ./prog 867-5309 | aplay
@@ -50,41 +89,63 @@ $ ./prog 867-5309 | aplay
 
 ### Interesting Features
 
-* When compiled with `gcc -pedantic -Wall -Wextra` there are no compiler warnings.
-* This program can be successfully compiled and run on Windows, using both Microsoft's C compiler and [TCC](https://bellard.org/tcc/).
-* This program resamples the incoming audio, so that it can accept audio data at any sample rate.
-* The code that generates the output sine-waves is the same as the code that looks for sine-waves in the input. (see Algorithm Details for roughly how this works)
-* Despite handling lots of sine waves, the program only uses basic arithmetic operations. It does not depend on `libm`.
-* All type punning is done with `memcpy` so there are no strict-aliasing violations.
-* The size of the source code using the IOCCC size tool is 1963, the year the first push-button telephones were made available to customers.
-* The source code is roughly in the shape of a telephone handset.
+* When compiled with `gcc -pedantic -Wall -Wextra` there are no compiler
+warnings.
+* This program can be successfully compiled and run on Windows, using both
+Microsoft's C compiler and [TCC](https://bellard.org/tcc/).
+* This program resamples the incoming audio, so that it can accept audio data at
+any sample rate.
+* The code that generates the output sine-waves is the same as the code that
+looks for sine-waves in the input. (see Algorithm Details for roughly how this
+works).
+* Despite handling lots of sine waves, the program only uses basic arithmetic
+operations. It does not depend on `libm`.
+* All type punning is done with `memcpy(3)` so there are no strict-aliasing
+violations.
+* The size of the source code using the IOCCC size tool is 1963, the year the
+first push-button telephones were made available to customers.
+* The source code (not counting the C pre-processor) is roughly in the shape of
+a telephone handset.
+
 
 ### Assumptions
 
-* Code is compiled using the C99 or C11 standard
-* `CHAR_BIT == 8`
-* Machine is little-endian
-* `int16_t`, `uint16_t`, and `uint32_t` exist
-* `int16_t` is 2's-complement
-* `double` is an IEEE 754 binary64 floating-point type
-* `sizeof(double) == 8`
+* Code is compiled using the C99 or C11 standard.
+* `CHAR_BIT == 8`.
+* Machine is little-endian.
+* `int16_t`, `uint16_t`, and `uint32_t` exist.
+* `int16_t` is 2's-complement.
+* `double` is an IEEE 754 binary64 floating-point type.
+* `sizeof(double) == 8`.
+
 
 ### Obfuscations
 
-  * DSP code is inherently somewhat difficult to understand.
-  * Lots of identifier reuse. Each identifier is used for about 2.2 different tasks, on average.
-    For example, `aa` is both a variable and a macro for error handling,
-    and `memcpy` is both a library function and a goto-label.
-  * Most of the identifiers are only 1 or 2 characters long, and are unrelated to their actual function.
-  * The `f` macro is used to unroll some of the loops.
-  * Some numerical constants are replaced with character literals, so the actual value is unclear.
-  * All of the strings used by the program have been combined into a single string literal.
-  * Most of the values used for the actual signal-processing all reside in one array, named `l`. This array is usually accessed at index `z` plus a constant. Accesses of this type have been rewritten from, e.g. `l[z+17]` to `17[l+z]`. `[l+z]` ends up occurring quite often, so I created the macro `a` as a shorthand.
+* DSP code is inherently somewhat difficult to understand.
+* Lots of identifier reuse. Each identifier is used for about 2.2 different
+tasks, on average. For example, `aa` is both a variable and a macro for error
+handling, and `memcpy(3)` is both a library function and a `oto` label.
+* Most of the identifiers are only 1 or 2 characters long, and are unrelated to
+their actual function.
+* The `f` macro is used to unroll some of the loops.
+* Some numerical constants are replaced with character literals, so the actual
+value is unclear.
+* All of the strings used by the program have been combined into a single string
+literal.
+* Most of the values used for the actual signal-processing all reside in one
+array, named `l`. This array is usually accessed at index `z` plus a constant.
+Accesses of this type have been rewritten from, e.g. `l[z+17]` to `17[l+z]`.
+`[l+z]` ends up occurring quite often, so I created the macro `a` as a
+shorthand.
 
 
 ### Algorithm Details
 
-Each tone in a DTMF signal is a combination of two frequencies. The lower frequency determines which row the digit is in, and the higher frequency determines the column. There are 4 possible row frequencies and 4 possible column frequencies.
+Each tone in a DTMF signal is a combination of two frequencies. The lower
+frequency determines which row the digit is in, and the higher frequency
+determines the column. There are 4 possible row frequencies and 4 possible
+column frequencies.
+
 
 ```
 |            | **1209 Hz** | **1336 Hz** | **1477 Hz** | **1633 Hz** |
@@ -95,9 +156,20 @@ Each tone in a DTMF signal is a combination of two frequencies. The lower freque
 | **941 Hz** | *           | 0           | #           | D           |
 ```
 
-This program determines which frequencies are present in the input by passing it through a set of 8 virtual resonators, each tuned to one of the frequencies used for DTMF. These can be implemented using only basic arithmetic, and they are able to 'select' a specific frequency from the input sound, blocking all other frequencies from reaching the output. The loudness of the sound output from each resonator can therefore be used as a measure of how much of a particular frequency was present in the input. The program then decides, over the course of one tone, which row frequency and which column frequency were most prominent.
+This program determines which frequencies are present in the input by passing it
+through a set of 8 virtual resonators, each tuned to one of the frequencies used
+for DTMF. These can be implemented using only basic arithmetic, and they are
+able to 'select' a specific frequency from the input sound, blocking all other
+frequencies from reaching the output. The loudness of the sound output from each
+resonator can therefore be used as a measure of how much of a particular
+frequency was present in the input. The program then decides, over the course of
+one tone, which row frequency and which column frequency were most prominent.
 
-Tones are generated using those same resonators by providing [an impulse](https://en.wikipedia.org/wiki/Kronecker_delta#Digital_signal_processing) as input. An impulse can be thought of as consisting of sine-waves at all frequencies, and when it is put through one of the resonators, the result is a single pure sine wave.
+Tones are generated using those same resonators by providing [an
+impulse](https://en.wikipedia.org/wiki/Kronecker_delta#Digital_signal_processing)
+as input. An impulse can be thought of as consisting of sine-waves at all
+frequencies, and when it is put through one of the resonators, the result is a
+single pure sine wave.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2020/giles/try.sh
+++ b/2020/giles/try.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2020/giles
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# try and find play(1). Should be available if SoX is installed.
+PLAY="$(type -P play)"
+
+if [[ -z "$PLAY" ]]; then
+    PLAY="$(type -P aplay)"
+    
+    if [[ -z "$PLAY" ]]; then
+	echo "Note: cannot find play(1) or aplay(1). Will not play sounds for you. Try installing" 1>&2
+	echo "SoX. See FAQ 3.10: How do I compile and use an IOCCC winner that requires sound?" 1>&2
+	echo 1>&2
+	echo "You will have to play the WAV output manually, sorry." 1>&2
+	echo 1>&2
+    fi
+fi
+
+read -r -n 1 -p "Press any key to convert pi.wav to its digits: "
+echo 1>&2
+echo "$ ./prog < pi.wav" 1>&2
+./prog < pi.wav
+if [[ -n "$PLAY" ]]; then
+    read -r -n 1 -p "Press any key to play pi.wav with $PLAY: "
+    echo 1>&2
+    echo "$ $PLAY pi.wav" 1>&2
+    "$PLAY" pi.wav
+fi
+
+read -r -n 1 -p "Press any key convert 867-5309: "
+echo 1>&2
+echo "$ ./prog 867-5309 > jenny.wav" 1>&2
+./prog 867-5309 > jenny.wav
+if [[ -n "$PLAY" ]]; then
+    read -r -n 1 -p "Press any key to play jenny.wav with $PLAY: "
+    echo 1>&2
+    echo "$ $PLAY jenny.wav" 1>&2
+    "$PLAY" jenny.wav
+    echo 1>&2
+    read -r -n 1 -p "Press any key to play 10666-28 ('IOCCC-28'): "
+    echo 1>&2
+    echo "$ ./prog 10666-28 | $PLAY -"
+    ./prog 10666-28 | "$PLAY" -
+else
+    echo 1>&2
+    echo "Now try playing jenny.wav with an audio player that can play WAV files."
+    echo 1>&2
+    read -r -n 1 -p "Press any key to convert 10666-28 ('IOCCC-28'): "
+    echo 1>&2
+    echo "$ ./prog 10666-28 > ioccc28.wav"
+    ./prog 10666-28 > ioccc28.wav
+    echo 1>&2
+    echo "Now try playing ioccc28.wav with an audio player that can play WAV files."
+fi

--- a/2020/kurdyukov1/README.md
+++ b/2020/kurdyukov1/README.md
@@ -4,34 +4,54 @@
 make
 ```
 
+There are alternate versions of this entry. See [Alternate
+code](#alternate-code) below for more details.
+
 
 ## To use:
 
 ```sh
 ./prog
+# input some text
+
+echo text | ./prog
+
+./prog < file
 ```
 
 
 ### Try:
 
 ```sh
-echo IOCCC | ./prog
-
-./prog < prog.x86.asm
-
-./prog < prog.x86_64.asm
+./try.sh
 ```
 
 
 ## Alternate code:
 
-An even smaller alternate version of this entry, prog.alt.c, is provided.  This code does not contain any headers, nor any workaround for WIN32 based platforms.
+There are a number of alternate versions for this program, some in C and some in
+assembly.
 
-To compile this alternate version:
+The file [prog.alt.c](prog.alt.c) is smaller and does not contain any
+headers or any workaround for WIN32 based platforms.
+
+The file [prog.extra.c](prog.extra.c) has a number of layouts including some for
+different social media profile covers as well as different shapes.
+
+The files [prog.x86_64.asm](prog.x86_64.asm) and [prog.x86.asm](prog.x86.asm)
+are the program in assembly for x86_64 linux and x86 linux respectively.
+
+
+### Alternate build:
+
+To build [prog.alt.c](prog.alt.c):
 
 ```sh
 make alt
 ```
+
+
+### Alternate use:
 
 Use `prog.alt` as you would `prog` above.
 
@@ -47,35 +67,51 @@ You should get a-round-to-it figuring it out!
 
 ### MD5 with integers
 
-Just a tiny MD5 checksum utility. Prints hash string of data from stdin.
-Work same as `(openssl md5 | cut -d' ' -f2)` command.
+Just a tiny MD5 checksum utility. Prints hash string of data from `stdin`.
+Works the same as `openssl md5 | cut -d' ' -f2` command.
 
 ### My objectives
 
-1. reduce code size as much as possible
-2. avoid warnings from GCC/CLANG `-Wall -Wextra -pedantic`
-3. portable (regardless of register size and endianness)
-4. fit code in a round shape
-5. no macro defines
-6. no floating-point arithmetics
+1. Reduce code size as much as possible.
+2. Avoid warnings from gcc/clang `-Wall -Wextra -pedantic`.
+3. Portable (regardless of register size and endianness).
+4. Fit code in a round shape.
+5. Mo macro defines.
+6. No floating-point arithmetics.
+
 
 ### Notes
 
-The main difficulty of making MD5 code smaller is a 64x4 bytes long table with constants. Which will take more than 512 bytes in text hex encoding. This table is a results of a sine function, so can be generated dynamically, but merging floating-point arithmetics with precise integer calculations is not a great idea, because can make portability issues.
+The main difficulty of making MD5 code smaller is a 64x4 bytes long table with
+constants which will take more than 512 bytes in hex encoding. This table is a
+results of a sine function, so can be generated dynamically, but merging
+floating-point arithmetics with precise integer calculations is not a great
+idea, because it can cause portability issues.
 
-Attempts to satisfy CLANG `-Weverything` will ruin comma magic, that is so great for obfuscation, so I don't want to care about that.
+Attempts to satisfy `clang -Weverything` will ruin comma magic, that is so great
+for obfuscation, so I don't want to care about that.
 
-Probably, should work correctly on any machines, but I have nothing exotic (like BE or not 32/64) to try it.
+Probably, should work correctly on any machines, but I have nothing exotic (like
+BE or not 32/64) to try it.
 
-Added a macro hack to make stdin work in binary mode under Windows (tested under mingw64), otherwise the hashes can be incorrect.
+Added a macro hack to make `stdin` work in binary mode under Windows (tested
+under mingw64), otherwise the hashes can be incorrect.
+
 
 ### Bonus
 
-- `prog.extra.c` the same with the sine function (so smaller), and in different shapes.
+- [prog.extra.c](prog.extra.c) is the same with the sine function (so smaller),
+and in different shapes.
 
-- `prog.x86_64.asm` contains same program, but written on assembly for x86_64 Linux, for the sake of less executable size. Which is 500 bytes long (where 120 is for ELF headers) after compilation. Algorithm details is slightly differ (like constants packing), just to make smaller binary code. It's interesting to compare density of binary code and obfuscated C.
+- [prog.x86_64.asm](prog.x86_64.asm) contains the same program, but written in
+assembly for x86_64 Linux, for the sake of smaller executable size which is 500
+bytes long (where 120 is for the ELF headers) after compilation. Algorithm
+details is slightly different (like constants packing), just to make smaller
+binary code. It's interesting to compare density of binary code and obfuscated
+C.
 
-- `prog.x86.asm` and for x86, although the headers are smaller, but the binary code is larger due to fewer registers and lack of 64-bit multiply.
+- [prog.x86.asm](prog.x86.asm) is for x86, although the headers are smaller, but
+the binary code is larger due to fewer registers and lack of 64-bit multiply.
 
 
 ## Copyright and CC BY-SA 4.0 License:

--- a/2020/kurdyukov1/try.sh
+++ b/2020/kurdyukov1/try.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2020/kurdyukov1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# try and find an md5sum tool
+MD5SUM="$(type -P md5sum)"
+if [[ -z "$MD5SUM" ]]; then
+    MD5SUM="$(type -P openssl)"
+fi
+
+read -r -n 1 -p "Press any key to run: echo IOCCC | ./prog: "
+echo 1>&2
+echo IOCCC | ./prog
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog < prog.c: "
+echo 1>&2
+./prog < prog.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog < prog: "
+echo 1>&2
+./prog < prog
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog < prog.x86.asm: "
+echo 1>&2
+./prog < prog.x86.asm
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog < prog.x86_64.asm: "
+echo 1>&2
+./prog < prog.x86_64.asm
+
+rm -f md5.txt prog.md5.txt
+if [[ -n "$MD5SUM" ]]; then
+    if [[ "$(basename $MD5SUM)" == "openssl" ]]; then
+	echo "$ $MD5SUM md5 prog.c | cut -f 2 -d' ' > md5.txt" 1>&2
+	"$MD5SUM" md5 prog.c | cut -f 2 -d' ' > md5.txt
+	echo "$ ./prog < prog.c > prog.md5.txt" 1>&2
+	./prog < prog.c > prog.md5.txt
+    else
+	echo "$ $MD5SUM prog.c | cut -f1 -d' ' > md5.txt" 1>&2
+	"$MD5SUM" prog.c | cut -f1 -d' ' > md5.txt
+	echo "$ ./prog < prog.c > prog.md5.txt" 1>&2
+	./prog < prog.c > prog.md5.txt
+    fi
+    read -r -n 1 -p "Press any key to compare the two files md5.txt and prog.md5.txt: "
+    echo 1>&2
+    diff -s md5.txt prog.md5.txt
+fi
+rm -f md5.txt prog.md5.txt

--- a/bugs.md
+++ b/bugs.md
@@ -3606,6 +3606,17 @@ things that are misinterpreted as bugs. See the
 [troubleshooting.md](2020/ferguson1/troubleshooting.md) files for details.
 
 
+## 2020 giles
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2020/giles/prog.c](2020/giles/prog.c)
+### Information: [2020/giles/README.md](2020/giles/README.md)
+
+The author noted that the program only supports WAV files that have
+exactly 16 bits per sample, but it allows any sample rate and any number of
+audio channels.
+
+
 # 2021
 
 There was no IOCCC in 2021.

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4390,6 +4390,19 @@ recommend you give it a go! :-) You're welcome to ask me questions if you wish
 and I encourage you to do so as the cake is quite picky!
 
 
+## <a name="2020_giles"></a>[2020/giles](/2020/giles/prog.c) ([README.md](/2020/giles/README.md))
+
+[Cody](#cody) added the [try.sh](/2020/giles/try.sh) script. This script does
+the conversion of `pi.wav` (showing the digits) and also converts the number for
+`jenny.wav` and a number Cody 'came up with': one that resembles `IOCCC 28`:
+`10666-28`. The `6` is the closest to `C` in his head even though it's not
+perfect.
+
+If `play(1)` from SoX is not installed the script checks for `aplay(1)`. If
+neither are installed it warns the user about this, linking to the FAQ about it,
+and tells them they will have to play the WAV files manually. Otherwise it'll
+use the program to play the WAV files (and in one case `stdout`).
+
 
 ## <a name="2020_kurdyukov2"></a>[2020/kurdyukov2](/2020/kurdyukov2/prog.c) ([README.md](/2020/kurdyukov2/README.md))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4404,6 +4404,11 @@ and tells them they will have to play the WAV files manually. Otherwise it'll
 use the program to play the WAV files (and in one case `stdout`).
 
 
+## <a name="2020_kurdyukov1"></a>[2020/kurdyukov1](/2020/kurdyukov1/prog.c) ([README.md](/2020/kurdyukov1/README.md))
+
+[Cody](#cody) added the [try.sh](/2020/kurdyukov1/try.sh) script.
+
+
 ## <a name="2020_kurdyukov2"></a>[2020/kurdyukov2](/2020/kurdyukov2/prog.c) ([README.md](/2020/kurdyukov2/README.md))
 
 [Cody](#cody) added `-L`/`-I` paths to the Makefile to let this compile more easily if

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4347,7 +4347,7 @@ knows it so he might be called unusual (and he argues, with pride, eccentric :-)
 ) :-)
 
 
-## <a name="2020_ferguson2"></a>[2020/ferguson2](/2020/ferguson1/prog.c) ([README.md](/2020/ferguson1/README.md))
+## <a name="2020_ferguson1"></a>[2020/ferguson1](/2020/ferguson1/prog.c) ([README.md](/2020/ferguson1/README.md))
 
 [Cody](#cody), with intentional irony here :-), fixed formatting, links and typos in
 various files.


### PR DESCRIPTION

The try.sh script tries to find md5sum and if it does not succeed it 
tries for openssl. If it is openssl it uses the subcommand md5; 
otherwise it just uses md5sum. Whatever the case if either is found it 
writes the checksum of prog.c to md5.txt and then it uses prog to write
the checksum to prog.md5.txt. Then it uses diff -s on the two. If 
neither tool is found it just skips that check.

Format/typo check README.md file.