### PR TITLE
Add try scripts to 1993/plummer

### DIFF
--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-security \
-	-Wno-deprecated-non-prototype
+	-Wno-deprecated-non-prototype -Wno-implicit-int
 
 # Common C compiler warning flags
 #
@@ -130,7 +130,6 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: this program will likely crash or do something else without enough args."
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # alternative executable
@@ -140,7 +139,7 @@ alt: data ${ALT_TARGET}
 
 # Variable to control amount of time to sleep between writes for alt code.
 #
-SLEEP= 200
+SLEEP= 1000
 
 ${PROG}.alt: ${PROG}.alt.c
 	${CC} ${CFLAGS} -DZ=${SLEEP} $< -o $@ ${LDFLAGS}

--- a/1993/plummer/README.md
+++ b/1993/plummer/README.md
@@ -1,17 +1,33 @@
 ## To build:
 
 ```sh
-make all
+make alt
 ```
 
-There is an [alternate version](#alternate-code) that lets you slow down the
-output of the program for modern systems.
+We recommend that you try the alternate version first to get a better idea of
+what this entry looked like back in 1993. The alternate version sleeps (via
+`usleep(3)`) in between writes, defaulting at 1000 microseconds (but
+reconfigurable). If you wish to see the original entry then see [original
+code](#original-code) below.
+
+If you wish to speed the entry up, say to 500 microseconds between writes, try:
+
+```sh
+make clobber SLEEP=500 alt
+```
+
+Alternatively if you wish to slow it down, say to 1500 microseconds between
+writes, try:
+
+```sh
+make clobber SLEEP=1500 alt
+```
 
 
 ## To use:
 
 ```sh
-./plummer number arg
+./plummer.alt number arg
 ```
 
 where:
@@ -19,43 +35,67 @@ where:
 - number is a number    (try 21701)
 - arg is any argument
 
+Wait until you're bored enough to send intr/ctrl-c to exit or until the
+[Vogons](https://hitchhikers.fandom.com/wiki/Vogon) build that [hyperspace
+bypass](https://hitchhikers.fandom.com/wiki/Bypass).
 
-### Try:
+
+## Try:
 
 ```sh
-./plummer 01234567890876543210 xxx
+./try.alt.sh
 
+./try.alt.sh 21701
+
+SLEEP=500 ./try.alt.sh
+
+SLEEP=900 ./try.alt.sh 789789789789789
+
+./try.alt.sh 789789789
+
+SLEEP=400 ./try.alt.sh 42424242424242
+
+SLEEP=1000 ./try.alt.sh xyzzyzzyx
+
+SLEEP=1200 ./try.alt.sh xyzzyzzyx 5555
 ```
 
 
-## Alternate code:
+## Original code:
 
-This version sleeps in between writes for a compiled in constant microseconds
-via `usleep(3)`, defaulting at 200.
+This version, the original, does not sleep in between writes, and is thus much
+faster (depending on the `SLEEP` parameter specified in the build of `alt`, of
+course).
 
 
-### Alternate build:
-
-```sh
-make alt
-```
-
-If you wish to change the time to sleep (default `200`) you can do so like:
+### Original build:
 
 ```sh
-make clobber SLEEP=50 alt
+make all
 ```
 
 
-### Alternate use:
+### Original use:
 
-Use `plummer.alt` as you would `plummer`.
+Use `plummer` as you would `plummer.alt` above.
 
 
-### Alternate try:
+### Original try:
 
 ```sh
-./plummer.alt xyzzyzzyx 5555
+./try.sh
+
+./try.sh 21701
+
+./try.sh 789789789789789
+
+./try.sh 789789789
+
+./try.sh 42424242424242
+
+./try.sh xyzzyzzyx
+
+./try.sh xyzzyzzyx 5555
 ```
 
 

--- a/1993/plummer/try.alt.sh
+++ b/1993/plummer/try.alt.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 1993/plummer alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# let user change the sleep duration if they wish
+#
+if [[ -z "$SLEEP" ]]; then
+    SLEEP=1000
+fi
+
+# let user change the number if they wish to
+#
+if [[ "$#" -lt 1 || -z "$1" ]]; then
+    NUMBER="01234567890876543210"
+else
+    NUMBER="$1"
+fi
+
+# let user change the arg if they wish to
+#
+if [[ "$#" -lt 2 || -z "$2" ]]; then
+    ARG="xxx"
+else
+    ARG="$2"
+fi
+
+make clobber CC="$CC" SLEEP="$SLEEP" alt >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./plummer.alt $NUMBER $ARG" 1>&2
+read -r -n 1 -p "Press any key to continue (send intr/ctrl-c to terminate): "
+echo 1>&2
+./plummer.alt "$NUMBER" "$ARG"

--- a/1993/plummer/try.sh
+++ b/1993/plummer/try.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1993/plummer
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# let user change the number if they wish to
+#
+if [[ "$#" -lt 1 || -z "$1" ]]; then
+    NUMBER="01234567890876543210"
+else
+    NUMBER="$1"
+fi
+
+# let user change the arg if they wish to
+#
+if [[ "$#" -lt 2 || -z "$2" ]]; then
+    ARG="xxx"
+else
+    ARG="$2"
+fi
+
+make CC="$CC" SLEEP="$SLEEP" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./plummer $NUMBER $ARG" 1>&2
+read -r -n 1 -p "Press any key to continue (send intr/ctrl-c to terminate): "
+echo 1>&2
+./plummer "$NUMBER" "$ARG"

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1772,8 +1772,14 @@ highly unlikely).
 [Cody](#cody) added check for two args.
 
 Cody also added an [alternate version](/1993/plummer/plummer.alt.c) which uses
-`usleep()` so you can see what is happening with faster systems. This version
-also checks for two args. See the README.md files for details.
+`usleep(3)` so you can see what is happening with faster systems. This version
+also checks for two args and it is the one we recommend one try first. See the
+README.md files for details.
+
+Cody also added the [try.sh](/1993/plummer/try.sh) and
+[try.alt.sh](/1993/plummer/try.alt.sh) scripts that correspond to the original
+entry and the alt version, both allowing one to change the args (and in the case
+of the alt one allowing one to change the amount to sleep).
 
 
 ## <a name="1993_rince"></a>[1993/rince](/1993/rince/rince.c) ([README.md](/1993/rince/README.md]))


### PR DESCRIPTION

The two scripts allow one to specify the number and the arg 
(corresponding to the argv[1] and argv[2] of the program). The alt 
script has a way to redefine the SLEEP variable (in the Makefile) like

    SLEEP=500 ./try.alt.sh