### PR TITLE
Fix location of fix details of 2006/toledo2

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -2512,16 +2512,11 @@ by [Yusuke Endoh](/winners.html#Yusuke_Endoh) and Cody's. Nevertheless there are
 two features that are not bugs.
 
 By design this program is supposed to crash on termination. This actually no
-longer does seems to happen but we don't need this to be added even if it might
+longer seems to happen but we don't need this to be added even if it might
 be called a bug :-)
 
 You must type in caps (except in strings) and this program is indeed
 case-sensitive.
-
-[Oscar Toledo G.](/winners.html#Oscar_Toledo) went back over the program
-and modified the fread/fwrite section to use the variable FILE *e instead of
-int y, making it to work on x86_64 Mac. Also, he added a note to clarify from
-where appears the `IMPORT.COM` and `HALT.COM` files.
 
 
 # 2007

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3273,6 +3273,13 @@ Cody also added the (untested) alt code that is based on the author's remarks to
 port this to systems that have the non-standard `kbhit()` and `getch()` (not the
 one from curses) which is typically (always?) in `conio.h`.
 
+The author, [Oscar Toledo G.](/winners.html#Oscar_Toledo), later went back over
+the program and modified the `fread(3)`/`fwrite(3)` section to use the variable
+`FILE *e` (that Cody changed) instead of `int y`, making it to work on x86_64
+(perhaps Cody's fix was for arm64 only?). Also, he added a note to clarify from
+where appears the `IMPORT.COM` and `HALT.COM` files.
+
+
 
 ## <a name="2006_toledo3"></a>[2006/toledo3](/2006/toledo3/toledo3.c) ([README.md](/2006/toledo3/README.md]))
 


### PR DESCRIPTION
Should be in thanks file as it updates what I originally fixed (maybe my changing the implicit ints to 'FILE *'s only worked for arm64 for some reason but I don't know): not in bugs.md file.