### PR TITLE
Fix typo (bad filename) in 2004/arachnid

### DIFF
--- a/1998/bas1/README.md
+++ b/1998/bas1/README.md
@@ -7,22 +7,8 @@ make all
 
 ## To use:
 
-If `lpr` on your system can print PostScript:
-
 ```sh
-./bemazing | gunzip | lpr
-```
-
-else, while in X Window System,
-
-```sh
-./bemazing | gunzip | gv -
-```
-
-or:
-
-```sh
-./bemazing | gunzip | gs -sDEVICE=pgmraw -sOutputFile='|xv -' -
+./bas1.sh
 ```
 
 

--- a/1998/bas1/bas1.sh
+++ b/1998/bas1/bas1.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# 
+# bas1.sh - run IOCCC winner 1998/bas1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "** Bemazing Modes **
+
+(0) Use lpr (if lpr(1) can print PostScript)
+(1) Use X11 (with gv(1))
+(2) Use X11 (with gs(1) and xv(1))
+"
+
+read -rp "Make a selection (0 - 2 or any other key to exit): " mode
+echo 1>&2
+
+case "${mode}" in
+    0)  ./bemazing | gunzip | lpr
+	;;
+    1)  ./bemazing | gunzip | gv -
+	;;
+    2)  ./bemazing | gunzip | gs -sDEVICE=pgmraw -sOutputFile='|xv -' -
+	;;
+    *)  exit 0
+esac

--- a/2000/natori/README.md
+++ b/2000/natori/README.md
@@ -22,6 +22,9 @@ version](#alternate-code) below.
 ./try.sh
 ```
 
+Try running this on different days, say a few days apart, and each time run it
+several times in a row (or several times in a day).
+
 Also try modifying the code so that it will show another Moon phase based on
 input or else just by the code itself. Bonus points if you can make it show all~
 
@@ -47,11 +50,23 @@ make alt
 ./natori.alt
 ```
 
+Try running this on different days, say a few days apart, and each time run it
+several times in a row (or several times in a day).
+
 What happens if you run it in the northern hemisphere? Are there any
 differences?
 
 Can you identify any Moon phases that result in the same output of both
 versions? Or are there any?
+
+
+### Alternate try:
+
+```sh
+./try.alt.sh
+```
+
+Like with [try.sh](try.sh), try using this multiple times.
 
 
 ## Judges' remarks:

--- a/2000/natori/try.alt.sh
+++ b/2000/natori/try.alt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# try.sh - demonstrate IOCCC winner 2000/natori
+# try.alt.sh - demonstrate IOCCC winner 2000/natori alt code
 #
 
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
@@ -23,10 +23,10 @@ moon()
     for ((i=0;i<=10;i++)); do
 	RAND=$((RANDOM % 1000))
 	if [[ "$RAND" -le 500 ]]; then
-	    ./"$NATORI"
+	    ./"$NATORI".alt
 	    echo 1>&2
 	else
-	    ./"$NATORI".alt
+	    ./"$NATORI"
 	    echo 1>&2
 	fi
     done
@@ -34,15 +34,6 @@ moon()
     echo 1>&2
     RAND=$((RANDOM % 1000))
     if [[ "$RAND" -gt 500 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	./"$NATORI".alt
@@ -51,6 +42,15 @@ moon()
 	./"$NATORI"
 	./"$NATORI".alt
 	./"$NATORI"
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
     fi
 
     echo 1>&2
@@ -58,15 +58,6 @@ moon()
     echo 1>&2
 
     if [[ "$RAND" -le 499 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	./"$NATORI".alt
@@ -75,6 +66,15 @@ moon()
 	./"$NATORI"
 	./"$NATORI".alt
 	./"$NATORI"
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
     fi
 
     echo 1>&2
@@ -83,15 +83,15 @@ moon()
     echo 1>&2
     RAND=$((RANDOM % 1000))
     if [[ "$RAND" -gt 500 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
 
     echo 1>&2
@@ -99,15 +99,15 @@ moon()
     echo "We now recommend that you try holding enter down." 1>&2
     echo 1>&2
     if [[ "$RAND" -gt 500 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
     echo 1>&2
 
@@ -117,15 +117,15 @@ moon()
     echo "We recommend that you try holding space down." 1>&2
     echo 1>&2
     if [[ "$RAND" -le 499 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
 
     echo 1>&2
@@ -133,28 +133,29 @@ moon()
     echo "We now recommend that you try holding enter down." 1>&2
     echo 1>&2
     if [[ "$RAND" -le 499 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
     echo 1>&2
 
-    # Finally, for the try.sh (original entry, northern hemisphere), force
-    # starting with northern hemisphere.
+    # Finally, for the try.alt.sh (alt code, southern hemisphere), force
+    # starting with southern hemisphere.
     echo "Will now use less(1): 'q' = quit, space = next page, enter = next line." 1>&2
     echo "We now recommend that you try holding enter down." 1>&2
-    read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+    read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
     echo 1>&2
-    ( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
+    ( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
+	./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
 
     echo 1>&2
+
 }
 
 # show the Moon phase in artistic ways!

--- a/2004/arachnid/README.md
+++ b/2004/arachnid/README.md
@@ -19,7 +19,7 @@ code](#alternate-code) below.
 ## Try:
 
 ```sh
-./arachnid arachnid.info
+./arachnid arachnid.txt
 ```
 
 and then try:

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2247,6 +2247,9 @@ appears that they do allow 1 but for instance 4 is not allowed. However as it's
 quite possible they will 'fix' this defect it would be better to have this not
 be a problem at such a time.
 
+Cody also added the [bas1.sh](/1998/bas1/bas1.sh) script to simplify running the
+program.
+
 
 ## <a name="1998_bas2"></a>[1998/bas2](/1998/bas2/bas2.c) ([README.md](/1998/bas2/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2930,6 +2930,11 @@ allows those like himself used to `h`, `j`, `k` and `l` movement keys to not get
 lost. Non rogue players, vi users and Dvorak typists are invited to get lost (or
 use the original version)! :-)
 
+Cody also renamed the `arachnid.info` file to
+[arachnid.txt](/2004/arachnid/arachnid.txt) as it's not really an informative
+file but a maze file. The extension `.maz` was not chosen to help with (some?)
+browsers knowing what to do with it.
+
 
 ## <a name="2004_burley"></a>[2004/burley](/2004/burley/burley.c) ([README.md](/2004/burley/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2534,8 +2534,12 @@ segfault when run or not compile at all (gcc and clang respectively).
 
 Cody also provided alternate code that supports the southern hemisphere.
 
-Cody also provided the [try.sh](/2000/natori/try.sh) script that shows the Moon
-phase in artistic ways.
+Cody also provided the [try.sh](/2000/natori/try.sh) and
+[try.alt.sh](/2000/natori/try.alt.sh) scripts that show the Moon phase in
+artistic ways. It is recommended one try both a number of times in a row on
+different days (that is run `./try.sh` several times in a row a few days apart,
+until you see all the Moon phases, and run `./try.alt.sh` a few times in a row a
+few days apart, until you see all the Moon phases).
 
 Later on Cody restored the `#include`s in the source code which had been changed
 by us to make it a one-liner again but this was an error as it was not a


### PR DESCRIPTION

I had renamed the arachnid.info to arachnid.txt as it's not really an 
informative file but I forgot to update the command in the README.md 
file. I was tempted to rename it to arachnid.maz as it's a maze file but
I kept it as a text file so that (some?) browsers know what to do with 
it (though I'm not sure how strictly necessary that is it doesn't hurt 
to have it as .txt either).