### PR TITLE
Add missing comment in all Makefiles

### DIFF
--- a/1984/Makefile
+++ b/1984/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1984/anonymous/Makefile
+++ b/1984/anonymous/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1984/laman/Makefile
+++ b/1984/laman/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1985/Makefile
+++ b/1985/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1985/applin/Makefile
+++ b/1985/applin/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/Makefile
+++ b/1986/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1986/applin/Makefile
+++ b/1986/applin/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/august/Makefile
+++ b/1986/august/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/bright/Makefile
+++ b/1986/bright/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/hague/Makefile
+++ b/1986/hague/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/holloway/Makefile
+++ b/1986/holloway/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/pawka/Makefile
+++ b/1986/pawka/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/stein/Makefile
+++ b/1986/stein/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1986/stein/stein.orig.c
+++ b/1986/stein/stein.orig.c
@@ -1,3 +1,1 @@
-typedef char*z;O;o;_=33303285;main(b,Z)z Z;{b=(b>=0||(main(b+1,Z+1),*Z=O%(o=(_%
-25))+'0',O/=o,_/=25))&&(b<1||(O=time(&b)%0250600,main(~5,*(z*)Z),write(1,*(z*)Z
-,9)));}
+typedef char*z;O;o;_=33303285;main(b,Z)z Z;{b=(b>=0||(main(b+1,Z+1),*Z=O%(o=(_%25))+'0',O/=o,_/=25))&&(b<1||(O=time(&b)%0250600,main(~5,*(z*)Z),write(1,*(z*)Z,9)));}

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/Makefile
+++ b/1987/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1987/biggar/Makefile
+++ b/1987/biggar/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/hines/Makefile
+++ b/1987/hines/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/korn/Makefile
+++ b/1987/korn/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -197,6 +197,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/Makefile
+++ b/1988/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -207,6 +207,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/isaak/Makefile
+++ b/1988/isaak/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/litmaath/Makefile
+++ b/1988/litmaath/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/phillipps/Makefile
+++ b/1988/phillipps/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/reddy/Makefile
+++ b/1988/reddy/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/robison/Makefile
+++ b/1988/robison/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -231,6 +231,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/Makefile
+++ b/1989/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1989/fubar/Makefile
+++ b/1989/fubar/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/jar.2/Makefile
+++ b/1989/jar.2/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/paul/Makefile
+++ b/1989/paul/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/robison/Makefile
+++ b/1989/robison/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/roemer/Makefile
+++ b/1989/roemer/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -195,6 +195,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/vanb/Makefile
+++ b/1989/vanb/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -205,6 +205,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/Makefile
+++ b/1990/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/cmills/Makefile
+++ b/1990/cmills/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/dds/Makefile
+++ b/1990/dds/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/dg/Makefile
+++ b/1990/dg/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -195,6 +195,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/pjr/Makefile
+++ b/1990/pjr/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/scjones/Makefile
+++ b/1990/scjones/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -207,6 +207,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/Makefile
+++ b/1991/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/davidguy/Makefile
+++ b/1991/davidguy/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1991/westley/Makefile
+++ b/1991/westley/Makefile
@@ -290,6 +290,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/Makefile
+++ b/1992/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -211,6 +211,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/albert/Makefile
+++ b/1992/albert/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/ant/Makefile
+++ b/1992/ant/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -216,6 +216,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -196,6 +196,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/imc/Makefile
+++ b/1992/imc/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/lush/Makefile
+++ b/1992/lush/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/Makefile
+++ b/1993/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1993/ant/Makefile
+++ b/1993/ant/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/dgibson/Makefile
+++ b/1993/dgibson/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/ejb/Makefile
+++ b/1993/ejb/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/jonth/Makefile
+++ b/1993/jonth/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -209,6 +209,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/schnitzi/Makefile
+++ b/1993/schnitzi/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1993/vanb/Makefile
+++ b/1993/vanb/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/Makefile
+++ b/1994/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1994/dodsond1/Makefile
+++ b/1994/dodsond1/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/imc/Makefile
+++ b/1994/imc/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -196,6 +196,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/shapiro/Makefile
+++ b/1994/shapiro/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/smr/Makefile
+++ b/1994/smr/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/Makefile
+++ b/1995/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/dodsond1/Makefile
+++ b/1995/dodsond1/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/dodsond2/Makefile
+++ b/1995/dodsond2/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/esde/Makefile
+++ b/1995/esde/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/heathbar/Makefile
+++ b/1995/heathbar/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/leo/Makefile
+++ b/1995/leo/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/schnitzi/Makefile
+++ b/1995/schnitzi/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/spinellis/Makefile
+++ b/1995/spinellis/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1995/vanschnitz/Makefile
+++ b/1995/vanschnitz/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/Makefile
+++ b/1996/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1996/august/Makefile
+++ b/1996/august/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/dalbec/Makefile
+++ b/1996/dalbec/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/huffman/Makefile
+++ b/1996/huffman/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/jonth/Makefile
+++ b/1996/jonth/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/rcm/Makefile
+++ b/1996/rcm/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/schweikh1/Makefile
+++ b/1996/schweikh1/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/schweikh2/Makefile
+++ b/1996/schweikh2/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/Makefile
+++ b/1998/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -202,6 +202,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/bas1/Makefile
+++ b/1998/bas1/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/bas2/Makefile
+++ b/1998/bas2/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/chaos/Makefile
+++ b/1998/chaos/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/df/Makefile
+++ b/1998/df/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/dlowe/Makefile
+++ b/1998/dlowe/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/dorssel/Makefile
+++ b/1998/dorssel/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/1998/tomtorfs/Makefile
+++ b/1998/tomtorfs/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/Makefile
+++ b/2000/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2000/anderson/Makefile
+++ b/2000/anderson/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/bellard/Makefile
+++ b/2000/bellard/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/bmeyer/Makefile
+++ b/2000/bmeyer/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/dhyang/Makefile
+++ b/2000/dhyang/Makefile
@@ -212,6 +212,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/dlowe/Makefile
+++ b/2000/dlowe/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/jarijyrki/Makefile
+++ b/2000/jarijyrki/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/natori/Makefile
+++ b/2000/natori/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/primenum/Makefile
+++ b/2000/primenum/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/rince/Makefile
+++ b/2000/rince/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/robison/Makefile
+++ b/2000/robison/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/schneiderwent/Makefile
+++ b/2000/schneiderwent/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -199,6 +199,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2000/tomx/Makefile
+++ b/2000/tomx/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/Makefile
+++ b/2001/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -236,6 +236,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/cheong/Makefile
+++ b/2001/cheong/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/dgbeards/Makefile
+++ b/2001/dgbeards/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/herrmann1/Makefile
+++ b/2001/herrmann1/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/jason/Makefile
+++ b/2001/jason/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/ollinger/Makefile
+++ b/2001/ollinger/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/rosten/Makefile
+++ b/2001/rosten/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/schweikh/Makefile
+++ b/2001/schweikh/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -213,6 +213,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/Makefile
+++ b/2004/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2004/anonymous/Makefile
+++ b/2004/anonymous/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/arachnid/Makefile
+++ b/2004/arachnid/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -199,6 +199,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/gavin/Makefile
+++ b/2004/gavin/Makefile
@@ -232,6 +232,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/hibachi/Makefile
+++ b/2004/hibachi/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/hoyle/Makefile
+++ b/2004/hoyle/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -199,6 +199,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/kopczynski/Makefile
+++ b/2004/kopczynski/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/newbern/Makefile
+++ b/2004/newbern/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/omoikane/Makefile
+++ b/2004/omoikane/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/schnitzi/Makefile
+++ b/2004/schnitzi/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/sds/Makefile
+++ b/2004/sds/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/vik1/Makefile
+++ b/2004/vik1/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2004/vik2/Makefile
+++ b/2004/vik2/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/Makefile
+++ b/2005/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2005/aidan/Makefile
+++ b/2005/aidan/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/anon/Makefile
+++ b/2005/anon/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/boutines/Makefile
+++ b/2005/boutines/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/chia/Makefile
+++ b/2005/chia/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -195,6 +195,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/jetro/Makefile
+++ b/2005/jetro/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/klausler/Makefile
+++ b/2005/klausler/Makefile
@@ -205,6 +205,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/mikeash/Makefile
+++ b/2005/mikeash/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/mynx/Makefile
+++ b/2005/mynx/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -195,6 +195,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/timwi/Makefile
+++ b/2005/timwi/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/toledo/Makefile
+++ b/2005/toledo/Makefile
@@ -189,6 +189,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/vik/Makefile
+++ b/2005/vik/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2005/vince/Makefile
+++ b/2005/vince/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/Makefile
+++ b/2006/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2006/birken/Makefile
+++ b/2006/birken/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/borsanyi/Makefile
+++ b/2006/borsanyi/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/grothe/Makefile
+++ b/2006/grothe/Makefile
@@ -181,6 +181,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/hamre/Makefile
+++ b/2006/hamre/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/meyer/Makefile
+++ b/2006/meyer/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -198,6 +198,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/night/Makefile
+++ b/2006/night/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/stewart/Makefile
+++ b/2006/stewart/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/sykes1/Makefile
+++ b/2006/sykes1/Makefile
@@ -198,6 +198,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/sykes2/Makefile
+++ b/2006/sykes2/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/toledo1/Makefile
+++ b/2006/toledo1/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2006/toledo3/Makefile
+++ b/2006/toledo3/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/Makefile
+++ b/2011/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -206,6 +206,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/blakely/Makefile
+++ b/2011/blakely/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/borsanyi/Makefile
+++ b/2011/borsanyi/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/dlowe/Makefile
+++ b/2011/dlowe/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/eastman/Makefile
+++ b/2011/eastman/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/fredriksson/Makefile
+++ b/2011/fredriksson/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/goren/Makefile
+++ b/2011/goren/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/hamaji/Makefile
+++ b/2011/hamaji/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/hou/Makefile
+++ b/2011/hou/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/konno/Makefile
+++ b/2011/konno/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/richards/Makefile
+++ b/2011/richards/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/toledo/Makefile
+++ b/2011/toledo/Makefile
@@ -203,6 +203,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/vik/Makefile
+++ b/2011/vik/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2011/zucker/Makefile
+++ b/2011/zucker/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/Makefile
+++ b/2012/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2012/blakely/Makefile
+++ b/2012/blakely/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/deckmyn/Makefile
+++ b/2012/deckmyn/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/dlowe/Makefile
+++ b/2012/dlowe/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -220,6 +220,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/endoh2/Makefile
+++ b/2012/endoh2/Makefile
@@ -342,6 +342,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/grothe/Makefile
+++ b/2012/grothe/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/hou/Makefile
+++ b/2012/hou/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/konno/Makefile
+++ b/2012/konno/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/tromp/Makefile
+++ b/2012/tromp/Makefile
@@ -195,6 +195,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/Makefile
+++ b/2013/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -196,6 +196,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/cable1/Makefile
+++ b/2013/cable1/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/cable2/Makefile
+++ b/2013/cable2/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/cable3/Makefile
+++ b/2013/cable3/Makefile
@@ -196,6 +196,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/dlowe/Makefile
+++ b/2013/dlowe/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/endoh1/Makefile
+++ b/2013/endoh1/Makefile
@@ -197,6 +197,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -224,6 +224,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/mills/Makefile
+++ b/2013/mills/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -258,6 +258,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/morgan1/Makefile
+++ b/2013/morgan1/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/morgan2/Makefile
+++ b/2013/morgan2/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2013/robison/Makefile
+++ b/2013/robison/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/Makefile
+++ b/2014/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -201,6 +201,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/Makefile
+++ b/2015/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2015/burton/Makefile
+++ b/2015/burton/Makefile
@@ -200,6 +200,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/dogon/Makefile
+++ b/2015/dogon/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/duble/Makefile
+++ b/2015/duble/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/endoh1/Makefile
+++ b/2015/endoh1/Makefile
@@ -249,6 +249,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/endoh2/Makefile
+++ b/2015/endoh2/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/endoh3/Makefile
+++ b/2015/endoh3/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/endoh4/Makefile
+++ b/2015/endoh4/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/howe/Makefile
+++ b/2015/howe/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -345,6 +345,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/mills2/Makefile
+++ b/2015/mills2/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/muth/Makefile
+++ b/2015/muth/Makefile
@@ -200,6 +200,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/schweikhardt/Makefile
+++ b/2015/schweikhardt/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2015/yang/Makefile
+++ b/2015/yang/Makefile
@@ -211,6 +211,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/Makefile
+++ b/2018/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2018/algmyr/Makefile
+++ b/2018/algmyr/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/anderson/Makefile
+++ b/2018/anderson/Makefile
@@ -186,6 +186,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/bellard/Makefile
+++ b/2018/bellard/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/burton1/Makefile
+++ b/2018/burton1/Makefile
@@ -187,6 +187,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/burton2/Makefile
+++ b/2018/burton2/Makefile
@@ -219,6 +219,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/ciura/Makefile
+++ b/2018/ciura/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/endoh1/Makefile
+++ b/2018/endoh1/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -195,6 +195,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -194,6 +194,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/giles/Makefile
+++ b/2018/giles/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/hou/Makefile
+++ b/2018/hou/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/mills/Makefile
+++ b/2018/mills/Makefile
@@ -269,6 +269,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -190,6 +190,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/vokes/Makefile
+++ b/2018/vokes/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2018/yang/Makefile
+++ b/2018/yang/Makefile
@@ -303,6 +303,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/Makefile
+++ b/2019/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -202,6 +202,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -197,6 +197,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/ciura/Makefile
+++ b/2019/ciura/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -198,6 +198,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -257,6 +257,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -191,6 +191,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -200,6 +200,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -365,6 +365,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -206,6 +206,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/Makefile
+++ b/2020/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt:
 	done
 	@echo '=-=-= ${YEAR} complete make $@ =-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-= ${YEAR} begin make $@ =-=-='
 	@echo

--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -206,6 +206,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/carlini/Makefile
+++ b/2020/carlini/Makefile
@@ -182,6 +182,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/endoh1/Makefile
+++ b/2020/endoh1/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/endoh3/Makefile
+++ b/2020/endoh3/Makefile
@@ -192,6 +192,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -216,6 +216,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/giles/Makefile
+++ b/2020/giles/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/kurdyukov1/Makefile
+++ b/2020/kurdyukov1/Makefile
@@ -185,6 +185,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -193,6 +193,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/kurdyukov3/Makefile
+++ b/2020/kurdyukov3/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/kurdyukov4/Makefile
+++ b/2020/kurdyukov4/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/otterness/Makefile
+++ b/2020/otterness/Makefile
@@ -183,6 +183,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/tsoj/Makefile
+++ b/2020/tsoj/Makefile
@@ -184,6 +184,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/2020/yang/Makefile
+++ b/2020/yang/Makefile
@@ -188,6 +188,7 @@ diff_orig_alt: ${PROG}.orig.c
 	    ${DIFF} -u ${PROG}.orig.c ${PROG}.alt.c; \
 	fi
 
+# diff alt and orig
 diff_alt_orig:
 	@-if [[ -e ${PROG}.alt.c ]]; then \
 	    ${DIFF} -u ${PROG}.alt.c ${PROG}.orig.c; \

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ diff_orig_alt:
         done
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
+# diff alt and orig
 diff_alt_orig:
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	@-for i in ${YEARS}; do \

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -399,6 +399,14 @@ for entertainment!
 `-D` needed to compile the entry.
 
 
+## <a name="1986_stein"></a>[1986/stein](/1986/stein/stein.c) ([README.md](/1986/stein/README.md]))
+
+[Cody](#cody) restored the original entry which was a single line. The code
+being longer (in 1986 a one liner could be longer) was split to three lines to
+avoid problems with news and mail but as it was the 'Best one liner' it is now
+one line.
+
+
 ## <a name="1986_wall"></a>[1986/wall](/1986/wall/wall.c) ([README.md](/1986/wall/README.md]))
 
 [Cody](#cody) fixed this so that it does not require `-traditional-cpp`. This took a fair


### PR DESCRIPTION

The comment for the rule diff_alt_orig was missing. It was added like:

    sgit -e '/diff_alt_orig:/i \
    # diff alt and orig' '*Makefile'
