### PR TITLE
Restore original entry of 1986/stein

### DIFF
--- a/1986/stein/stein.orig.c
+++ b/1986/stein/stein.orig.c
@@ -1,3 +1,1 @@
-typedef char*z;O;o;_=33303285;main(b,Z)z Z;{b=(b>=0||(main(b+1,Z+1),*Z=O%(o=(_%
-25))+'0',O/=o,_/=25))&&(b<1||(O=time(&b)%0250600,main(~5,*(z*)Z),write(1,*(z*)Z
-,9)));}
+typedef char*z;O;o;_=33303285;main(b,Z)z Z;{b=(b>=0||(main(b+1,Z+1),*Z=O%(o=(_%25))+'0',O/=o,_/=25))&&(b<1||(O=time(&b)%0250600,main(~5,*(z*)Z),write(1,*(z*)Z,9)));}

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -399,6 +399,14 @@ for entertainment!
 `-D` needed to compile the entry.
 
 
+## <a name="1986_stein"></a>[1986/stein](/1986/stein/stein.c) ([README.md](/1986/stein/README.md]))
+
+[Cody](#cody) restored the original entry which was a single line. The code
+being longer (in 1986 a one liner could be longer) was split to three lines to
+avoid problems with news and mail but as it was the 'Best one liner' it is now
+one line.
+
+
 ## <a name="1986_wall"></a>[1986/wall](/1986/wall/wall.c) ([README.md](/1986/wall/README.md]))
 
 [Cody](#cody) fixed this so that it does not require `-traditional-cpp`. This took a fair


### PR DESCRIPTION
The entry won best one liner but (in 1986 they could be longer) but to make mail and news happy it was split to three lines. As it's not distributed in news or mail now it can be one line. This was only updated in stein.orig.c (for now?).