### PR TITLE
Remove item about usleep macro name from todo file

### DIFF
--- a/1992/kivinen/README.md
+++ b/1992/kivinen/README.md
@@ -6,11 +6,12 @@ If your machine support the X Window System, Version 11:
 make alt
 ```
 
-We recommend the alt version first as the original goes too fast on modern
-systems. See [original code](#original-code) for the original should you wish to
-see what we mean.
+We recommend the alt version first as the so you can see more what it looked
+like back in 1992, with modern systems. See [original code](#original-code) for
+the original should you wish to see what we mean.
 
 You can reconfigure the value to `usleep(3)`; see [try](#try) section below.
+
 
 ### Bugs and (Mis)features:
 

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -83,14 +83,6 @@ instead change it to make pull requests. See the
 requests rather than emailing judges. This can be done on the final pass of the
 files.
 
-- In the entries with the alt code that use `usleep(3)` make the macro name
-consistent across all entries. At one point `Z` was used but in one entry `Z`
-was taken so this would not work. It appears at this time (16 November 2023)
-that it might be that `S` will work in all cases (currently?) though one has two
-values so the second would could be changed to `SS` (which is convenient as it's
-for SDL). This is low priority but it would be nice to have done as it would
-make it consistent and easy to remember.
-
 - With the entries that we recommend the alt code first when it comes to it
 going too fast we should say not what it looks like in modern systems but rather
 what it LOOKED LIKE AT THE TIME. At Wed 22 Nov 2023 13:02:04 UTC the only entry


### PR DESCRIPTION

In alt code where a call to usleep(3) is made to allow for configuring 
speed originally I used the macro 'Z'. In one case 'Z' was already taken
so I changed it to 'S' for that entry. I had the thought it might be 
nice to make it always the same. This however is not possible as more 
entries already have 'S' used. Also it's not important since I changed 
the Makefiles so that one can specify it like 'make clobber SLEEP=500 
alt' or whatever, removing the macro name and having to mess with 
'CDEFINE'.
