### PR TITLE
Fix typos in thanks file

### DIFF
--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
-	-Wno-int-conversion
+	-Wno-int-conversion -Wno-implicit-int -Wno-return-type
 
 # Common C compiler warning flags
 #

--- a/1995/makarios/makarios.c
+++ b/1995/makarios/makarios.c
@@ -1,3 +1,3 @@
-pain(int n, char **ia, char **aa, char **ma){int i=ia, a=aa, m=ma; while(i=++n)
-for(a=0;a<i?a=a*8+i%8,i/=8,m=a==i|a/8==i,1:(n-++m||printf("%o\n",n))&&n%m;);}
-main(int n, char **ia, char **aa) { return pain(n, ia, aa, 0); }
+pain(n,i,a,p){while(i=++n)
+for(a=0;a<i?a=a*8+i%8,i/=8,p=a==i|a/8==i,1:(n-++p||printf("%o\n",n))&&n%p;);}
+main(n,i,a/*,m*/)char**i,**a;{return pain(n,i,a,0);}

--- a/1996/rcm/.gitignore
+++ b/1996/rcm/.gitignore
@@ -6,4 +6,7 @@ indent.c
 indent.o
 prog.orig
 rcm
+rcm.cp2.c
+rcm.cp.c
+rcm.cp.c.gz
 rcm.orig

--- a/1996/rcm/README.md
+++ b/1996/rcm/README.md
@@ -8,8 +8,10 @@ make all
 ## To use:
 
 ```sh
-./rcm < rfc1951.gz
+./rcm < file.gz
 ```
+
+where `file.gz` is some gzipped file.
 
 
 ## Try:
@@ -17,7 +19,7 @@ make all
 For more information try:
 
 ```sh
-./rcm < rfc1952.gz
+./try.sh
 ```
 
 
@@ -28,6 +30,9 @@ For a good no-op try:
 ```sh
 gzip -c < rcm.c | ./rcm
 ```
+
+NOTE: this is done in the [try.sh](try.sh) script as well, along with some other
+commands including a way to do the above command but with more steps.
 
 
 ## Author's remarks:

--- a/1996/rcm/try.sh
+++ b/1996/rcm/try.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# try.sh - show IOCCC winner 1996/rcm
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./rcm < rfc1951.gz (space = next page, q = quit): "
+echo 1>&2
+./rcm < rfc1951.gz | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./rcm < rfc1952.gz (space = next page, q = quit): "
+echo 1>&2
+./rcm < rfc1952.gz | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: cp -vf rcm.c rcm.cp.c; gzip rcm.cp.c: "
+echo 1>&2
+cp -vf rcm.c rcm.cp.c; gzip rcm.cp.c
+
+read -r -n 1 -p "Press any key to run: ./rcm < rcm.cp.c.gz | tee rcm.cp.c (space = next page, q = quit): "
+echo 1>&2
+./rcm < rcm.cp.c.gz | tee rcm.cp.c | less -rEXF
+echo 1>&2
+rm rcm.cp.c.gz
+
+read -r -n 1 -p "Press any key to run: gzip -c < rcm.c | ./rcm | tee rcm.cp2.c (space = next page, q = quit): "
+echo 1>&2
+gzip -c < rcm.c | ./rcm | tee rcm.cp2.c | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show diff between rcm.cp.c and rcm.cp2.c: "
+echo 1>&2
+diff -s rcm.cp.c rcm.cp2.c
+echo 1>&2
+rm -f rcm.cp.c rcm.cp2.c
+

--- a/1996/schweikh1/README.md
+++ b/1996/schweikh1/README.md
@@ -14,10 +14,11 @@ make all
 
 ## Try:
 
-To find the day that Easter falls on in the current year:
+To find the day that Easter falls on in the current year and to show all Easter
+dates from 1582 to 2199:
 
 ```sh
-./schweikh1 |grep $(date +%Y)
+./try.sh
 ```
 
 

--- a/1996/schweikh1/try.sh
+++ b/1996/schweikh1/try.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# try.sh - show IOCCC winner 1996/schweikh1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to show date of Easter this year (./schweikh1 |grep \$(date +%Y)): "
+echo 1>&2
+./schweikh1 |grep "$(date +%Y)"
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show Easter dates from 1582 to 2199 (space = next page, q = quit): "
+echo 1>&2
+./schweikh1 | less -rEXF
+echo 1>&2

--- a/1996/schweikh2/README.md
+++ b/1996/schweikh2/README.md
@@ -41,8 +41,8 @@ while :; do grep -v '#' schweikh2.c; done
 ```
 
 (and we do too) which works with `sh`, `bash`, `ksh` and `zsh` as well. Press
-ctrl-c to stop it. Observe how the [try.sh](try.sh) script does this a number of
-times.
+ctrl-c to stop it. Observe how the [try.sh](try.sh) script does this once to
+make it easier to see what is happening.
 
 
 ## Judges' remarks:

--- a/1996/schweikh2/try.sh
+++ b/1996/schweikh2/try.sh
@@ -15,16 +15,17 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to to run ./schweikh2: " 1>&2
-./schweikh2
+read -r -n 1 -p "Press any key to to run ./schweikh2 (space = next page, q = quit): " 1>&2
+echo >&2
+./schweikh2 | less -rEXF
 echo >&2
 
 read -r -n 1 -p "Press any key to run: ./schweikh2 15 1 0 0/0 | head -n 15: " 1>&2
+echo >&2
 ./schweikh2 15 1 0 0/0 | head -n 15
 echo >&2
 
-read -r -n 1 -p "Press any key one more time: " 1>&2
-i=0
-while ((i++<15)); do
-    grep -v '#' schweikh2.c
-done
+read -r -n 1 -p "Press any key to run grep -v '#' schweikh2.c (space = next page, q = quit): "
+echo 1>&2
+grep -v '#' schweikh2.c | less -rEXF
+echo 1>&2

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -129,7 +129,8 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} || \
+	    ${CC} ${CFLAGS} -I. '-Ddifftime(a,b)=(double)(b-a)' $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #

--- a/1996/schweikh3/README.md
+++ b/1996/schweikh3/README.md
@@ -33,14 +33,6 @@ But still it is a useful utility.  To use try:
 
 and thanks for the virtual memories!  :-)
 
-NOTE: On some systems such as SunOS, one may need to compile with:
-
-```make
-	${CC} ${CFLAGS} \
-	  -I. -D_POSIX_SOURCE '-Ddifftime(a,b)=(double)(b-a)' \
-	  schweikh3.c -o schweikh3
-```
-
 
 ## Author's remarks:
 

--- a/1996/westley/try.alt.sh
+++ b/1996/westley/try.alt.sh
@@ -15,13 +15,22 @@ make CC="$CC" everything >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "Showing alt grandfather clock:" 1>&2
+echo "WARNING: this is likely to segfault after showing the output." 1>&2
+echo "It might also show one or more environmental variables. Use" 1>&2
+echo "try.sh if you want to see the fixed version." 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show alt grandfather clock: "
+echo 1>&2
 WESTLEY=./westley.alt ./clock1.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing alt mantle clock that runs backwards:" 1>&2
+read -r -n 1 -p "Press any key to show alt mantle clock that runs backwards: "
+echo 1>&2
 WESTLEY=./westley.alt ./clock2.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing alt linear style clock:" 1>&2
+read -r -n 1 -p "Press any key to show alt linear style clock: "
+echo 1>&2
 WESTLEY=./westley.alt ./clock3.sh
+echo 1>&2

--- a/1996/westley/try.sh
+++ b/1996/westley/try.sh
@@ -15,13 +15,17 @@ make CC="$CC" everything >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "Showing grandfather clock:" 1>&2
+read -r -n 1 -p "Press any key to show grandfather clock: "
+echo 1>&2
 WESTLEY=./westley ./clock1.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing mantle clock that runs backwards:" 1>&2
+read -r -n 1 -p "Press any key to show alt mantle clock that runs backwards: "
+echo 1>&2
 WESTLEY=./westley ./clock2.sh
-read -r -n 1 -p "Press any key to continue: " 1>&2
+echo 1>&2
 
-echo "Showing linear style clock:" 1>&2
+read -r -n 1 -p "Press any key to show alt linear style clock: "
+echo 1>&2
 WESTLEY=./westley ./clock3.sh
+echo 1>&2

--- a/1998/banks/README.md
+++ b/1998/banks/README.md
@@ -4,10 +4,12 @@
 make all
 ```
 
+If you do not have a page up or page down key you might wish to see the
+[Alternate code](#alternate-code) section below. You may redefine all the keys
+and the time step with predefined macros, however, so one lacking page up / page
+down does not strictly need the alternate code; it jut gives those controls a
+default value. The author provided the following table:
 
-
-You may redefine all the keys and the time step with predefined macros. The
-author provided the following able:
 
 ```
 Control         Description         Default Key
@@ -94,12 +96,13 @@ arrows at the same time as typing on the right side.
 
 As the Makefile allows you to configure the keys to use you may redefine the
 keys but with the alt build you cannot, as described earlier, redefine the page
-up and page down replacement keys. If you want to do that you should use the
-original entry as described in the to build section above.
+up and page down replacement keys. The other controls you may redefine; this is
+just a convenience build. If you want to redefine the page up / page down keys
+you should use the original entry as described in the to build section above.
 
-In the alt build it is `f` and `d` respectively as these are letters on the left
-side of the keyboard which is easier to use if one is using the right side for
-movement. These are hard coded, as noted.
+In the alt build it is `f` (for page up) and `d` (for page down) as these are
+letters on the left side of the keyboard which is easier to use if one is using
+the right side for movement. These are hard coded, as noted.
 
 To use the default settings for the alternate build:
 
@@ -114,7 +117,7 @@ want to use page up and page down.
 
 ### Alternate use:
 
-Use `banks.alt` as you would `banks` but for use the different keys as
+Use `banks.alt` as you would `banks` but use the different keys as
 configured at compilation.
 
 

--- a/1998/bas2/README.md
+++ b/1998/bas2/README.md
@@ -19,6 +19,8 @@ echo text | ./bas2
 ./try.sh
 
 ./try.sh "foo bar" "baz" "IOCCC 1998/bas2" README.md
+
+./try.sh try.sh "bas2.c" bas2.orig.c
 ```
 
 

--- a/1998/bas2/try.sh
+++ b/1998/bas2/try.sh
@@ -15,30 +15,44 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./bas2 < bas2.c" 1>&2
+read -r -n 1 -p "Press any key to run: ./bas2 < bas2.c: "
+echo 1>&2
 ./bas2 < bas2.c
+echo 1>&2
 
-echo "$ ./bas2 < README.md" 1>&2
+read -r -n 1 -p "Press any key to run: ./bas2 < README.md: "
+echo 1>&2
 ./bas2 < README.md
+echo 1>&2
 
-echo "$ ./bas2 < Makefile" 1>&2
+read -r -n 1 -p "Press any key to run: ./bas2 < Makefile: "
+echo 1>&2
 ./bas2 < Makefile
+echo 1>&2
 
-echo "$ echo foo bar baz | ./bas2" 1>&2
+read -r -n 1 -p "Press any key to run: echo foo bar baz | ./bas2: "
+echo 1>&2
 echo foo bar baz | ./bas2
+echo 1>&2
 
-echo "$ cat README.md Makefile bas2.c | ./bas2" 1>&2
+read -r -n 1 -p "Press any key to run: cat README.md Makefile bas2.c | ./bas2: "
+echo 1>&2
 cat README.md Makefile bas2.c | ./bas2
+echo 1>&2
 
 # while we have an arg check if it's a file. If it is a regular file that is
 # readable feed it to the program; otherwise act as if it's a string.
 while [[ "$#" -gt 0 ]]; do
     if [[ -f "$1" && -r "$1" ]]; then
-	echo "$ ./bas2 < $1" 1>&2
+	read -r -n 1 -p "Press any key to run: ./bas2 < $1: "
+	echo 1>&2
 	./bas2 < "$1"
+	echo 1>&2
     else
-	echo "$ echo $1 | ./bas2" 1>&2
+	read -r -n 1 -p "Press any key to run: echo $1 | ./bas2: "
+	echo 1>&2
 	echo "$1" | ./bas2
+	echo 1>&2
     fi
     shift 1
 done

--- a/1998/chaos/README.md
+++ b/1998/chaos/README.md
@@ -21,6 +21,21 @@ make chaos_nohalf
 ```
 
 
+## Try:
+
+
+```sh
+./try.sh
+```
+
+This script will run the program on each data file. To quit the program hit `q`.
+If not all files have been used it will go to the next one; otherwise the script
+will be finished. To end the script early send intr/ctrl-c.
+
+The script will give you instructions on how to use the program and things to
+try each time it is run, as a helpful reminder.
+
+
 ## Judge's Comments:
 
 This is the author's first IOCCC entry.  We thought the entry was

--- a/1998/chaos/try.sh
+++ b/1998/chaos/try.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# 
+# try.sh - demonstrate IOCCC winner 1998/chaos
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+show_instructions()
+{
+    echo 1>&2
+    echo "Try the keys 'y', 'u', 'i', 'h', 'j' and 'k'; 'a' and 'z' zoom in and out." 1>&2
+    echo "When tired of moving it manually wait a short bit and watch what happens. You" 1>&2
+    echo "might try zooming in and out and then wait for it to start moving (again or" 1>&2
+    echo "initially). You can interrupt the automatic movement by pressing any key or 'q' to" 1>&2
+    echo "quit. Send intr/ctrl-c to quit the script prematurely." 1>&2
+    echo 1>&2
+}
+
+for f in cube.data desk.data ioccc.data pyramid.data xwing.data; do
+    clear
+    show_instructions
+    read -r -n 1 -p "Press any key to run: ./chaos $f: "
+    echo 1>&2
+    ./chaos "$f"
+done

--- a/1998/df/README.md
+++ b/1998/df/README.md
@@ -11,6 +11,19 @@ make all
 ./df
 ```
 
+
+## Try:
+
+```sh
+./try.sh
+```
+
+This will run the program in a loop until you exit (`q` when prompted or
+ctrl-c/intr).
+
+Can you figure out a very simple pipeline to cheat?
+
+
 ## Judges' remarks;
 
 Everyone talks about how data hiding can produce clearer code; I am
@@ -33,6 +46,7 @@ Extra credit questions:
 - Where are the words stored?
 - How many words does this entry use?
 - Can you add more words to the program and still make it work?
+- Are there any misspelt words? If yes what are they?
 
 
 ## Author's remarks:

--- a/1998/df/try.sh
+++ b/1998/df/try.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 
+# try.sh - demonstrate IOCCC winner 1998/df
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+while [[ 1 ]]; do
+    read -r -n 1 -p "Press any key to run ./df or 'q' to quit: "
+    echo 1>&2
+    if [[ "$REPLY" = "q" || "$REPLY" = "Q" ]]; then
+	exit 0
+    fi
+    ./df
+done

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -11,7 +11,9 @@ below for more details.
 ## To use:
 
 ```sh
-./dlowe < anyfile > pootfile
+./dlowe < file > pootfile
+
+./dlowe < file
 ```
 
 
@@ -42,6 +44,8 @@ Also try:
 ./try.sh
 ```
 
+Did you spot the Easter egg there?
+
 
 ## Alternate code:
 
@@ -59,7 +63,7 @@ make alt
 ### Alternate use:
 
 ```
-./dlowe.alt < anyfile > pootfile
+./dlowe.alt < file > pootfile
 ```
 
 What's the difference between this and `dlowe`?
@@ -70,6 +74,9 @@ What's the difference between this and `dlowe`?
 ```sh
 ./try.alt.sh
 ```
+
+Did you spot the Easter egg there?
+
 
 
 ## Judges' remarks:

--- a/1998/dlowe/try.alt.sh
+++ b/1998/dlowe/try.alt.sh
@@ -5,18 +5,18 @@
 
 make everything || exit 1
 
-CAT="$(type -P cat)"
-MAN="$(type -P man)"
-COL="$(type -P col)"
+[[ -z "$CAT" ]] && CAT="$(type -P cat)"
+[[ -z "$MAN" ]] && MAN="$(type -P man)"
+[[ -z "$COL" ]] && COL="$(type -P col)"
 
 if [[ -z "$CAT" || ! -e "$CAT" ]]; then
-    echo "$0: no cat found" 1>&2
+    echo "$0: no cat '$CAT' found" 1>&2
     exit 1
 elif [[ -z "$COL" || ! -e "$COL" ]]; then
-    echo "$0: col not found" 1>&2
+    echo "$0: col '$COL' not found" 1>&2
     exit 1
 elif [[ -z "$MAN" || ! -e "$MAN" ]]; then
-    echo "$0: can't execute man" 1>&2
+    echo "$0: can't execute '$MAN'" 1>&2
     exit 1
 fi
 

--- a/1998/dlowe/try.sh
+++ b/1998/dlowe/try.sh
@@ -5,18 +5,18 @@
 
 make all || exit 1
 
-CAT="$(type -P cat)"
-MAN="$(type -P man)"
-COL="$(type -P col)"
+[[ -z "$CAT" ]] && CAT="$(type -P cat)"
+[[ -z "$MAN" ]] && MAN="$(type -P man)"
+[[ -z "$COL" ]] && COL="$(type -P col)"
 
 if [[ -z "$CAT" || ! -e "$CAT" ]]; then
-    echo "$0: no cat found" 1>&2
+    echo "$0: no cat '$CAT' found" 1>&2
     exit 1
 elif [[ -z "$COL" || ! -e "$COL" ]]; then
-    echo "$0: col not found" 1>&2
+    echo "$0: col '$COL' not found" 1>&2
     exit 1
 elif [[ -z "$MAN" || ! -e "$MAN" ]]; then
-    echo "$0: can't execute man" 1>&2
+    echo "$0: can't execute '$MAN'" 1>&2
     exit 1
 fi
 

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -27,8 +27,8 @@ For more detailed information see [1998 dloweneil in bugs.md](/bugs.md#1998-dlow
 ./pootris [X size of board] [Y size of board]
 ```
 
-Pressing `a` moves the current letter position counterclockwise around the
-border of the playing field.
+Pressing `a` moves the current letter position counterclockwise/anticlockwise
+(a)round the border of the playing field.
 
 Pressing `s` moves the current letter one position clockwise around the border
 of the playing field.
@@ -39,7 +39,7 @@ Pressing `d` drops the current letter onto the board.
 ## Alternate code:
 
 This version has it so that where in addition to `a` moving you
-anticlockwise/counterclockwise `h` does as well; and in addition to `s` moving
+counterclockwise/anticlockwise `h` does as well; and in addition to `s` moving
 clockwise `l` does as well. Instead of using `d` to drop the letter you can do
 `j` or space. Finally to quit this version you can press `q`.
 

--- a/1998/dorssel/README.md
+++ b/1998/dorssel/README.md
@@ -21,12 +21,6 @@ echo text | ./dorssel
 ./try.sh
 ```
 
-Also try:
-
-```sh
-./dorssel < dorssel.md
-```
-
 
 ## Judges' remarks:
 

--- a/1998/dorssel/try.sh
+++ b/1998/dorssel/try.sh
@@ -15,24 +15,36 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ echo 'Simple as 123' | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to run: echo 'Simple as 123' | ./dorssel: "
+echo 1>&2
 echo 'Simple as 123' | ./dorssel
+echo 1>&2
 
-echo "$ echo 'Binary as simple as 1, 10 11.' | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to run: echo 'Binary as simple as 1, 10 11.' | ./dorssel: " 1>&2
+echo 1>&2
 echo 'Binary as simple as 1, 10 11.' | ./dorssel
+echo 1>&2
 
 echo "$ echo '.... --- .--  -.. --- . ...  .. -  -.. ---  - .... .- -' | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo '.... --- .--  -.. --- . ...  .. -  -.. ---  - .... .- -' | ./dorssel
+echo 1>&2
 
-echo "$ echo 'HOW DOES IT DO THAT' | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to run: echo 'HOW DOES IT DO THAT' | ./dorssel: "
+echo 1>&2
 echo 'HOW DOES IT DO THAT' | ./dorssel
+echo 1>&2
 
-echo "$ echo 'HOW DOES IT DO THAT' | ./dorssel | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to run: echo 'HOW DOES IT DO THAT' | ./dorssel | ./dorssel: "
+echo 1>&2
 echo 'HOW DOES IT DO THAT' | ./dorssel | ./dorssel
+echo 1>&2
 
-
-echo "$ ./dorssel < dorssel.c | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to run: ./dorssel < dorssel.c | ./dorssel: "
+echo 1>&2
 ./dorssel < dorssel.c | ./dorssel
+echo 1>&2
 
 
 echo "$ echo '
@@ -40,6 +52,8 @@ echo "$ echo '
 
 . -..- . .-. -.-. .. ... .
 -.-. .... .- -. --. .  - .... .  .--. .-. --- --. .-. .- --  ... ---  .. -  -.. --- . ...  -. --- -  ... .... --- ..- -' | ./dorssel" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 
 echo "
 ..  - .... .. -. -.-  - .... .. ...  ... .--. --- .. .-.. . .-.  .. ...  -- --- .-. .  --- -... ..-. ..- ... -.-. .- - . -..  - .... .- -.  - .... .  .--. .-. --- --. .-. .- --
@@ -47,3 +61,7 @@ echo "
 . -..- . .-. -.-. .. ... .
 -.-. .... .- -. --. .  - .... .  .--. .-. --- --. .-. .- --  ... ---  .. -  -.. --- . ...  -. --- -  ... .... --- ..- -" | ./dorssel
 
+read -r -n 1 -p "Press any key to run: ./dorssel < dorssel.md (space = next page, q = quit): "
+echo 1>&2
+./dorssel < dorssel.md | less -rEXF
+echo 1>&2

--- a/1998/fanf/try.sh
+++ b/1998/fanf/try.sh
@@ -15,7 +15,8 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ echo '((\a(\b(\c(d)))) e' | ./fanf" 1>&2
+read -r -n 1 -p "Press any key to run: echo '((\a(\b(\c(d)))) e)' | ./fanf: "
+echo 1>&2
 echo '((\a(\b(\c(d)))) e)' | ./fanf
 echo 1>&2
 
@@ -25,6 +26,8 @@ echo "$ echo '
     (g x) (f x)
   ) K K z
 )'|./fanf" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo '
 (\f\g\x
   (
@@ -35,6 +38,8 @@ echo 1>&2
 
 
 echo "$ echo '(\f(\f\g\x( (f((\a(g(b))) e)) (g x) ) K K z))' | ./fanf" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo '(\f(\f\g\x( (f((\a(g(b))) e)) (g x) ) K K z))' | ./fanf
 echo 1>&2
 
@@ -45,6 +50,8 @@ echo "$ echo '
    (* n (f (- n 1)))
   )
 )' | ./fanf" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 
 echo '(Y\f\n
   ((= n 0)
@@ -52,3 +59,5 @@ echo '(Y\f\n
    (* n (f (- n 1)))
   )
 )' | ./fanf
+
+exit 0

--- a/1998/schnitzi/try.sh
+++ b/1998/schnitzi/try.sh
@@ -15,67 +15,62 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./schnitzi 3 > sort.c" 1>&2
+read -r -n 1 -p "Press any key to run: ./schnitzi 3 > sort.c: "
+echo 1>&2
 ./schnitzi 3 > sort.c
+echo 1>&2
 
-echo "Compiling sort.c:" 1>&2
+read -r -n 1 -p "Press any key to run: make sort >/dev/null || exit 1: "
+echo 1>&2
 make sort >/dev/null || exit 1
 
+echo 1>&2
 echo "...built sort." 1>&2
+echo 1>&2
 
 echo "Creating data:" 1>&2
 
-echo "$ echo 234 > data" 1>&2
-echo 234 > data
-
-echo "$ echo 413 >> data" 1>&2
-echo 413 >> data
-
-echo "$ echo 123 >> data" 1>&2
-echo 123 >> data
+read -r -n 1 -p "Press any key to run: printf \"234\n413\n123\" > data: "
+echo 1>&2
+printf "234\n413\n123" > data
+echo 1>&2
 
 echo "Sorting data:" 1>&2
-echo "$ ./sort < data" 1>&2
+read -r -n 1 -p "Press any key to run: ./sort < data: "
+echo 1>&2
 ./sort < data
-
 echo 1>&2
 
 echo "Using stdin/stdout:" 1>&2
-echo "$ echo 10 7 9 | ./sort" 1>&2
+read -r -n 1 -p "Press any key to run: echo \"10 7 9\" | ./sort: "
+echo 1>&2
 echo "10 7 9" | ./sort
+echo 1>&2
 
-echo "$ ./schnitzi 5 > sort.c" 1>&2
-./schnitzi 5 > sort.c
+read -r -n 1 -p "Press any key to run: ./schnitzi 5 | tee sort.c (space = next page, q = quit): "
+echo 1>&2
+./schnitzi 5 | tee sort.c | less -rEXF
 
 echo "Compiling sort.c:" 1>&2
 make sort >/dev/null || exit 1
-
+echo 1>&2
 echo "...built sort." 1>&2
 
 echo "Creating data:" 1>&2
 
-echo "$ echo 124 > data" 1>&2
-echo 124 > data
-
-echo "$ echo 422 >> data" 1>&2
-echo 422 >> data
-
-echo "$ echo 120 >> data" 1>&2
-echo 120 >> data
-
-echo "$ echo 100 >> data" 1>&2
-echo 100 >> data
-
-echo "$ echo 777 >> data" 1>&2
-echo 777 >> data
+read -r -n 1 -p "Press any key to run: printf \"124\n422\n120\n100\n777\" > data: "
+echo 1>&2
+printf "124\n422\n120\n100\n777" > data
 
 echo "Sorting data:" 1>&2
-echo "$ ./sort < data" 1>&2
+read -r -n 1 -p "Press any key to run: ./sort < data: "
+echo 1>&2
 ./sort < data
 
 echo 1>&2
 
 echo "Using stdin/stdout:" 1>&2
-echo "$ echo 5 10 7 9 1 | ./sort" 1>&2
+read -r -n 1 -p "Press any key to run: echo "5 10 7 9 1" | ./sort: "
+echo 1>&2
 echo "5 10 7 9 1" | ./sort
 echo 1>&2

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -21,13 +21,14 @@ or
 ## Try:
 
 ```sh
-./yarng 5
+./try.sh
 
 ./yarng
 # watch what it does
 ```
 
-What is the difference there?
+What is the difference between what is in the script and running `yarng` without
+an arg?
 
 
 ## Judges' remarks:

--- a/1998/schweikh2/try.sh
+++ b/1998/schweikh2/try.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# 
+# try.sh - demonstrate IOCCC winner 1998/schweikh2
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+i=0
+while [[ "$i" -lt 3 ]]; do
+    NUM="$((RANDOM % 10))"
+    read -r -n 1 -p "Press any key to run: ./yarng $NUM: "
+    echo 1>&2
+    ./yarng "$NUM"
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./yarng $NUM: "
+    echo 1>&2
+    ./yarng "$NUM"
+    echo 1>&2
+
+    ((i++))
+done

--- a/1998/schweikh3/try.sh
+++ b/1998/schweikh3/try.sh
@@ -15,16 +15,30 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ cp -f schweikh3 file1"
-cp -f schweikh3 file1
-echo "$ cp -f schweikh3 file2"
-cp -f schweikh3 file2
-echo "$ cp -f schweikh3.c file3"
-cp -f schweikh3.c file3
-echo "$ ln -f file3 file4"
-ln -f file3 file4
-echo "$ find . -type f -name 'file?' | ./samefile"
-find . -type f -name 'file?' | ./samefile
+read -r -n 1 -p "Press any key to run: cp -vf schweikh3 file1: "
+echo 1>&2
+cp -vf schweikh3 file1
+echo 1>&2
 
-echo "find . -type f -print | ./samefile" 1>&2
+read -r -n 1 -p "Press any key to run: cp -vf schweikh3 file2: "
+echo 1>&2
+cp -vf schweikh3 file2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: cp -vf schweikh3.c file3: "
+echo 1>&2
+cp -vf schweikh3.c file3
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ln -vf file3 file4: "
+echo 1>&2
+ln -vf file3 file4
+read -r -n 1 -p "Press any key to run: find . -type f -name 'file?' | ./samefile: "
+echo 1>&2
+find . -type f -name 'file?' | ./samefile
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: find . -type f -print | ./samefile: "
+echo 1>&2
 find . -type f -print | ./samefile
+echo 1>&2

--- a/1998/tomtorfs/try.sh
+++ b/1998/tomtorfs/try.sh
@@ -17,19 +17,32 @@ clear
 
 rm -f file.A file.B file.C
 
-echo "$ echo abscond conferrable > file.A" 1>&2
+read -r -n 1 -p "Press any key to run: echo \"abscond conferrable\" > file.A: "
+echo 1>&2
 echo "abscond conferrable" > file.A
-echo "$ ./tomtorfs file.A 32 04C11DB7 1 FFFFFFFF FFFFFFFF" 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./tomtorfs file.A 32 04C11DB7 1 FFFFFFFF FFFFFFFF: "
+echo 1>&2
 ./tomtorfs file.A 32 04C11DB7 1 FFFFFFFF FFFFFFFF
+echo 1>&2
 
-echo "$ echo adorn condolence > file.B" 1>&2
+read -r -n 1 -p "Press any key to run: echo \"adorn condolence\" > file.B: "
+echo 1>&2
 echo "adorn condolence" > file.B
-echo "$ ./tomtorfs file.B 32 04C11DB7 1 FFFFFFFF FFFFFFFF" 1>&2
-./tomtorfs file.B 32 04C11DB7 1 FFFFFFFF FFFFFFFF
 
-echo "$ echo adorn condolence too > file.C" 1>&2
+read -r -n 1 -p "Press any key to run: ./tomtorfs file.B 32 04C11DB7 1 FFFFFFFF FFFFFFFF: "
+echo 1>&2
+./tomtorfs file.B 32 04C11DB7 1 FFFFFFFF FFFFFFFF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo \"adorn condolence too\" > file.C: "
+echo 1>&2
 echo "adorn condolence too" > file.C
-echo "$ ./tomtorfs file.C 32 04C11DB7 1 FFFFFFFF FFFFFFFF" 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./tomtorfs file.C 32 04C11DB7 1 FFFFFFFF FFFFFFFF: "
+echo 1>&2
 ./tomtorfs file.C 32 04C11DB7 1 FFFFFFFF FFFFFFFF
+echo 1>&2
 
 rm -f file.A file.B file.C

--- a/2000/anderson/try.sh
+++ b/2000/anderson/try.sh
@@ -16,16 +16,26 @@ make CC="$CC" all >/dev/null || exit 1
 clear
 
 read -r -n 1 -p "Press any key to run: echo Obfuscate | ./anderson: "
+echo 1>&2
 echo Obfuscate | ./anderson
+echo 1>&2
 
 read -r -n 1 -p "Press any key to run: echo 'Hello, world!' | ./anderson: "
+echo 1>&2
 echo 'Hello, world!' | ./anderson
+echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./anderson < anderson.c: "
+echo 1>&2
 ./anderson < anderson.c
+echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./anderson < README.md: "
+echo 1>&2
 ./anderson < README.md
+echo 1>&2
 
 read -r -n 1 -p "Press any key to run: cat README.md anderson.c | ./anderson: "
+echo 1>&2
 cat README.md anderson.c | ./anderson
+echo 1>&2

--- a/2000/bmeyer/try.sh
+++ b/2000/bmeyer/try.sh
@@ -45,33 +45,42 @@ if [[ "$COLUMNS" -lt 81 ]]; then
 fi
 
 
-read -r -n 1 -p "Press any key to start: "
-echo "$ ./glicbawls < michael.pgm > michael.glic" 1>&2
+read -r -n 1 -p "Press any key to run: ./glicbawls < michael.pgm > michael.glic: "
+echo 1>&2
 ./glicbawls < michael.pgm > michael.glic
 echo "Now compare the michael.pgm to the screen output." 1>&2
+echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
 echo "$ ./glicbawls < michael.pgm 2>/dev/null | ./glicbawls > new.pgm" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./glicbawls < michael.pgm 2>/dev/null | ./glicbawls > new.pgm
+echo 1>&2
 
 echo "Now compare the michael.pgm to the screen output." 1>&2
 
 read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo "Now compare the new.pgm file to the michael.pgm file."
 
 read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 
-read -r -n -p 1 "Press any key to trying and use your screen width on lava bus pic: "
+read -r -n 1 -p "Press any key to try and use your screen width on lava bus pic: "
+echo 1>&2
 
-echo "$ ./glicbawls $COLUMNS < lavabus.pgm > lavabus.glic" 1>&2
+read -r -n 1 -p "Press any key to run: ./glicbawls $COLUMNS < lavabus.pgm > lavabus.glic: "
+echo 1>&2
 ./glicbawls "$COLUMNS" < lavabus.pgm > lavabus.glic
+echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
-
-echo "$ ./glicbawls -2 "$COLUMNS" < lavabus.pgm > lavabus.glic2"
+read -r -n 1 -p "Press any key to run: ./glicbawls -2 "$COLUMNS" < lavabus.pgm > lavabus.glic2: "
+echo 1>&2
 ./glicbawls -2 "$COLUMNS" < lavabus.pgm > lavabus.glic2
+echo 1>&2
 
 read -r -n 1 -p "Press any key to decompress the smaller glic-file: "
+echo 1>&2
 echo "$ ./glicbawls -2 150 < lavabus.glic2 > new.pgm" 1>&2
 ./glicbawls -2 150 < lavabus.glic2 > new.pgm
 

--- a/2000/dhyang/try.sh
+++ b/2000/dhyang/try.sh
@@ -16,38 +16,40 @@ make CC="$CC" all >/dev/null || exit 1
 clear
 
 
-echo "$ make saitou >/dev/null" 1>&2
-make saitou >/dev/null
-
-echo "$ ./saitou > aku.c" 1>&2
-./saitou > aku.c
-
-read -r -n 1 -p "Press any key to run: cat aku.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to run: make saitou >/dev/null || exit 1: "
 echo 1>&2
-cat aku.c | less -EXF
-
-echo "$ make soku >/dev/null" 1>&2
-make soku >/dev/null
-
-echo "$ ./soku > soku.c" 1>&2
-./soku > soku.c
-
-read -r -n 1 -p "Press any key to run: cat soku.c (space = next page, q = quit): "
+make saitou >/dev/null || exit 1
 echo 1>&2
-cat soku.c | less -EXF
 
-echo "$ make zan >/dev/null" 1>&2
-make zan >/dev/null
-
-echo "$ ./zan > zan.c" 1>&2
-./zan > zan.c
-
-read -r -n 1 -p "Press any key to run: cat zan.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to run: ./saitou | tee aku.c (space = next page, q = quit): "
 echo 1>&2
-cat zan.c | less -EXF
+./saitou | tee aku.c | less -rEXF
 
-echo "$ make aku >/dev/null" 1>&2
-make aku >/dev/null
+read -r -n 1 -p "Press any key to run: make soku >/dev/null || exit 1: "
+echo 1>&2
+make soku >/dev/null || exit 1
+echo 1>&2
 
-echo "$ ./aku | diff - aku.c" 1>&2
-./aku | diff - aku.c
+read -r -n 1 -p "Press any key to run: ./soku | tee soku.c (space = next page, q = quit): "
+echo 1>&2
+./soku | tee soku.c | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: make zan >/dev/null || exit 1: "
+echo 1>&2
+make zan >/dev/null || exit 1
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./zan | tee zan.c (space = next page, q = quit): "
+echo 1>&2
+./zan | tee zan.c | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: make aku >/dev/null || exit 1: "
+echo 1>&2
+make aku >/dev/null || exit 1
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./aku | diff -s - aku.c: "
+echo 1>&2
+./aku | diff -s - aku.c

--- a/2000/dlowe/try.sh
+++ b/2000/dlowe/try.sh
@@ -15,23 +15,37 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ echo '13 14 15 16 17 + - * / p' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '13 14 15 16 17 + - * / p' | ./dlowe: "
+echo 1>&2
 echo '13 14 15 16 17 + - * / p' | ./dlowe
+echo 1>&2
 
-echo "$ echo '12 13 14 15 16 + + + + f' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '12 13 14 15 16 + + + + f' | ./dlowe: "
+echo 1>&2
 echo '12 13 14 15 16 + + + + f' | ./dlowe
+echo 1>&2
 
-echo "$ echo '12 13 14 15 16 17 + - * / p' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '12 13 14 15 16 17 + - * / p' | ./dlowe: "
+echo 1>&2
 echo '12 13 14 15 16 17 + - * / p' | ./dlowe
+echo 1>&2
 
-echo "$ echo '+' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '+' | ./dlowe: "
+echo 1>&2
 echo '+' | ./dlowe
+echo 1>&2
 
-echo "$ echo '999999999999999 1 + p' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '999999999999999 1 + p' | ./dlowe: "
+echo 1>&2
 echo '999999999999999 1 + p' | ./dlowe
+echo 1>&2
 
-echo "$ echo '99999999999999 1 + p' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '99999999999999 1 + p' | ./dlowe: "
+echo 1>&2
 echo '99999999999999 1 + p' | ./dlowe
+echo 1>&2
 
-echo "$ echo '12.5 9 % 10 * 15 + f' | ./dlowe" 1>&2
+read -r -n 1 -p "Press any key to run: echo '12.5 9 % 10 * 15 + f' | ./dlowe: "
+echo 1>&2
 echo '12.5 9 % 10 * 15 + f' | ./dlowe
+echo 1>&2

--- a/2000/natori/try.sh
+++ b/2000/natori/try.sh
@@ -19,12 +19,15 @@ NATORI="natori"
 moon()
 {
     read -r -n 1 -p "Press any key to randomly show the northern/southern hemisphere Moon: "
+    echo 1>&2
     for ((i=0;i<=10;i++)); do
 	RAND=$((RANDOM % 1000))
 	if [[ "$RAND" -le 500 ]]; then
 	    ./"$NATORI"
+	    echo 1>&2
 	else
 	    ./"$NATORI".alt
+	    echo 1>&2
 	fi
     done
 
@@ -32,6 +35,7 @@ moon()
     RAND=$((RANDOM % 1000))
     if [[ "$RAND" -gt 500 ]]; then
 	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
 	./"$NATORI"
 	./"$NATORI".alt
 	./"$NATORI"
@@ -40,6 +44,7 @@ moon()
 	./"$NATORI".alt
     else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
+	echo 1>&2
 	./"$NATORI".alt
 	./"$NATORI"
 	./"$NATORI".alt
@@ -54,6 +59,7 @@ moon()
 
     if [[ "$RAND" -le 499 ]]; then
 	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
 	./"$NATORI"
 	./"$NATORI".alt
 	./"$NATORI"
@@ -62,6 +68,7 @@ moon()
 	./"$NATORI".alt
     else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
+	echo 1>&2
 	./"$NATORI".alt
 	./"$NATORI"
 	./"$NATORI".alt
@@ -77,12 +84,14 @@ moon()
     RAND=$((RANDOM % 1000))
     if [[ "$RAND" -gt 500 ]]; then
 	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
-	    ./"$NATORI.alt"; ./"$NATORI" ) | less
+	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
     fi
 
     echo 1>&2
@@ -91,12 +100,14 @@ moon()
     echo 1>&2
     if [[ "$RAND" -gt 500 ]]; then
 	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
-	    ./"$NATORI.alt"; ./"$NATORI" ) | less
+	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
     fi
     echo 1>&2
 
@@ -107,12 +118,14 @@ moon()
     echo 1>&2
     if [[ "$RAND" -le 499 ]]; then
 	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
-	    ./"$NATORI.alt"; ./"$NATORI" ) | less
+	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
     fi
 
     echo 1>&2
@@ -121,12 +134,14 @@ moon()
     echo 1>&2
     if [[ "$RAND" -le 499 ]]; then
 	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
+	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
-	    ./"$NATORI.alt"; ./"$NATORI" ) | less
+	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
     fi
     echo 1>&2
 }

--- a/2000/primenum/try.sh
+++ b/2000/primenum/try.sh
@@ -16,19 +16,29 @@ make CC="$CC" all >/dev/null || exit 1
 clear
 
 
-echo "$ echo IOCCC 23209 | ./primenum 23209" 1>&2
+read -r -n 1 -p "Press any key to run: echo IOCCC 23209 | ./primenum 23209: "
+echo 1>&2
 echo IOCCC 23209 | ./primenum 23209
 echo 1>&2
 
-echo "$ echo THIS MESSAGE IS IN ALL CAPS | ./primenum 32" 1>&2
+read -r -n 1 -p "Press any key to run: echo THIS MESSAGE IS IN ALL CAPS | ./primenum 32: "
+echo 1>&2
 echo THIS MESSAGE IS IN ALL CAPS | ./primenum 32
 echo 1>&2
 
 rm -f try.sh.txt
-echo "$ ./primenum 101 < try.sh | ./primenum n > try.sh.txt" 1>&2
+read -r -n 1 -p "Press any key to run: ./primenum 101 < try.sh | ./primenum n > try.sh.txt: "
+echo 1>&2
 ./primenum 101 < try.sh | ./primenum n > try.sh.txt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to show try.sh.txt (space = next page, q = quit): "
+echo 1>&2
+less -rEXF try.sh.txt
+echo 1>&2
+
 echo "$ diff try.sh try.sh.txt"
 read -r -n 1 -p "Press any key to see diff (space = next page, q = quit): " 1>&2
-diff try.sh try.sh.txt|less -EXF
+diff try.sh try.sh.txt | less -rEXF
 
 rm -f try.sh.txt

--- a/2000/rince/try.sh
+++ b/2000/rince/try.sh
@@ -15,26 +15,42 @@ make CC="$CC" everything >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./rince" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince: "
+echo 1>&2
 ./rince
+echo 1>&2
 
-echo "$ ./rince 0.001 $(./dmy2jd 7.8 1 1610)" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0.001 $(./dmy2jd 7.8 1 1610): "
+echo 1>&2
 ./rince 0.001 $(./dmy2jd 7.8 1 1610)
+echo 1>&2
 
-echo "$ ./rince 0.01" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0.01: "
+echo 1>&2
 ./rince 0.01
+echo 1>&2
 
-echo "$ ./rince 0 2441193.6" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0 2441193.6: "
+echo 1>&2
 ./rince 0 2441193.6
+echo 1>&2
 
-echo "$ ./rince 0.01 2441193.6" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0.01 2441193.6: "
+echo 1>&2
 ./rince 0.01 2441193.6
+echo 1>&2
 
-echo "$ ./rince 0 $(./dmy2jd 7.8 1 1610)" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0 $(./dmy2jd 7.8 1 1610): "
+echo 1>&2
 ./rince 0 $(./dmy2jd 7.8 1 1610)
+echo 1>&2
 
-echo "$ ./rince 0 $(./dmy2jd 8.8 1 1610)" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0 $(./dmy2jd 8.8 1 1610): "
+echo 1>&2
 ./rince 0 $(./dmy2jd 8.8 1 1610)
+echo 1>&2
 
-echo "$ ./rince 0 $(./dmy2jd 10.8 1 1610)" 1>&2
+read -r -n 1 -p "Press any key to run: ./rince 0 $(./dmy2jd 10.8 1 1610): "
+echo 1>&2
 ./rince 0 $(./dmy2jd 10.8 1 1610)
+echo 1>&2

--- a/2000/schneiderwent/README.md
+++ b/2000/schneiderwent/README.md
@@ -21,6 +21,13 @@ make
 
 What's the difference?
 
+If you have a long while to spare (and you're bored enough that you could watch
+paint dry :-) ) you might also try:
+
+```sh
+./try.sh
+```
+
 
 ## Judges' remarks:
 

--- a/2000/schneiderwent/try.sh
+++ b/2000/schneiderwent/try.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2000/schneiderwent
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "This will take a long time to run to completion: " 1>&2
+i=0
+while [[ "$i" -lt 60 ]]; do
+    ./schneiderwent
+    ./schneiderwent schneiderwent.data
+    sleep 60
+    ((i++))
+done
+
+
+

--- a/2000/tomx/try.alt.sh
+++ b/2000/tomx/try.alt.sh
@@ -16,21 +16,33 @@ make CC="$CC" alt >/dev/null || exit 1
 clear
 
 echo "Using tomx.alt.c to compile mkentry.c directly:" 1>&2
-echo "$ chmod +x tomx.alt.c" 1>&2
+read -r -n 1 -p "Press any key to run: chmod +x tomx.alt.c: "
+echo 1>&2
 chmod +x tomx.alt.c
-echo "$ rm -f mkentry" 1>&2
-rm -f mkentry
-echo "$ ./tomx.alt.c" 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: rm -vf mkentry: "
+echo 1>&2
+rm -vf mkentry
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./tomx.alt.c: "
+echo 1>&2
 ./tomx.alt.c
 echo 1>&2
 
 echo "Using tomx.alt.c as a Makefile to compile mkentry.c:" 1>&2
-echo "$ rm -f mkentry"
-rm mkentry
-echo "$ make -f tomx.alt.c" 1>&2
+read -r -n 1 -p "Press any key to run: rm -vf mkentry: "
+echo 1>&2
+rm -vf mkentry
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: make -f tomx.alt.c: "
+echo 1>&2
 make -f tomx.alt.c
 echo 1>&2
 
-echo "Running mkentry via tomx.alt:" 1>&2
-echo "$ ./tomx.alt" 1>&2
+read -r -n 1 -p "Press any key to run: ./tomx.alt: "
+echo 1>&2
 ./tomx.alt
+echo 1>&2

--- a/2000/tomx/try.sh
+++ b/2000/tomx/try.sh
@@ -15,28 +15,43 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "Running tomx:" 1>&2
-echo "$ ./tomx" 1>&2
+read -r -n 1 -p "Press any key to run: ./tomx: "
+echo 1>&2
 ./tomx
 echo 1>&2
 
 echo "Using source code to compile tomx.c: " 1>&2
-echo "$ rm -f tomx" 1>&2
-rm -f tomx
-echo "$ chmod +x tomx.c" 1>&2
+read -r -n 1 -p "Press any key to run: rm -vf tomx: "
+echo 1>&2
+rm -vf tomx
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: chmod +x tomx.c: "
+echo 1>&2
 chmod +x tomx.c
-echo "$ ./tomx.c" 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./tomx.c: "
+echo 1>&2
 ./tomx.c
-echo "Running tomx again:" 1>&2
-echo "$ ./tomx" 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./tomx (a second time): "
+echo 1>&2
 ./tomx
 
 echo 1>&2
 echo "Using tomx.c as a Makefile:" 1>&2
-echo "$ rm -f tomx" 1>&2
-rm -f tomx
-echo "$ make -f tomx.c" 1>&2
+read -r -n 1 -p "Press any key to run: rm -vf tomx: "
+echo 1>&2
+rm -vf tomx
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: make -f tomx.c: "
+echo 1>&2
 make -f tomx.c
-echo "Running tomx again:" 1>&2
-echo "$ ./tomx"
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./tomx (a third time): "
+echo 1>&2
 ./tomx
+echo 1>&2

--- a/2001/anonymous/try.sh
+++ b/2001/anonymous/try.sh
@@ -19,26 +19,55 @@ clear
 
 TARGET="anonymous.ten"
 if [[ -f "$TARGET" ]]; then
-    echo "$ cp $TARGET anonymous.ten.bak" 1>&2
-    cp "$TARGET" anonymous.ten.bak
-    echo "$ ./anonymous $TARGET" 1>&2
-    ./anonymous "$TARGET"
-    echo "$ ./$TARGET" 1>&2
-    ./"$TARGET"
-    echo "$ diff -s $TARGET anonymous.ten.bak" 1>&2
+    read -r -n 1 -p "Press any key to run: cp -vf $TARGET anonymous.ten.bak: "
+    echo 1>&2
+    cp -vf "$TARGET" anonymous.ten.bak
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./anonymous $TARGET (space = next page, q = quit): "
+    echo 1>&2
+    ./anonymous "$TARGET" | less -rEXF
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./$TARGET (space = next page, q = quit): "
+    echo 1>&2
+    ./"$TARGET" | less -rEXF
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: diff -s $TARGET anonymous.ten.bak: "
+    echo 1>&2
     diff -s "$TARGET" anonymous.ten.bak
-    echo "$ od -t x1 $TARGET > ten.od" 1>&2
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: od -t x1 $TARGET > ten.od: "
+    echo 1>&2
     od -t x1 "$TARGET" > ten.od
-    echo "$ od -t x1 anonymous.ten.bak > ten.bak.od" 1>&2
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: od -t x1 anonymous.ten.bak > ten.bak.od: "
+    echo 1>&2
     od -t x1 anonymous.ten.bak > ten.bak.od
-    echo "$ diff ten.bak.od ten.od" 1>&2
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: diff ten.bak.od ten.od: "
+    echo 1>&2
     diff ten.bak.od ten.od
-    echo "$ ./$TARGET > ten.txt" 1>&2
-    ./"$TARGET" > ten.txt
-    echo "$ ./anonymous.ten.bak > ten.bak.txt" 1>&2
-    ./anonymous.ten.bak > ten.bak.txt
-    echo "$ diff -s ten.txt ten.bak.txt" 1>&2
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./$TARGET | tee ten.txt (space = next page, q = quit): "
+    echo 1>&2
+    ./"$TARGET" | tee ten.txt | less -rEXF
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./anonymous.ten.bak | tee ten.bak.txt (space = next page, q = quit): "
+    echo 1>&2
+    ./anonymous.ten.bak | tee ten.bak.txt | less -rEXF
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: diff -s ten.txt ten.bak.txt: "
+    echo 1>&2
     diff -s ten.txt ten.bak.txt
+    echo 1>&2
 else
     echo "cannot compile anonymous.ten.c as 32-bit, sorry."
     echo "will run alt versions directly."

--- a/2001/cheong/try.sh
+++ b/2001/cheong/try.sh
@@ -15,21 +15,33 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./cheong 1024" 1>&2
+read -r -n 1 -p "Press any key to run: ./cheong 1024: "
+echo 1>&2
 ./cheong 1024
+echo 1>&2
 
-echo "$ ./cheong 0512" 1>&2
+read -r -n 1 -p "Press any key to run: ./cheong 0512: "
+echo 1>&2
 ./cheong 0512
+echo 1>&2
 
-echo "$ ./cheong 12345678901234567890" 1>&2
+read -r -n 1 -p "Press any key to run: ./cheong 12345678901234567890: "
+echo 1>&2
 ./cheong 12345678901234567890
+echo 1>&2
 
-echo "$ ./cheong 05305265226926441255040573044986873789" 1>&2
+read -r -n 1 -p "Press any key to run: ./cheong 05305265226926441255040573044986873789: "
+echo 1>&2
 ./cheong 05305265226926441255040573044986873789
+echo 1>&2
 
-echo "$ ./cheong 1234567890" 1>&2
+read -r -n 1 -p "Press any key to run: ./cheong 1234567890: "
+echo 1>&2
 ./cheong 1234567890
+echo 1>&2
 
-echo "$ ./cheong 0200000000000000000000000000" 1>&2
+read -r -n 1 -p "Press any key to run: ./cheong 0200000000000000000000000000: "
+echo 1>&2
 ./cheong 0200000000000000000000000000
+echo 1>&2
 

--- a/2001/herrmann1/README.md
+++ b/2001/herrmann1/README.md
@@ -31,13 +31,7 @@ need an older compiler perhaps gcc 2.95.
 ## Try:
 
 ```sh
-./herrmann1.sh 'prg=herrmann1.times2'
-```
-
--or-
-
-```sh
-./herrmann1.sh 'prg=herrmann1.gcd'
+./try.sh
 ```
 
 

--- a/2001/herrmann1/try.sh
+++ b/2001/herrmann1/try.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2001/herrmann1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# in this case we won't fail if we can't compile the code because we can still
+# run the supplementary program.
+make CC="$CC" everything >/dev/null
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "$ ./herrmann1.sh 'prg=herrmann1.times2'" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./herrmann1.sh 'prg=herrmann1.times2'
+echo 1>&2
+
+echo "$ ./herrmann1.sh 'prg=herrmann1.gcd'" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./herrmann1.sh 'prg=herrmann1.gcd'
+echo 1>&2
+

--- a/2001/herrmann2/try.sh
+++ b/2001/herrmann2/try.sh
@@ -28,7 +28,8 @@ echo "$ ./herrmann2 \
 '++  &&r:b<<2+a +w) ((!main(n*n,V) , +-) ),l)),w= +T-->o +o+;{ &!'\
 'a;}return _+= ' < herrmann2.ioccc > herrmann2.orig.c && \
 echo && diff -s herrmann2.alt.c herrmann2.orig.c" 1>&2
-
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./herrmann2 \
 'char*d,A[9876];e;b;*ad,a,c;  tw,ndr,T; wri; ;*h; _,ar  ;on;'\
 ' ;l ;i(V)man,n    {-!har  ;   =Aadre(0,&e,o||n -- +,o4,=9,l=b=8,'\
@@ -39,26 +40,31 @@ echo && diff -s herrmann2.alt.c herrmann2.orig.c" 1>&2
 '++  &&r:b<<2+a +w) ((!main(n*n,V) , +-) ),l)),w= +T-->o +o+;{ &!'\
 'a;}return _+= ' < herrmann2.ioccc > herrmann2.orig.c && \
 echo && diff -s herrmann2.alt.c herrmann2.orig.c
-
 echo 1>&2
+
 echo "./herrmann2 "234 84 045 5 6765 7487 65190 84 656 254 12 43931 818 0 6542 \
 341 45 567 76967 7244 606 976567 895 81898 095 68678 1843 4650547 \
 565980691 389 04974" < herrmann2.ioccc" 1>&2
-
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./herrmann2 "234 84 045 5 6765 7487 65190 84 656 254 12 43931 818 0 6542 \
 341 45 567 76967 7244 606 976567 895 81898 095 68678 1843 4650547 \
 565980691 389 04974" < herrmann2.ioccc
 echo 1>&2
 
-rm -f ioccc.out ioccc.out2
+read -r -n 1 -p "Press any key to run: rm -vf ioccc.out ioccc.out2: "
+echo 1>&2
+rm -vf ioccc.out ioccc.out2
+
 read -r -n 1 -p "Press any key to test the output a couple times on herrmann2.ioccc: "
 echo "$ ./herrmann2 < herrmann2.ioccc" 1>&2
 ./herrmann2 < herrmann2.ioccc | tee ioccc.out
 sleep 2
 echo "$ ./herrmann2 < herrmann2.ioccc" 1>&2
 ./herrmann2 < herrmann2.ioccc | tee ioccc.out2
-echo "$ diff ioccc.out ioccc.out2" 1>&2
-diff ioccc.out ioccc.out2
+read -r -n 1 -p "Press any key to run: diff -s ioccc.out ioccc.out2: "
+echo 1>&2
+diff -s ioccc.out ioccc.out2
 rm -f ioccc.out ioccc.out2
 echo 1>&2
 
@@ -68,7 +74,9 @@ echo "$ ./herrmann2 < herrmann2.cup" 1>&2
 sleep 2
 echo "$ ./herrmann2 < herrmann2.cup" 1>&2
 ./herrmann2 < herrmann2.cup | tee cup.out2
-echo "$ diff cup.out cup.out2" 1>&2
-diff cup.out cup.out2
+read -r -n 1 -p "Press any key to run: diff -s cup.out cup.out2: "
+echo 1>&2
+diff -s cup.out cup.out2
+echo 1>&2
 
 rm -f cup.out cup.out2

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -15,7 +15,7 @@ make
 ## Try:
 
 ```sh
-./ollinger 1000 | cut -c -200
+./try.sh
 ```
 
 Try the above command in a large window, say 200 chars wide and 100

--- a/2001/ollinger/try.sh
+++ b/2001/ollinger/try.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2001/ollinger
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# in this case we won't fail if we can't compile the code because we can still
+# run the supplementary program.
+make CC="$CC" everything >/dev/null
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: ./ollinger 1000 | cut -c -200 (space = next page, q = quit): "
+echo 1>&2
+./ollinger 1000 | cut -c -200 | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./ollinger 1000 | cut -c -100 (space = next page, q = quit): "
+echo 1>&2
+./ollinger 1000 | cut -c -100 | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./ollinger 42 (space = next page, q = quit): "
+echo 1>&2
+./ollinger 42 | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./ollinger 42 | cut -c -100 (space = next page, q = quit): "
+echo 1>&2
+./ollinger 42 | cut -c -100 | less -rEXF
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./ollinger 42 | cut -c -200 (space = next page, q = quit): "
+echo 1>&2
+./ollinger 42 | cut -c -200 | less -rEXF
+echo 1>&2

--- a/2001/schweikh/try.sh
+++ b/2001/schweikh/try.sh
@@ -15,11 +15,17 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./schweikh foo 'f??'; echo \$?" 1>&2
+read -r -n 1 -p "Press any key to run: ./schweikh foo 'f??'; echo \$?: "
+echo 1>&2
 ./schweikh foo 'f??'; echo $?
+echo 1>&2
 
-echo "$ ./schweikh 'best short program' '??st*o**p?*'; echo \$?" 1>&2
+read -r -n 1 -p "Press any key to run: ./schweikh 'best short program' '??st*o**p?*'; echo \$?: "
+echo 1>&2
 ./schweikh 'best short program' '??st*o**p?*'; echo $?
+echo 1>&2
 
-echo "$ ./schweikh bar 'f??'; echo \$?" 1>&2
+read -r -n 1 -p "Press any key to run: ./schweikh bar 'f??'; echo \$?: "
+echo 1>&2
 ./schweikh bar 'f??'; echo $?
+echo 1>&2

--- a/2001/westley/try.sh
+++ b/2001/westley/try.sh
@@ -15,40 +15,67 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "./westley < westley.c 2>/dev/null > westley2.c" 1>&2
-./westley < westley.c 2>/dev/null > westley2.c
+echo "$ ./westley < westley.c 2>/dev/null | tee westley2.c" 1>&2
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./westley < westley.c 2>/dev/null | tee westley2.c | less -rEXF
+
 echo "Compiling westley2.c..." 1>&2
 make CC="$CC" westley2 2>/dev/null 1>&2
-echo
+echo 1>&2
 echo "$ echo 'Bozos, please deflate shoes before entering the bus!'| ./westley2 2>/dev/null"
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo 'Bozos, please deflate shoes before entering the bus!'| ./westley2 2>/dev/null
-echo
+echo 1>&2
 
+read -r -n 1 -p "Press any key to run: make CC=\"$CC\" westley.sort 2>/dev/null: "
+echo 1>&2
 make CC="$CC" westley.sort 2>/dev/null 1>&2
-echo
-echo "./westley.sort < westley.c 2>/dev/null | diff - westley.c"
+echo 1>&2
+
+echo "$ ./westley.sort < westley.c 2>/dev/null | diff -s - westley.c"
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
 # SC2094 (info): Make sure not to read and write the same file in the same pipeline.
 # shellcheck disable=SC2094
-./westley.sort < westley.c 2>/dev/null | diff - westley.c
-echo "./westley.sort < westley.c 2>/dev/null | diff - westley2.c"
-./westley.sort < westley.c 2>/dev/null | diff - westley2.c
-echo "./westley.sort < westley.c 2>/dev/null | diff - westley.sort.c"
-./westley.sort < westley.c 2>/dev/null | diff - westley.sort.c
-echo "./westley.sort < westley.c 2>/dev/null | diff - westley.punch.c"
-./westley.sort < westley.c 2>/dev/null | diff - westley.punch.c
+./westley.sort < westley.c 2>/dev/null | diff -s - westley.c | less -rEXF
+echo 1>&2
 
-echo
+echo "$ ./westley.sort < westley.c 2>/dev/null | diff - westley2.c"
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./westley.sort < westley.c 2>/dev/null | diff -s - westley2.c | less -rEXF
+echo 1>&2
+
+echo "$ ./westley.sort < westley.c 2>/dev/null | diff - westley.sort.c"
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./westley.sort < westley.c 2>/dev/null | diff - westley.sort.c | less -rEXF
+echo 1>&2
+
+echo "$ ./westley.sort < westley.c 2>/dev/null | diff - westley.punch.c"
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
+echo 1>&2
+./westley.sort < westley.c 2>/dev/null | diff - westley.punch.c | less -rEXF
+
+echo 1>&2
 # SC2028 (info): echo may not expand escape sequences. Use printf.
 # shellcheck disable=SC2028
-echo "printf \"1\n\4\n5\" | ./westley 2>/dev/null"
+read -r -n 1 -p "Press any key to run: printf \"1\n\4\n5\" | ./westley 2>/dev/null: "
+echo 1>&2
 printf "1\n4\n5" | ./westley 2>/dev/null
+echo 1>&2
 
-echo
+echo 1>&2
 # SC2028 (info): echo may not expand escape sequences. Use printf.
 # shellcheck disable=SC2028
-echo "printf \"1\n4\n5\" | ./westley 2>/dev/null"
+read -r -n 1 -p "Press any key to run: printf \"1\n4\n5\" | ./westley 2>/dev/null: "
+echo 1>&2
 printf "1\n4\n5" | ./westley 2>/dev/null
+echo 1>&2
 
-echo
-echo "echo 'Hello, world!' | ./westley.punch 2>/dev/null"
+echo 1>&2
+read -r -n 1 -p "Press any key to run: echo 'Hello, world!' | ./westley.punch 2>/dev/null: "
+echo 1>&2
 echo 'Hello, world!' | ./westley.punch 2>/dev/null

--- a/faq.md
+++ b/faq.md
@@ -886,17 +886,19 @@ will too but it won't reset the terminal).
 ### <a name="faq3_7"></a><a name="X11macos"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC winner that requires X11?
 
 
-#### <a name="X11_general"></a>Generically, to compile and run an IOCCC winner that requires X11:
+#### <a name="X11_general"></a>Generally, to compile and run an IOCCC winner that requires X11:
 
-In order to have the X11 related include files and X11 libraries in order to compile the IOCCC winner,
-you will need to install Xorg and related packages including development related packages. In particular:
+You must have the X11 related include files and X11 libraries in order to
+compile the IOCCC winner. In order to do this you will need to install Xorg and
+related packages including development related packages. If you have macOS see
+further down for different instructions. Otherwise: in particular you must:
 
-* Install the Xorg server
-* Configure the Xorg server for your graphics environment
-* Install a X11 terminal application
-* Start the Xorg server
-* Launch the X11 terminal application
-* Run the IOCCC winner in the X11 terminal application
+* Install the Xorg server.
+* Configure the Xorg server for your graphics environment.
+* Install a X11 terminal application.
+* Start the Xorg server.
+* Launch the X11 terminal application.
+* Run the IOCCC winner in the X11 terminal application.
 
 By X11 terminal application we suggest one of:
 
@@ -904,42 +906,49 @@ By X11 terminal application we suggest one of:
 * [KDE](https://kde.org) terminal application
 * `xterm(`) terminal application
 
-See the below for various system related hints that may be of help.
+See below for various system related hints that may be of help.
 
 
 #### <a name="Xorg_deprecated"></a>X.org server has been deprecated
 
-The Red Hat RHEL9.0 release notes state that [X.org Server is now deprecated](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#deprecated-functionality_graphics-infrastructures).
+The Red Hat RHEL9.0 release notes state that [X.org Server is now
+deprecated](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality#deprecated-functionality_graphics-infrastructures).
 
-According to this [Linux for Devices tutorial on XOrg](https://www.linuxfordevices.com/tutorials/linux/install-xorg-on-linux)
-as of 2023 Mar 25::
+According to this [Linux for Devices tutorial on
+XOrg](https://www.linuxfordevices.com/tutorials/linux/install-xorg-on-linux) as
+of 2023 Mar 25:
 
-```
-Recently, RHEL developers categorized Xorg was put in the ‘deprecated’
-software, as its development has mostly halted. Subsequent updates
-will completely replace it with Wayland, a more modern windowing
-system.. Although Wayland is not fully developed yet, many applications
-do not support it properly yet and screen sharing might not work
-sometime, but it is the future. Fedora, also developed by RHEL, has
-switched to a Wayland session as it’s default windowing system (And
-it works flawlessly on my Laptop).
-```
+
+> Recently, RHEL developers categorized [Xorg was put in the ‘deprecated’
+software](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality),
+as its development has mostly halted. Subsequent updates will completely replace
+it with Wayland, a more modern windowing system.. Although Wayland is not fully
+developed yet, many applications do not support it properly yet and screen
+sharing might not work sometime, but it is the future. Fedora, also developed by
+RHEL, has switched to a Wayland session as it’s default windowing system (And it
+works flawlessly on my Laptop).
 
 See the [Wayland](https://wayland.freedesktop.org) web site for more details.
 
-**IMPORTANT NOTE**: We do **NOT** know if IOCCC winners will run under **Wayland**.
-Some IOCCC winners that use X11 might be OK while other IOCCC winners that use X11 in an unusual way might fail
-under **Wayland**.
+**IMPORTANT NOTE**: We do **NOT** know if IOCCC winners will run under
+**Wayland**.  Some IOCCC winners that use X11 might be OK while other IOCCC
+winners that use X11 in an unusual way might fail under **Wayland**.
 
-See the [Wayland FAQ](https://wayland.freedesktop.org/faq.html) for more information.
 
-If your system uses **Wayland** and not X11, you might give the IOCCC winners that use X11 a try.
-They might work.
+See the [Wayland FAQ](https://wayland.freedesktop.org/faq.html) for more
+information.
 
-**IMPORTANT NOTE**: The [IOCCC judges [do not support support IOCCC winners](#no_support).
+If your system uses **Wayland** and not X11, you might give the IOCCC winners
+that use X11 a try.  They might work but again we do not know.
+
+**IMPORTANT NOTE**: The [IOCCC judges](/judges.html) [do not support IOCCC winners](#no_support).
 So if an IOCCC winner that uses X11 fails under **Wayland**, and you wish to
 provide a fix to the IOCCC winner so that it will run under **Wayland**,
 then consider [submitting a fix](#fix_a_winner) so that it will run under **Wayland**.
+
+Basically: if you discover an entry does not work in Wayland you are welcome to
+provide **alternate code** that works for Wayland. We will happily credit you in
+the [thanks-for-help.md](/thanks-for-help.md) file.
 
 
 #### Red Hat based Linux
@@ -956,7 +965,8 @@ See also:
 
 * [How to Configure X11 in Linux](https://www.wikihow.com/Configure-X11-in-Linux)
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### macOS
@@ -973,7 +983,7 @@ with macOS 14.2.1 (macOS Sonoma).
 First of all you will need to install the [most recent
 XQuartz](https://www.xquartz.org), preferably on an [Apple supported version of
 macOS, preferably the most recent version](https://support.apple.com/macos).
-Then open the "XQuartz" application (usually located in
+After it is installed, open the "XQuartz" application (usually located in
 `/Applications/Utilities/XQuartz.app`) by typing at the command line:
 
 ```sh
@@ -996,30 +1006,35 @@ And then run the program as directed by the `README.md` file. For example with
 <img alt="running 1993/jonth in macOS" src="png/xquartz-1993-jonth.png">
 
 Note that you can compile the code in your regular terminal prior to opening
-XQuartz, should you wish to.
+XQuartz, should you wish to. You can even run it from that terminal and it
+should open XQuartz.
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### Debian based Linux
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-According to the [Debian Xorg wiki](https://wiki.debian.org/Xorg), installing X11 requires:
+According to the [Debian Xorg wiki](https://wiki.debian.org/Xorg), installing
+X11 requires:
 
 ```sh
 sudo apt install xorg
 ```
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### Other Linux distributions
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-For general documentation on installing  X11, this [ServerGUI for Ubuntu](https://help.ubuntu.com/community/ServerGUI),
-and in particular, this may be helpful:
+For general documentation on installing  X11, this [ServerGUI for
+Ubuntu](https://help.ubuntu.com/community/ServerGUI), and in particular, these
+may be helpful:
 
 * [X11 Client Installation](https://help.ubuntu.com/community/ServerGUI#X11_Client_Installation)
 * [X11 Server Installation](https://help.ubuntu.com/community/ServerGUI#X11_Server_Installation)
@@ -1041,7 +1056,8 @@ For systems that have the `yum(1)` command:
 sudo yum install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
 ```
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 #### package website
@@ -1050,7 +1066,8 @@ First, see the above note on [installing and starting Xorg](#X11_general).
 
 See the [X.org](https://x.org/wiki/) foundation web site.
 
-**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).  See the above note for details.
+**IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
+See the above note for details.
 
 
 ### <a name="faq3_8"></a><a name="SDL"></a>FAQ 3.8: How do I compile an IOCCC winner that requires SDL1 or SDL2?

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2269,10 +2269,14 @@ prior to each run.
 [Cody](#cody) changed a `int *` used for `fopen(3)` to be a `FILE *` to be more correct
 and prevent any possible problems in some systems (which has happened).
 
-Cody also made the fixed version look more like the original version by using
+Cody also made the fixed version to look more like the original version by using
 the old style of `main()` args so that it reads `i,love_unix` more naturally,
-and by changing the typedef `lint` (to `int` - see the code for why this has to
-be done in modern systems) to be `_int`.
+and by changing the `typedef int lint` to be `typedef int _int`. See the code
+for why this has to be done this way.
+
+Cody also added the [try.sh](/1998/df/try.sh) script which runs the program in a
+loop until one hits `q` (or `Q`) or sends intr/ctrl-c. He also proposed there's
+a way to cheat very easily. Can you figure out how?
 
 
 ## <a name="1998_dlowe"></a>[1998/dlowe](/1998/dlowe/dlowe.c) ([README.md](/1998/dlowe/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2192,6 +2192,13 @@ suggested that one try the longer version too but it will run in an infinite
 loop so having it in a script is less desired).
 
 
+## <a name="1996_schweikh3"></a>[1996/schweikh3](/1996/schweikh3/schweikh3.c) ([README.md](/1996/schweikh3/README.md]))
+
+[Cody](#cody) updated the Makefile so that if it fails to compile it will try he
+method suggested for SunOS rather than having to update the Makefile manually or
+running a more complicated command: now one can just run `make`.
+
+
 ## <a name="1996_westley"></a>[1996/westley](/1996/westley/westley.c) ([README.md](/1996/westley/README.md]))
 
 [Cody](#cody) fixed a segfault in this entry as well as it displaying environmental

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -35,9 +35,9 @@ on a winner by winner basis.
 
 [Cody](#cody) fixed this to work for macOS.
 
-The problem was to do with the way that the `read(/2)` function was redefined.
+The problem was to do with the way that the `read(2)` function was redefined.
 With macOS the second arg needs to be a `void *` and this also necessitated some
-casts to `int` (on the second arg) in the call to `write(/2)` (in `read()`).
+casts to `int` (on the second arg) in the call to `write(2)` (in `read()`).
 
 Later Cody corrected the mistake where the `"hello, world!"` string was on one
 line rather than two lines which the author told us (Landon) that they liked.
@@ -788,7 +788,7 @@ Cody also added the [try.sh](/1989/fubar/try.sh) script.
 ## <a name="1989_jar.1"></a>[1989/jar.1](/1989/jar.1/jar.1.c) ([README.md](/1989/jar.1/README.md]))
 
 To prevent annoying output to `/dev/tty` we changed the code to simulate the
-output via `strings(/1)` but [Cody](#cody) removed the ill-famed `useless use of cat` to
+output via `strings(1)` but [Cody](#cody) removed the ill-famed `useless use of cat` to
 shut [ShellCheck](https://github.com/koalaman/shellcheck) up.
 Why is it ill-famed? Because there is no such thing as a
 useless cat, that's why! For instance, the fact they even exist is proof that
@@ -1435,14 +1435,14 @@ was never fixed in any of the files, not the code or the documentation, and thus
 was entirely incorrect code. A fun fact is that one can do:
 
 ```c
-W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(/1);
+W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(1);
 ```
 
 but one _CANNOT_ do:
 
 ```c
-W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(/1);
-if (W==NULL)exit(/1);
+W= fopen(wc>= 2 ? V[1] : __FILE__,"rt");if(!W)exit(1);
+if (W==NULL)exit(1);
 ```
 
 because `adwc.c` will be empty! The difference is it is on a newline, the check.
@@ -1647,7 +1647,7 @@ that we suggested as well as one he provided.
 [Cody](#cody) fixed an infinite loop if one were to input numbers < `0` or > `077`. The
 problem was that it tried to use `scanf(3)` with the format specifier `"%o %o"` in a
 loop, reading again if `scanf(3)` did not return 2 (that was not a problem in
-that `scanf(/2)` will not return until the number of specifiers have been
+that `scanf(2)` will not return until the number of specifiers have been
 processed or some error occurs) or a function it called returned non-zero.
 
 Instead the fix involves the `scanf(3)` specifiers being `"%4s %4s"` on two
@@ -1785,7 +1785,7 @@ of the alt one allowing one to change the amount to sleep).
 ## <a name="1993_rince"></a>[1993/rince](/1993/rince/rince.c) ([README.md](/1993/rince/README.md]))
 
 [Yusuke](#yusuke) supplied a patch to get this to work in modern systems. This fix also
-applies the compatibility issue of `select(/2)` described in the README.md file.
+applies the compatibility issue of `select(2)` described in the README.md file.
 
 [Cody](#cody) added a call to `endwin()` to help with terminal sanity after the program
 ends.
@@ -2100,7 +2100,7 @@ also fixed an infinite loop in the try commands.
 
 The problem with the infinite loop is that the file `august.oc` had to have
 lines starting with `#` removed and it was not being done. After this is done
-with say `sed(/1)` (like `sed -i'' '/^#/d' august.oc` which has been added to
+with say `sed(1)` (like `sed -i'' '/^#/d' august.oc` which has been added to
 both the remarks and the `try.sh` script noted below) the code can proceed. This
 problem existed in macOS.
 
@@ -2343,7 +2343,7 @@ doesn't crash. At this point since the author stated it has no `while`,
 doing:
 
 ```c
-((V[1]&&((atoi(V[1])>0&&atoi(V[1])<27))||(exit(/1),1)));
+((V[1]&&((atoi(V[1])>0&&atoi(V[1])<27))||(exit(1),1)));
 ```
 
 Cody also added the [try.sh](/1998/schnitzi/try.sh) script to help users try the
@@ -3030,7 +3030,7 @@ is entirely possible it will eventually be that they don't.
 Cody also added the [try.sh](/2004/kopczynski/try.sh) script and various data
 files: [kopczynski-a](kopczynski-a) to demonstrate what happens when art more
 like a letter is fed to the program and the `kopczynski*-rev` files which are
-the data files reversed with `rev(/1)`. One had to be modified additionally to
+the data files reversed with `rev(1)`. One had to be modified additionally to
 get it to work, that being `kopczynski-10-rev`.
 
 
@@ -3141,7 +3141,7 @@ suite.
 not work and end up causing a bus error. Instead of `stty sane` it uses `stty
 echo` which is what it was trying to accomplish.
 
-The author noted that one can define `NO_STTY` to not use `stty(/1)` at all
+The author noted that one can define `NO_STTY` to not use `stty(1)` at all
 (either to prevent having to hit enter or to turn echo off/on) which is
 explained in the README.md.
 
@@ -3931,8 +3931,8 @@ this broke `make` which Cody also fixed.
 ## <a name="2013_mills"></a>[2013/mills](/2013/mills/mills.c) ([README.md)[2013/mills/README.md))
 
 [Cody](#cody) fixed this so that the server would not refuse the connection
-after the first call to `close(/2)`. The problem was that because the backlog to
-`listen(/2)` was 1 once the connection closed the server was essentially 'dead'.
+after the first call to `close(2)`. The problem was that because the backlog to
+`listen(2)` was 1 once the connection closed the server was essentially 'dead'.
 The backlog was changed to 10 and this solves the problem. It is not known if
 this was specific to macOS but it was not specific to a browser as Safari and
 Firefox both had the problem.

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2173,14 +2173,15 @@ NOTE: if there is no X server running this program will still crash.
 
 ## <a name="1996_schweikh1"></a>[1996/schweikh1](/1996/schweikh1/schweikh1.c) ([README.md](/1996/schweikh1/README.md]))
 
+[Cody](#cody) added the [try.sh](/1996/schweikh1/try.sh) script.
+
 The author stated that `-I/usr/include` is needed by gcc in Solaris because
 `errno.h` has two identical extern declarations of `errno`. That leads to an
 error due to the redefinition of `main` but the `-I` option makes sure the
 working `/usr/include/rrno.h` is found first, which shouldn't cause any problems
 on other systems (the other file is
-`gcc-lib/sparc-sun-solaris2.5/2.7.2/include/errno.h`). Thus Cody added this to
+`gcc-lib/sparc-sun-solaris2.5/2.7.2/include/errno.h`). Thus Cody also added this to
 the Makefile despite the fact that very few probably use Solaris nowadays.
-
 
 
 ## <a name="1996_schweikh2"></a>[1996/schweikh2](/1996/schweikh2/schweikh2.c) ([README.md](/1996/schweikh2/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2096,15 +2096,17 @@ Cody also added the [try.sh](/1995/vanschnitz/try.sh) script.
 ## <a name="1996_august"></a>[1996/august](/1996/august/august.c) ([README.md](/1996/august/README.md]))
 
 [Cody](#cody) fixed a segfault in this program that prevented it from working right and
-also fixed an infinite loop in the try commands. The problem with the infinite
-loop is that the file `august.oc` had to have lines starting with `#` removed
-and it was not being done. After this is done with say `sed(/1)` (like `sed -i''
-'/^#/d' august.oc` which has been added to both the remarks and the `try.sh`
-script noted below) the code can proceed. This problem existed in macOS.
+also fixed an infinite loop in the try commands.
+
+The problem with the infinite loop is that the file `august.oc` had to have
+lines starting with `#` removed and it was not being done. After this is done
+with say `sed(/1)` (like `sed -i'' '/^#/d' august.oc` which has been added to
+both the remarks and the `try.sh` script noted below) the code can proceed. This
+problem existed in macOS.
 
 Cody also added the [try.sh](/1996/august/try.sh) script that runs all the
-commands given in the try section to simplify it as there are quite a lot of
-commands.
+commands that were given by the judges in the try section, with the fix above
+applied.
 
 
 ## <a name="1996_dalbec"></a>[1996/dalbec](/1996/dalbec/dalbec.c) ([README.md](/1996/dalbec/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2166,6 +2166,11 @@ the function in the pointer assignment.
 NOTE: if there is no X server running this program will still crash.
 
 
+## <a name="1996_rcm"></a>[1996/rcm](/1996/rcm/rcm.c) ([README.md](/1996/rcm/README.md]))
+
+[Cody](#cody) added the [try.sh](/1996/rcm/try.sh) script.
+
+
 ## <a name="1996_schweikh1"></a>[1996/schweikh1](/1996/schweikh1/schweikh1.c) ([README.md](/1996/schweikh1/README.md]))
 
 The author stated that `-I/usr/include` is needed by gcc in Solaris because

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2849,6 +2849,8 @@ SC2248 (style): Prefer double quoting even when variables don't contain special 
 
 errors/warnings.
 
+Cody also added the [try.sh](/2001/herrmann1/try.sh) script.
+
 
 ## <a name="2001_herrmann2"></a>[2001/herrmann2](/2001/herrmann2/herrmann2.c) ([README.md](/2001/herrmann2/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2570,6 +2570,11 @@ on it to assign to the `int`s, much like with `1987/lievaart`. The strings are
 `char[5]` and the `%` specifier is `%4s` which is enough for the game.
 
 
+## <a name="2000_schneiderwent"></a>[2000/schneiderwent](/2000/schneiderwent/schneiderwent.c) ([README.md](/2000/schneiderwent/README.md]))
+
+[Cody](#cody) added the [try.sh](/2000/schneiderwent/try.sh) script.
+
+
 ## <a name="2000_thadgavin"></a>[2000/thadgavin](/2000/thadgavin/thadgavin.c) ([README.md](/2000/thadgavin/README.md]))
 
 [Cody](#cody) fixed the code and added an appropriate make rule so that the

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2259,6 +2259,10 @@ as well as allowing one to pass in different file names or strings.
 [Cody](#cody) added a call to `endwin()` to restore terminal sanity (echo etc.) when
 exiting the program (in both versions).
 
+Cody also added the [try.sh](/1998/chaos/try.sh) script that runs the program on
+all the data files, giving instructions on how to rotate and zoom in and out,
+prior to each run.
+
 
 ## <a name="1998_df"></a>[1998/df](/1998/df/df.c) ([README.md](/1998/df/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2889,7 +2889,11 @@ without having to sacrifice playability by running `make`.
 
 ## <a name="2001_ollinger"></a>[2001/ollinger](/2001/ollinger/ollinger.c) ([README.md](/2001/ollinger/README.md))
 
-[Cody](#cody) fixed to not crash if not enough args, exiting 1 instead.
+[Cody](#cody) added the [try.sh](/2001/ollinger/try.sh) script.
+
+Cody also fixed it to not crash if not enough args, exiting 1 instead. This was
+done at a time where it was said to be a bug that should be fixed, for better or
+worse.
 
 
 ## <a name="2001_schweikh"></a>[2001/schweikh](/2001/schweikh/schweikh.c) ([README.md](/2001/schweikh/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2428,6 +2428,8 @@ Cody also added an `int` after `register` in `main()` in case clang decides to
 have a problem with that in the future which is not entirely out of the
 question.
 
+Cody also added the [try.sh](/1998/schweikh2/try.sh) script.
+
 
 ## <a name="1998_schweikh3"></a>[1998/schweikh3](/1998/schweikh3/schweikh3.c) ([README.md](/1998/schweikh3/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2213,14 +2213,11 @@ when reading the author's comments. To see how to use the original, see the
 README.md file.
 
 Cody also added the two scripts, [try.sh](/1996/westley/try.sh) and
-[try.alt.sh](/1996/westley/try.alt.sh) to show automate showing the different
+[try.alt.sh](/1996/westley/try.alt.sh) to automate showing the different
 clocks, both with the fixed version and the original (alt) version.
 
 Also, to fix any potential problem with displaying in GitHub the scripts
-provided by the author, Cody added '.sh'.
-
-Later Cody made the entry look more like the original, removing the `argc` in
-`main()` (K&R style functions).
+provided by the author, Cody added '.sh' to the `clock[1-3].sh` scripts.
 
 
 # <a name="1998"></a>1998


### PR DESCRIPTION
There was an erroneous '/' in some places (particularly with 
`[a-z](\/`). This likely happened when changing the paths to be absolute
paths.