### PR TITLE
Make usage of 1998/dloweneil more inclusive

### DIFF
--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
-	-Wno-int-conversion
+	-Wno-int-conversion -Wno-implicit-int -Wno-return-type
 
 # Common C compiler warning flags
 #

--- a/1995/makarios/makarios.c
+++ b/1995/makarios/makarios.c
@@ -1,3 +1,3 @@
-pain(int n, char **ia, char **aa, char **ma){int i=ia, a=aa, m=ma; while(i=++n)
-for(a=0;a<i?a=a*8+i%8,i/=8,m=a==i|a/8==i,1:(n-++m||printf("%o\n",n))&&n%m;);}
-main(int n, char **ia, char **aa) { return pain(n, ia, aa, 0); }
+pain(n,i,a,p){while(i=++n)
+for(a=0;a<i?a=a*8+i%8,i/=8,p=a==i|a/8==i,1:(n-++p||printf("%o\n",n))&&n%p;);}
+main(n,i,a/*,m*/)char**i,**a;{return pain(n,i,a,0);}

--- a/1996/rcm/.gitignore
+++ b/1996/rcm/.gitignore
@@ -6,4 +6,7 @@ indent.c
 indent.o
 prog.orig
 rcm
+rcm.cp2.c
+rcm.cp.c
+rcm.cp.c.gz
 rcm.orig

--- a/1996/rcm/README.md
+++ b/1996/rcm/README.md
@@ -8,8 +8,10 @@ make all
 ## To use:
 
 ```sh
-./rcm < rfc1951.gz
+./rcm < file.gz
 ```
+
+where `file.gz` is some gzipped file.
 
 
 ## Try:
@@ -17,7 +19,7 @@ make all
 For more information try:
 
 ```sh
-./rcm < rfc1952.gz
+./try.sh
 ```
 
 
@@ -28,6 +30,9 @@ For a good no-op try:
 ```sh
 gzip -c < rcm.c | ./rcm
 ```
+
+NOTE: this is done in the [try.sh](try.sh) script as well, along with some other
+commands including a way to do the above command but with more steps.
 
 
 ## Author's remarks:

--- a/1996/rcm/try.sh
+++ b/1996/rcm/try.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# try.sh - show IOCCC winner 1996/rcm
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./rcm < rfc1951.gz (space = next page, q = quit): "
+echo 1>&2
+./rcm < rfc1951.gz | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./rcm < rfc1952.gz (space = next page, q = quit): "
+echo 1>&2
+./rcm < rfc1952.gz | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: cp -vf rcm.c rcm.cp.c; gzip rcm.cp.c: "
+echo 1>&2
+cp -vf rcm.c rcm.cp.c; gzip rcm.cp.c
+
+read -r -n 1 -p "Press any key to run: ./rcm < rcm.cp.c.gz | tee rcm.cp.c (space = next page, q = quit): "
+echo 1>&2
+./rcm < rcm.cp.c.gz | tee rcm.cp.c | less -rEXF
+echo 1>&2
+rm rcm.cp.c.gz
+
+read -r -n 1 -p "Press any key to run: gzip -c < rcm.c | ./rcm | tee rcm.cp2.c (space = next page, q = quit): "
+echo 1>&2
+gzip -c < rcm.c | ./rcm | tee rcm.cp2.c | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show diff between rcm.cp.c and rcm.cp2.c: "
+echo 1>&2
+diff -s rcm.cp.c rcm.cp2.c
+echo 1>&2
+rm -f rcm.cp.c rcm.cp2.c
+

--- a/1996/schweikh1/README.md
+++ b/1996/schweikh1/README.md
@@ -14,10 +14,11 @@ make all
 
 ## Try:
 
-To find the day that Easter falls on in the current year:
+To find the day that Easter falls on in the current year and to show all Easter
+dates from 1582 to 2199:
 
 ```sh
-./schweikh1 |grep $(date +%Y)
+./try.sh
 ```
 
 

--- a/1996/schweikh1/try.sh
+++ b/1996/schweikh1/try.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# try.sh - show IOCCC winner 1996/schweikh1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to show date of Easter this year (./schweikh1 |grep \$(date +%Y)): "
+echo 1>&2
+./schweikh1 |grep "$(date +%Y)"
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show Easter dates from 1582 to 2199 (space = next page, q = quit): "
+echo 1>&2
+./schweikh1 | less -rEXF
+echo 1>&2

--- a/1996/schweikh2/README.md
+++ b/1996/schweikh2/README.md
@@ -41,8 +41,8 @@ while :; do grep -v '#' schweikh2.c; done
 ```
 
 (and we do too) which works with `sh`, `bash`, `ksh` and `zsh` as well. Press
-ctrl-c to stop it. Observe how the [try.sh](try.sh) script does this a number of
-times.
+ctrl-c to stop it. Observe how the [try.sh](try.sh) script does this once to
+make it easier to see what is happening.
 
 
 ## Judges' remarks:

--- a/1996/schweikh2/try.sh
+++ b/1996/schweikh2/try.sh
@@ -15,16 +15,17 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to to run ./schweikh2: " 1>&2
-./schweikh2
+read -r -n 1 -p "Press any key to to run ./schweikh2 (space = next page, q = quit): " 1>&2
+echo >&2
+./schweikh2 | less -rEXF
 echo >&2
 
 read -r -n 1 -p "Press any key to run: ./schweikh2 15 1 0 0/0 | head -n 15: " 1>&2
+echo >&2
 ./schweikh2 15 1 0 0/0 | head -n 15
 echo >&2
 
-read -r -n 1 -p "Press any key one more time: " 1>&2
-i=0
-while ((i++<15)); do
-    grep -v '#' schweikh2.c
-done
+read -r -n 1 -p "Press any key to run grep -v '#' schweikh2.c (space = next page, q = quit): "
+echo 1>&2
+grep -v '#' schweikh2.c | less -rEXF
+echo 1>&2

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -129,7 +129,8 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} || \
+	    ${CC} ${CFLAGS} -I. '-Ddifftime(a,b)=(double)(b-a)' $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1996/schweikh3/README.md
+++ b/1996/schweikh3/README.md
@@ -33,14 +33,6 @@ But still it is a useful utility.  To use try:
 
 and thanks for the virtual memories!  :-)
 
-NOTE: On some systems such as SunOS, one may need to compile with:
-
-```make
-	${CC} ${CFLAGS} \
-	  -I. -D_POSIX_SOURCE '-Ddifftime(a,b)=(double)(b-a)' \
-	  schweikh3.c -o schweikh3
-```
-
 
 ## Author's remarks:
 

--- a/1996/westley/try.alt.sh
+++ b/1996/westley/try.alt.sh
@@ -15,13 +15,22 @@ make CC="$CC" everything >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "Showing alt grandfather clock:" 1>&2
+echo "WARNING: this is likely to segfault after showing the output." 1>&2
+echo "It might also show one or more environmental variables. Use" 1>&2
+echo "try.sh if you want to see the fixed version." 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show alt grandfather clock: "
+echo 1>&2
 WESTLEY=./westley.alt ./clock1.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing alt mantle clock that runs backwards:" 1>&2
+read -r -n 1 -p "Press any key to show alt mantle clock that runs backwards: "
+echo 1>&2
 WESTLEY=./westley.alt ./clock2.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing alt linear style clock:" 1>&2
+read -r -n 1 -p "Press any key to show alt linear style clock: "
+echo 1>&2
 WESTLEY=./westley.alt ./clock3.sh
+echo 1>&2

--- a/1996/westley/try.sh
+++ b/1996/westley/try.sh
@@ -15,13 +15,17 @@ make CC="$CC" everything >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "Showing grandfather clock:" 1>&2
+read -r -n 1 -p "Press any key to show grandfather clock: "
+echo 1>&2
 WESTLEY=./westley ./clock1.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing mantle clock that runs backwards:" 1>&2
+read -r -n 1 -p "Press any key to show alt mantle clock that runs backwards: "
+echo 1>&2
 WESTLEY=./westley ./clock2.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing linear style clock:" 1>&2
+read -r -n 1 -p "Press any key to show alt linear style clock: "
+echo 1>&2
 WESTLEY=./westley ./clock3.sh
+echo 1>&2

--- a/1998/banks/README.md
+++ b/1998/banks/README.md
@@ -4,10 +4,12 @@
 make all
 ```
 
+If you do not have a page up or page down key you might wish to see the
+[Alternate code](#alternate-code) section below. You may redefine all the keys
+and the time step with predefined macros, however, so one lacking page up / page
+down does not strictly need the alternate code; it jut gives those controls a
+default value. The author provided the following table:
 
-
-You may redefine all the keys and the time step with predefined macros. The
-author provided the following able:
 
 ```
 Control         Description         Default Key
@@ -94,12 +96,13 @@ arrows at the same time as typing on the right side.
 
 As the Makefile allows you to configure the keys to use you may redefine the
 keys but with the alt build you cannot, as described earlier, redefine the page
-up and page down replacement keys. If you want to do that you should use the
-original entry as described in the to build section above.
+up and page down replacement keys. The other controls you may redefine; this is
+just a convenience build. If you want to redefine the page up / page down keys
+you should use the original entry as described in the to build section above.
 
-In the alt build it is `f` and `d` respectively as these are letters on the left
-side of the keyboard which is easier to use if one is using the right side for
-movement. These are hard coded, as noted.
+In the alt build it is `f` (for page up) and `d` (for page down) as these are
+letters on the left side of the keyboard which is easier to use if one is using
+the right side for movement. These are hard coded, as noted.
 
 To use the default settings for the alternate build:
 
@@ -114,7 +117,7 @@ want to use page up and page down.
 
 ### Alternate use:
 
-Use `banks.alt` as you would `banks` but for use the different keys as
+Use `banks.alt` as you would `banks` but use the different keys as
 configured at compilation.
 
 

--- a/1998/bas2/README.md
+++ b/1998/bas2/README.md
@@ -19,6 +19,8 @@ echo text | ./bas2
 ./try.sh
 
 ./try.sh "foo bar" "baz" "IOCCC 1998/bas2" README.md
+
+./try.sh try.sh "bas2.c" bas2.orig.c
 ```
 
 

--- a/1998/bas2/try.sh
+++ b/1998/bas2/try.sh
@@ -15,30 +15,44 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./bas2 < bas2.c" 1>&2
+read -r -n 1 -p "Press any key to run: ./bas2 < bas2.c: "
+echo 1>&2
 ./bas2 < bas2.c
+echo 1>&2
 
-echo "$ ./bas2 < README.md" 1>&2
+read -r -n 1 -p "Press any key to run: ./bas2 < README.md: "
+echo 1>&2
 ./bas2 < README.md
+echo 1>&2
 
-echo "$ ./bas2 < Makefile" 1>&2
+read -r -n 1 -p "Press any key to run: ./bas2 < Makefile: "
+echo 1>&2
 ./bas2 < Makefile
+echo 1>&2
 
-echo "$ echo foo bar baz | ./bas2" 1>&2
+read -r -n 1 -p "Press any key to run: echo foo bar baz | ./bas2: "
+echo 1>&2
 echo foo bar baz | ./bas2
+echo 1>&2
 
-echo "$ cat README.md Makefile bas2.c | ./bas2" 1>&2
+read -r -n 1 -p "Press any key to run: cat README.md Makefile bas2.c | ./bas2: "
+echo 1>&2
 cat README.md Makefile bas2.c | ./bas2
+echo 1>&2
 
 # while we have an arg check if it's a file. If it is a regular file that is
 # readable feed it to the program; otherwise act as if it's a string.
 while [[ "$#" -gt 0 ]]; do
     if [[ -f "$1" && -r "$1" ]]; then
-	echo "$ ./bas2 < $1" 1>&2
+	read -r -n 1 -p "Press any key to run: ./bas2 < $1: "
+	echo 1>&2
 	./bas2 < "$1"
+	echo 1>&2
     else
-	echo "$ echo $1 | ./bas2" 1>&2
+	read -r -n 1 -p "Press any key to run: echo $1 | ./bas2: "
+	echo 1>&2
 	echo "$1" | ./bas2
+	echo 1>&2
     fi
     shift 1
 done

--- a/1998/chaos/README.md
+++ b/1998/chaos/README.md
@@ -21,6 +21,21 @@ make chaos_nohalf
 ```
 
 
+## Try:
+
+
+```sh
+./try.sh
+```
+
+This script will run the program on each data file. To quit the program hit `q`.
+If not all files have been used it will go to the next one; otherwise the script
+will be finished. To end the script early send intr/ctrl-c.
+
+The script will give you instructions on how to use the program and things to
+try each time it is run, as a helpful reminder.
+
+
 ## Judge's Comments:
 
 This is the author's first IOCCC entry.  We thought the entry was

--- a/1998/chaos/try.sh
+++ b/1998/chaos/try.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# 
+# try.sh - demonstrate IOCCC winner 1998/chaos
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+show_instructions()
+{
+    echo 1>&2
+    echo "Try the keys 'y', 'u', 'i', 'h', 'j' and 'k'; 'a' and 'z' zoom in and out." 1>&2
+    echo "When tired of moving it manually wait a short bit and watch what happens. You" 1>&2
+    echo "might try zooming in and out and then wait for it to start moving (again or" 1>&2
+    echo "initially). You can interrupt the automatic movement by pressing any key or 'q' to" 1>&2
+    echo "quit. Send intr/ctrl-c to quit the script prematurely." 1>&2
+    echo 1>&2
+}
+
+for f in cube.data desk.data ioccc.data pyramid.data xwing.data; do
+    clear
+    show_instructions
+    read -r -n 1 -p "Press any key to run: ./chaos $f: "
+    echo 1>&2
+    ./chaos "$f"
+done

--- a/1998/df/README.md
+++ b/1998/df/README.md
@@ -11,6 +11,19 @@ make all
 ./df
 ```
 
+
+## Try:
+
+```sh
+./try.sh
+```
+
+This will run the program in a loop until you exit (`q` when prompted or
+ctrl-c/intr).
+
+Can you figure out a very simple pipeline to cheat?
+
+
 ## Judges' remarks;
 
 Everyone talks about how data hiding can produce clearer code; I am
@@ -33,6 +46,7 @@ Extra credit questions:
 - Where are the words stored?
 - How many words does this entry use?
 - Can you add more words to the program and still make it work?
+- Are there any misspelt words? If yes what are they?
 
 
 ## Author's remarks:

--- a/1998/df/try.sh
+++ b/1998/df/try.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 
+# try.sh - demonstrate IOCCC winner 1998/df
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+while [[ 1 ]]; do
+    read -r -n 1 -p "Press any key to run ./df or 'q' to quit: "
+    echo 1>&2
+    if [[ "$REPLY" = "q" || "$REPLY" = "Q" ]]; then
+	exit 0
+    fi
+    ./df
+done

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -11,7 +11,9 @@ below for more details.
 ## To use:
 
 ```sh
-./dlowe < anyfile > pootfile
+./dlowe < file > pootfile
+
+./dlowe < file
 ```
 
 
@@ -42,6 +44,8 @@ Also try:
 ./try.sh
 ```
 
+Did you spot the Easter egg there?
+
 
 ## Alternate code:
 
@@ -59,7 +63,7 @@ make alt
 ### Alternate use:
 
 ```
-./dlowe.alt < anyfile > pootfile
+./dlowe.alt < file > pootfile
 ```
 
 What's the difference between this and `dlowe`?
@@ -70,6 +74,9 @@ What's the difference between this and `dlowe`?
 ```sh
 ./try.alt.sh
 ```
+
+Did you spot the Easter egg there?
+
 
 
 ## Judges' remarks:

--- a/1998/dlowe/try.alt.sh
+++ b/1998/dlowe/try.alt.sh
@@ -5,18 +5,18 @@
 
 make everything || exit 1
 
-CAT="$(type -P cat)"
-MAN="$(type -P man)"
-COL="$(type -P col)"
+[[ -z "$CAT" ]] && CAT="$(type -P cat)"
+[[ -z "$MAN" ]] && MAN="$(type -P man)"
+[[ -z "$COL" ]] && COL="$(type -P col)"
 
 if [[ -z "$CAT" || ! -e "$CAT" ]]; then
-    echo "$0: no cat found" 1>&2
+    echo "$0: no cat '$CAT' found" 1>&2
     exit 1
 elif [[ -z "$COL" || ! -e "$COL" ]]; then
-    echo "$0: col not found" 1>&2
+    echo "$0: col '$COL' not found" 1>&2
     exit 1
 elif [[ -z "$MAN" || ! -e "$MAN" ]]; then
-    echo "$0: can't execute man" 1>&2
+    echo "$0: can't execute '$MAN'" 1>&2
     exit 1
 fi
 

--- a/1998/dlowe/try.sh
+++ b/1998/dlowe/try.sh
@@ -5,18 +5,18 @@
 
 make all || exit 1
 
-CAT="$(type -P cat)"
-MAN="$(type -P man)"
-COL="$(type -P col)"
+[[ -z "$CAT" ]] && CAT="$(type -P cat)"
+[[ -z "$MAN" ]] && MAN="$(type -P man)"
+[[ -z "$COL" ]] && COL="$(type -P col)"
 
 if [[ -z "$CAT" || ! -e "$CAT" ]]; then
-    echo "$0: no cat found" 1>&2
+    echo "$0: no cat '$CAT' found" 1>&2
     exit 1
 elif [[ -z "$COL" || ! -e "$COL" ]]; then
-    echo "$0: col not found" 1>&2
+    echo "$0: col '$COL' not found" 1>&2
     exit 1
 elif [[ -z "$MAN" || ! -e "$MAN" ]]; then
-    echo "$0: can't execute man" 1>&2
+    echo "$0: can't execute '$MAN'" 1>&2
     exit 1
 fi
 

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -27,8 +27,8 @@ For more detailed information see [1998 dloweneil in bugs.md](/bugs.md#1998-dlow
 ./pootris [X size of board] [Y size of board]
 ```
 
-Pressing `a` moves the current letter position counterclockwise around the
-border of the playing field.
+Pressing `a` moves the current letter position counterclockwise/anticlockwise
+(a)round the border of the playing field.
 
 Pressing `s` moves the current letter one position clockwise around the border
 of the playing field.
@@ -39,7 +39,7 @@ Pressing `d` drops the current letter onto the board.
 ## Alternate code:
 
 This version has it so that where in addition to `a` moving you
-anticlockwise/counterclockwise `h` does as well; and in addition to `s` moving
+counterclockwise/anticlockwise `h` does as well; and in addition to `s` moving
 clockwise `l` does as well. Instead of using `d` to drop the letter you can do
 `j` or space. Finally to quit this version you can press `q`.
 

--- a/faq.md
+++ b/faq.md
@@ -886,17 +886,19 @@ will too but it won't reset the terminal).
 ### <a name="faq3_7"></a><a name="X11macos"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC winner that requires X11?
 
 
-#### <a name="X11_general"></a>Generically, to compile and run an IOCCC winner that requires X11:
+#### <a name="X11_general"></a>Generally, to compile and run an IOCCC winner that requires X11:
 
-In order to have the X11 related include files and X11 libraries in order to compile the IOCCC winner,
-you will need to install Xorg and related packages including development related packages. In particular:
+You must have the X11 related include files and X11 libraries in order to
+compile the IOCCC winner. In order to do this you will need to install Xorg and
+related packages including development related packages. If you have macOS see
+further down for different instructions. Otherwise: in particular you must:
 
-* Install the Xorg server
-* Configure the Xorg server for your graphics environment
-* Install a X11 terminal application
-* Start the Xorg server
-* Launch the X11 terminal application
-* Run the IOCCC winner in the X11 terminal application
+* Install the Xorg server.
+* Configure the Xorg server for your graphics environment.
+* Install a X11 terminal application.
+* Start the Xorg server.
+* Launch the X11 terminal application.
+* Run the IOCCC winner in the X11 terminal application.
 
 By X11 terminal application we suggest one of:
 
@@ -904,42 +906,49 @@ By X11 terminal application we suggest one of:
 * [KDE](https://kde.org) terminal application
 * `xterm(`) terminal application
 
-See the below for various system related hints that may be of help.
+See below for various system related hints that may be of help.
 
 
 #### <a name="Xorg_deprecated"></a>X.org server has been deprecated
 
-The Red Hat RHEL9.0 release notes state that [X.org Server is now deprecated](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#deprecated-functionality_graphics-infrastructures).
+The Red Hat RHEL9.0 release notes state that [X.org Server is now
+deprecated](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#deprecated-functionality_graphics-infrastructures).
 
-According to this [Linux for Devices tutorial on XOrg](https://www.linuxfordevices.com/tutorials/linux/install-xorg-on-linux)
-as of 2023 Mar 25::
+According to this [Linux for Devices tutorial on
+XOrg](https://www.linuxfordevices.com/tutorials/linux/install-xorg-on-linux) as
+of 2023 Mar 25:
 
-```
-Recently, RHEL developers categorized Xorg was put in the ‘deprecated’
-software, as its development has mostly halted. Subsequent updates
-will completely replace it with Wayland, a more modern windowing
-system.. Although Wayland is not fully developed yet, many applications
-do not support it properly yet and screen sharing might not work
-sometime, but it is the future. Fedora, also developed by RHEL, has
-switched to a Wayland session as it’s default windowing system (And
-it works flawlessly on my Laptop).
-```
+
+> Recently, RHEL developers categorized [Xorg was put in the ‘deprecated’
+software](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality),
+as its development has mostly halted. Subsequent updates will completely replace
+it with Wayland, a more modern windowing system.. Although Wayland is not fully
+developed yet, many applications do not support it properly yet and screen
+sharing might not work sometime, but it is the future. Fedora, also developed by
+RHEL, has switched to a Wayland session as it’s default windowing system (And it
+works flawlessly on my Laptop).
 
 See the [Wayland](https://wayland.freedesktop.org) web site for more details.
 
-**IMPORTANT NOTE**: We do **NOT** know if IOCCC winners will run under **Wayland**.
-Some IOCCC winners that use X11 might be OK while other IOCCC winners that use X11 in an unusual way might fail
-under **Wayland**.
+**IMPORTANT NOTE**: We do **NOT** know if IOCCC winners will run under
+**Wayland**.  Some IOCCC winners that use X11 might be OK while other IOCCC
+winners that use X11 in an unusual way might fail under **Wayland**.
 
-See the [Wayland FAQ](https://wayland.freedesktop.org/faq.html) for more information.
 
-If your system uses **Wayland** and not X11, you might give the IOCCC winners that use X11 a try.
-They might work.
+See the [Wayland FAQ](https://wayland.freedesktop.org/faq.html) for more
+information.
 
-**IMPORTANT NOTE**: The [IOCCC judges [do not support support IOCCC winners](#no_support).
+If your system uses **Wayland** and not X11, you might give the IOCCC winners
+that use X11 a try.  They might work but again we do not know.
+
+**IMPORTANT NOTE**: The [IOCCC judges](/judges.html) [do not support IOCCC winners](#no_support).
 So if an IOCCC winner that uses X11 fails under **Wayland**, and you wish to
 provide a fix to the IOCCC winner so that it will run under **Wayland**,
 then consider [submitting a fix](#fix_a_winner) so that it will run under **Wayland**.
+
+Basically: if you discover an entry does not work in Wayland you are welcome to
+provide **alternate code** that works for Wayland. We will happily credit you in
+the [thanks-for-help.md](/thanks-for-help.md) file.
 
 
 #### Red Hat based Linux
@@ -956,7 +965,8 @@ See also:
 
 * [How to Configure X11 in Linux](https://www.wikihow.com/Configure-X11-in-Linux)
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### macOS
@@ -973,7 +983,7 @@ with macOS 14.2.1 (macOS Sonoma).
 First of all you will need to install the [most recent
 XQuartz](https://www.xquartz.org), preferably on an [Apple supported version of
 macOS, preferably the most recent version](https://support.apple.com/macos).
-Then open the "XQuartz" application (usually located in
+After it is installed, open the "XQuartz" application (usually located in
 `/Applications/Utilities/XQuartz.app`) by typing at the command line:
 
 ```sh
@@ -996,30 +1006,35 @@ And then run the program as directed by the `README.md` file. For example with
 <img alt="running 1993/jonth in macOS" src="png/xquartz-1993-jonth.png">
 
 Note that you can compile the code in your regular terminal prior to opening
-XQuartz, should you wish to.
+XQuartz, should you wish to. You can even run it from that terminal and it
+should open XQuartz.
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### Debian based Linux
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-According to the [Debian Xorg wiki](https://wiki.debian.org/Xorg), installing X11 requires:
+According to the [Debian Xorg wiki](https://wiki.debian.org/Xorg), installing
+X11 requires:
 
 ```sh
 sudo apt install xorg
 ```
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### Other Linux distributions
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-For general documentation on installing  X11, this [ServerGUI for Ubuntu](https://help.ubuntu.com/community/ServerGUI),
-and in particular, this may be helpful:
+For general documentation on installing  X11, this [ServerGUI for
+Ubuntu](https://help.ubuntu.com/community/ServerGUI), and in particular, these
+may be helpful:
 
 * [X11 Client Installation](https://help.ubuntu.com/community/ServerGUI#X11_Client_Installation)
 * [X11 Server Installation](https://help.ubuntu.com/community/ServerGUI#X11_Server_Installation)
@@ -1041,7 +1056,8 @@ For systems that have the `yum(1)` command:
 sudo yum install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
 ```
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### package website
@@ -1050,7 +1066,8 @@ First, see the above note on [installing and starting Xorg](#X11_general).
 
 See the [X.org](https://x.org/wiki/) foundation web site.
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 ### <a name="faq3_8"></a><a name="SDL"></a>FAQ 3.8: How do I compile an IOCCC winner that requires SDL1 or SDL2?

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2269,10 +2269,14 @@ prior to each run.
 [Cody](#cody) changed a `int *` used for `fopen(3)` to be a `FILE *` to be more correct
 and prevent any possible problems in some systems (which has happened).
 
-Cody also made the fixed version look more like the original version by using
+Cody also made the fixed version to look more like the original version by using
 the old style of `main()` args so that it reads `i,love_unix` more naturally,
-and by changing the typedef `lint` (to `int` - see the code for why this has to
-be done in modern systems) to be `_int`.
+and by changing the `typedef int lint` to be `typedef int _int`. See the code
+for why this has to be done this way.
+
+Cody also added the [try.sh](/1998/df/try.sh) script which runs the program in a
+loop until one hits `q` (or `Q`) or sends intr/ctrl-c. He also proposed there's
+a way to cheat very easily. Can you figure out how?
 
 
 ## <a name="1998_dlowe"></a>[1998/dlowe](/1998/dlowe/dlowe.c) ([README.md](/1998/dlowe/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2192,6 +2192,13 @@ suggested that one try the longer version too but it will run in an infinite
 loop so having it in a script is less desired).
 
 
+## <a name="1996_schweikh3"></a>[1996/schweikh3](/1996/schweikh3/schweikh3.c) ([README.md](/1996/schweikh3/README.md]))
+
+[Cody](#cody) updated the Makefile so that if it fails to compile it will try he
+method suggested for SunOS rather than having to update the Makefile manually or
+running a more complicated command: now one can just run `make`.
+
+
 ## <a name="1996_westley"></a>[1996/westley](/1996/westley/westley.c) ([README.md](/1996/westley/README.md]))
 
 [Cody](#cody) fixed a segfault in this entry as well as it displaying environmental

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2173,14 +2173,15 @@ NOTE: if there is no X server running this program will still crash.
 
 ## <a name="1996_schweikh1"></a>[1996/schweikh1](/1996/schweikh1/schweikh1.c) ([README.md](/1996/schweikh1/README.md]))
 
+[Cody](#cody) added the [try.sh](/1996/schweikh1/try.sh) script.
+
 The author stated that `-I/usr/include` is needed by gcc in Solaris because
 `errno.h` has two identical extern declarations of `errno`. That leads to an
 error due to the redefinition of `main` but the `-I` option makes sure the
 working `/usr/include/rrno.h` is found first, which shouldn't cause any problems
 on other systems (the other file is
-`gcc-lib/sparc-sun-solaris2.5/2.7.2/include/errno.h`). Thus Cody added this to
+`gcc-lib/sparc-sun-solaris2.5/2.7.2/include/errno.h`). Thus Cody also added this to
 the Makefile despite the fact that very few probably use Solaris nowadays.
-
 
 
 ## <a name="1996_schweikh2"></a>[1996/schweikh2](/1996/schweikh2/schweikh2.c) ([README.md](/1996/schweikh2/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2096,15 +2096,17 @@ Cody also added the [try.sh](/1995/vanschnitz/try.sh) script.
 ## <a name="1996_august"></a>[1996/august](/1996/august/august.c) ([README.md](/1996/august/README.md]))
 
 [Cody](#cody) fixed a segfault in this program that prevented it from working right and
-also fixed an infinite loop in the try commands. The problem with the infinite
-loop is that the file `august.oc` had to have lines starting with `#` removed
-and it was not being done. After this is done with say `sed(/1)` (like `sed -i''
-'/^#/d' august.oc` which has been added to both the remarks and the `try.sh`
-script noted below) the code can proceed. This problem existed in macOS.
+also fixed an infinite loop in the try commands.
+
+The problem with the infinite loop is that the file `august.oc` had to have
+lines starting with `#` removed and it was not being done. After this is done
+with say `sed(/1)` (like `sed -i'' '/^#/d' august.oc` which has been added to
+both the remarks and the `try.sh` script noted below) the code can proceed. This
+problem existed in macOS.
 
 Cody also added the [try.sh](/1996/august/try.sh) script that runs all the
-commands given in the try section to simplify it as there are quite a lot of
-commands.
+commands that were given by the judges in the try section, with the fix above
+applied.
 
 
 ## <a name="1996_dalbec"></a>[1996/dalbec](/1996/dalbec/dalbec.c) ([README.md](/1996/dalbec/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2166,6 +2166,11 @@ the function in the pointer assignment.
 NOTE: if there is no X server running this program will still crash.
 
 
+## <a name="1996_rcm"></a>[1996/rcm](/1996/rcm/rcm.c) ([README.md](/1996/rcm/README.md]))
+
+[Cody](#cody) added the [try.sh](/1996/rcm/try.sh) script.
+
+
 ## <a name="1996_schweikh1"></a>[1996/schweikh1](/1996/schweikh1/schweikh1.c) ([README.md](/1996/schweikh1/README.md]))
 
 The author stated that `-I/usr/include` is needed by gcc in Solaris because

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2259,6 +2259,10 @@ as well as allowing one to pass in different file names or strings.
 [Cody](#cody) added a call to `endwin()` to restore terminal sanity (echo etc.) when
 exiting the program (in both versions).
 
+Cody also added the [try.sh](/1998/chaos/try.sh) script that runs the program on
+all the data files, giving instructions on how to rotate and zoom in and out,
+prior to each run.
+
 
 ## <a name="1998_df"></a>[1998/df](/1998/df/df.c) ([README.md](/1998/df/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2213,14 +2213,11 @@ when reading the author's comments. To see how to use the original, see the
 README.md file.
 
 Cody also added the two scripts, [try.sh](/1996/westley/try.sh) and
-[try.alt.sh](/1996/westley/try.alt.sh) to show automate showing the different
+[try.alt.sh](/1996/westley/try.alt.sh) to automate showing the different
 clocks, both with the fixed version and the original (alt) version.
 
 Also, to fix any potential problem with displaying in GitHub the scripts
-provided by the author, Cody added '.sh'.
-
-Later Cody made the entry look more like the original, removing the `argc` in
-`main()` (K&R style functions).
+provided by the author, Cody added '.sh' to the `clock[1-3].sh` scripts.
 
 
 # <a name="1998"></a>1998


### PR DESCRIPTION

This is a cosmetic change only and rather unimportant but I have to be
complete: when I added the alt code I used the word anticlockwise (as I 
would) instead of counterclockwise. But since the original entry
referred only to counterclockwise I decided to make it use both like the
alt code does.
