### PR TITLE
Remove \ from $ in code blocks in 2020/carlini

### DIFF
--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -25,13 +25,6 @@ For more detailed information see [2000 rince in bugs.md](/bugs.md#2000-rince).
 If `DISPLAY` is not set the program will very likely crash or do something
 different.
 
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
-```
-
 
 ## Try:
 

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -111,9 +111,9 @@ additional chunks are copied into the resulting image.
 For some reason the chocolate image seems to have some special properties.
 Apart from being quite big and a little bit noisy, it appears that when embedded
 into another image and extracted, the bitmap data is also a valid
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) program. It is of course
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) program. It is of course
 possible to get the bitmap data from the extracted image, and run it through any
-of the previous winning brain\$#@\$ interpreters, but I thought it would be easier
+of the previous winning brainfuck interpreters, but I thought it would be easier
 to include an interpreter in the program to avoid the hassle:
 
 ```sh
@@ -122,7 +122,7 @@ to include an interpreter in the program to avoid the hassle:
 ```
 
 It is of course also possible to embed a
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) program as a text file
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) program as a text file
 (as explained above) and decode it, e.g.:
 
 ```sh
@@ -172,7 +172,7 @@ program to crash.
 
 Since a lot of care was taken to keep the code simple, it turned out to be
 quite easy to extend functionality. I did include a small
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) after I
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) after I
 realized that the chocolate image had some interesting properties.
 
 But there is more functionality I added that didn't fit within the size
@@ -181,9 +181,9 @@ format source code based on a PNG image. So the format of the program is
 actually done by the program itself.
 
 And to be honest, the chocolate image did not have a
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) program
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) program
 embedded to begin with. I added functionality to the program to embed a
-brain\$#@\$ into a PNG image and used it to create the image provided with
+brainfuck into a PNG image and used it to create the image provided with
 the entry.
 
 I also added a method to analyze PNG images, to print the size and format,

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -209,8 +209,7 @@ but `pcc` handles them correctly, and neither compiler accepts `char o[]` or
 not yet written for UNIX).
 
 [1]: http://minnie.tuhs.org/cgi-bin/utree.pl
-[2]: http://ioccc.org/all/README
-[3]: https://web.archive.org/web/20180521074522/http://www.computerworld.com.au/article/279011/a-z_programming_languages_bourne_shell_sh/?pp=4
+[2]: https://web.archive.org/web/20180521074522/http://www.computerworld.com.au/article/279011/a-z_programming_languages_bourne_shell_sh/?pp=4
 
 More significant is that v7 `printf(3)` does not report the number of characters
 written, and therefore 111 compiles but does not work correctly; 113 is the

--- a/2020/carlini/README.md
+++ b/2020/carlini/README.md
@@ -242,9 +242,9 @@ the following expression
 where argument 1 is a pointer to a temporary variable followed by a NUL byte.
 
 This works because if the current count is 0 mod 256, then `"%1$hhn"` will write
-zero to argument 1 and then "%1\$s" will never emit any text. If, on the other
+zero to argument 1 and then `"%1$s"` will never emit any text. If, on the other
 hand, the count is not 0 mod 256, a length-1 string will be written to argument
-1, and then `"%1\$s"` will increment the count by one. By repeating this 256
+1, and then `"%1$s"` will increment the count by one. By repeating this 256
 times we're eventually going to reach 0 mod 256.
 
 Checking if there has been an invalid move is achieved similarly.

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -267,11 +267,11 @@ configurations, for both players.</p>
 <p>where argument 1 is a pointer to a temporary variable followed by a
 NUL byte.</p>
 <p>This works because if the current count is 0 mod 256, then
-<code>"%1$hhn"</code> will write zero to argument 1 and then “%1$s” will
-never emit any text. If, on the other hand, the count is not 0 mod 256,
-a length-1 string will be written to argument 1, and then
-<code>"%1\$s"</code> will increment the count by one. By repeating this
-256 times we’re eventually going to reach 0 mod 256.</p>
+<code>"%1$hhn"</code> will write zero to argument 1 and then
+<code>"%1$s"</code> will never emit any text. If, on the other hand, the
+count is not 0 mod 256, a length-1 string will be written to argument 1,
+and then <code>"%1$s"</code> will increment the count by one. By
+repeating this 256 times we’re eventually going to reach 0 mod 256.</p>
 <p>Checking if there has been an invalid move is achieved similarly.</p>
 <p>In order to decide what to print out, we have to cast the “in-memory”
 array of bits to Xs and Os to print out. This is actually rather


### PR DESCRIPTION

I believe it was a mistake to add the \ before the $ as it was in a code 
block. In one case a pair of '`'s was missing and those were added there
so that both are now code blocks. If it is not an error to have the '\'
before the '$' then the code block added should still be there but I 
believe it was a mistake anyway.