### PR TITLE
Add 1991/brnstnd/try.sh and try.txt

### DIFF
--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -8,6 +8,18 @@ There is an alternate version for those using Turbo-C or MSC. See [alternate
 code](#alternate-code) below for details.
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1990 baruch in bugs.md](/bugs.md#1990-baruch).
+
+
+
 ## To use:
 
 ```sh

--- a/1990/baruch/try.sh
+++ b/1990/baruch/try.sh
@@ -20,6 +20,11 @@ echo 1>&2
 echo 5 | ./baruch | less -rEXF
 echo 1>&2
 
+read -r -n 1 -p "Press any key to run: echo 8 | ./baruch (space = next page, q = quit): "
+echo 1>&2
+echo 8 | ./baruch | less -rEXF
+echo 1>&2
+
 read -r -n 1 -p "Press any key to run: echo 2 | ./baruch: "
 echo 1>&2
 echo 2 | ./baruch

--- a/1991/brnstnd/README.md
+++ b/1991/brnstnd/README.md
@@ -8,11 +8,10 @@ make all
 ### Try:
 
 ```sh
-./brnstnd < sorta.i2+2
-./brnstnd < sorta.iwhosort
-```
+./try.sh
 
-See also the other `sorta.*` files.
+./sorta < sorta.itailrec
+```
 
 
 ## Judges' remarks:

--- a/1991/brnstnd/try.sh
+++ b/1991/brnstnd/try.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1991/brnstnd
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+sorta_with_arg()
+{
+    if [[ "$#" != 2 ]]; then
+	echo "$0: sorta_with_arg() expects a file and arg, only got file name" 1>&2
+	return
+    fi
+
+    read -r -n 1 -p "Press any key to run: ./sorta < $1 $2: "
+    echo 1>&2
+    ./sorta < "$1" "$2"
+    echo 1>&2
+}
+
+sorta()
+{
+    if [[ "$#" != 1 ]]; then
+	echo "$0: sorta() expects 1 arg, got: $#" 1>&2
+	return
+    fi
+
+    read -r -n 1 -p "Press any key to run: ./sorta < $1: "
+    echo 1>&2
+    ./sorta < "$1"
+    echo 1>&2
+}
+
+sorta sorta.i2+2
+sorta sorta.icalc
+sorta_with_arg sorta.iecho "IOCCC 1991/brnstnd"
+sorta sorta.ifact2
+sorta sorta.iio
+sorta sorta.isleep
+sorta sorta.iwhosort
+sorta sorta.iarg0
+sorta sorta.idup
+sorta sorta.ifact1
+sorta sorta.ifact3
+read -r -n 1 -p "Press any key to show try.txt: "
+echo 1>&2
+cat try.txt
+echo 1>&2
+sorta_with_arg sorta.irot13 try.txt

--- a/1991/brnstnd/try.txt
+++ b/1991/brnstnd/try.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dog.

--- a/bugs.md
+++ b/bugs.md
@@ -673,6 +673,75 @@ Enjoy! :-)
 # 1990
 
 
+## 1990 baruch
+
+### STATUS: known bug - please help us fix
+### Source code: [1990/baruch/baruch.c](1990/baruch/baruch.c)
+### Information: [1990/baruch/README.md](1990/baruch/README.md)
+
+A point worth considering is that as the number passed into the program gets
+bigger the number of lines of output gets substantially larger and it takes much
+more time and resources to run as well. For instance:
+
+```sh
+$ for n in $(seq 1 18); do echo "$n"; echo "$n" | time "./baruch" | wc -l | sed -E -e 's/[[:space:]]//g'; done
+1
+3
+./baruch  0.00s user 0.00s system 5% cpu 0.115 total
+2
+1
+./baruch  0.00s user 0.00s system 64% cpu 0.004 total
+3
+1
+./baruch  0.00s user 0.00s system 60% cpu 0.003 total
+4
+11
+./baruch  0.00s user 0.00s system 64% cpu 0.003 total
+5
+61
+./baruch  0.00s user 0.00s system 66% cpu 0.003 total
+6
+29
+./baruch  0.00s user 0.00s system 61% cpu 0.003 total
+7
+321
+./baruch  0.00s user 0.00s system 69% cpu 0.002 total
+8
+829
+./baruch  0.00s user 0.00s system 76% cpu 0.003 total
+9
+3521
+./baruch  0.00s user 0.00s system 87% cpu 0.005 total
+10
+7965
+./baruch  0.01s user 0.00s system 95% cpu 0.014 total
+11
+32161
+./baruch  0.05s user 0.00s system 98% cpu 0.053 total
+12
+184601
+./baruch  0.29s user 0.00s system 99% cpu 0.294 total
+13
+1031969
+./baruch  1.78s user 0.00s system 99% cpu 1.794 total
+14
+5483941
+./baruch  11.26s user 0.02s system 99% cpu 11.311 total
+15
+36466945
+./baruch  79.20s user 0.15s system 99% cpu 1:19.72 total
+16
+251132705
+./baruch  592.89s user 0.77s system 99% cpu 9:55.34 total
+17
+1724671873
+./baruch  4535.71s user 5.25s system 99% cpu 1:15:49.76 total
+18
+12655721857
+./baruch  37496.97s user 58.50s system 99% cpu 10:27:48.29 total
+```
+
+
 ## 1990 jaw
 
 ### STATUS: known bug - please help us fix

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1177,6 +1177,9 @@ invalid operands to binary expressions were resolved with the comma operator.
 Later on, Cody added back the macro `#define D define` to make it look ever so
 slightly more like the original, even though it's unused.
 
+Cody also added the [try.sh](/1991/brnstnd/try.sh) script and
+[try.txt](/1991/brnstnd/try.txt) which the script uses.
+
 
 ## <a name="1991_buzzard"></a>[1991/buzzard](/1991/buzzard/buzzard.c) ([README.md](/1991/buzzard/README.md]))
 


### PR DESCRIPTION

The try.txt is a file for the rot13 SORTA file. All but one of the 
sorta.* files is used. The only one that is not prints out a verr long 
line of output and would flood the screen. The try section in the 
README.md does suggest one try it just to be complete.