### PR TITLE
Add 1987/hines/try.sh

### DIFF
--- a/1987/biggar/README.md
+++ b/1987/biggar/README.md
@@ -9,13 +9,15 @@ make all
 
 ```sh
 some_command | ./biggar | od -c
+
+./biggar < file | od -c
 ```
 
 
 ### Try:
 
 ```sh
-./biggar < biggar.c | od -c
+./try.sh
 ```
 
 

--- a/1987/biggar/try.sh
+++ b/1987/biggar/try.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1987/biggar
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: ./biggar < biggar.c: "
+echo 1>&2
+./biggar < biggar.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./biggar < biggar.c | od -c: "
+echo 1>&2
+./biggar < biggar.c | od -c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./biggar < Makefile (space = next page, q = quit): "
+./biggar < Makefile | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./biggar < Makefile | od -c (space = next page, q = quit): "
+echo 1>&2
+./biggar < Makefile | od -c | less -rEXF

--- a/1987/heckbert/README.md
+++ b/1987/heckbert/README.md
@@ -20,15 +20,7 @@ where col is the number of columns to fold at and file is the file to fold.
 ### Try:
 
 ```sh
-./heckbert 40 < heckbert.c > ph.c; make ph
-./ph 21 < heckbert.c > bar.c; make bar
-
-```
-
-Ask yourself what happens to `foo.md` if you try:
-
-```sh
-./ph 40 < README.md > foo.md
+./try.sh
 ```
 
 

--- a/1987/heckbert/try.sh
+++ b/1987/heckbert/try.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1987/heckbert
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to show heckbert.c (space = next page, q = quit): "
+echo 1>&2
+less -rEXF heckbert.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./heckbert 40 < heckbert.c: "
+echo 1>&2
+./heckbert 40 < heckbert.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./heckbert 40 < heckbert.c > ph.c; make ph: "
+./heckbert 40 < heckbert.c > ph.c; make ph
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show ph.c (space = next page, q = quit): "
+echo 1>&2
+less -rEXF ph.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./ph 21 < heckbert.c > bar.c; make bar: "
+echo 1>&2
+./ph 21 < heckbert.c > bar.c; make bar
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show bar.c (space = next page, q = quit): "
+echo 1>&2
+less -rEXF bar.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./bar 79 < bar.c > foo.c: "
+echo 1>&2
+./bar 79 < bar.c > foo.c
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show difference between foo.c and heckbert.c: "
+echo 1>&2
+diff -s heckbert.c foo.c
+
+read -r -n 1 -p "Press any key to run: ./ph 40 < README.md > foo.md: "
+./ph 40 < README.md > foo.md
+echo 1>&2
+echo "Now what happened to foo.md?"

--- a/1987/hines/.gitignore
+++ b/1987/hines/.gitignore
@@ -1,6 +1,7 @@
 #
 # sort with: sort -d -u
 *.dSYM
+goto
 hines
 hines.alt
 hines.orig

--- a/1987/hines/README.md
+++ b/1987/hines/README.md
@@ -15,7 +15,7 @@ make all
 ### Try:
 
 ```sh
-./hines hines.c
+./try.sh
 ```
 
 

--- a/1987/hines/goto.c
+++ b/1987/hines/goto.c
@@ -1,0 +1,9 @@
+int main(void)
+{
+    goto x;
+    x: goto y;
+    y: goto z;
+    z: goto a;
+    a: goto end;
+    end: return 0;
+}

--- a/1987/hines/goto.txt
+++ b/1987/hines/goto.txt
@@ -1,0 +1,2 @@
+Goto goto goto goto
+goto goto goto goto

--- a/1987/hines/try.sh
+++ b/1987/hines/try.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1987/hines
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+show()
+{
+    if [[ "$#" -ne 1 ]]; then
+	echo "$0: expected 1 arg to show(), got: $#" 1>&2
+	return
+    fi
+
+    read -r -n 1 -p "Press any key to show $1 (space = next page, q = quit): "
+    echo 1>&2
+    less -rEXF "$1"
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./hines $1: "
+    echo 1>&2
+    ./hines "$1"
+    echo 1>&2
+}
+
+show hines.c
+
+show goto.c
+
+show goto.txt

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -519,6 +519,14 @@ that for System V we had to do this) Cody added to the Makefile
 `-Dindex=strchr`.
 
 
+## <a name="1987_hines"></a>[1987/hines](/1987/hines/hines.c) ([README.md](/1987/hines/README.md))
+
+[Cody](#cody) added the [try.sh](1987/hines/try.sh) script and the C file
+[goto.c](1987/hines/goto.c) and the text file [goto.txt](1987/hines/goto.txt)
+for demonstration purposes. Notice that the program is case sensitive which
+running the program on the text file demonstrates.
+
+
 ## <a name="1987_lievaart"></a>[1987/lievaart](/1987/lievaart/lievaart.c) ([README.md](/1987/lievaart/README.md))
 
 [Cody](#cody) added back the documented checks for invalid input which no longer worked

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -500,6 +500,11 @@ There might have been other changes as well.
 # <a name="1987"></a>1987
 
 
+## <a name="1987_biggar"></a>[1987/biggar](/1987/biggar/biggar.c) ([README.md](/1987/biggar/README.md))
+
+[Cody](#cody) added the [try.sh](1987/biggar/try.sh) script.
+
+
 ## <a name="1987_heckbert"></a>[1987/heckbert](/1987/heckbert/heckbert.c) ([README.md](/1987/heckbert/README.md))
 
 [Cody](#cody) made this look more like the original entry by restoring the `#define` of

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -510,6 +510,9 @@ There might have been other changes as well.
 [Cody](#cody) made this look more like the original entry by restoring the `#define` of
 `define`. It's not used but it now looks closer to the original.
 
+Cody also added the [try.sh](1987/heckbert/try.sh) script which shows how the
+program works but also how the folded code can recreate the original.
+
 Also because `index(3)` is deprecated and in some systems requires the inclusion
 of `strings.h` and because it's identical in use to `strchr(3)` (and we noted
 that for System V we had to do this) Cody added to the Makefile


### PR DESCRIPTION

The files goto.c and goto.txt were also added. The first one is a short
file that is easy to see how many 'goto's there are and the goto.txt 
file has seven 'goto's and one 'Goto' to demonstrate that the program is
case-sensitive.

The .gitignore file was updated with 'goto' though the Makefile does not
have (of course) a 'goto' rule as it's only there to have a C file which 
is easy to see how many 'goto's there are.