### PR TITLE
Add 1996/rcm/try.sh

### DIFF
--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
-	-Wno-int-conversion
+	-Wno-int-conversion -Wno-implicit-int -Wno-return-type
 
 # Common C compiler warning flags
 #

--- a/1995/makarios/makarios.c
+++ b/1995/makarios/makarios.c
@@ -1,3 +1,3 @@
-pain(int n, char **ia, char **aa, char **ma){int i=ia, a=aa, m=ma; while(i=++n)
-for(a=0;a<i?a=a*8+i%8,i/=8,m=a==i|a/8==i,1:(n-++m||printf("%o\n",n))&&n%m;);}
-main(int n, char **ia, char **aa) { return pain(n, ia, aa, 0); }
+pain(n,i,a,p){while(i=++n)
+for(a=0;a<i?a=a*8+i%8,i/=8,p=a==i|a/8==i,1:(n-++p||printf("%o\n",n))&&n%p;);}
+main(n,i,a/*,m*/)char**i,**a;{return pain(n,i,a,0);}

--- a/1996/rcm/.gitignore
+++ b/1996/rcm/.gitignore
@@ -6,4 +6,7 @@ indent.c
 indent.o
 prog.orig
 rcm
+rcm.cp2.c
+rcm.cp.c
+rcm.cp.c.gz
 rcm.orig

--- a/1996/rcm/README.md
+++ b/1996/rcm/README.md
@@ -8,8 +8,10 @@ make all
 ## To use:
 
 ```sh
-./rcm < rfc1951.gz
+./rcm < file.gz
 ```
+
+where `file.gz` is some gzipped file.
 
 
 ## Try:
@@ -17,7 +19,7 @@ make all
 For more information try:
 
 ```sh
-./rcm < rfc1952.gz
+./try.sh
 ```
 
 
@@ -28,6 +30,9 @@ For a good no-op try:
 ```sh
 gzip -c < rcm.c | ./rcm
 ```
+
+NOTE: this is done in the [try.sh](try.sh) script as well, along with some other
+commands including a way to do the above command but with more steps.
 
 
 ## Author's remarks:

--- a/1996/rcm/try.sh
+++ b/1996/rcm/try.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# try.sh - show IOCCC winner 1996/rcm
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./rcm < rfc1951.gz (space = next page, q = quit): "
+echo 1>&2
+./rcm < rfc1951.gz | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./rcm < rfc1952.gz (space = next page, q = quit): "
+echo 1>&2
+./rcm < rfc1952.gz | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: cp -vf rcm.c rcm.cp.c; gzip rcm.cp.c: "
+echo 1>&2
+cp -vf rcm.c rcm.cp.c; gzip rcm.cp.c
+
+read -r -n 1 -p "Press any key to run: ./rcm < rcm.cp.c.gz | tee rcm.cp.c (space = next page, q = quit): "
+echo 1>&2
+./rcm < rcm.cp.c.gz | tee rcm.cp.c | less -rEXF
+echo 1>&2
+rm rcm.cp.c.gz
+
+read -r -n 1 -p "Press any key to run: gzip -c < rcm.c | ./rcm | tee rcm.cp2.c (space = next page, q = quit): "
+echo 1>&2
+gzip -c < rcm.c | ./rcm | tee rcm.cp2.c | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show diff between rcm.cp.c and rcm.cp2.c: "
+echo 1>&2
+diff -s rcm.cp.c rcm.cp2.c
+echo 1>&2
+rm -f rcm.cp.c rcm.cp2.c
+

--- a/faq.md
+++ b/faq.md
@@ -886,17 +886,19 @@ will too but it won't reset the terminal).
 ### <a name="faq3_7"></a><a name="X11macos"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC winner that requires X11?
 
 
-#### <a name="X11_general"></a>Generically, to compile and run an IOCCC winner that requires X11:
+#### <a name="X11_general"></a>Generally, to compile and run an IOCCC winner that requires X11:
 
-In order to have the X11 related include files and X11 libraries in order to compile the IOCCC winner,
-you will need to install Xorg and related packages including development related packages. In particular:
+You must have the X11 related include files and X11 libraries in order to
+compile the IOCCC winner. In order to do this you will need to install Xorg and
+related packages including development related packages. If you have macOS see
+further down for different instructions. Otherwise: in particular you must:
 
-* Install the Xorg server
-* Configure the Xorg server for your graphics environment
-* Install a X11 terminal application
-* Start the Xorg server
-* Launch the X11 terminal application
-* Run the IOCCC winner in the X11 terminal application
+* Install the Xorg server.
+* Configure the Xorg server for your graphics environment.
+* Install a X11 terminal application.
+* Start the Xorg server.
+* Launch the X11 terminal application.
+* Run the IOCCC winner in the X11 terminal application.
 
 By X11 terminal application we suggest one of:
 
@@ -904,42 +906,49 @@ By X11 terminal application we suggest one of:
 * [KDE](https://kde.org) terminal application
 * `xterm(`) terminal application
 
-See the below for various system related hints that may be of help.
+See below for various system related hints that may be of help.
 
 
 #### <a name="Xorg_deprecated"></a>X.org server has been deprecated
 
-The Red Hat RHEL9.0 release notes state that [X.org Server is now deprecated](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#deprecated-functionality_graphics-infrastructures).
+The Red Hat RHEL9.0 release notes state that [X.org Server is now
+deprecated](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#deprecated-functionality_graphics-infrastructures).
 
-According to this [Linux for Devices tutorial on XOrg](https://www.linuxfordevices.com/tutorials/linux/install-xorg-on-linux)
-as of 2023 Mar 25::
+According to this [Linux for Devices tutorial on
+XOrg](https://www.linuxfordevices.com/tutorials/linux/install-xorg-on-linux) as
+of 2023 Mar 25:
 
-```
-Recently, RHEL developers categorized Xorg was put in the ‘deprecated’
-software, as its development has mostly halted. Subsequent updates
-will completely replace it with Wayland, a more modern windowing
-system.. Although Wayland is not fully developed yet, many applications
-do not support it properly yet and screen sharing might not work
-sometime, but it is the future. Fedora, also developed by RHEL, has
-switched to a Wayland session as it’s default windowing system (And
-it works flawlessly on my Laptop).
-```
+
+> Recently, RHEL developers categorized [Xorg was put in the ‘deprecated’
+software](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality),
+as its development has mostly halted. Subsequent updates will completely replace
+it with Wayland, a more modern windowing system.. Although Wayland is not fully
+developed yet, many applications do not support it properly yet and screen
+sharing might not work sometime, but it is the future. Fedora, also developed by
+RHEL, has switched to a Wayland session as it’s default windowing system (And it
+works flawlessly on my Laptop).
 
 See the [Wayland](https://wayland.freedesktop.org) web site for more details.
 
-**IMPORTANT NOTE**: We do **NOT** know if IOCCC winners will run under **Wayland**.
-Some IOCCC winners that use X11 might be OK while other IOCCC winners that use X11 in an unusual way might fail
-under **Wayland**.
+**IMPORTANT NOTE**: We do **NOT** know if IOCCC winners will run under
+**Wayland**.  Some IOCCC winners that use X11 might be OK while other IOCCC
+winners that use X11 in an unusual way might fail under **Wayland**.
 
-See the [Wayland FAQ](https://wayland.freedesktop.org/faq.html) for more information.
 
-If your system uses **Wayland** and not X11, you might give the IOCCC winners that use X11 a try.
-They might work.
+See the [Wayland FAQ](https://wayland.freedesktop.org/faq.html) for more
+information.
 
-**IMPORTANT NOTE**: The [IOCCC judges [do not support support IOCCC winners](#no_support).
+If your system uses **Wayland** and not X11, you might give the IOCCC winners
+that use X11 a try.  They might work but again we do not know.
+
+**IMPORTANT NOTE**: The [IOCCC judges](/judges.html) [do not support IOCCC winners](#no_support).
 So if an IOCCC winner that uses X11 fails under **Wayland**, and you wish to
 provide a fix to the IOCCC winner so that it will run under **Wayland**,
 then consider [submitting a fix](#fix_a_winner) so that it will run under **Wayland**.
+
+Basically: if you discover an entry does not work in Wayland you are welcome to
+provide **alternate code** that works for Wayland. We will happily credit you in
+the [thanks-for-help.md](/thanks-for-help.md) file.
 
 
 #### Red Hat based Linux
@@ -956,7 +965,8 @@ See also:
 
 * [How to Configure X11 in Linux](https://www.wikihow.com/Configure-X11-in-Linux)
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### macOS
@@ -973,7 +983,7 @@ with macOS 14.2.1 (macOS Sonoma).
 First of all you will need to install the [most recent
 XQuartz](https://www.xquartz.org), preferably on an [Apple supported version of
 macOS, preferably the most recent version](https://support.apple.com/macos).
-Then open the "XQuartz" application (usually located in
+After it is installed, open the "XQuartz" application (usually located in
 `/Applications/Utilities/XQuartz.app`) by typing at the command line:
 
 ```sh
@@ -996,30 +1006,35 @@ And then run the program as directed by the `README.md` file. For example with
 <img alt="running 1993/jonth in macOS" src="png/xquartz-1993-jonth.png">
 
 Note that you can compile the code in your regular terminal prior to opening
-XQuartz, should you wish to.
+XQuartz, should you wish to. You can even run it from that terminal and it
+should open XQuartz.
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### Debian based Linux
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-According to the [Debian Xorg wiki](https://wiki.debian.org/Xorg), installing X11 requires:
+According to the [Debian Xorg wiki](https://wiki.debian.org/Xorg), installing
+X11 requires:
 
 ```sh
 sudo apt install xorg
 ```
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### Other Linux distributions
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-For general documentation on installing  X11, this [ServerGUI for Ubuntu](https://help.ubuntu.com/community/ServerGUI),
-and in particular, this may be helpful:
+For general documentation on installing  X11, this [ServerGUI for
+Ubuntu](https://help.ubuntu.com/community/ServerGUI), and in particular, these
+may be helpful:
 
 * [X11 Client Installation](https://help.ubuntu.com/community/ServerGUI#X11_Client_Installation)
 * [X11 Server Installation](https://help.ubuntu.com/community/ServerGUI#X11_Server_Installation)
@@ -1041,7 +1056,8 @@ For systems that have the `yum(1)` command:
 sudo yum install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
 ```
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### package website
@@ -1050,7 +1066,8 @@ First, see the above note on [installing and starting Xorg](#X11_general).
 
 See the [X.org](https://x.org/wiki/) foundation web site.
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 ### <a name="faq3_8"></a><a name="SDL"></a>FAQ 3.8: How do I compile an IOCCC winner that requires SDL1 or SDL2?

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2096,15 +2096,17 @@ Cody also added the [try.sh](/1995/vanschnitz/try.sh) script.
 ## <a name="1996_august"></a>[1996/august](/1996/august/august.c) ([README.md](/1996/august/README.md]))
 
 [Cody](#cody) fixed a segfault in this program that prevented it from working right and
-also fixed an infinite loop in the try commands. The problem with the infinite
-loop is that the file `august.oc` had to have lines starting with `#` removed
-and it was not being done. After this is done with say `sed(/1)` (like `sed -i''
-'/^#/d' august.oc` which has been added to both the remarks and the `try.sh`
-script noted below) the code can proceed. This problem existed in macOS.
+also fixed an infinite loop in the try commands.
+
+The problem with the infinite loop is that the file `august.oc` had to have
+lines starting with `#` removed and it was not being done. After this is done
+with say `sed(/1)` (like `sed -i'' '/^#/d' august.oc` which has been added to
+both the remarks and the `try.sh` script noted below) the code can proceed. This
+problem existed in macOS.
 
 Cody also added the [try.sh](/1996/august/try.sh) script that runs all the
-commands given in the try section to simplify it as there are quite a lot of
-commands.
+commands that were given by the judges in the try section, with the fix above
+applied.
 
 
 ## <a name="1996_dalbec"></a>[1996/dalbec](/1996/dalbec/dalbec.c) ([README.md](/1996/dalbec/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2166,6 +2166,11 @@ the function in the pointer assignment.
 NOTE: if there is no X server running this program will still crash.
 
 
+## <a name="1996_rcm"></a>[1996/rcm](/1996/rcm/rcm.c) ([README.md](/1996/rcm/README.md]))
+
+[Cody](#cody) added the [try.sh](/1996/rcm/try.sh) script.
+
+
 ## <a name="1996_schweikh1"></a>[1996/schweikh1](/1996/schweikh1/schweikh1.c) ([README.md](/1996/schweikh1/README.md]))
 
 The author stated that `-I/usr/include` is needed by gcc in Solaris because


### PR DESCRIPTION

The 'to use' section was fixed also: it's not just specific gzipped
files but any so it now says 'file.gz' and adds that file.gz is any
gzipped file.

The try.sh script now has the command that used to be in to use and also
what was in the try section. It also copies rcm.c to rcm.cp.c and gzips
that file and then runs the program on that to show the source. All
paged through less(1), of course. Finally it does what the judges have
in their comments (which have been updated to say that the command is in
the try.sh script). The judges' command is naturally a shorter way to do
the one added in the try.sh script but it uses tee(1) to write both to 
another file (piped to less(1)) so that it can compare the two. 
Obviously the files will be the same but it shows how it works in 
multiple ways.
