### PR TITLE
Fix how 2001/anonymous alt code is built

### DIFF
--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -136,8 +136,9 @@ ${PROG}: ${PROG}.c
 	${CP} lmfjyh.c \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${CC} ${CFLAGS} \
 	    \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c -o $@ ${LDFLAGS} || \
-	    ${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
+	   ${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
+	${CC} ${CFLAGS} ${PROG}.alt.c -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -22,6 +22,10 @@ alternate version for [those of
 us](https://www.collinsdictionary.com/dictionary/english/everyone) with gcc >=
 2.3.3. See [Alternate code](#alternate-code) section below for more details.
 
+However, there is an another version that will be compiled in case this fails.
+This should happen automatically. See [Alternate code](#alternate-code) below
+for more details on it.
+
 
 ### Bugs and (Mis)features:
 
@@ -47,9 +51,13 @@ If you have gcc < 2.3.3 (i.e. the entry can compile):
 
 This version does what the code did but in a way that will work with modern
 compilers. We'd like to say there's something special about it but there isn't.
+Nonetheless it will be compiled in case the original entry fails to compile
+(which will happen unless you have gcc < 2.3.3.
 
 
 ### Alternate build:
+
+Should you wish to build this version manually:
 
 ```sh
 make alt
@@ -59,7 +67,8 @@ make alt
 ### Alternate use:
 
 Use `lmfjyh.alt` as you would `lmfjyh` above. Note that other code could also be
-done with this bug; see the author's remarks for more details.
+done with the bug that the entry abuses but that would have to be manually
+programmed for this version; see the author's remarks for more details.
 
 
 ## Judges' remarks:

--- a/2001/anonymous/.gitignore
+++ b/2001/anonymous/.gitignore
@@ -2,11 +2,11 @@
 # sort with: sort -d -u
 anonymous
 anonymous.bed
-anonymous.bed.64
+anonymous.bed.alt
 anonymous.orig
 anonymous.ten
 anonymous.ten.32
-anonymous.ten.64
+anonymous.ten.alt
 *.dSYM
 indent
 indent.c

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -118,10 +118,10 @@ PROG= ${ENTRY}
 #
 OBJ= ${PROG}.o
 DATA=
-TARGET= ${PROG} ${PROG}.ten ${PROG}.ten.64 ${PROG}.bed ${PROG}.bed.64
+TARGET= ${PROG} ${PROG}.ten ${PROG}.ten.alt ${PROG}.bed ${PROG}.bed.alt
 #
-ALT_OBJ= ${PROG}.ten.64.o ${PROG}.bed.64.o
-ALT_TARGET= ${PROG}.ten.64 ${PROG}.bed.64
+ALT_OBJ= ${PROG}.ten.alt.o ${PROG}.bed.alt.o
+ALT_TARGET= ${PROG}.ten.alt ${PROG}.bed.alt
 
 
 #################
@@ -147,42 +147,56 @@ ${PROG}: ${PROG}.c
 ${PROG}.ten: ${PROG}.ten.c
 	@echo "WARNING: ${PROG}.ten.c must be compiled as a 32-bit ELF binary to use with"
 	@echo "the entry itself; this is because the program works on 32-bit ELF binaries."
-	@echo "If you cannot use -m32 this will NOT work!"
+	@echo "If you cannot use -m32 or it cannot compile for some other reason this will"
+	@echo "NOT work!"
 	@echo
-	@echo "If you want to use it where this is not possible e.g. with a Mac, say to"
-	@echo "use by itself, try:"
+	@echo "If you want to use this program where this is not possible e.g. with a Mac,"
+	@echo "say to use by itself, try:"
 	@echo
-	@echo "	    make anonymous.ten.64"
+	@echo "	    make anonymous.ten.alt"
 	@echo
-	@echo "but running ${PROG} on the resulting binary will crash."
+	@echo "but running ${PROG} on the resulting binary will crash. The build of"
+	@echo "anonymous.ten.alt is done automatically in case anonymous.ten fails to"
+	@echo "compile. Nevertheless again the entry will not work with it."
 	@echo
-	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS} || ${MAKE} ${PROG}.ten.alt
 
-${PROG}.ten.64: ${PROG}.ten.c
-	@echo "WARNING: the file created by this rule will NOT work with the entry itself;"
-	@echo "this is because it works ONLY on 32-bit ELF binaries! This however at least"
-	@echo "lets you see the supplementary program in action."
+${PROG}.ten.alt: ${PROG}.ten.c
+	@echo
+	@echo "-=-=-=-="
+	@echo "WARNING: the file created by this rule, ${PROG}.ten.alt, will NOT work with"
+	@echo "the entry itself; this is because it works ONLY on 32-bit ELF binaries! This"
+	@echo "however at least lets you see the supplementary program in action:"
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	@echo "-=-=-=-="
+	@echo
 
 ${PROG}.bed: ${PROG}.bed.c
 	@echo "WARNING: ${PROG}.bed.c must be compiled as a 32-bit ELF binary to use with"
 	@echo "the entry itself; this is because the program works on 32-bit ELF binaries."
-	@echo "If you cannot use -m32 this will NOT work!"
+	@echo "If you cannot use -m32 or it cannot compile for some other reason this will"
+	@echo "NOT work!"
 	@echo
-	@echo "If you want to use it where this is not possible e.g. with a Mac, say to"
-	@echo "use by itself, try:"
+	@echo "If you want to use this program where this is not possible e.g. with a Mac,"
+	@echo "say to use by itself, try:"
 	@echo
-	@echo "	    make anonymous.bed.64"
+	@echo "	    make anonymous.bed.alt"
 	@echo
-	@echo "but running ${PROG} on the resulting binary will crash."
+	@echo "but running ${PROG} on the resulting binary will crash. The build of"
+	@echo "anonymous.bed.alt is done automatically in case anonymous.bed fails to"
+	@echo "compile. Nevertheless again the entry will not work with it."
 	@echo
-	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS} || ${MAKE} ${PROG}.bed.alt
 
-${PROG}.bed.64: ${PROG}.bed.c
-	@echo "WARNING: the file created by this rule will NOT work with the entry itself;"
-	@echo "this is because it works ONLY on 32-bit ELF binaries! This however at least"
-	@echo "lets you see the supplementary program in action."
+${PROG}.bed.alt: ${PROG}.bed.c
+	@echo
+	@echo "-=-=-=-="
+	@echo "WARNING: the file created by this rule, ${PROG}.bed.alt, will NOT work with"
+	@echo "the entry itself; this is because it works ONLY on 32-bit ELF binaries! This"
+	@echo "however at least lets you see the supplementary program in action:"
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	@echo "-=-=-=-="
+	@echo
 
 
 # alternative executable

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -4,6 +4,15 @@
 make
 ```
 
+The programs that this program is supposed to act on,
+[anonymous.ten.c](anonymous.ten.c) and [anonymous.bed.c](anonymous.bed.c),
+compiled with `make`, MUST be compiled as 32-bit ELF binaries. In the case that
+this fails these programs will be compiled as 64-bit binaries as alternate code,
+`anonymous.ten.alt` and `anonymous.bed.alt`, ELF or otherwise. However trying to
+use the entry on these files will fail. See [Alternate code](#alternate-code)
+below for information on how to compile these programs as 64-bit binaries (or
+whatever your system will compile them as).
+
 
 ### Bugs and (Mis)features:
 
@@ -32,19 +41,8 @@ For more detailed information see [2001 anonymous in bugs.md](/bugs.md#2001-anon
 ```
 
 NOTE: if the 32-bit version cannot be compiled the script will at least compile
-[anonymous.ten](anonymous.ten.c) as a 64-bit program and run it directly. If it
-can be compiled but it's not an ELF binary the program is likely to crash.
-
-For fun and so that there's another program that is a bit different (it uses a `char
-*[]` array for example) that this program will still work on:
-
-```sh
-make anonymous.bed # if able to compile as 32-bit (-m32) ELF binary
-./anonymous anonymous.bed
-
-make anonymous.bed.64 # if unable to compile as a 32-bit (-m32) ELF binary
-./anonymous.bed.64
-```
+[anonymous.ten](anonymous.ten.c) as a 64-bit program (or whatever your system is
+set to) and run it directly.
 
 What happens if the x86 program has already been modified by this program? The
 judges' remarks below might give you a hint!
@@ -53,20 +51,30 @@ What happens if you try it on another file like [anonymous.c](anonymous.c)? Can
 you recompile it okay? What if you run it on `anonymous` itself? Can you run the
 program successfully after it without recompiling?
 
-If you do not specify a 32-bit ELF binary as the arg of this program it will
-very likely crash or do something terribly wrong like slaughtering all the
+
+## Alternate code:
+
+In the case you you wish to manually compile the extra programs as 64-bit code
+you may do so. Using the entry on these binaries will very likely crash the
+program or do something terribly wrong like slaughtering all the
 [elves](https://www.glyphweb.com/arda/e/elves.html) of
 [Imladris](https://www.glyphweb.com/arda/i/imladris.php)! :-) so please don't do
 that :-(
 
-If the program cannot be run (for instance under macOS as an ELF file) then
-the program will fail to execute it and might not even touch it.
 
-These are supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
+### Alternate build:
 
+```sh
+make alt
 ```
-That's not a bug, that's a feature.
+
+
+### Alternate use:
+
+```sh
+./anonymous.ten.alt
+
+./anonymous.bed.alt
 ```
 
 
@@ -81,7 +89,7 @@ modification might not be entirely correct for that reason though it does appear
 to be correct.
 
 It appears that the corruption happens only if the modification fails in the
-middle of doing so so that might be why it's not yet been observed.
+middle of doing so so that might be why it hasn't been observed.
 
 
 ## Judges' remarks:

--- a/2001/anonymous/anonymous.c
+++ b/2001/anonymous/anonymous.c
@@ -43,6 +43,6 @@ pain(char *ck, char **k)
 {
 c (z?(stat(M,&t)?P+=a+'{'?0:3:execv(M,k),a=G,i=P,y=G&255,sprintf(Q,y/'@'-3?"*L(V(%d+%d)+%d,0)":"R[%d]",(y&7),'\r',y/0100-1?0:G),(a+127&&a+'}'&&a+1?(a+61&&a+24&&a+025?(P=a+'H'&&a%061<=0?P:i,D(a>0?"                           R[%d]=E(~-E(R[%d])),\0               U R[%d],\0               R[%d] O,\0                                          U %d,\0R[%d]=0,"+(a&'8')*3:a  <-  'c'?" %d, %c%s = R[%d], \0    %d, *R=%c%s==R[%d], \0          R[%d]=(int)%c%s,"-a%'w'%'j'*5:"%d,%d,%s=%d,",a>0?a-'h'?a-49?a&7:g:I:g,a>0?a&7:"& "[a%3%2+1],a+72?Q:A(*R),a>0|a<-99?g:I,0) ,(char* ) P):(P=i,i=a+61?a+21?E(I):G:0, D(a%' '+29+"P O,\0 U %d,P=%d,",P,P+i,0,0,0) , p(d,"A'",b)),z):(n=g-4?g%5-1?a+127?G:I:0:(Scan(), *( x86?processor :d)=0, (int)(ss+V(i))),g%5<2?d+=sprintf( d,g%5?"    %s=E(~-E(%s)), \0    U %s,"+4*g:"%s=E(E(%s)%c%d),",Q,Q,"+    -  "[g],n,0 ),(char* ) P:(a=G-'u'?'!':'=', D(g-4?"P=%d%c=%s?%d:%d,":"*R=E(((int(*)(l,l,l))%s)(K(1),K(2),K(3))),P O,",n,a,Q,P,P+G), p(d,"A'",b) ,z)))):(Run((z=(char*)&ck,stat(k[1],&t),B=(l)mmap(0,N=i=t.st_size,PROT_READ|PROT_WRITE,1,f=open(k[1],2),0))), magic((R[4]=E(B+i/4),run(),P=V(-~i), R[4]=E(V(17)-4),*(int*)V(021))), sprintf(M,A(.%s%d),k[1],P), D("%s %s '-DX=A(%s)' -o %s '-Dmagic=",X,__FILE__,X,M,fflush(0)) ,(char* ) P));
 }
-int main (int cka, char **k) { char *ck = (char *)cka;
+main (int cka, char **k) { char *ck = (char *)cka;
   (E((ck?pain((char*)cka,k):p(M,A(rm -f .%s),M),*R)));munmap(B,N);close(f);execv(k[1],k);
 }

--- a/2001/anonymous/try.sh
+++ b/2001/anonymous/try.sh
@@ -41,9 +41,14 @@ if [[ -f "$TARGET" ]]; then
     diff -s ten.txt ten.bak.txt
 else
     echo "cannot compile anonymous.ten.c as 32-bit, sorry."
-    echo "will run 64-bit version directly."
-    make anonymous.ten.64
-    sleep 3
-    echo "$ ./$TARGET.64"
-    ./"$TARGET".64
+    echo "will run alt versions directly."
+    make alt || exit 1
+    read -r -n 1 -p "Press any key to run: ./anonymous.ten.alt (space = next page, q = quit): "
+    echo 1>&2
+    ./anonymous.ten.alt | less -rEXF
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./anonymous.bed.alt (space = next page, q = quit): "
+    echo 1>&2
+    ./anonymous.bed.alt | less -rEXF
 fi

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2483,7 +2483,7 @@ main (char *ck, char **k)
 to:
 
 ```c
-int main (int cka, char **k) { char *ck = (char *)cka; /* ... */ }
+main (int cka, char **k) { char *ck = (char *)cka; /* ... */ }
 ```
 
 The following change was also made to be more portable, in case the constants

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1668,9 +1668,12 @@ files for functions.
 
 ## <a name="1993_lmfjyh"></a>[1993/lmfjyh](/1993/lmfjyh/lmfjyh.c) ([README.md](/1993/lmfjyh/README.md]))
 
-[Cody](#cody) added an [alternate version](/1993/lmfjyh/lmfjyh.alt.c) which does what the
-program did with gcc < 2.3.3. See the README.md file for details and for why
-this was made the alternate version, not the actual entry.
+[Cody](#cody) added an [alternate
+version](/1993/lmfjyh/README.md#alternate-code) which does what the program did
+with gcc < 2.3.3. See the README.md file for details and for why this was made
+the alternate version, not the actual entry. This alternate version will compile
+automatically in the very likely case (if you don't have gcc < 2.3.3) that the
+entry fails to compile.
 
 
 ## <a name="1993_plummer"></a>[1993/plummer](/1993/plummer/plummer.c) ([README.md](/1993/plummer/README.md]))


### PR DESCRIPTION

The 64-bit code binaries have been renamed to .alt: anonymous.ten.alt 
and anonymous.bed.alt. This is because it's theoretically possible that
they are not compiled as 64-bit binaries (though how this might be I 
cannot think of at this time) and in any case they are alt builds 
(though they use the same source).

In the case the -m32 fails (whether due to compiler[0] or no access to 
32-bit binary compilation) make alt will be used with warnings that the
entry cannot work with them. The reason these are built as .alt and not
the original is to be clearer whereas in other cases (like 
1985/sicherman) the point was just a backup plan in case a compiler 
objects to it. Here they must be compiled as 32-bit ELF binaries (though
we cannot check if they are ELF - at least not easily and in an entirely
portable way - we can at least determine if they compiled as 32-bit) so
the alt builds are set to be .alt in filenames.

The try.sh script has been updated for this and in the case. However
this file needs to be looked at again and will be later. The purpose of
this commit was to resolve another issue that is in the todo file (this 
is not yet done and might or might not be done later today).