### PR TITLE
Deal with shellcheck warnings in 1993/plummer

### DIFF
--- a/1985/sicherman/try.alt.sh
+++ b/1985/sicherman/try.alt.sh
@@ -33,5 +33,10 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./sicherman.alt < sicherman.alt.c | ./sicherman.alt | diff -s - sicherman.alt.c: "
 echo 1>&2
+# This warning from ShellCheck is incorrect:
+#
+#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+#
+# shellcheck disable=SC2094
 ./sicherman.alt < sicherman.alt.c | ./sicherman.alt | diff -s - sicherman.alt.c
 echo "Now explain any differences." 1>&2

--- a/1985/sicherman/try.sh
+++ b/1985/sicherman/try.sh
@@ -33,5 +33,11 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./sicherman < sicherman.c | ./sicherman | diff -s - sicherman.c: "
 echo 1>&2
+
+# This warning from ShellCheck is incorrect:
+#
+#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+#
+# shellcheck disable=SC2094
 ./sicherman < sicherman.c | ./sicherman | diff -s - sicherman.c
 echo "Now explain any differences." 1>&2

--- a/1988/dale/try.sh
+++ b/1988/dale/try.sh
@@ -32,6 +32,14 @@ echo "Why do they differ in the format from the above command? Finally how can y
 echo "get the more likely desired behaviour?" 1>&2
 echo 1>&2
 echo 1>&2
+# This warning from ShellCheck is incorrect:
+#
+#   SC2028 (info): echo may not expand escape sequences. Use printf.
+#
+# because we deliberately have \\n to show that there will be a newline printed
+# WITH printf(1). Thus this does show correct output.
+#
+# shellcheck disable=SC2028
 echo "$ ./dale \$(printf "the following files exist in this directory:\\n%s\\n" *)"
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
@@ -40,6 +48,14 @@ echo 1>&2
 ./dale $(printf "the following files exist in this directory:\n%s\n" *)
 echo 1>&2
 
+# This warning from ShellCheck is incorrect:
+#
+#   SC2028 (info): echo may not expand escape sequences. Use printf.
+#
+# because we deliberately have \\n to show that there will be a newline printed
+# WITH printf(1). Thus this does show correct output.
+#
+# shellcheck disable=SC2028
 echo "$ ./dale \"\$(printf \"the following files exist in this directory:\\n%s\\n\" *)\""
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2

--- a/1993/plummer/try.alt.sh
+++ b/1993/plummer/try.alt.sh
@@ -12,9 +12,7 @@ fi
 
 # let user change the sleep duration if they wish
 #
-if [[ -z "$SLEEP" ]]; then
-    SLEEP=1000
-fi
+[[ -z "$SLEEP" ]] && SLEEP=1000
 
 # let user change the number if they wish to
 #

--- a/1993/plummer/try.sh
+++ b/1993/plummer/try.sh
@@ -26,7 +26,7 @@ else
     ARG="$2"
 fi
 
-make CC="$CC" SLEEP="$SLEEP" all >/dev/null || exit 1
+make CC="$CC" all >/dev/null || exit 1
 
 # clear screen after compilation so that only the entry is shown
 clear


### PR DESCRIPTION

This was only in try.sh: SLEEP is not needed which is why the error was
not detected. SLEEP is only relevant to the alt code. But the try.alt.sh
was updated to make it shorter for assigning the default:

    [[ -z "$SLEEP" ]] && SLEEP=1000

1000 is the default in the Makefile.
