### PR TITLE
Add 1992/adrian/try.sh

### DIFF
--- a/1989/fubar/fubar.c
+++ b/1989/fubar/fubar.c
@@ -9,12 +9,12 @@
 if(m && q=='T' && o=='T'){m=0;(void)fread(tt,11,1,stdin);(void)printf("T %9d\n",atoi(tt)*QQ);}else {q=o;(void)putchar(o);}}exit(0);}
 cc ouroboros.c -o x 
 #define zxc ;{/*
-cat ./ouroboros.c | ./x $1 > x1
+cat ouroboros.c | ./x $1 > x1
 if [[ $? -ne 0 ]]; then
 exit
 fi
-mv x1 ./ouroboros.c
-chmod +x ./ouroboros.c
+mv x1 ouroboros.c
+chmod +x ouroboros.c
 exec ./ouroboros.c $1
 exit
 */

--- a/1989/fubar/fubar.sh
+++ b/1989/fubar/fubar.sh
@@ -9,8 +9,7 @@ fi
 
 # run/compile it
 rm -f ouroboros.c x1 x
-ex - <<EOF
-r fubar.c
+ex fubar.c <<EOF
 8,9j
 w ouroboros.c
 EOF

--- a/1992/adrian/.gitignore
+++ b/1992/adrian/.gitignore
@@ -13,8 +13,10 @@ adsleep
 adsleep.c
 adwc
 adwc.c
+adwc.adwc.txt
 *.dSYM
 indent
 indent.c
 indent.o
 prog.orig
+wc.adwc.txt

--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -20,7 +20,7 @@ For more detailed information see [1992 adrian in bugs.md](/bugs.md#1992-adrian)
 ### Try:
 
 ```sh
-./adrian adrian.grep.try < README.md
+./try.sh
 ```
 
 For the slow minded, try:
@@ -28,9 +28,6 @@ For the slow minded, try:
 ```sh
 ./adsleep 32767
 ```
-
-NOTE: if you do not specify an arg some of the programs such as `adsleep` it
-will very likely segfault do something funny. This is supposed to happen.
 
 
 ## Judges' remarks:
@@ -160,11 +157,11 @@ Running:
 
 will perform a function similar to that of the unix `from` command.
 
-If no filename is specified on the command line, then `__FILE__` is used
-as the specification for the automaton.  (Originally `"adgrep.c"` the file was renamed
-to `adrian.c` by the judges but for more portability the arg was changed to
-`__FILE__`.)  In this case, the program will search for
-matches to the regular expression:
+If no filename is specified on the command line, then `__FILE__` is used as the
+specification for the automaton. (Originally this was `"adgrep.c"` but the file
+was renamed to `adrian.c` by the judges and for more portability the arg was
+changed to `__FILE__`.)  In this case, the program will search for matches to
+the regular expression:
 
 ```
 ^.[^|C][^w[Q]*(Q|[w[]c).*|^.[C|]$
@@ -219,7 +216,7 @@ you can search for matches to
 
 By some freak happenstance, lines of `adrian.c` which match this regular
 expression form a unix `head(1)` command.  It prints the first ten lines of
-the file specified on the command line or adrian.c if no file is
+the file specified on the command line or `adrian.c` if no file is
 specified (again this was changed to `__FILE__`).
 
 By setting the first line to

--- a/1992/adrian/try.sh
+++ b/1992/adrian/try.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1992/adrian
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# don't redirect output to /dev/null so that they can see how it's done,
+# assuming it's not already built
+make CC="$CC" everything || exit 1
+# DON'T clear the screen so they can see how the files are generated!
+
+echo 1>&2
+read -r -n 1 -p "Press any key to show: adrian.grep.try: "
+echo 1>&2
+cat adrian.grep.try
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./adrian adrian.grep.try < README.md: "
+echo 1>&2
+./adrian adrian.grep.try < README.md
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./adhead try.sh: "
+echo 1>&2
+./adhead try.sh
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./adecho 1992 IOCCC adrian: "
+echo 1>&2
+./adecho 1992 IOCCC adrian
+echo 1>&2
+
+rm -f wc.adwc.txt adwc.adwc.txt
+echo "$ wc adwc.c | sed -e 's/^[[:space:]]//g' | tr -s '[:space:]' | cut -d' ' -f1-3 | tee wc.adwc.txt" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+wc adwc.c | sed -e 's/^[[:space:]]//g' | tr -s '[:space:]' | cut -d' ' -f1-3 | tee wc.adwc.txt
+echo 1>&2
+
+echo "$ ./adwc adwc.c|tr -s ' '|sed -e 's/^[[:space:]]//g' | tee adwc.adwc.txt" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+./adwc adwc.c|tr -s ' '|sed -e 's/^[[:space:]]//g' | tee adwc.adwc.txt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show diff between wc.adwc.txt and adwc.adwc.txt: "
+echo 1>&2
+diff -s wc.adwc.txt adwc.adwc.txt
+echo 1>&2
+rm -f wc.adwc.txt adwc.adwc.txt
+
+echo "$ ./adsleep 10" 1>&2
+read -r -n 1 -p "Press any key to take a 10 second nap: "
+echo 1>&2
+./adsleep 10

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -29,7 +29,7 @@ For more detailed information see [1992 albert in bugs.md](/bugs.md#1992-albert)
 ### Try:
 
 ```sh
-./albert 1234567890123456789
+./try.sh
 ```
 
 
@@ -73,6 +73,12 @@ make alt
 
 Use `albert.alt` as you would `albert` above.
 
+
+### Alternate try:
+
+```sh
+./try.alt.sh
+```
 
 ## Judges' remarks:
 

--- a/1992/albert/try.alt.sh
+++ b/1992/albert/try.alt.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1992/albert alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" alt >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./albert.alt 1234567890123456789: "
+echo 1>&2
+./albert.alt 1234567890123456789
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert.alt 12345678987654321: "
+echo 1>&2
+./albert.alt 12345678987654321
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert.alt 42: "
+echo 1>&2
+./albert.alt 42
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert.alt 4242424242: "
+echo 1>&2
+./albert.alt 4242424242
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert.alt 10000000001: "
+echo 1>&2
+./albert.alt 10000000001
+echo 1>&2

--- a/1992/albert/try.sh
+++ b/1992/albert/try.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1992/albert
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./albert 1234567890123456789: "
+echo 1>&2
+./albert 1234567890123456789
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert 12345678987654321: "
+echo 1>&2
+./albert 12345678987654321
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert 42: "
+echo 1>&2
+./albert 42
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./albert 4242424242: "
+echo 1>&2
+./albert 4242424242
+echo 1>&2

--- a/1992/ant/README.md
+++ b/1992/ant/README.md
@@ -9,24 +9,18 @@ make all
 
 ```sh
 ./ant Makefile
+
+./ant Makefile rule
 ```
 
-where `Makefile` is a Makefile to use.
+where `Makefile` is a Makefile to use and `rule` is an optional rule to use.
 
 
 ### Try:
 
-First build the tool itself with our Makefile:
 
 ```sh
-./ant Makefile am
-```
-
-Now use `am` to do some things:
-
-```sh
-./am Makefile am_clobber	# clobber everything except am
-./am ant.test.mk		# run the test Makefile with am
+./try.sh
 ```
 
 

--- a/1992/ant/ant.test.mk
+++ b/1992/ant/ant.test.mk
@@ -57,7 +57,7 @@ TEXT_2	= test macro split \
 	three lines
 TEXT_3	= test dollar macro '$$'
 TEXT_4	= test dollar again "$$(TEXT_1)"
-TEXT_5	=	imbeded macro '$(TEXT_1)'
+TEXT_5	=	embedded macro '$(TEXT_1)'
 
 redefine : r1 r2 r3 r4 r5 
 
@@ -161,7 +161,7 @@ leaf.5 :
 
 #  Command lines split across lines.
 split.cmd:
-	echo Try spliting command \
+	echo Try splitting command \
 		lines across more \
 	than one line.
 

--- a/1992/ant/try.sh
+++ b/1992/ant/try.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1992/ant
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./ant Makefile am    # build the tool itself" 1>&2
+read -r -n 1 -p "Press any key to run: ./ant Makefile am: "
+echo 1>&2
+./ant Makefile am
+echo 1>&2
+
+echo "$ ./am Makefile am_clobber    # clobber everything except am" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+./am Makefile am_clobber	# clobber everything except am
+echo 1>&2
+
+echo "$ ./am ant.test.mk    # run the test Makefile with am" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+./am ant.test.mk		# run the test Makefile with am

--- a/1992/buzzard.2/.gitignore
+++ b/1992/buzzard.2/.gitignore
@@ -1,9 +1,11 @@
 #
 # sort with: sort -d -u
 buzzard.2
+buzzard.2.alt
 buzzard.2.orig
 *.dSYM
 first
+first.alt
 indent
 indent.c
 indent.o

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -114,7 +114,7 @@ DATA=
 TARGET= ${PROG} first
 #
 ALT_OBJ= ${PROG}.alt.o
-ALT_TARGET= ${PROG}.alt
+ALT_TARGET= ${PROG}.alt first.alt
 
 
 #################
@@ -143,6 +143,10 @@ alt: data ${ALT_TARGET}
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+first.alt: ${PROG}.alt
+	${RM} -f $@
+	${LN} $< $@
 
 # data files
 #

--- a/1992/buzzard.2/README.md
+++ b/1992/buzzard.2/README.md
@@ -10,8 +10,8 @@ code](#alternate-code) below for details.
 
 ## To use:
 
-First, you must make sure that first is made first (even though `make all`
-should do it :-) ):
+First, you must make sure that `first` is made first (even though `make all`
+should make first first :-) ):
 
 ```sh
 make first
@@ -48,6 +48,13 @@ Sorry, this is third!
 ```
 
 
+## Try:
+
+```sh
+./try.sh
+```
+
+
 ## Alternate code:
 
 This alternate version, [buzzard.2.alt.c](buzzard.2.alt.c), does not contain a
@@ -65,6 +72,12 @@ make alt
 
 Use `buzzard.2.alt` as you would `buzzard.2` above.
 
+
+### Alternate try:
+
+```sh
+./try.alt.sh
+```
 
 ## Judges' remarks:
 
@@ -99,8 +112,8 @@ further down.
 `first` expects you to first enter the names of the 13 primitives,
 separated by whitespace--it doesn't care what you name them, but
 if all the names aren't unique, you won't be able to use some of
-them.  After this you may type any sequence of valid first input.
-Valid first input is defined as any sequence of whitespace-delimited
+them.  After this you may type any sequence of valid `first` input.
+Valid `first` input is defined as any sequence of whitespace-delimited
 tokens which consist of primitives, new words you've defined, and
 integers (as parsed by `"%d"`).  Invalid input behaves unpredictably,
 but gives no warning messages.  A sample program, `demo1.1st`, is
@@ -108,7 +121,7 @@ included, but it only works on ASCII systems.
 
 Do not expect to be able to do anything interesting with `first`.
 
-To do something interesting, you need to feed first the file
+To do something interesting, you need to feed `first` the file
 [third](third) first.  In unix, you can do
 
 ```sh
@@ -159,7 +172,7 @@ Other related obfuscations are still present.  The top of the stack is cached in
 a variable, which increases performance massively if the compiler can figure out
 to keep it in a register; it also obfuscates the code.  (Unfortunately, the top
 of stack is a global variable and neither gcc nor most bundled compilers seem to
-register allocate it.)
+`register` allocate it.)
 
 More significant are the design obfuscations.  `m[0]` is the "dictionary
 pointer", used when compiling words, and `m[1]` is the return stack index.  Both
@@ -205,15 +218,14 @@ are primitives in
 [FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) (like swap)
 take a significant amount of time in THIRD.
 
-When you get the `Ok.` message from third, try out some sample
-[FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) code (first
-has no way of knowing if keyboard input is waiting, so it can't actually prompt
+When you get the `Ok.` message from `third`, try out some sample
+[FORTH](https://en.wikipedia.org/wiki/Forth_(programming_language)) code
+(`first` has no way of knowing if keyboard input is waiting, so it can't actually prompt
 you in a normal way.  It only prints `'Ok.'` after you define a word).
 
 
 ```sh
 2 3 + . cr
-
 ```
 
 (which adds 2 and 3, and print the result and a newline.)

--- a/1992/buzzard.2/buzzard.2.alt.c
+++ b/1992/buzzard.2/buzzard.2.alt.c
@@ -17,7 +17,7 @@ a(x)
 r(x)
 {
    switch(x++[m]){
-	z 5:	for(w=scanf("%s",s)<1?exit(0):L;strcmp(s,&w[&m[1]][s]);w=m[w]);
+	z 5:	for(w=scanf("%s",s)<1?exit(0),0:L;strcmp(s,&w[&m[1]][s]);w=m[w]);
 		w-1 ? r(w+2) : (c 2,c atoi(s))
 	z 12:	I=1[m]--[m]
 	z 15:	f=S[-f]

--- a/1992/buzzard.2/help.th
+++ b/1992/buzzard.2/help.th
@@ -1,7 +1,7 @@
 : help key  ( flush the carriage return form the input buffer )
 
 " The following are the standard known words; words marked with (*) are
-immediate words, which cannot be used from command mode, but only in
+immediate words, which cannot be used in command mode, but only in
 word definitions.  Words marked by (**) declare new words, so are always
 followed by the new word.
 

--- a/1992/buzzard.2/try.alt.sh
+++ b/1992/buzzard.2/try.alt.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1992/buzzard.2 alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" alt >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ echo help | cat third help.th - | ./first.alt" 1>&2
+read -r -n 1 -p "Press any key to read help (space = next page, q = quit): "
+echo 1>&2
+echo help | cat third help.th - | ./first.alt | less -rEXF
+
+for i in demo[1-6].th; do
+    # try out each demo
+    #
+    read -r -n 1 -p "Press any key to show $i (space = next page, q = quit): "
+    echo 1>&2
+    less -rEXF "$i"
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run cat third $i | ./first.alt (demo $i): "
+    echo 1>&2
+    cat third "$i" | ./first.alt
+    echo 1>&2
+done

--- a/1992/buzzard.2/try.sh
+++ b/1992/buzzard.2/try.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1992/buzzard.2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ echo help | cat third help.th - | ./first" 1>&2
+read -r -n 1 -p "Press any key to read help (space = next page, q = quit): "
+echo 1>&2
+echo help | cat third help.th - | ./first | less -rEXF
+
+for i in demo[1-6].th; do
+    # try out each demo
+    #
+    read -r -n 1 -p "Press any key to show $i (space = next page, q = quit): "
+    echo 1>&2
+    less -rEXF "$i"
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run cat third $i | ./first (demo $i): "
+    echo 1>&2
+    cat third "$i" | ./first
+    echo 1>&2
+done

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1427,7 +1427,7 @@ from (`__FILE__`), not	`adgrep.c`, as the latter does not exist: `adgrep` is
 simply a link to `adrian` as `adgrep` is what the program was submitted as but
 the winner is `adrian.c`.
 
-Not fixing the above problem would have also cause the program to crash if no
+Not fixing the above problem would have also caused the program to crash if no
 arg was specified as the file doesn't exist. In making the above fix, at first
 the change to check for a `NULL` file was added. Then it was noticed that the
 problem is that `adgrep.c` was an incorrect reference that never existed and it
@@ -1488,6 +1488,11 @@ one must keep the `Y[strlen(Y)-1]='\0';` part and keep it there.
 
 These fixes are complex changes due to the way the program and Makefile generate
 the additional tools.
+
+Cody finally added the [try.sh](/1992/adrian/try.sh) script that shows the entry
+and some of the tools this entry generates. Unlike other scripts, it does not
+clear the screen after compilation so that one can see how the other files are
+generated.
 
 
 ## <a name="1992_albert"></a>[1992/albert](/1992/albert/albert.c) ([README.md](/1992/albert/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1530,6 +1530,16 @@ He also added the [try.sh](/1991/buzzard.1/try.sh) script to try out some
 commands that we suggested and some additional ones that provide for some fun.
 
 
+## <a name="1992_buzzard.2"></a>[1992/buzzard.2](/1992/buzzard.2/buzzard.2.c) ([README.md](/1992/buzzard.2/README.md))
+
+[Cody](#cody) fixed the alt code to compile. The problem was it assumed that
+`exit(3)` returns a value, not `void`. This was fixed with a `,0`.
+
+Cody also added the [try.sh](/1992/buzzard.2/try.sh) and
+[try.alt.sh](/1992/buzzard.2/try.alt.sh) scripts that correspond to the entry
+and its alt code.
+
+
 ## <a name="1992_gson"></a>[1992/gson](/1992/gson/gson.c) ([README.md](/1992/gson/README.md]))
 
 [Cody](#cody) fixed a crash that prevented this entry from working in some cases in some

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1496,8 +1496,12 @@ the additional tools.
 applied to the code, provided as the alt code as that version is not obfuscated.
 Thus Cody's fix applies to the original entry. The problems were that `malloc.h`
 is not the correct header file now (at least in some systems?) and a non-void
-(implicit int) function returning without a value. That function was changed to
-return void.
+(implicit `int`) function returning without a value. That function was changed to
+return `void`.
+
+Cody also added the [try.sh](/1992/albert/try.sh) and
+[try.alt.sh](/1992/albert/try.alt.sh) scripts that correspond to the entry and
+the alt code.
 
 
 ## <a name="1992_ant"></a>[1992/ant](/1992/ant/ant.c) ([README.md](/1992/ant/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -758,6 +758,27 @@ not strictly necessary but nonetheless more correct, even if not warned against.
 `$PATH`) to files referred to in the code. The path problem was also fixed in
 [fubar.sh](/1989/fubar/fubar.sh).
 
+A strange problem occurred where if one made modifications to the C file it
+might end up failing to work even after changing it back. This was resolved by:
+
+```diff
+--- i/1989/fubar/fubar.sh
++++ w/1989/fubar/fubar.sh
+@@ -7,13 +7,12 @@ if [[ $# -ne 1 ]]; then
+     exit 1
+ fi
+ 
+ # run/compile it
+ rm -f ouroboros.c x1 x
+-ex - <<EOF
+-r fubar.c
++ex fubar.c <<EOF
+ 8,9j
+ w ouroboros.c
+ EOF
+ chmod +x ouroboros.c
+```
+
 Cody also 'modernised' the script to use `bash` and fixed for ShellCheck. The
 `if [ .. ]` was changed in the C code as well as the script.
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1505,7 +1505,7 @@ return void.
 [Cody](#cody) fixed the Makefile so that the program will actually work with it (or at
 least the rule to clobber files and link `am` to `ant`). The issue was that the
 variables in the Makefile could not be evaluated in the same way as it's not as
-feature-rich as other implementations of `make`. Thus the use of `${RM}` and
+feature-rich as other implementations of `make(1)`. Thus the use of `${RM}` and
 `${CP}` were in the respective rules changed to `rm` and `cp`, for two examples.
 A new rule had to be added as well. The variable situation might be because they
 are obtained from the root variable Makefile `var.mk` via `include` which the
@@ -1516,7 +1516,10 @@ Cody also fixed another problem, unrelated, in the Makefile with the `.PHONY`
 rule where a line was not ended with a `\` but should have been.
 
 The author stated that in some systems like DOS with Turbo C, it might be
-necessary to include `time.h` so Cody did this as well.
+necessary to include `time.h` so Cody did this as well as this exists in other
+systems too.
+
+Cody also added the [try.sh](/1992/ant/try.sh) script.
 
 
 ## <a name="1992_buzzard.1"></a>[1992/buzzard.1](/1992/buzzard.1/buzzard.1.c) ([README.md](/1992/buzzard.1/README.md))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1526,8 +1526,8 @@ used. This was not originally done but at a time it was changed to be considered
 a bug so it was fixed at that point as it only took a few seconds and had to be
 verified that it was consistent with the [bugs.md](/bugs.md) file.
 
-He also added the [try.sh](/1991/buzzard.1/try.sh) script to try out some
-commands that we suggested and some additional ones that provide for some fun.
+He also added the [try.sh](/1992/buzzard.1/try.sh) script to try out some
+commands that we suggested and some additional ones that he provide for some fun.
 
 
 ## <a name="1992_buzzard.2"></a>[1992/buzzard.2](/1992/buzzard.2/buzzard.2.c) ([README.md](/1992/buzzard.2/README.md))


### PR DESCRIPTION

This script shows the entry itself as well as some of the other tools 
that the entry generates. The adwc / wc one uses a pipeline to show the
output (with leading spaces and filename removed along with squeezing 
spaces) and also writes each to a text file to use diff on, to show how
they have the same output.

Not all the tools are in the script. The adbasename might have a bug 
(in any case it doesn't appear to function exactly like basename(1) in 
that it requires two args, not one) so it is not used and adgrep is not
used either. For the latter one the author's remarks might provide some
clues as to why I did not include it.