### PR TITLE
Fix how 1993/lmfjyh alt code is built

### DIFF
--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -136,8 +136,9 @@ ${PROG}: ${PROG}.c
 	${CP} lmfjyh.c \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${CC} ${CFLAGS} \
 	    \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c -o $@ ${LDFLAGS} || \
-	    ${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
+	   ${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
+	${CC} ${CFLAGS} ${PROG}.alt.c -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -22,6 +22,10 @@ alternate version for [those of
 us](https://www.collinsdictionary.com/dictionary/english/everyone) with gcc >=
 2.3.3. See [Alternate code](#alternate-code) section below for more details.
 
+However, there is an another version that will be compiled in case this fails.
+This should happen automatically. See [Alternate code](#alternate-code) below
+for more details on it.
+
 
 ### Bugs and (Mis)features:
 
@@ -47,9 +51,13 @@ If you have gcc < 2.3.3 (i.e. the entry can compile):
 
 This version does what the code did but in a way that will work with modern
 compilers. We'd like to say there's something special about it but there isn't.
+Nonetheless it will be compiled in case the original entry fails to compile
+(which will happen unless you have gcc < 2.3.3.
 
 
 ### Alternate build:
+
+Should you wish to build this version manually:
 
 ```sh
 make alt
@@ -59,7 +67,8 @@ make alt
 ### Alternate use:
 
 Use `lmfjyh.alt` as you would `lmfjyh` above. Note that other code could also be
-done with this bug; see the author's remarks for more details.
+done with the bug that the entry abuses but that would have to be manually
+programmed for this version; see the author's remarks for more details.
 
 
 ## Judges' remarks:

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1668,9 +1668,12 @@ files for functions.
 
 ## <a name="1993_lmfjyh"></a>[1993/lmfjyh](/1993/lmfjyh/lmfjyh.c) ([README.md](/1993/lmfjyh/README.md]))
 
-[Cody](#cody) added an [alternate version](/1993/lmfjyh/lmfjyh.alt.c) which does what the
-program did with gcc < 2.3.3. See the README.md file for details and for why
-this was made the alternate version, not the actual entry.
+[Cody](#cody) added an [alternate
+version](/1993/lmfjyh/README.md#alternate-code) which does what the program did
+with gcc < 2.3.3. See the README.md file for details and for why this was made
+the alternate version, not the actual entry. This alternate version will compile
+automatically in the very likely case (if you don't have gcc < 2.3.3) that the
+entry fails to compile.
 
 
 ## <a name="1993_plummer"></a>[1993/plummer](/1993/plummer/plummer.c) ([README.md](/1993/plummer/README.md]))


### PR DESCRIPTION
In the case that the original entry fails to compile (if you don't have gcc < 2.3.3 this will happen) the alt code will automatically be built. One can still manually compile the alt code, of course, but this way one can at least use the entry. Note that in the case the alt code is automatically compiled it is compiled to the lmfjyh just like what I did with 1985/sicherman. This was discussed after I did the 1985/sicherman (which will compile anyway after my fixes unless a compiler objects to main() having only one arg).