### PR TITLE
Further fixes to 1998/fanf for clang

### DIFF
--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -38,7 +38,8 @@ include ../../var.mk
 
 # Common C compiler warnings to silence
 #
-CSILENCE= -Wno-pointer-bool-conversion -Wno-unused-parameter -Wno-main -Wno-implicit-function-declaration
+CSILENCE= -Wno-pointer-bool-conversion -Wno-unused-parameter -Wno-main -Wno-implicit-function-declaration \
+	  -Wno-int-conversion
 
 # Common C compiler warning flags
 #

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -133,9 +133,11 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
+	@echo "=-=-=-=-="
+	@echo "WARNING: ${PROG}.c must be compiled as a 32-bit binary and it must be used"
+	@echo "in i386 linux. If either of these cannot be done this entry will NOT work!"
+	@echo "=-=-=-=-="
 	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS} || :
-	@echo "WARNING: ${PROG}.c must be compiled as 32-bit to use with the entry itself:"
-	@echo "if you cannot use -m32 this will NOT work! This entry also requires i386 linux."
 
 ${PROG}.otccex: ${PROG}.otccex.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2134,8 +2134,11 @@ Cody also added a second arg to `main()` out of an abundance of caution as some
 versions of clang whine about the number of args to `main()`. These versions
 claim that only 0, 2 or 3 are allowed but it does allow 1 anyway. It is quite
 possible though that this will change so it is fixed in case this happens. As it
-is mostly just through the C pre-processor Cody added a new macro to do
-translate to the rest of `main()`'s args.
+is mostly just through the C pre-processor Cody added a new macro to make the
+code look like the original with just an extra arg.
+
+In some versions of clang `-Wno-int-conversion` had to be added to the
+`CSILENCE` variable of the Makefile.
 
 Cody also added the [try.sh](/1998/fanf/try.sh) script to show the output of some
 of the expressions that we selected.


### PR DESCRIPTION

Some versions of clang need -Wno-int-conversion.