### PR TITLE
Fix 1992/buzzard.2 alt code, add try scripts

### DIFF
--- a/1989/fubar/fubar.c
+++ b/1989/fubar/fubar.c
@@ -9,12 +9,12 @@
 if(m && q=='T' && o=='T'){m=0;(void)fread(tt,11,1,stdin);(void)printf("T %9d\n",atoi(tt)*QQ);}else {q=o;(void)putchar(o);}}exit(0);}
 cc ouroboros.c -o x 
 #define zxc ;{/*
-cat ./ouroboros.c | ./x $1 > x1
+cat ouroboros.c | ./x $1 > x1
 if [[ $? -ne 0 ]]; then
 exit
 fi
-mv x1 ./ouroboros.c
-chmod +x ./ouroboros.c
+mv x1 ouroboros.c
+chmod +x ouroboros.c
 exec ./ouroboros.c $1
 exit
 */

--- a/1989/fubar/fubar.sh
+++ b/1989/fubar/fubar.sh
@@ -9,8 +9,7 @@ fi
 
 # run/compile it
 rm -f ouroboros.c x1 x
-ex - <<EOF
-r fubar.c
+ex fubar.c <<EOF
 8,9j
 w ouroboros.c
 EOF

--- a/1992/buzzard.2/.gitignore
+++ b/1992/buzzard.2/.gitignore
@@ -1,9 +1,11 @@
 #
 # sort with: sort -d -u
 buzzard.2
+buzzard.2.alt
 buzzard.2.orig
 *.dSYM
 first
+first.alt
 indent
 indent.c
 indent.o

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -114,7 +114,7 @@ DATA=
 TARGET= ${PROG} first
 #
 ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_TARGET= ${PROG}.alt first.alt
 
 
 #################
@@ -143,6 +143,10 @@ alt: data ${ALT_TARGET}
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+first.alt: ${PROG}.alt
+	${RM} -f $@
+	${LN} $< $@
 
 # data files
 #

--- a/1992/buzzard.2/README.md
+++ b/1992/buzzard.2/README.md
@@ -10,8 +10,8 @@ code](#alternate-code) below for details.
 
 ## To use:
 
-First, you must make sure that first is made first (even though `make all`
-should do it :-) ):
+First, you must make sure that `first` is made first (even though `make all`
+should make first first :-) ):
 
 ```sh
 make first
@@ -48,6 +48,13 @@ Sorry, this is third!
 ```
 
 
+## Try:
+
+```sh
+./try.sh
+```
+
+
 ## Alternate code:
 
 This alternate version, [buzzard.2.alt.c](buzzard.2.alt.c), does not contain a
@@ -65,6 +72,12 @@ make alt
 
 Use `buzzard.2.alt` as you would `buzzard.2` above.
 
+
+### Alternate try:
+
+```sh
+./try.alt.sh
+```
 
 ## Judges' remarks:
 
@@ -99,8 +112,8 @@ further down.
 `first` expects you to first enter the names of the 13 primitives,
 separated by whitespace--it doesn't care what you name them, but
 if all the names aren't unique, you won't be able to use some of
-them.  After this you may type any sequence of valid first input.
-Valid first input is defined as any sequence of whitespace-delimited
+them.  After this you may type any sequence of valid `first` input.
+Valid `first` input is defined as any sequence of whitespace-delimited
 tokens which consist of primitives, new words you've defined, and
 integers (as parsed by `"%d"`).  Invalid input behaves unpredictably,
 but gives no warning messages.  A sample program, `demo1.1st`, is
@@ -108,7 +121,7 @@ included, but it only works on ASCII systems.
 
 Do not expect to be able to do anything interesting with `first`.
 
-To do something interesting, you need to feed first the file
+To do something interesting, you need to feed `first` the file
 [third](third) first.  In unix, you can do
 
 ```sh
@@ -159,7 +172,7 @@ Other related obfuscations are still present.  The top of the stack is cached in
 a variable, which increases performance massively if the compiler can figure out
 to keep it in a register; it also obfuscates the code.  (Unfortunately, the top
 of stack is a global variable and neither gcc nor most bundled compilers seem to
-register allocate it.)
+`register` allocate it.)
 
 More significant are the design obfuscations.  `m[0]` is the "dictionary
 pointer", used when compiling words, and `m[1]` is the return stack index.  Both
@@ -205,15 +218,14 @@ are primitives in
 [FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) (like swap)
 take a significant amount of time in THIRD.
 
-When you get the `Ok.` message from third, try out some sample
-[FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) code (first
-has no way of knowing if keyboard input is waiting, so it can't actually prompt
+When you get the `Ok.` message from `third`, try out some sample
+[FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) code
+(`first` has no way of knowing if keyboard input is waiting, so it can't actually prompt
 you in a normal way.  It only prints `'Ok.'` after you define a word).
 
 
 ```sh
 2 3 + . cr
-
 ```
 
 (which adds 2 and 3, and print the result and a newline.)

--- a/1992/buzzard.2/buzzard.2.alt.c
+++ b/1992/buzzard.2/buzzard.2.alt.c
@@ -17,7 +17,7 @@ a(x)
 r(x)
 {
    switch(x++[m]){
-	z 5:	for(w=scanf("%s",s)<1?exit(0):L;strcmp(s,&w[&m[1]][s]);w=m[w]);
+	z 5:	for(w=scanf("%s",s)<1?exit(0),0:L;strcmp(s,&w[&m[1]][s]);w=m[w]);
 		w-1 ? r(w+2) : (c 2,c atoi(s))
 	z 12:	I=1[m]--[m]
 	z 15:	f=S[-f]

--- a/1992/buzzard.2/help.th
+++ b/1992/buzzard.2/help.th
@@ -1,7 +1,7 @@
 : help key  ( flush the carriage return form the input buffer )
 
 " The following are the standard known words; words marked with (*) are
-immediate words, which cannot be used from command mode, but only in
+immediate words, which cannot be used in command mode, but only in
 word definitions.  Words marked by (**) declare new words, so are always
 followed by the new word.
 

--- a/1992/buzzard.2/try.alt.sh
+++ b/1992/buzzard.2/try.alt.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1992/buzzard.2 alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" alt >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ echo help | cat third help.th - | ./first.alt" 1>&2
+read -r -n 1 -p "Press any key to read help (space = next page, q = quit): "
+echo 1>&2
+echo help | cat third help.th - | ./first.alt | less -rEXF
+
+for i in demo[1-6].th; do
+    # try out each demo
+    #
+    read -r -n 1 -p "Press any key to show $i (space = next page, q = quit): "
+    echo 1>&2
+    less -rEXF "$i"
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run cat third $i | ./first.alt (demo $i): "
+    echo 1>&2
+    cat third "$i" | ./first.alt
+    echo 1>&2
+done

--- a/1992/buzzard.2/try.sh
+++ b/1992/buzzard.2/try.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1992/buzzard.2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ echo help | cat third help.th - | ./first" 1>&2
+read -r -n 1 -p "Press any key to read help (space = next page, q = quit): "
+echo 1>&2
+echo help | cat third help.th - | ./first | less -rEXF
+
+for i in demo[1-6].th; do
+    # try out each demo
+    #
+    read -r -n 1 -p "Press any key to show $i (space = next page, q = quit): "
+    echo 1>&2
+    less -rEXF "$i"
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run cat third $i | ./first (demo $i): "
+    echo 1>&2
+    cat third "$i" | ./first
+    echo 1>&2
+done

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1530,6 +1530,16 @@ He also added the [try.sh](/1991/buzzard.1/try.sh) script to try out some
 commands that we suggested and some additional ones that provide for some fun.
 
 
+## <a name="1992_buzzard.2"></a>[1992/buzzard.2](/1992/buzzard.2/buzzard.2.c) ([README.md](/1992/buzzard.2/README.md))
+
+[Cody](#cody) fixed the alt code to compile. The problem was it assumed that
+`exit(3)` returns a value, not `void`. This was fixed with a `,0`.
+
+Cody also added the [try.sh](/1992/buzzard.2/try.sh) and
+[try.alt.sh](/1992/buzzard.2/try.alt.sh) scripts that correspond to the entry
+and its alt code.
+
+
 ## <a name="1992_gson"></a>[1992/gson](/1992/gson/gson.c) ([README.md](/1992/gson/README.md]))
 
 [Cody](#cody) fixed a crash that prevented this entry from working in some cases in some

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -758,6 +758,27 @@ not strictly necessary but nonetheless more correct, even if not warned against.
 `$PATH`) to files referred to in the code. The path problem was also fixed in
 [fubar.sh](/1989/fubar/fubar.sh).
 
+A strange problem occurred where if one made modifications to the C file it
+might end up failing to work even after changing it back. This was resolved by:
+
+```diff
+--- i/1989/fubar/fubar.sh
++++ w/1989/fubar/fubar.sh
+@@ -7,13 +7,12 @@ if [[ $# -ne 1 ]]; then
+     exit 1
+ fi
+ 
+ # run/compile it
+ rm -f ouroboros.c x1 x
+-ex - <<EOF
+-r fubar.c
++ex fubar.c <<EOF
+ 8,9j
+ w ouroboros.c
+ EOF
+ chmod +x ouroboros.c
+```
+
 Cody also 'modernised' the script to use `bash` and fixed for ShellCheck. The
 `if [ .. ]` was changed in the C code as well as the script.
 


### PR DESCRIPTION

The bug fix is simply so it can compile. It assumed exit(3) returned a
value, not void. The fixes noted in the remarks (though I did not see
them at a quick glance) of the author are not in the alt version (that's
the purpose of it).

The try.sh and try.alt.sh scripts correspond to the entry and the alt
code.

Updated .gitignore.

Added 'first.alt' to Makefile for the try.alt.sh script.