### PR TITLE
Add 1995/savastio/try.sh and update bugs.md

### DIFF
--- a/1995/heathbar/README.md
+++ b/1995/heathbar/README.md
@@ -17,7 +17,7 @@ where num is a non-negative number.
 ## Try:
 
 ```sh
-./heathbar 4253 2281
+./try.sh
 ```
 
 

--- a/1995/heathbar/try.sh
+++ b/1995/heathbar/try.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1995/heathbar
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+heathbar()
+{
+    if [[ "$#" -ne 2 ]]; then
+	echo "$0: heathbar() expects two args, got $#" 1>&2
+	return
+    elif [[ "$1" -lt 0 || "$2" -lt 0 ]]; then
+	echo "$0: heathbar() expects two positive digits, got $1 $2" 1>&2
+	return
+    fi
+
+    read -r -n 1 -p "Press any key to run: ./heathbar $1 $2: "
+    echo 1>&2
+    ./heathbar "$1" "$2"
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: echo \$(($1 + $2)): "
+    echo 1>&2
+    echo "$(("$1" + "$2"))"
+    echo 1>&2
+
+    if [[ $(("$1"+"$2")) == "$(./heathbar "$1" "$2")" ]]; then
+	echo "\$(($1+$2)) == ./heathbar $1 $2: $(./heathbar "$1" "$2")" 1>&2
+    else
+	echo "ERROR: \$(($1+$2)) != ./heathbar $1 $2: $(($1+$2)) != $(./heathbar "$1" "$2")" 1>&2
+    fi
+
+    echo 1>&2
+}
+heathbar 4253 2281
+heathbar 1 2
+heathbar 3 5
+heathbar 1234 999
+read -r -n 1 -p "Press any key to try non-numbers: "
+echo 1>&2
+heathbar foo bar

--- a/1995/savastio/.gitignore
+++ b/1995/savastio/.gitignore
@@ -1,6 +1,8 @@
 #
 # sort with: sort -d -u
 *.dSYM
+bar.txt
+foo.txt
 indent
 indent.c
 indent.o

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -39,7 +39,8 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-empty-body -Wno-format -Wno-incompatible-library-redeclaration \
-	-Wno-non-literal-null-conversion -Wno-deprecated-non-prototype -Wno-strict-prototypes
+	-Wno-non-literal-null-conversion -Wno-deprecated-non-prototype -Wno-strict-prototypes \
+	-Wno-implicit-int
 
 # Common C compiler warning flags
 #

--- a/1995/savastio/README.md
+++ b/1995/savastio/README.md
@@ -5,18 +5,32 @@ make all
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1995 savastio in bugs.md](/bugs.md#1995-savastio).
+
+
 ## To use:
 
 ```sh
 ./savastio
-# enter a number such as 100
+# enter a POSITIVE number such as 100
 ```
+
+NOTE: if you specify a negative number it will get stuck, showing no output. But
+what happens if you give a non-number?
 
 
 ## Try:
 
 ```sh
-echo 42 | ./savastio
+./try.sh
 ```
 
 

--- a/1995/savastio/try.sh
+++ b/1995/savastio/try.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 1995/savastio
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: echo 42 | ./savastio: "
+echo 1>&2
+echo 42 | ./savastio
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo 24 | ./savastio: "
+echo 1>&2
+echo 24 | ./savastio
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo 6 | ./savastio: "
+echo 1>&2
+echo 6 | ./savastio
+echo 1>&2
+
+rm -f foo.txt
+read -r -n 1 -p "Press any key to run: echo foo | ./savastio | tee foo.txt: "
+echo 1>&2
+echo foo | ./savastio | tee foo.txt
+echo 1>&2
+
+rm -f bar.txt
+read -r -n 1 -p "Press any key to run: echo bar | ./savastio | tee bar.txt: "
+echo 1>&2
+echo bar | ./savastio | tee bar.txt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show the diff of foo.txt and bar.txt: "
+echo 1>&2
+diff -s foo.txt bar.txt
+echo 1>&2
+rm foo.txt bar.txt

--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -25,13 +25,6 @@ For more detailed information see [2000 rince in bugs.md](/bugs.md#2000-rince).
 If `DISPLAY` is not set the program will very likely crash or do something
 different.
 
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
-```
-
 
 ## Try:
 

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -111,9 +111,9 @@ additional chunks are copied into the resulting image.
 For some reason the chocolate image seems to have some special properties.
 Apart from being quite big and a little bit noisy, it appears that when embedded
 into another image and extracted, the bitmap data is also a valid
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) program. It is of course
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) program. It is of course
 possible to get the bitmap data from the extracted image, and run it through any
-of the previous winning brain\$#@\$ interpreters, but I thought it would be easier
+of the previous winning brainfuck interpreters, but I thought it would be easier
 to include an interpreter in the program to avoid the hassle:
 
 ```sh
@@ -122,7 +122,7 @@ to include an interpreter in the program to avoid the hassle:
 ```
 
 It is of course also possible to embed a
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) program as a text file
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) program as a text file
 (as explained above) and decode it, e.g.:
 
 ```sh
@@ -172,7 +172,7 @@ program to crash.
 
 Since a lot of care was taken to keep the code simple, it turned out to be
 quite easy to extend functionality. I did include a small
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) after I
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) after I
 realized that the chocolate image had some interesting properties.
 
 But there is more functionality I added that didn't fit within the size
@@ -181,9 +181,9 @@ format source code based on a PNG image. So the format of the program is
 actually done by the program itself.
 
 And to be honest, the chocolate image did not have a
-[brain\$#@\$](https://en.wikipedia.org/wiki/Brainfuck) program
+[brainfuck](https://en.wikipedia.org/wiki/Brainfuck) program
 embedded to begin with. I added functionality to the program to embed a
-brain\$#@\$ into a PNG image and used it to create the image provided with
+brainfuck into a PNG image and used it to create the image provided with
 the entry.
 
 I also added a method to analyze PNG images, to print the size and format,

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -209,8 +209,7 @@ but `pcc` handles them correctly, and neither compiler accepts `char o[]` or
 not yet written for UNIX).
 
 [1]: http://minnie.tuhs.org/cgi-bin/utree.pl
-[2]: http://ioccc.org/all/README
-[3]: https://web.archive.org/web/20180521074522/http://www.computerworld.com.au/article/279011/a-z_programming_languages_bourne_shell_sh/?pp=4
+[2]: https://web.archive.org/web/20180521074522/http://www.computerworld.com.au/article/279011/a-z_programming_languages_bourne_shell_sh/?pp=4
 
 More significant is that v7 `printf(3)` does not report the number of characters
 written, and therefore 111 compiles but does not work correctly; 113 is the

--- a/2020/carlini/README.md
+++ b/2020/carlini/README.md
@@ -242,9 +242,9 @@ the following expression
 where argument 1 is a pointer to a temporary variable followed by a NUL byte.
 
 This works because if the current count is 0 mod 256, then `"%1$hhn"` will write
-zero to argument 1 and then "%1\$s" will never emit any text. If, on the other
+zero to argument 1 and then `"%1$s"` will never emit any text. If, on the other
 hand, the count is not 0 mod 256, a length-1 string will be written to argument
-1, and then `"%1\$s"` will increment the count by one. By repeating this 256
+1, and then `"%1$s"` will increment the count by one. By repeating this 256
 times we're eventually going to reach 0 mod 256.
 
 Checking if there has been an invalid move is achieved similarly.

--- a/bugs.md
+++ b/bugs.md
@@ -1479,6 +1479,16 @@ supposed to be printed again and one is supposed to press a key as at that point
 it calls `getchar()` via the pointer `m`. So this is a feature not a bug.
 
 
+## 1995 savastio
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1995/savastio/savastio.c](1995/savastio/savastio.c)
+### Information: [1995/savastio/README.md](1995/savastio/README.md)
+
+This program expects a POSITIVE number. If you specify a negative number it will
+not show any output, stuck in a loop.
+
+
 ## 1995 vanschnitz
 
 ### STATUS: missing file - please provide it

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2071,6 +2071,11 @@ function (`pain()` as it's annoying that clang is this way :-) ) that `main()`
 calls which has the four args.
 
 
+## <a name="1995_savastio"></a>[1995/savastio](/1995/savastio/savastio.c) ([README.md](/1995/savastio/README.md]))
+
+[Cody](#cody) added the [try.sh](/1995/savastio/try.sh) script.
+
+
 ## <a name="1995_vanschnitz"></a>[1995/vanschnitz](/1995/vanschnitz/vanschnitz.c) ([README.md](/1995/vanschnitz/README.md))
 
 [Cody](#cody) added the authors' [spoiler as a C

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2052,6 +2052,11 @@ to specify which one to use is to make it easier on the user as typing
 running `./try.alt.sh`.
 
 
+## <a name="1995_heathbar"></a>[1995/heathbar](/1995/heathbar/heathbar.c) ([README.md](/1995/heathbar/README.md]))
+
+[Cody](#cody) added the [try.sh](/1995/heathbar/try.sh) script.
+
+
 ## <a name="1995_leo"></a>[1995/leo](/1995/leo/leo.c) ([README.md](/1995/leo/README.md]))
 
 At our change in how to deal with spoilers, [Cody](#cody) uudecoded the spoiler provided


### PR DESCRIPTION

The try.sh script demonstrates both positive numbers and input that is
not a number at all (comparing two different strings).

The bugs.md has a new INABIAF - negative numbers will hang the program.
It is not clear if another version should be added to gracefully handle
this but that can be decided another time. It is not a documented
feature so it might be called a bug to fix.
