### PR TITLE
Add 1994/tvr try scripts

### DIFF
--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -26,15 +26,15 @@ For more detailed information see [1994 tvr in bugs.md](/bugs.md#1994-tvr).
 ./tvr mode screensize/2 < colormapfile
 ```
 
+Mode may be a value from 0 to 12.
+
 
 ## Try:
 
 ```sh
-./tvr 0 128 < tvr.color		(for color displays)
-./tvr 0 128 < tvr.bw		(for Black & White displays)
+./try.color.sh			# for colour displays
+./try.bw.sh			# for Black & White displays
 ```
-
-Mode may be a value from 0 to 12.
 
 
 ## Alternate code:
@@ -57,6 +57,14 @@ make alt
 
 where `altmode` `1` - `4` correspond to mode `0` - `3` in the original entry and
 `altmode 0` calculates Mandelbrot/Julian sets correctly.
+
+
+## Alternate try:
+
+```sh
+./try.alt.color.sh			# for colour displays
+./try.alt.bw.sh			# for Black & White displays
+```
 
 
 ## Judges' remarks:

--- a/1994/tvr/try.alt.bw.sh
+++ b/1994/tvr/try.alt.bw.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# try.alt.bw.sh - demonstrate IOCCC winner 1994/tvr alt code B&W mode
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" alt >/dev/null || exit 1
+
+for mode in $(seq 0 4); do
+    for size in 128 256; do
+	read -r -n 1 -p "Press any key to run: ./tvr.alt $mode $size < tvr.bw (q = quit, s = skip): "
+	echo 1>&2
+	if [[ "$REPLY" == "q" || "$REPLY" == "Q" ]]; then
+	    exit 0
+	elif [[ "$REPLY" == "s" || "$REPLY" == "S" ]]; then
+	    continue
+	fi
+	echo 1>&2
+	./tvr.alt "$mode" "$size" < tvr.bw
+	echo 1>&2
+    done
+done

--- a/1994/tvr/try.alt.color.sh
+++ b/1994/tvr/try.alt.color.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# try.color.sh - demonstrate IOCCC winner 1994/tvr alt code colour mode
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" alt >/dev/null || exit 1
+
+for mode in $(seq 0 4); do
+    for size in 128 256; do
+	read -r -n 1 -p "Press any key to run: ./tvr.alt $mode $size < tvr.color (q = quit, s = skip): "
+	echo 1>&2
+	if [[ "$REPLY" == "q" || "$REPLY" == "Q" ]]; then
+	    exit 0
+	elif [[ "$REPLY" == "s" || "$REPLY" == "S" ]]; then
+	    continue
+	fi
+	echo 1>&2
+	./tvr.alt "$mode" "$size" < tvr.color
+	echo 1>&2
+    done
+done

--- a/1994/tvr/try.bw.sh
+++ b/1994/tvr/try.bw.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# try.bw.sh - demonstrate IOCCC winner 1994/tvr B&W mode
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+for mode in $(seq 0 12); do
+    for size in 128 256; do
+	read -r -n 1 -p "Press any key to run: ./tvr $mode $size < tvr.bw (q = quit, s = skip): "
+	echo 1>&2
+	if [[ "$REPLY" == "q" || "$REPLY" == "Q" ]]; then
+	    exit 0
+	elif [[ "$REPLY" == "s" || "$REPLY" == "S" ]]; then
+	    continue
+	fi
+	echo 1>&2
+	./tvr "$mode" "$size" < tvr.bw
+	echo 1>&2
+    done
+done

--- a/1994/tvr/try.color.sh
+++ b/1994/tvr/try.color.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# try.color.sh - demonstrate IOCCC winner 1994/tvr colour mode
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+for mode in $(seq 0 12); do
+    for size in 128 256; do
+	read -r -n 1 -p "Press any key to run: ./tvr $mode $size < tvr.color (q = quit, s = skip): "
+	echo 1>&2
+	if [[ "$REPLY" == "q" || "$REPLY" == "Q" ]]; then
+	    exit 0
+	elif [[ "$REPLY" == "s" || "$REPLY" == "S" ]]; then
+	    continue
+	fi
+	echo 1>&2
+	./tvr "$mode" "$size" < tvr.color
+	echo 1>&2
+    done
+done

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1960,7 +1960,15 @@ check the [bugs.md](bugs.md) file.
 
 ## <a name="1994_tvr"></a>[1994/tvr](/1994/tvr/tvr.c) ([README.md](/1994/tvr/README.md]))
 
-[Cody](#cody) made this use `fgets(3)` instead of `gets(3)`. In this case the newline had
+[Cody](#cody) added the try scripts, four total, colour and black and white
+pairs for the original entry and the alt code. These scripts are
+[try.color.sh](/1994/tvr/try.color.sh), [try.bw.sh](/1994/tvr/try.bw.sh),
+[try.alt.color.sh](/1994/tvr/try.alt.color.sh) and
+[try.alt.bw.sh](/1994/tvr/try.alt.bw.sh), respectively. The scripts go through
+each mode allowed with two sizes, 128 and 256, allowing one to quit or skip each
+(given that there are a lot of invocations this seemed like a good idea).
+
+Cody also made this use `fgets(3)` instead of `gets(3)`. In this case the newline had
 to be terminated but it was a pretty straightforward fix. `gets()` was defined
 to use `fgets()` and the inclusion of `stdio.h` had to be added but to make it
 more like the original entry this was done in the Makefile. The alt code was


### PR DESCRIPTION
There are four scripts:

    try.color.sh	# original entry colour mode
    try.bw.sh		# original entry black and white mode
    try.alt.color.sh	# alt code colour mode
    try.alt.bw.sh	# alt code black and white mode

NOTE: This is an experiment using the gh tools to process a pull
request and "modify" it.  In this case the modification is **ONLY**
to add this note to the commit message and the text that follows.

In the future, such as after the **great fork merge**, where
a pull request is made on the [official IOCCC repo](https://github.com/ioccc-src/winner),
the IOCCC judges may have to modify the pull request to include various
other changes.  

For example, if someone were to add a missing file to a winner, the
IOCCC judges would need to update the manifest in the winner
`.winner.json` file.  We would **NOT** expect everyone to understand
the all the details.

For example, if someone were to try and modify a winner `index.html`
file, we would instead apply their changes to the winner `README.md`
file and rebuild the `index.html` file using bin tools.

For example, if some author wanted to change their name and
author_handle, the IOCCC judges would perform the actions needed
to update files such as the top level `winners.html` file,
as well as changes to the related `.winner.json` file(s).
