### PR TITLE
Remove reference to jargon file in 2000/rince

### DIFF
--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -25,13 +25,6 @@ For more detailed information see [2000 rince in bugs.md](/bugs.md#2000-rince).
 If `DISPLAY` is not set the program will very likely crash or do something
 different.
 
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
-```
-
 
 ## Try:
 


### PR DESCRIPTION
The bugs.md file is all that's needed; the information is already there in bugs.md and the purpose of having the 'STATUS: ...' lines in the bugs and (mis)features section of the README.md files was to not have that. Still having the reference to DISPLAY being unset being a problem seems like a good idea.