### PR TITLE
Add 1986/stein/stein.sh

### DIFF
--- a/1986/stein/README.md
+++ b/1986/stein/README.md
@@ -19,7 +19,7 @@ into 3 lines.  Join all lines into a single line to recreate
 the original file.
 
 
-The 015 in the above printf command produces a control-N.
+The `\015` in the above `printf(1)` command produces a control-N.
 
 One some machines, a control-M control-N arg is needed
 to get the command to output cleanly:

--- a/1986/stein/stein.sh
+++ b/1986/stein/stein.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1986/stein
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./stein \$(printf \"\\015\\015\"); echo" 1>&2
+./stein $(printf "\015\015"); echo
+
+echo "$ ./stein \$(printf \"\\014\\015\"); echo" 1>&2
+./stein $(printf "\014\015"); echo
+
+echo "$ ./stein" 1>&2
+./stein

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -406,6 +406,9 @@ being longer (in 1986 a one liner could be longer) was split to three lines to
 avoid problems with news and mail but as it was the 'Best one liner' it is now
 one line.
 
+Cody also added the [stein.sh](/1986/stein/stein.sh) script which runs the two
+commands that we suggest in order to get it to show clean output.
+
 
 ## <a name="1986_wall"></a>[1986/wall](/1986/wall/wall.c) ([README.md](/1986/wall/README.md]))
 

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Wed 27 Dec 2023 16:38:05 UTC*
+*Last updated: Thu 28 Dec 2023 14:56:35 UTC*
 
 This document is primarily for [Cody Boone
 Ferguson](/winners.html#Cody_Boone_Ferguson) as he (that is I :-) ) wanted a way
@@ -13,15 +13,6 @@ done (many times it's thought that a task was done only to find out it wasn't).
 It is hoped that this will be referenced and updated as this is an easy way to
 keep track of things that have been done already and what hasn't been done (in
 this file the case is mostly _NOT_ been done).
-
-- Resolve as many of the issues in [bugs.md](/bugs.md) with the exception of the
-INABIAF ones. This is likely not possible for all (one in particular comes to
-mind that abuses a bug in a now very old gcc version - this obviously cannot be
-fixed but I added an alt version that does what it used to do so it's fine) but
-many certainly can be - and actually most have been - fixed. Another one crashes
-in macOS but this is almost certainly because of the version of perl installed.
-Another one crashes in macOS but this is almost certainly because of
-`mmap(2)`/JIT code with the Apple silicon chip etc.
 
 - Typo fix ALL markdown files. For the README.md files the entries have all been
 done (along with format fixes) but the YYYY/README.md files have not been
@@ -52,36 +43,6 @@ run) or else they'll have to be put above the compilation.
 - Check the [GitHub issue #3 comment
 1615962832](https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1615962832)
 for links about the todo items wrt the [FAQ](/faq.md).
-
-- Check for dead links of all kinds: not only author URLs but file URLs on the
-website. I (Cody) would be seriously surprised if I did not make a typo
-somewhere (or some places!) in the many thousands of changes I made in the
-README.md files, the [bugs.md](/bugs.md) files and maybe even the
-[thanks-for-help.md](/thanks-for-help.md) file plus others that might be
-there.
-    * In the case of author URLs sometimes the Internet Wayback Machine is
-    helpful (and has helped) but in other cases it has not. Note that sometimes
-    the Internet Wayback Machine helped find more recent URLs so this should be
-    attempted first before adding the last archive link.
-    * Remember to update the author JSON files if it's an author URL!
-    * For URLs that cannot be located at all remove them entirely but add them
-    to [bugs.md](/bugs.md) as a missing link to the respective entry. See that file for the
-    correct status to add. Remember that each type of issue per entry in the
-    [bugs.md](/bugs.md) file should have its own status.
-    * If it's a link in the repo then there's no need (in almost all cases if
-    not all cases) to have the Internet Wayback Machine: instead just update the
-    link to point to the right location.
-    * Do we need to update the links that point to GitHub raw content? I'm not
-    sure.
-
-
-- For the YYYY/README.md files where it refers to emailing the judges fixes
-instead change it to make pull requests. See the
-[1995/README.md](1995/README.md) file for example.
-
-- Check the YYYY/README.md files for other things besides the GitHub pull
-requests rather than emailing judges. This can be done on the final pass of the
-files.
 
 - With the entries that we recommend the alt code first when it comes to it
 going too fast we should say not what it looks like in modern systems but rather


### PR DESCRIPTION
    
This script runs the two commands suggested in order to get it to output cleanly. It is suggested other systems might need another set of characters but one can also get away with just using ./stein so this is also done but at the end of the script to not cause any problems (it doesn't show a newline at output).