### PR TITLE
Fix 2004/hibachi/src/localhost/index.html

### DIFF
--- a/1998/bas1/README.md
+++ b/1998/bas1/README.md
@@ -7,22 +7,8 @@ make all
 
 ## To use:
 
-If `lpr` on your system can print PostScript:
-
 ```sh
-./bemazing | gunzip | lpr
-```
-
-else, while in X Window System,
-
-```sh
-./bemazing | gunzip | gv -
-```
-
-or:
-
-```sh
-./bemazing | gunzip | gs -sDEVICE=pgmraw -sOutputFile='|xv -' -
+./bas1.sh
 ```
 
 

--- a/1998/bas1/bas1.sh
+++ b/1998/bas1/bas1.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# 
+# bas1.sh - run IOCCC winner 1998/bas1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "** Bemazing Modes **
+
+(0) Use lpr (if lpr(1) can print PostScript)
+(1) Use X11 (with gv(1))
+(2) Use X11 (with gs(1) and xv(1))
+"
+
+read -rp "Make a selection (0 - 2 or any other key to exit): " mode
+echo 1>&2
+
+case "${mode}" in
+    0)  ./bemazing | gunzip | lpr
+	;;
+    1)  ./bemazing | gunzip | gv -
+	;;
+    2)  ./bemazing | gunzip | gs -sDEVICE=pgmraw -sOutputFile='|xv -' -
+	;;
+    *)  exit 0
+esac

--- a/2000/natori/README.md
+++ b/2000/natori/README.md
@@ -22,6 +22,9 @@ version](#alternate-code) below.
 ./try.sh
 ```
 
+Try running this on different days, say a few days apart, and each time run it
+several times in a row (or several times in a day).
+
 Also try modifying the code so that it will show another Moon phase based on
 input or else just by the code itself. Bonus points if you can make it show all~
 
@@ -47,11 +50,23 @@ make alt
 ./natori.alt
 ```
 
+Try running this on different days, say a few days apart, and each time run it
+several times in a row (or several times in a day).
+
 What happens if you run it in the northern hemisphere? Are there any
 differences?
 
 Can you identify any Moon phases that result in the same output of both
 versions? Or are there any?
+
+
+### Alternate try:
+
+```sh
+./try.alt.sh
+```
+
+Like with [try.sh](try.sh), try using this multiple times.
 
 
 ## Judges' remarks:

--- a/2000/natori/try.alt.sh
+++ b/2000/natori/try.alt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# try.sh - demonstrate IOCCC winner 2000/natori
+# try.alt.sh - demonstrate IOCCC winner 2000/natori alt code
 #
 
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
@@ -23,10 +23,10 @@ moon()
     for ((i=0;i<=10;i++)); do
 	RAND=$((RANDOM % 1000))
 	if [[ "$RAND" -le 500 ]]; then
-	    ./"$NATORI"
+	    ./"$NATORI".alt
 	    echo 1>&2
 	else
-	    ./"$NATORI".alt
+	    ./"$NATORI"
 	    echo 1>&2
 	fi
     done
@@ -34,15 +34,6 @@ moon()
     echo 1>&2
     RAND=$((RANDOM % 1000))
     if [[ "$RAND" -gt 500 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	./"$NATORI".alt
@@ -51,6 +42,15 @@ moon()
 	./"$NATORI"
 	./"$NATORI".alt
 	./"$NATORI"
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
     fi
 
     echo 1>&2
@@ -58,15 +58,6 @@ moon()
     echo 1>&2
 
     if [[ "$RAND" -le 499 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-	./"$NATORI"
-	./"$NATORI".alt
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	./"$NATORI".alt
@@ -75,6 +66,15 @@ moon()
 	./"$NATORI"
 	./"$NATORI".alt
 	./"$NATORI"
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
+	./"$NATORI"
+	./"$NATORI".alt
     fi
 
     echo 1>&2
@@ -83,15 +83,15 @@ moon()
     echo 1>&2
     RAND=$((RANDOM % 1000))
     if [[ "$RAND" -gt 500 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
 
     echo 1>&2
@@ -99,15 +99,15 @@ moon()
     echo "We now recommend that you try holding enter down." 1>&2
     echo 1>&2
     if [[ "$RAND" -gt 500 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
     echo 1>&2
 
@@ -117,15 +117,15 @@ moon()
     echo "We recommend that you try holding space down." 1>&2
     echo 1>&2
     if [[ "$RAND" -le 499 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
 
     echo 1>&2
@@ -133,28 +133,29 @@ moon()
     echo "We now recommend that you try holding enter down." 1>&2
     echo 1>&2
     if [[ "$RAND" -le 499 ]]; then
-	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
-	echo 1>&2
-	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
-    else
 	read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
 	echo 1>&2
 	( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
 	    ./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
+    else
+	read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+	echo 1>&2
+	( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
+	    ./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
     fi
     echo 1>&2
 
-    # Finally, for the try.sh (original entry, northern hemisphere), force
-    # starting with northern hemisphere.
+    # Finally, for the try.alt.sh (alt code, southern hemisphere), force
+    # starting with southern hemisphere.
     echo "Will now use less(1): 'q' = quit, space = next page, enter = next line." 1>&2
     echo "We now recommend that you try holding enter down." 1>&2
-    read -r -n 1 -p "Press any key to alternate between the northern/southern hemisphere Moon: "
+    read -r -n 1 -p "Press any key to alternate between the southern/northern hemisphere Moon: "
     echo 1>&2
-    ( ./"$NATORI"; ./"$NATORI.alt" ; ./"$NATORI" ; ./"$NATORI.alt"; \
-	./"$NATORI"; ./"$NATORI.alt" ) | less -rEXF
+    ( ./"$NATORI.alt"; ./"$NATORI" ; ./"$NATORI.alt" ; ./"$NATORI"; \
+	./"$NATORI.alt"; ./"$NATORI" ) | less -rEXF
 
     echo 1>&2
+
 }
 
 # show the Moon phase in artistic ways!

--- a/2004/arachnid/README.md
+++ b/2004/arachnid/README.md
@@ -19,7 +19,7 @@ code](#alternate-code) below.
 ## Try:
 
 ```sh
-./arachnid arachnid.info
+./arachnid arachnid.txt
 ```
 
 and then try:

--- a/2004/gavare/README.md
+++ b/2004/gavare/README.md
@@ -11,20 +11,33 @@ for more details.
 ## To use:
 
 ```sh
-./gavare
-```
-
-
-## Try:
-
-```sh
 ./gavare > ioccc_ray.ppm
 ```
+
+Open `ioccc_ray.ppm` with a viewer capable of viewing PPM files. Alternatively,
+if you have ImageMagick installed, you can convert it to a jpeg:
+
+```sh
+convert ioccc_ray.ppm ioccc_ray.jpg
+```
+
+and then view `ioccc_ray.jpg` in a graphics viewer, editor or web browser.
+
+
+### Try:
+
+If you have `xv(1)` you can do:
+
+```sh
+./gavare | xv -
+```
+
+to not worry about writing it to a file and just viewing the image it creates.
 
 
 ## Alternate code:
 
-The alt code, [gavare.alt.c](gavare.alt.c), allows you to change the size of the
+The alt code [gavare.alt.c](gavare.alt.c) allows you to change the size of the
 image as well as the anti-alias setting, when compiling.
 
 The author also provided [on their web page for the
@@ -32,7 +45,7 @@ entry](https://gavare.se/ioccc/ioccc_gavare.c.html) an unobfuscated version that
 was used during development, which we have included in the file
 [gavare.r3.c](gavare.r3.c).
 
-Finally, there's a version, [gavare.alt2.c](gavare.alt2.c) that sets binary mode
+Finally, the file [gavare.alt2.c](gavare.alt2.c) sets binary mode
 on `stdout` which theoretically should work in Windows.
 
 
@@ -55,6 +68,9 @@ You might also wish to change the anti-alias setting:
 ```sh
 make clobber AA=2 alt
 ```
+
+You may of course combine the above two commands and give any combination you
+wish.
 
 This is not possible with the author's version but it is with the alt versions
 (Windows - see below - and otherwise).
@@ -97,7 +113,7 @@ entry contains no reserved words (I don't count `main` as a reserved word,
 although the compiler gives it special meaning) and no preprocessor
 directives.
 
-The program is a small
+This program is a small
 [ray-tracer](https://en.wikipedia.org/wiki/Ray_tracing_(graphics)). The first
 line of the source code may be modified if you want the resulting image to be of
 some other resolution than the predefined. The `A` value is an anti-alias

--- a/2004/hibachi/README.md
+++ b/2004/hibachi/README.md
@@ -11,18 +11,11 @@ make
 cd build; ./hibachi-start.sh &
 ```
 
-
-## Try:
-
-```sh
-cd build; ./hibachi-start.sh &
-```
-
 Then use your web browser to visit `http://localhost:8008/`. When you're
 finished make sure to kill `hibachi`.
 
-NOTE: you must be in the `build` directory when running `hibachi` for this to
-work.
+NOTE: you must be in the `build` directory when running `hibachi-start.sh` for
+this to work right.
 
 
 ## Judges' remarks:
@@ -45,9 +38,9 @@ so the file does not exist here.
 
 `Hibachi` is a simple, small, and (probably) very secure web server.
 
-There is a `hibachi.tgz` file that unpacks several support
-files and a subdirectory tree containing the documentation and
-examples. It can be viewed by:
+There is a `hibachi.tgz` file (NOTE: this file was removed by the judges after
+extraction) that unpacks several support files and a subdirectory tree
+containing the documentation and examples. It can be viewed by:
 
 ```sh
 tar -zxf hibachi.tgz

--- a/2004/hibachi/src/localhost/index.html
+++ b/2004/hibachi/src/localhost/index.html
@@ -49,7 +49,7 @@ Snert . Com - Software - Hibachi
 	they're completely portable.
 
 	<p class="small">-
-	<a href="http://eat.epicurious.com/dictionary/food/index.ssf?DEF_ID=2150">
+	<a href="https://www.epicurious.com/?DEF_ID=2150">
 	epicurious.com food dictionary</a>
 	</p>
 </blockquote>
@@ -60,20 +60,20 @@ Snert . Com - Software - Hibachi
 <p>
 <span class="hibachi">HIBACHI</span> is a simple, small, and secure web server with virtual
 host and CGI support. It is a limited implementation of <a href="reference/rfc2616.html">RFC 2616</a>
-and the <a href="http://www.w3.org/CGI/">CGI/1.1 Specification</a>.
+and the <a href="https://www.w3.org/CGI/">CGI/1.1 Specification</a>.
 <span class="hibachi">HIBACHI</span> was written as an entry for the
 <a href="https://www.ioccc.org/">International Obfuscated C Code Contest</a> and works
-for any Unix variant including the <a href="http://sources.redhat.com/cygwin/">Cygwin</a>
+for any Unix variant including the <a href="https://www.cygwin.com">Cygwin</a>
 environment for Windows.
 </p>
 <p>
 <span class="hibachi">HIBACHI</span> supports dynamic web content through the use of the
-<a href="http://www.w3.org/CGI/">Common Gateway Interface (CGI)</a> specification.
+<a href="https://www.w3.org/CGI/">Common Gateway Interface (CGI)</a> specification.
 Just about any scripting or programming language can be used, such as a POSIX shell,
-<a href="http://www.perl.com/">Perl</a>,
-<a href="http://www.php.net/">PHP</a>,
-<a href="http://www.python.org/">Python</a>, and/or
-<a href="http://www.ruby-lang.org/">Ruby</a>.
+<a href="https://www.perl.com/">Perl</a>,
+<a href="https://www.php.net/">PHP</a>,
+<a href="https://www.python.org/">Python</a>, and/or
+<a href="https://www.ruby-lang.org/">Ruby</a>.
 Existing CGI scripts can be used with little or no modification.
 Hibachi executes all CGI scripts as though they were "nph" prefixed, which is to say that it is
 the script's responsibility to send the HTTP status line and necessary headers direct to the client.
@@ -97,9 +97,10 @@ document tree is rooted at /usr/local/share/hibachi, then:
 <p>
 <span class="hibachi">HIBACHI</span> is ideal
 for special floppy-Linux distributions, like
-<a href="http://leka.muumilaakso.org/">Leka</a>, which can be used for rescue, firewall,
+<a href="https://web.archive.org/web/20040727072140/http://leka.muumilaakso.org/">Leka</a>, which can be used for rescue, firewall,
 demo, or dedicated servers. In theory, with some modifications,
-<span class="hibachi">HIBACHI</span> and a script interpreter, like <a href="http://www.php.net/">PHP</a>, could also be
+<span class="hibachi">HIBACHI</span> and a script interpreter, like <a
+      href="https://www.php.net/">PHP</a>, could also be
 bundled with CDROMS that require a means of presenting dynamic web pages.
 </p>
 
@@ -109,22 +110,26 @@ bundled with CDROMS that require a means of presenting dynamic web pages.
 <ul>
 <li>Supports virtual hosts.</li>
 <li>Supports all MIME types.</li>
-<li>Supports Common Gateway Interface (<a href="http://www.w3.org/CGI/">CGI</a>) scripts and programs.</li>
+<li>Supports Common Gateway Interface (<a href="https://www.w3.org/CGI/">CGI</a>) scripts and programs.</li>
 <li>Supports multiple index.* file types, ie. index.html, index.php, index.pl</li>
 <li>Supports subset of <a href="reference/rfc2616.html">RFC 2616</a> HTTP/1.1 methods GET, HEAD, and POST.</li>
 <li>Simple &amp; straight forward configuration using environment variables.</li>
-<li>Portability across Unix-like environments, ie. <a href="http://sources.redhat.com/cygwin/">Cygwin</a>, <a href="http://www.freebsd.org/">FreeBSD</a>, Linux, SunOS.</li>
-<li>Known to work with <a href="http://lynx.isc.org/lynx-2.8.3/index.html">Lynx</a>, <a href="http://www.mozilla.org/">Mozilla</a>, <a href="http://www.opera.com/">Opera</a>, and Internet Explorer web browsers.</li>
+<li>Portability across Unix-like environments, ie. <a
+	href="https://www.cygwin.com">Cygwin</a>, <a href="https://www.freebsd.org/">FreeBSD</a>, Linux, SunOS.</li>
+<li>Known to work with <a href="https://lynx.invisible-island.net">Lynx</a>, <a
+	href="https://www.mozilla.org/">Mozilla</a>, <a href="https://www.opera.com/">Opera</a>, and Internet Explorer web browsers.</li>
 <li>Is a dedicated process-forking server that does not use inetd.</li>
 <li>Is secure against relative path file snooping.</li>
 <li>Is secure against directory searches.</li>
 <li>~155 lines of source, 1940 bytes long by <a href="https://www.ioccc.org/">IOCCC</a> 2004 rules, ~6KB compiled &amp; stripped on FreeBSD.</li>
-<li>Superior &amp; smaller than <a href="http://www.acme.com/software/micro_httpd/">micro_httpd</a> from <a href="http://www.acme.com/">ACME</a>.</li>
+<li>Superior &amp; smaller than <a
+					href="https://www.acme.com/software/micro_httpd/">micro_httpd</a>
+    from <a href="https://www.acme.com/">ACME</a>.</li>
 <li>And has a really cool animated logo too.</li>
 </ul>
 
 <!--
-<a href="http://www.borland.com/products/downloads/download_cbuilder.html">Borland C++ 5.5</a> free command-line compiler and debugger
+<a href="https://web.archive.org/web/20041231023050/http://www.borland.com/products/downloads/download_cbuilder.html">Borland C++ 5.5</a> free command-line compiler and debugger
 -->
 
 <a name="Installation"></a>
@@ -212,7 +217,7 @@ you should be able to access the server from the Internet using an IP or host na
 </p>
 
 <blockquote><pre>
-http://64.81.251.233:8008/
+https://185.199.111.153
 https://www.ioccc.org:8008/
 </pre></blockquote>
 
@@ -241,21 +246,21 @@ These CGI scripts perform some basic tests on the handling of GET and POST reque
 cookies, and the passing of environment variables to CGI scripts. These CGI scripts 
 assume that <span class="path">/bin/sh</span> is a POSIX compliant shell and the
 standard set of POSIX utilities are available. Should work for all Unix variants 
-and <a href="http://sources.redhat.com/cygwin/">Cygwin</a>.
+and <a href="https://www.cygwin.com">Cygwin</a>.
 
 </dd>
 
 <dt><a href="test/perl/">Perl Example</a></dt>
 <dd>
-<a href="http://www.perl.com/"><img alt="Powered by Perl" src="Img/rectangle_power_perl.gif" width="88" height="31" border="0" hspace="20" align="right"></a>
+<a href="https://www.perl.com/"><img alt="Powered by Perl" src="Img/rectangle_power_perl.gif" width="88" height="31" border="0" hspace="20" align="right"></a>
 This example queries the Yahoo web site for a stock quote to insert into a web page.
 <u><i>This example requires a browser with JavaScript support </i></u> and
-should work for all Unix variants and <a href="http://sources.redhat.com/cygwin/">Cygwin</a>, when Perl is installed.
+should work for all Unix variants and <a href="https://www.cygwin.com">Cygwin</a>, when Perl is installed.
 </dd>
 
 <dt><a href="test/php/">PHP Example</a></dt>
 <dd>
-<a href="http://www.php.net/"><img alt="Powered by PHP" src="Img/php-small-trans-light.gif" width="88" height="31" border="0" hspace="20" align="right"></a>
+<a href="https://www.php.net/"><img alt="Powered by PHP" src="Img/php-small-trans-light.gif" width="88" height="31" border="0" hspace="20" align="right"></a>
 This PHP example generates a calendar complete with ISO 8601:2000 week numbers.
 <!--
 This example shows how PHP might be used to format the result of a web form into
@@ -264,7 +269,7 @@ something human readable suitable for sending by email.
 
 <p>
 The Windows PHP CGI binary distribution from the
-<a href="http://www.php.net/">PHP</a> web site does not work within the <a href="http://sources.redhat.com/cygwin/">Cygwin</a>
+<a href="https://www.php.net/">PHP</a> web site does not work within the <a href="https://www.cygwin.com">Cygwin</a>
 environment.  Instead, download the source distribution and build the PHP CGI and CLI versions from scratch
 from within Cygwin. <!-- The CLI is desired, since it behaves more like an nph-CGI. -->
 The following commands were used to build:
@@ -311,7 +316,7 @@ Click here to display the <a href="test/php/info.php">PHP Info</a> configuration
 <dt><a href="test/ruby/">Ruby Example</a></dt>
 <dd>
 This example validates and/or generates Luhn check-digits.
-Should work for all Unix variants and <a href="http://sources.redhat.com/cygwin/">Cygwin</a>,
+Should work for all Unix variants and <a href="https://www.cygwin.com/">Cygwin</a>,
 when Ruby is installed.
 </dd>
 </dl>
@@ -323,7 +328,7 @@ when Ruby is installed.
 <table border="0" cellspacing="4" cellpadding="0">
 <tr valign="middle">
 	<td align="right">
-		<a href="http://www.freebsd.org/"><img alt="FreeBSD" src="Img/freebsd.gif" width="94" height="39" border="0" hspace="20" border="0"></a>
+		<a href="https://www.freebsd.org/"><img alt="FreeBSD" src="Img/freebsd.gif" width="94" height="39" border="0" hspace="20" border="0"></a>
 	</td>
 	<td rowspan="4">&nbsp;&nbsp;&nbsp;</td>
 	<td>
@@ -340,7 +345,7 @@ when Ruby is installed.
 </tr>
 <tr valign="middle">
 	<td bgcolor="#594FBF" align="right">
-		<a href="http://www.sun.com/"><img src="Img/sun_logo.gif" width="94" height="39" border="0" alt="Sun Microsystems Logo" vspace="0" hspace="20"></a>
+		<a href="https://www.oracle.com/it-infrastructure/"><img src="Img/sun_logo.gif" width="94" height="39" border="0" alt="Sun Microsystems Logo" vspace="0" hspace="20"></a>
 	</td>
 	<td>
 		5.8
@@ -348,12 +353,13 @@ when Ruby is installed.
 </tr>
 <tr valign="middle">
 	<td align="right">
-<!--		<span class="large" style="position: relative; top: -8px">+</span> --><a href="http://sources.redhat.com/cygwin/"><img alt="Cygwin Unix Emulation" src="Img/cygwin-icon.gif" width="28" height="28" border="0" hspace="20" vspace="8" align="right"></a>
+<!--		<span class="large" style="position: relative; top:
+    -8px">+</span> --><a href="https://www.cygwin.com"><img alt="Cygwin Unix Emulation" src="Img/cygwin-icon.gif" width="28" height="28" border="0" hspace="20" vspace="8" align="right"></a>
 		<img alt="Microsoft Windows" src="Img/win.gif" width="40" height="40" border="0" style="padding: 3px 6px 0 0;" align="right">
 	</td>
 	<td>
 		Windows 2000 SP4, Windows XP Pro SP1
-		<br>with <a href="http://sources.redhat.com/cygwin/">Cygwin</a>, gcc 2.95.3-5
+		<br>with <a href="https://www.cygwin.com">Cygwin</a>, gcc 2.95.3-5
 	</td>
 </tr>
 </table>
@@ -371,7 +377,7 @@ this is an original work and placed in the public domain.
 
 <!--
 <p>
-In all cases a monetary donation and/or <a href="http://www.amazon.com/">Amazon</a>
+In all cases a monetary donation and/or <a href="https://www.amazon.com/">Amazon</a>
 wishlist gifts to the author are welcomed, but not required, for the continued
 encouragment, moral support, and ego pumping needed to work in foriegn non-english
 speaking lands.
@@ -406,7 +412,7 @@ enhancements requests and problem reports are welcome (see logo above).
 
 
 <div align="center">
-<a href="http://hibachi.snert.org:8008/">
+<a href="https://hibachi.snert.org:8008/">
 <img alt="Powered by Hibachi" src="Img/powered-by-hibachi-150x75.png" width="150" height="75" border="1" style="color: #000000"></a>
 </div>
 

--- a/2004/hibachi/src/localhost/test/shell/test0.sh
+++ b/2004/hibachi/src/localhost/test/shell/test0.sh
@@ -58,14 +58,14 @@ else
 	echo "<tr><td>[ BAD ] DOCUMENT_ROOT</td></tr>"
 fi
 
-# Test for existance only, since the location changes.
+# Test for existence only, since the location changes.
 if [ X"$SCRIPT_FILENAME" = X ]; then
 	echo "<tr><td>[ BAD ] SCRIPT_FILENAME</td></tr>"
 else
 	echo "<tr><td>[ OK  ] SCRIPT_FILENAME</td></tr>"
 fi
 
-# Test for existance only, since the default value might change.
+# Test for existence only, since the default value might change.
 if [ X"$SERVER_PORT" = X ]; then
 	echo "<tr><td>[ BAD ] SERVER_PORT</td></tr>"
 else

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2247,6 +2247,9 @@ appears that they do allow 1 but for instance 4 is not allowed. However as it's
 quite possible they will 'fix' this defect it would be better to have this not
 be a problem at such a time.
 
+Cody also added the [bas1.sh](/1998/bas1/bas1.sh) script to simplify running the
+program.
+
 
 ## <a name="1998_bas2"></a>[1998/bas2](/1998/bas2/bas2.c) ([README.md](/1998/bas2/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2930,6 +2930,11 @@ allows those like himself used to `h`, `j`, `k` and `l` movement keys to not get
 lost. Non rogue players, vi users and Dvorak typists are invited to get lost (or
 use the original version)! :-)
 
+Cody also renamed the `arachnid.info` file to
+[arachnid.txt](/2004/arachnid/arachnid.txt) as it's not really an informative
+file but a maze file. The extension `.maz` was not chosen to help with (some?)
+browsers knowing what to do with it.
+
 
 ## <a name="2004_burley"></a>[2004/burley](/2004/burley/burley.c) ([README.md](/2004/burley/README.md]))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2994,6 +2994,14 @@ is done this way to prevent extraction from the entry directory overwriting the
 files and causing `make clobber` to wipe some of them out.
 
 
+## <a name="2004_hibachi"></a>[2004/hibachi](/2004/hibachi/hibachi.c) ([README.md](/2004/hibachi/README.md]))
+
+[Cody](#cody) fixed a bunch of links in the index.html provided with the entry
+(web server) that no longer exist or have changed in some other way (`https`
+instead of `http` for instance). In most cases a new link or change to https was
+all that was necessary but at least one or two URLs required the Internet
+Wayback Machine.
+
 
 ## <a name="2004_jdalbec"></a>[2004/jdalbec](/2004/jdalbec/jdalbec.c) ([README.md](/2004/jdalbec/README.md))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2534,8 +2534,12 @@ segfault when run or not compile at all (gcc and clang respectively).
 
 Cody also provided alternate code that supports the southern hemisphere.
 
-Cody also provided the [try.sh](/2000/natori/try.sh) script that shows the Moon
-phase in artistic ways.
+Cody also provided the [try.sh](/2000/natori/try.sh) and
+[try.alt.sh](/2000/natori/try.alt.sh) scripts that show the Moon phase in
+artistic ways. It is recommended one try both a number of times in a row on
+different days (that is run `./try.sh` several times in a row a few days apart,
+until you see all the Moon phases, and run `./try.alt.sh` a few times in a row a
+few days apart, until you see all the Moon phases).
 
 Later on Cody restored the `#include`s in the source code which had been changed
 by us to make it a one-liner again but this was an error as it was not a


### PR DESCRIPTION

Many links no longer worked, had changed or are https enabled now. In at
least two cases the Internet Wayback Machine was required but most were
just changed to https. The link to cygwin had changed entirely. The link
to lynx(1) had changed too.

Typo fixes in src/localhost/test0.sh.

Minor updates to README.md.