### PR TITLE
Fix funny problem in 1989/fubar

### DIFF
--- a/1989/fubar/fubar.c
+++ b/1989/fubar/fubar.c
@@ -9,12 +9,12 @@
 if(m && q=='T' && o=='T'){m=0;(void)fread(tt,11,1,stdin);(void)printf("T %9d\n",atoi(tt)*QQ);}else {q=o;(void)putchar(o);}}exit(0);}
 cc ouroboros.c -o x 
 #define zxc ;{/*
-cat ./ouroboros.c | ./x $1 > x1
+cat ouroboros.c | ./x $1 > x1
 if [[ $? -ne 0 ]]; then
 exit
 fi
-mv x1 ./ouroboros.c
-chmod +x ./ouroboros.c
+mv x1 ouroboros.c
+chmod +x ouroboros.c
 exec ./ouroboros.c $1
 exit
 */

--- a/1989/fubar/fubar.sh
+++ b/1989/fubar/fubar.sh
@@ -9,8 +9,7 @@ fi
 
 # run/compile it
 rm -f ouroboros.c x1 x
-ex - <<EOF
-r fubar.c
+ex fubar.c <<EOF
 8,9j
 w ouroboros.c
 EOF

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -758,6 +758,27 @@ not strictly necessary but nonetheless more correct, even if not warned against.
 `$PATH`) to files referred to in the code. The path problem was also fixed in
 [fubar.sh](/1989/fubar/fubar.sh).
 
+A strange problem occurred where if one made modifications to the C file it
+might end up failing to work even after changing it back. This was resolved by:
+
+```diff
+--- i/1989/fubar/fubar.sh
++++ w/1989/fubar/fubar.sh
+@@ -7,13 +7,12 @@ if [[ $# -ne 1 ]]; then
+     exit 1
+ fi
+ 
+ # run/compile it
+ rm -f ouroboros.c x1 x
+-ex - <<EOF
+-r fubar.c
++ex fubar.c <<EOF
+ 8,9j
+ w ouroboros.c
+ EOF
+ chmod +x ouroboros.c
+```
+
 Cody also 'modernised' the script to use `bash` and fixed for ShellCheck. The
 `if [ .. ]` was changed in the C code as well as the script.
 


### PR DESCRIPTION
In some cases if one were to modify the C code (possibly the same with the script) in certain ways the program would fail to work even after changing the code back. Trying to figure out what to put in bugs.md and on a hunch, changing the fubar.sh script (in particular the ex(1) part) remedies the problem (or so it seems from the various tests I have performed including some that caused a problem). In particular:

    --- i/1989/fubar/fubar.sh
    +++ w/1989/fubar/fubar.sh
    @@ -7,13 +7,12 @@ if [[ $# -ne 1 ]]; then
	 exit 1
     fi

     # run/compile it
     rm -f ouroboros.c x1 x
    -ex - <<EOF
    -r fubar.c
    +ex fubar.c <<EOF
     8,9j
     w ouroboros.c
     EOF
     chmod +x ouroboros.c

The C code was also changed to make it even more like the original code.