### PR TITLE
Deal with shellcheck warnings in 1988/dale

### DIFF
--- a/1985/sicherman/try.alt.sh
+++ b/1985/sicherman/try.alt.sh
@@ -33,5 +33,10 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./sicherman.alt < sicherman.alt.c | ./sicherman.alt | diff -s - sicherman.alt.c: "
 echo 1>&2
+# This warning from ShellCheck is incorrect:
+#
+#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+#
+# shellcheck disable=SC2094
 ./sicherman.alt < sicherman.alt.c | ./sicherman.alt | diff -s - sicherman.alt.c
 echo "Now explain any differences." 1>&2

--- a/1985/sicherman/try.sh
+++ b/1985/sicherman/try.sh
@@ -33,5 +33,11 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./sicherman < sicherman.c | ./sicherman | diff -s - sicherman.c: "
 echo 1>&2
+
+# This warning from ShellCheck is incorrect:
+#
+#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+#
+# shellcheck disable=SC2094
 ./sicherman < sicherman.c | ./sicherman | diff -s - sicherman.c
 echo "Now explain any differences." 1>&2

--- a/1988/dale/try.sh
+++ b/1988/dale/try.sh
@@ -32,6 +32,14 @@ echo "Why do they differ in the format from the above command? Finally how can y
 echo "get the more likely desired behaviour?" 1>&2
 echo 1>&2
 echo 1>&2
+# This warning from ShellCheck is incorrect:
+#
+#   SC2028 (info): echo may not expand escape sequences. Use printf.
+#
+# because we deliberately have \\n to show that there will be a newline printed
+# WITH printf(1). Thus this does show correct output.
+#
+# shellcheck disable=SC2028
 echo "$ ./dale \$(printf "the following files exist in this directory:\\n%s\\n" *)"
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
@@ -40,6 +48,14 @@ echo 1>&2
 ./dale $(printf "the following files exist in this directory:\n%s\n" *)
 echo 1>&2
 
+# This warning from ShellCheck is incorrect:
+#
+#   SC2028 (info): echo may not expand escape sequences. Use printf.
+#
+# because we deliberately have \\n to show that there will be a newline printed
+# WITH printf(1). Thus this does show correct output.
+#
+# shellcheck disable=SC2028
 echo "$ ./dale \"\$(printf \"the following files exist in this directory:\\n%s\\n\" *)\""
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2


### PR DESCRIPTION

In these scripts, try.sh and try.alt.sh, the warning triggered is
entirely incorrect and not a problem so they are now disabled. The 
comments explain why this is.