### PR TITLE
Fix arg check in ioccc-status.sh

### DIFF
--- a/bin/ioccc-status.sh
+++ b/bin/ioccc-status.sh
@@ -110,7 +110,7 @@ shift $(( OPTIND - 1 ));
 # verify arg count
 #
 if [[ $# != 1 ]]; then
-    echo "$0: ERROR: expected no more than 1 arg, found: $#" 1>&2
+    echo "$0: ERROR: expected exactly one arg, got: $#" 1>&2
     echo 1>&2
     echo "$USAGE" 1>&2
     exit 3

--- a/bin/ioccc-status.sh
+++ b/bin/ioccc-status.sh
@@ -24,7 +24,7 @@
 #
 # The -G option lets one set the path to grep(1).
 #
-export IOCCC_STATUS_SCRIPT_VERSION="0.0.3-0 2024-01-15" # major.minor.release-patch YYYY-MM-DD
+export IOCCC_STATUS_SCRIPT_VERSION="0.0.4-0 2024-01-22" # major.minor.release-patch YYYY-MM-DD
 
 SED="$(type -P sed)"
 GREP="$(type -P grep)"
@@ -109,8 +109,9 @@ shift $(( OPTIND - 1 ));
 
 # verify arg count
 #
-if [[ $# -gt 1 ]]; then
+if [[ $# != 1 ]]; then
     echo "$0: ERROR: expected no more than 1 arg, found: $#" 1>&2
+    echo 1>&2
     echo "$USAGE" 1>&2
     exit 3
 fi


### PR DESCRIPTION
It should be != 1 rather than -gt 1. Not having this meant that if no arg was specified the usage message was not printed and instead the arg of the status.json file (which was not given) was shown to not exist (because it was empty so not a file).