### PR TITLE
Fix tmp/format-headers.sh, format headers

### DIFF
--- a/1985/shapiro/README.md
+++ b/1985/shapiro/README.md
@@ -14,6 +14,7 @@ There is alternate code which allows one to change the size of the maze. See
 ./shapiro
 ```
 
+
 ## Alternate code:
 
 The code has a define `C` set to 39 but this can be modified to change the size
@@ -22,10 +23,10 @@ of the maze. The alt code allows one to easily do this.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
+
 
 ### Alternate try:
 

--- a/1988/spinellis/README.md
+++ b/1988/spinellis/README.md
@@ -10,7 +10,7 @@ If your compiler will not read from `/dev/tty` see the [Alternate
 code](#alternate-code) section below.
 
 
-### To use:
+## To use:
 
 ```sh
 ./spinellis

--- a/1988/westley/README.md
+++ b/1988/westley/README.md
@@ -76,7 +76,6 @@ cc -E westley.alt.c
 ```
 
 
-
 ## Author's remarks:
 
 No remarks were provided by the author.

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -60,7 +60,6 @@ directory it is run from.
 
 ## Authors' remarks:
 
-
 ### ABSTRACT
 
 #### Minimal, Universal File Bundling (or, Functional Obfuscation in a Self-Decoding Unix Shell Archive)

--- a/1990/pjr/README.md
+++ b/1990/pjr/README.md
@@ -34,7 +34,6 @@ well.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -64,7 +63,6 @@ This program prints out the string:
 
 
 ## Author's remarks:
-
 
 It is simple to make the program print other strings.  Each
 alphabetical character from a to z is printed out as its

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -37,8 +37,8 @@ If you have an old enough compiler try and to see how C has changed over the yea
 make alt
 ```
 
-### Alternate use:
 
+### Alternate use:
 
 ```sh
 ./westley.alt <number>

--- a/1991/ant/README.md
+++ b/1991/ant/README.md
@@ -46,7 +46,6 @@ rest was unchanged.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -26,6 +26,7 @@ bugs.md](/bugs.md#1991-buzzard).
 ./buzzard
 ```
 
+
 ## Alternate code:
 
 This version changes the keys `f` for forward, `l` for left and `r` for right by
@@ -57,7 +58,6 @@ You are invited to try to cheat, ... if you can figure out how!  :-)
 
 
 ## Author's remarks:
-
 
 ### How to play
 

--- a/1991/rince/README.md
+++ b/1991/rince/README.md
@@ -30,7 +30,6 @@ The author set the maximum number of moves to 484.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -7,6 +7,7 @@ make all
 There is an [alternate version](#alternate-code) that is supposed to win all the
 time.
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:
@@ -19,7 +20,6 @@ For more detailed information see [1991 westley in bugs.md](/bugs.md#1991-westle
 
 
 ## To use:
-
 
 NOTE: we have provided a script to perform the below procedure which we include
 for the interested. See the [try](#try) section if you just want to play.
@@ -124,10 +124,10 @@ can lose if you cheat. That's supposed to happen. Can you win any other time?
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
+
 
 ### Alternate use:
 

--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -4,6 +4,7 @@
 make all
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:

--- a/1992/buzzard.2/README.md
+++ b/1992/buzzard.2/README.md
@@ -53,6 +53,7 @@ Sorry, this is third!
 This alternate version, [buzzard.2.alt.c](buzzard.2.alt.c), does not contain a
 fix that the author notes in their remarks.
 
+
 ### Alternate build:
 
 To compile this alternate version:

--- a/1992/imc/README.md
+++ b/1992/imc/README.md
@@ -29,7 +29,6 @@ cause problems for some systems where `exit(3)` returns a void.  The file
 declared argc to be a `long` which was fixed.
 
 
-
 ## Author's remarks:
 
 ### Portability

--- a/1992/kivinen/README.md
+++ b/1992/kivinen/README.md
@@ -6,11 +6,12 @@ If your machine support the X Window System, Version 11:
 make alt
 ```
 
-We recommend the alt version first as the original goes too fast on modern
-systems. See [original code](#original-code) for the original should you wish to
-see what we mean.
+We recommend the alt version first as the so you can see more what it looked
+like back in 1992, with modern systems. See [original code](#original-code) for
+the original should you wish to see what we mean.
 
 You can reconfigure the value to `usleep(3)`; see [try](#try) section below.
+
 
 ### Bugs and (Mis)features:
 

--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -24,7 +24,6 @@ To see some other fun uses:
 
 ## Judges' remarks:
 
-
 ### WARNING:
 
 The judges make no claim as to the strength or security

--- a/1992/vern/README.md
+++ b/1992/vern/README.md
@@ -16,7 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [1992 vern in bugs.md](/bugs.md#1992-vern).
 
 
-
 ## To use:
 
 ```sh

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -4,6 +4,7 @@
 make all
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:
@@ -14,7 +15,6 @@ STATUS: known bug - please help us fix
 ```
 
 For more detailed information see [1992 westley in bugs.md](/bugs.md#1992-westley).
-
 
 
 ## To use:

--- a/1993/ant/README.md
+++ b/1993/ant/README.md
@@ -4,6 +4,7 @@
 make all
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:

--- a/1993/cmills/README.md
+++ b/1993/cmills/README.md
@@ -57,6 +57,7 @@ on but you can use the original without any delays if you wish.
 make all
 ```
 
+
 ### Original use:
 
 Use `cmills` as you would `cmills.alt` above.

--- a/1993/dgibson/README.md
+++ b/1993/dgibson/README.md
@@ -25,7 +25,6 @@ where:
 
 ## Judges' remarks:
 
-
 We have provided the shell script [dgibson.sh](dgibson.sh) to make it easier
 to run this entry.  Run this shell script several times to
 see what happens.

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -23,7 +23,6 @@ us](https://www.collinsdictionary.com/dictionary/english/everyone) with gcc >=
 2.3.3. See [Alternate code](#alternate-code) section below for more details.
 
 
-
 ### Bugs and (Mis)features:
 
 The current status of this entry is:
@@ -52,10 +51,10 @@ compilers. We'd like to say there's something special about it but there isn't.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
+
 
 ### Alternate use:
 

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -7,6 +7,7 @@ make all
 There is an [alternate version](#alternate-code) that lets you slow down the
 output of the program for modern systems.
 
+
 ## To use:
 
 ```sh
@@ -17,7 +18,6 @@ where:
 
 - number is a number    (try 21701)
 - arg is any argument
-
 
 
 ### Try:
@@ -36,7 +36,6 @@ via `usleep(3)`, defaulting at 200.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -49,7 +48,6 @@ make clobber SLEEP=50 alt
 
 
 ### Alternate use:
-
 
 Use `plummer.alt` as you would `plummer`.
 

--- a/1993/rince/README.md
+++ b/1993/rince/README.md
@@ -31,7 +31,7 @@ where:
 `[cabbage]` is a CABBAGE description file  (default: `rince.c`)
 
 
-## Alternate code
+## Alternate code:
 
 Some people may want to slow down the game by increasing the
 value 17 in the lines:
@@ -56,7 +56,6 @@ changed).
 
 
 ### Alternate build:
-
 
 ```sh
 make SLEEP=18 clobber alt

--- a/1993/schnitzi/README.md
+++ b/1993/schnitzi/README.md
@@ -16,7 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [1993 schnitzi in bugs.md](/bugs.md#1993-schnitzi).
 
 
-
 ## To use:
 
 ```sh

--- a/1993/vanb/README.md
+++ b/1993/vanb/README.md
@@ -4,6 +4,7 @@
 make all
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:

--- a/1994/dodsond1/README.md
+++ b/1994/dodsond1/README.md
@@ -11,7 +11,8 @@ make all
 ./dodsond1
 ```
 
-## Try:
+
+### Try:
 
 At the prompt, try entering `E3`.
 

--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -27,6 +27,7 @@ For more detailed information see [1994 dodsond2 in bugs.md](/bugs.md#1994-dodso
 ./dodsond2
 ```
 
+
 ## Alternate code:
 
 This version allows you to choose how many arrows to start with, instead of the
@@ -35,8 +36,8 @@ default 0. If one tried specifying a value < 0 it will set it to 0.
 Fun fact: this version helped uncover and fix a bug that prevented the entry
 from working on some cases.
 
-### Alternate build:
 
+### Alternate build:
 
 ```sh
 make alt

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -14,9 +14,7 @@ make all
 `A`, `B`, `C` and `D` are numeric arguments.
 
 
-
 ### Try:
-
 
 ```sh
 ./horton 3 2 1 0
@@ -28,6 +26,7 @@ Also try:
 ./gtface  < gtface.data
 ```
 
+
 ## Alternate code:
 
 This confuses cb greatly. See [horton.alt.c](horton.alt.c) for an unobfuscated/enhanced
@@ -36,14 +35,12 @@ version.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
 
 
 ### Alternate use:
-
 
 ```sh
 ./horton.alt A B C D

--- a/1994/weisberg/README.md
+++ b/1994/weisberg/README.md
@@ -55,7 +55,6 @@ it was read on `stdin` instead of via `cc -E`.
 
 ## Author's remarks:
 
-
 ### Description
 
 The following short program implements the "Yet Another" algorithm for

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -206,6 +206,7 @@ end
 
 ```
 
+
 ## Copyright and CC BY-SA 4.0 License:
 
 This file is Copyright (c) 2023 by Landon Curt Noll.  All Rights Reserved.

--- a/1996/eldby/README.md
+++ b/1996/eldby/README.md
@@ -47,6 +47,7 @@ If however you wish to see the original version in modern systems, try:
 make all
 ```
 
+
 ### Original use:
 
 Use `./eldby` as you would `./eldby.alt` above.

--- a/1996/gandalf/README.md
+++ b/1996/gandalf/README.md
@@ -37,7 +37,6 @@ BTW: it is perilous to 'try' the patience of
 [Gandalf](https://www.glyphweb.com/arda/g/gandalf.html). Go ahead, 'try' it! :-)
 
 
-
 ## Judges' remarks:
 
 For misleading C pre-processor output, try:

--- a/1996/westley/README.md
+++ b/1996/westley/README.md
@@ -18,7 +18,6 @@ alt version.
 ```
 
 
-
 ### Try:
 
 ```sh
@@ -32,8 +31,8 @@ The original version had a display problem in modern systems which somewhat
 affected the usability of the program. This alternate code, the original, is
 provided, to show the differences.
 
-### Alternate build:
 
+### Alternate build:
 
 ```sh
 make alt

--- a/1998/banks/README.md
+++ b/1998/banks/README.md
@@ -69,7 +69,7 @@ See the author's remarks in [scenery](#scenery) for more details on the scenery
 files.
 
 
-## Try:
+### Try:
 
 For a fun time after running the above command, hold down the up arrow and left
 arrow for about 10 seconds and see what happens. Or, if you wish to really use
@@ -110,7 +110,6 @@ make alt
 You may change the other keys as described in the build instructions, above, but
 this alt code can be seen as an alternative for those who don't have or don't
 want to use page up and page down.
-
 
 
 ### Alternate use:

--- a/1998/bas2/README.md
+++ b/1998/bas2/README.md
@@ -13,7 +13,7 @@ echo text | ./bas2
 ```
 
 
-## Try:
+### Try:
 
 ```sh
 ./try.sh
@@ -23,7 +23,6 @@ echo text | ./bas2
 
 
 ## Judges' remarks:
-
 
 ### Questions to ponder:
 

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -58,7 +58,6 @@ make alt
 
 ### Alternate use:
 
-
 ```
 ./dlowe.alt < anyfile > pootfile
 ```

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -50,6 +50,7 @@ clockwise `l` does as well. Instead of using `d` to drop the letter you can do
 make alt
 ```
 
+
 ### Alternate use:
 
 ```sh

--- a/1998/fanf/README.md
+++ b/1998/fanf/README.md
@@ -26,7 +26,6 @@ Enter an expression on standard input.  To try some we have selected:
 
 ## Judges' remarks:
 
-
 ### Historical aside:
 
 At a time the code in [fanf.c](fanf.c) was that of [fanf.orig.c](fanf.orig.c)

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -30,7 +30,6 @@ if you don't have a Mac as it has some interesting details about the entry.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -39,6 +38,7 @@ make alt
 ### Alternate build:
 
 Use `schweikh1.alt` as you would `schweikh1` above.
+
 
 ### Alternate try:
 

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -137,7 +137,6 @@ and now it works with both clang and gcc.
 
 ## Author's remarks:
 
-
 ### What this program does
 
 My entry is a `yarng`, which stands for, you guessed it, yet another

--- a/1998/tomtorfs/README.md
+++ b/1998/tomtorfs/README.md
@@ -22,6 +22,7 @@ init      : initial value for the CRC (hexadecimal)
 xor       : value to xor the final CRC with (hexadecimal)
 ```
 
+
 ### Try:
 
 ```sh

--- a/2000/jarijyrki/README.md
+++ b/2000/jarijyrki/README.md
@@ -58,7 +58,6 @@ program needs now is a [flight simulator](1998/banks/README.md)!
 
 ## Author's remarks:
 
-
 ### 1. OVERVIEW
 
 This program is an X-Windows based spreadsheet program.  The main functions it

--- a/2000/natori/README.md
+++ b/2000/natori/README.md
@@ -18,7 +18,6 @@ version](#alternate-code) below.
 
 ### Try:
 
-
 ```sh
 ./try.sh
 ```

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -45,7 +45,6 @@ it successfully fooled half of the judges, including me.
 
 ## Author's remarks:
 
-
 ### Description
 
 For 15 years, IOCCC winners have obfuscated programs using esoteric,

--- a/2000/robison/README.md
+++ b/2000/robison/README.md
@@ -26,7 +26,6 @@ author a patent he applied for.  :-)
 
 ## Author's remarks:
 
-
 ### TITLE OF INVENTION
 
 Highly Compressed Program for Playing Hygienic Checkers

--- a/2000/thadgavin/README.md
+++ b/2000/thadgavin/README.md
@@ -22,6 +22,7 @@ We recommend that you use the alternate code in modern systems. See the
 
 You can press 'q' at any time to exit.
 
+
 ### Try:
 
 If you have SDL1 installed:
@@ -77,11 +78,13 @@ problem there.
 make all
 ```
 
+
 ### Original use:
 
 ```sh
 ./thadgavin
 ```
+
 
 ### Original try:
 
@@ -101,7 +104,6 @@ less than dazzling. We could not test this entry in DOS mode.
 
 
 ## Authors' remarks:
-
 
 ### To use under DOS:
 

--- a/2001/ctk/README.md
+++ b/2001/ctk/README.md
@@ -23,10 +23,10 @@ This alternate version adds to the movement keys `l` for right, `h` for left and
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
+
 
 ### Alternate use:
 

--- a/2001/kev/README.md
+++ b/2001/kev/README.md
@@ -129,7 +129,6 @@ box.
 
 ## Author's remarks:
 
-
 **NETWORK PONG!**
 
 ### REQUIREMENTS

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -29,7 +29,6 @@ Do get lost in the program's line of thought!  :-)
 
 ## Author's remarks:
 
-
 ### What's this?
 
 What do you see? On the left, you will see an enumeration of all successive

--- a/2001/rosten/README.md
+++ b/2001/rosten/README.md
@@ -16,7 +16,6 @@ STATUS: missing files - please provide them
 For more detailed information see [2001 rosten in bugs.md](/bugs.md#2001-rosten).
 
 
-
 ## To use:
 
 ```sh
@@ -50,7 +49,6 @@ cursor) in the wrong way.  :-)
 
 
 ## Author's remarks:
-
 
 ### NAME
 

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -22,8 +22,6 @@ STATUS: missing files - please provide them
 For more detailed information see [2001 westley in bugs.md](/bugs.md#2001-westley).
 
 
-
-
 ## To use:
 
 ```sh
@@ -34,6 +32,7 @@ echo foo | ./westley 2>/dev/null
 
 ./westley < westley.c 2>/dev/null
 ```
+
 
 ### Try:
 
@@ -73,7 +72,6 @@ This alternate code might be less portable.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -82,7 +80,6 @@ make alt
 ### Alternate use:
 
 Use `westley.alt` as you would `westley` above.
-
 
 
 ## Judges' remarks:

--- a/2001/williams/README.md
+++ b/2001/williams/README.md
@@ -4,6 +4,7 @@
 make
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:
@@ -13,7 +14,6 @@ STATUS: known bug - please help us fix
 ```
 
 For more detailed information see [2001 williams in bugs.md](/bugs.md#2001-williams).
-
 
 
 ## To use:

--- a/2004/arachnid/README.md
+++ b/2004/arachnid/README.md
@@ -45,6 +45,7 @@ instead.
 make alt
 ```
 
+
 ### Alternate use:
 
 Use `arachnid.alt` as you would `arachnid` above.

--- a/2004/gavare/README.md
+++ b/2004/gavare/README.md
@@ -21,6 +21,7 @@ for more details.
 ./gavare > ioccc_ray.ppm
 ```
 
+
 ## Alternate code:
 
 The alt code, [gavare.alt.c](gavare.alt.c), allows you to change the size of the

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -90,6 +90,7 @@ you can use it with `QEMU`.
 make alt
 ```
 
+
 ### Alternate use:
 
 The use is mostly the same as `gavin` except that one initially executes `gavin.alt`

--- a/2004/jdalbec/README.md
+++ b/2004/jdalbec/README.md
@@ -32,6 +32,7 @@ For more detailed information see [2004 jdalbec in bugs.md](/bugs.md#2004-jdalbe
 ./try.sh
 ```
 
+
 ## Alternate code:
 
 This version lets you control how many numbers to show on a line before adding a

--- a/2004/kopczynski/README.md
+++ b/2004/kopczynski/README.md
@@ -34,7 +34,6 @@ does.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2005/boutines/README.md
+++ b/2005/boutines/README.md
@@ -20,7 +20,6 @@ ruby -e '20.times{puts "#{rand} #{rand}"}' | ./boutines > test.svg
 
 ### Try:
 
-
 ```sh
 ./boutines < input.txt > result.svg
 ```

--- a/2005/mikeash/README.md
+++ b/2005/mikeash/README.md
@@ -33,7 +33,6 @@ under 64-bit (x86_64, arm64) machines too.
 ```
 
 
-
 ## Judges' remarks:
 
 Having problems speaking code?  Do you [LISP][]?  Parenthetically

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -58,7 +58,6 @@ must just appreciate the entry for what it once was.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2005/persano/README.md
+++ b/2005/persano/README.md
@@ -41,6 +41,7 @@ let it work with Windows.
 make alt
 ```
 
+
 ### Alternate use:
 
 Use `persano.alt` as you would `persano` above.

--- a/2005/toledo/README.md
+++ b/2005/toledo/README.md
@@ -34,6 +34,7 @@ To compile the alternate versions:
 make alt
 ```
 
+
 ### Alternate use:
 
 Use Use `toledo2` and `toledo3` as you would `toledo` above.

--- a/2005/vince/README.md
+++ b/2005/vince/README.md
@@ -15,7 +15,7 @@ make
 ```
 
 
-## Try:
+### Try:
 
 When running this in the program's window try hitting space a few times and see
 what happens!
@@ -34,6 +34,7 @@ To compile this alternate version:
 ```sh
 make alt
 ```
+
 
 ### Alternate use:
 
@@ -58,7 +59,6 @@ Challenge: Try modifying the texture to something of your own design.
 
 
 ## Author's remarks:
-
 
 ### ABUSE OF RULES
 

--- a/2006/borsanyi/README.md
+++ b/2006/borsanyi/README.md
@@ -16,8 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2006 borsanyi in bugs.md](/bugs.md#2006-borsanyi).
 
 
-
-
 ## To use:
 
 ```sh

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -53,7 +53,6 @@ as the number of iterations to perform.
 
 ### Alternate build:
 
-
 To use the default values, the same as [monge.c](monge.c), just do:
 
 

--- a/2006/night/README.md
+++ b/2006/night/README.md
@@ -23,7 +23,6 @@ keys.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2006/sloane/README.md
+++ b/2006/sloane/README.md
@@ -45,7 +45,6 @@ Should you wish to see the original you may do so with the original code,
 
 ### Original build:
 
-
 ```sh
 make clobber all
 ```

--- a/2006/sykes1/README.md
+++ b/2006/sykes1/README.md
@@ -16,8 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2006 sykes1 in bugs.md](/bugs.md#2006-sykes1).
 
 
-
-
 ## To use:
 
 ```sh

--- a/2006/toledo3/README.md
+++ b/2006/toledo3/README.md
@@ -9,7 +9,6 @@ another that makes it text only. The author also provided a version that they
 tested with Windows.  See [alternate code](#alternate-code) below.
 
 
-
 ## To use:
 
 ```sh

--- a/2011/borsanyi/README.md
+++ b/2011/borsanyi/README.md
@@ -4,6 +4,7 @@
 make
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:

--- a/2011/fredriksson/README.md
+++ b/2011/fredriksson/README.md
@@ -46,7 +46,6 @@ program and calls it. As an exercise, try writing the compressor.
 
 ## Author's remarks:
 
-
 ### Approximate grep
 
 Implements a variant of `grep`.

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -57,6 +57,7 @@ make alt
 
 ```
 
+
 ### Alternate use:
 
 Use `vik.alt` as you would `vik` above.

--- a/2012/dlowe/README.md
+++ b/2012/dlowe/README.md
@@ -16,7 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2012 dlowe in bugs.md](/bugs.md#2012-dlowe).
 
 
-
 ## To use:
 
 ```sh

--- a/2012/konno/README.md
+++ b/2012/konno/README.md
@@ -32,7 +32,6 @@ This alternate code is an unobfuscated version of the winning code.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2012/tromp/README.md
+++ b/2012/tromp/README.md
@@ -18,7 +18,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2012 tromp in bugs.md](/bugs.md#2012-tromp).
 
 
-
 ## To use:
 
 ```sh

--- a/2012/zeitak/README.md
+++ b/2012/zeitak/README.md
@@ -41,6 +41,7 @@ this extremely subtle entry.
 make alt
 ```
 
+
 ### Alternate use:
 
 Use `zeitak.alt` as you would `zeitak` above.
@@ -58,7 +59,6 @@ just to understand 18 key characters of this code.
 
 
 ## Author's remarks:
-
 
 ### Nesting Errors Detector
 

--- a/2013/birken/README.md
+++ b/2013/birken/README.md
@@ -10,7 +10,6 @@ see the [original code](#original-code) section.
 
 ## To use:
 
-
 ```sh
 ./birken.alt < 17_columns_wide_paint_by_numbers_file
 ```
@@ -64,7 +63,6 @@ hard to see the art of the entry but you may do so if you wish.
 
 
 ### Original build:
-
 
 ```sh
 make all

--- a/2013/cable2/README.md
+++ b/2013/cable2/README.md
@@ -16,8 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2013 cable2 in bugs.md](/bugs.md#2013-cable2).
 
 
-
-
 ## To use:
 
 ```sh

--- a/2013/cable3/README.md
+++ b/2013/cable3/README.md
@@ -78,7 +78,6 @@ Update: This entry now has its own website:
 
 ## Author's remarks:
 
-
 ### A tiny but highly functional PC emulator/virtual machine
 
 The author hereby presents, for the delectation (?) of the judges, a portable PC

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -4,6 +4,7 @@
 make
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:

--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -32,7 +32,6 @@ Next look at `jpeg.jpg` in an image viewer program.
 
 ## Judges' remarks:
 
-
 This is a program which, when fed its own source, generates a program that
 almost is its whitespace inverse, which, in its order, generates a JPEG file
 (speaking of file size abuse, that is about 16.4 times larger than a PBM file

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -4,6 +4,7 @@
 make
 ```
 
+
 ### Bugs and (Mis)features:
 
 The current status of this entry is:

--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -70,7 +70,6 @@ You can combine them both of course.
 
 ### Alternate use:
 
-
 Use `prog.alt` as you would `prog` above. Remember that ports < 1024 are
 privileged ports that unprivileged users cannot use.
 

--- a/2014/deak/README.md
+++ b/2014/deak/README.md
@@ -63,6 +63,7 @@ Use `prog.alt` as you would `prog`.
 ./try.alt.sh
 ```
 
+
 ## Judges' remarks:
 
 We consider this entry a tribute to all "Abuse of the C preprocessor"
@@ -72,7 +73,6 @@ We liked the use of unary notation facilitated by variadic macros.
 
 
 ## Author's remarks:
-
 
 ### Portability
 

--- a/2014/endoh1/README.md
+++ b/2014/endoh1/README.md
@@ -57,7 +57,6 @@ more than 1000 words.
 
 ## Author's remarks:
 
-
 ### Remarks
 
 You may want to use a large display with a very small terminal font.

--- a/2014/endoh2/README.md
+++ b/2014/endoh2/README.md
@@ -32,7 +32,6 @@ in the DNA code of the code? Perhaps there are 23 reasons? :-)
 
 ## Author's remarks:
 
-
 ### Remarks
 
 This chromosome program synthesizes a double helix.

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -20,7 +20,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2014 maffiodo1 in bugs.md](/bugs.md#2014-maffiodo1).
 
 
-
 ## To use:
 
 ```sh
@@ -39,7 +38,6 @@ The parameters to the program are:
 8. Filename of the music (WAVE 8000 Hz 8bit Mono).
 9. Sky color. This number depends on the system where you run the program. See
 note on macOS.
-
 
 
 ### Try:

--- a/2014/maffiodo2/README.md
+++ b/2014/maffiodo2/README.md
@@ -19,7 +19,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2014 maffiodo2 in bugs.md](/bugs.md#2014-maffiodo2).
 
 
-
 ## To use:
 
 ```sh
@@ -41,7 +40,6 @@ as fun but it's 121 bytes instead of 140.
 
 
 ### Alternate build:
-
 
 ```sh
 make alt

--- a/2014/morgan/README.md
+++ b/2014/morgan/README.md
@@ -83,6 +83,7 @@ prog.c:23:72: warning: signed and unsigned type in conditional expression [-Wsig
 prog.c:12:11: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
 ```
 
+
 ## Copyright and CC BY-SA 4.0 License:
 
 This file is Copyright (c) 2023 by Landon Curt Noll.  All Rights Reserved.

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -44,7 +44,6 @@ instructions on how to get it to work with Windows.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -75,7 +74,6 @@ might help? :-)
 
 
 ## Author's remarks:
-
 
 ### Remarks
 

--- a/2015/burton/README.md
+++ b/2015/burton/README.md
@@ -41,6 +41,7 @@ Finally, if you wish to read the man page:
 man ./calc.1
 ```
 
+
 ## Alternate code:
 
 An alternate version of this entry, [prog.alt.c](prog.alt.c), is provided.
@@ -50,10 +51,10 @@ author's remarks below.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
+
 
 ### Alternate use:
 
@@ -72,7 +73,6 @@ process.
 
 
 ## Author's remarks:
-
 
 ### calc - an integer expression calculator that outputs in both hex and decimal
 

--- a/2015/dogon/README.md
+++ b/2015/dogon/README.md
@@ -108,7 +108,6 @@ number function keys such as F30 or F31?  :-)
 
 ## Author's remarks:
 
-
 ### What is it?
 
 Just run `./prog` with no arguments on an X11-compatible system. The scenery, though

--- a/2015/duble/README.md
+++ b/2015/duble/README.md
@@ -40,7 +40,7 @@ make alt
 Use `prog.alt` as you would `prog` above.
 
 
-### Judges' remarks:
+## Judges' remarks:
 
 Beautiful penmanship! However, your fonts may vary.
 

--- a/2015/endoh3/README.md
+++ b/2015/endoh3/README.md
@@ -53,7 +53,6 @@ clue, see the end of the author's remarks.) If in doubt, use
 
 ## Author's remarks:
 
-
 ### Hint / Compatibility
 
 * A little-endian system is required due to an external factor.

--- a/2015/endoh4/README.md
+++ b/2015/endoh4/README.md
@@ -32,7 +32,6 @@ Dogon](/winners.html#Gil_Dogon); it is the author's original entry.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2015/hou/README.md
+++ b/2015/hou/README.md
@@ -16,8 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2015 hou in bugs.md](/bugs.md#2015-hou).
 
 
-
-
 ## To use:
 
 ```sh

--- a/2015/howe/README.md
+++ b/2015/howe/README.md
@@ -32,7 +32,6 @@ entry but was changed to be the alt version.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -70,7 +69,6 @@ NOTE: Unlike the original entry source, [prog.alt.c](prog.alt.c),
 
 
 ## Author's remarks:
-
 
 ### Features
 

--- a/2015/schweikhardt/README.md
+++ b/2015/schweikhardt/README.md
@@ -101,7 +101,6 @@ code is magic number free.
 
 ## Author's remarks:
 
-
 ### The TL;DR version
 
 This is the cleanest program ever submitted. If for some input it enters

--- a/2018/algmyr/README.md
+++ b/2018/algmyr/README.md
@@ -50,7 +50,6 @@ sound sample?
 
 ## Author's remarks:
 
-
 ### What is this?
 
 To put it brief, this entry is akin to a sound based cat. It takes characters as

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -32,7 +32,6 @@ with `-Wno-` options.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2018/ciura/README.md
+++ b/2018/ciura/README.md
@@ -33,7 +33,6 @@ useful bug fix.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -53,7 +52,6 @@ vocabulary has it?
 
 
 ## Author's remarks:
-
 
 ### The Program:
 

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -31,7 +31,6 @@ about this under the [keyboards](#keyboards) section, briefly referred to in the
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```

--- a/2018/mills/README.md
+++ b/2018/mills/README.md
@@ -73,7 +73,7 @@ But there is much more to this entry! See below.
 NOTE: To quit, press Control-E.
 
 
-### Judges' remarks:
+## Judges' remarks:
 
 Do small machines only need small programs?  This program weighs in at just
 3636 bytes, which is considerably lighter than the original machine it can replace.
@@ -129,7 +129,6 @@ NOTE: To quit v6, press Control-E.
 
 
 ## Author's remarks:
-
 
 ### *This IOCCC entry is dedicated to the late Dennis M. Ritchie*
 

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -16,7 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2018 vokes in bugs.md](/bugs.md#2018-vokes).
 
 
-
 ## To use:
 
 ```sh
@@ -43,7 +42,6 @@ answer you seek with no hocus pocus.
 
 
 ## Author's remarks:
-
 
 ### Introduction:
 

--- a/2019/dogon/README.md
+++ b/2019/dogon/README.md
@@ -62,7 +62,6 @@ In the interest of saving lives, this entry was not fuzzed.
 
 ## Author's remarks:
 
-
 ### What is it?
 
 Just run with no arguments on an X11-compatible system using one of the supplied

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -115,7 +115,6 @@ or `l` (they toggle).
 
 ## Author's remarks:
 
-
 ### Introduction:
 
 This program is a **graphics editor**, running in the terminal.

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -55,7 +55,6 @@ ascii` when debugging it to reveal its purpose.
 
 ## Author's remarks:
 
-
 ### backtrace quine:
 
 Compile prog.c with no optimization.

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -19,7 +19,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2019 karns in bugs.md](/bugs.md#2019-karns).
 
 
-
 ## To use:
 
 ```sh

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -16,7 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2019 mills in bugs.md](/bugs.md#2019-mills).
 
 
-
 ## To use:
 
 ```sh

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -102,7 +102,6 @@ Nyk&auml;nen](https://en.wikipedia.org/wiki/Matti_Nyk%C3%A4nen).
 
 ## Author's remarks:
 
-
 ### How to build:
 
 ```sh

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -73,7 +73,6 @@ and to make it a bit more like the real thing.
 
 ### Alternate build:
 
-
 ```sh
 make alt
 ```
@@ -94,7 +93,6 @@ Use `prog.alt` as you would `prog` above.
 
 
 ### Alternate try:
-
 
 ```sh
 ./try.alt.sh

--- a/2020/giles/README.md
+++ b/2020/giles/README.md
@@ -16,8 +16,6 @@ STATUS: INABIAF - please **DO NOT** fix
 For more detailed information see [2020 giles in bugs.md](/bugs.md#2020-giles).
 
 
-
-
 ## To use:
 
 ```sh

--- a/2020/kurdyukov2/README.md
+++ b/2020/kurdyukov2/README.md
@@ -34,7 +34,6 @@ rectangles.  What is the complexity? Is it obvious from the source code?
 
 ## Author's remarks:
 
-
 ### Usage
 
 This program divides the image into a specified number of rectangles. This

--- a/2020/kurdyukov3/README.md
+++ b/2020/kurdyukov3/README.md
@@ -57,7 +57,6 @@ exactly what it says nonetheless.
 
 ## Author's remarks:
 
-
 ### Letter Mixer
 
 Compile and try this:

--- a/2020/kurdyukov4/README.md
+++ b/2020/kurdyukov4/README.md
@@ -68,7 +68,6 @@ Now can you appreciate the award title a bit better?
 
 ## Author's remarks:
 
-
 ### Building:
 
 ```sh

--- a/2020/otterness/README.md
+++ b/2020/otterness/README.md
@@ -46,7 +46,6 @@ While doing that, you can be audibly *entertained* by a sample of its output.
 
 ## Author's remarks:
 
-
 ### MIDI "boots and cats"
 
 This program seeks to automatically "improve" standard MIDI files (.mid) by

--- a/2020/tsoj/README.md
+++ b/2020/tsoj/README.md
@@ -37,6 +37,7 @@ where instead of `w`, `a`, `s` and `d`, you can use `k`, `h`, `j` and `l`.
 make alt
 ```
 
+
 ### Alternate use:
 
 ```sh

--- a/tmp/format-headers.sh
+++ b/tmp/format-headers.sh
@@ -9,7 +9,7 @@
 # the [0-9]{4} directories.
 #
 
-for i in "$(git ls-files '[0-9][0-9][0-9][0-9]/*README.md')"; do
+for i in $(git ls-files '[0-9][0-9][0-9][0-9]/*README.md'); do
     perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(To build):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"
     perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(Bugs and \(Mis\)features):?\n\n*([^\n])?/$1\n\n### $2:\n\n$3/' "$i"
     perl -0777 -p -i -e 's/([^\n]\n)\n*##*[[:space:]]*(To use):?\n\n*([^\n])?/$1\n\n## $2:\n\n$3/' "$i"

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Sat 23 Dec 2023 13:28:11 UTC*
+*Last updated: Wed 27 Dec 2023 16:38:05 UTC*
 
 This document is primarily for [Cody Boone
 Ferguson](/winners.html#Cody_Boone_Ferguson) as he (that is I :-) ) wanted a way
@@ -99,3 +99,8 @@ the rest of the entries are done, assuming that it's possible.
 - Although I will have to do this when another issue is opened up I am aware of
 some issues in 2020/ferguson1/.winner.json. I do not want to forget this,
 however, so I am noting it here.
+
+- Verify that all entries that should have (or could be benefited by) a try
+script do in fact have one. Also verify (mostly in earlier years) consistency in
+the way it is displayed and interactivity. The later years are probably done
+better.

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -83,14 +83,6 @@ instead change it to make pull requests. See the
 requests rather than emailing judges. This can be done on the final pass of the
 files.
 
-- In the entries with the alt code that use `usleep(3)` make the macro name
-consistent across all entries. At one point `Z` was used but in one entry `Z`
-was taken so this would not work. It appears at this time (16 November 2023)
-that it might be that `S` will work in all cases (currently?) though one has two
-values so the second would could be changed to `SS` (which is convenient as it's
-for SDL). This is low priority but it would be nice to have done as it would
-make it consistent and easy to remember.
-
 - With the entries that we recommend the alt code first when it comes to it
 going too fast we should say not what it looks like in modern systems but rather
 what it LOOKED LIKE AT THE TIME. At Wed 22 Nov 2023 13:02:04 UTC the only entry


### PR DESCRIPTION

The script had "s surrounding the git ls-files command which turned it
to a single file which of course is wrong.
 
Ran script again fixing many README.md files that had incorrect number
of blank lines for critical headers.

This will have to be done a final but a good number of files have been
corrected.