### PR TITLE
Deal with shellcheck warnings in 1985/sicherman

### DIFF
--- a/1985/sicherman/try.alt.sh
+++ b/1985/sicherman/try.alt.sh
@@ -33,5 +33,10 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./sicherman.alt < sicherman.alt.c | ./sicherman.alt | diff -s - sicherman.alt.c: "
 echo 1>&2
+# This warning from ShellCheck is incorrect:
+#
+#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+#
+# shellcheck disable=SC2094
 ./sicherman.alt < sicherman.alt.c | ./sicherman.alt | diff -s - sicherman.alt.c
 echo "Now explain any differences." 1>&2

--- a/1985/sicherman/try.sh
+++ b/1985/sicherman/try.sh
@@ -33,5 +33,11 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./sicherman < sicherman.c | ./sicherman | diff -s - sicherman.c: "
 echo 1>&2
+
+# This warning from ShellCheck is incorrect:
+#
+#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+#
+# shellcheck disable=SC2094
 ./sicherman < sicherman.c | ./sicherman | diff -s - sicherman.c
 echo "Now explain any differences." 1>&2


### PR DESCRIPTION
In these scripts, try.sh and try.alt.sh, the warning triggered is entirely incorrect and not a problem so they are now disabled.