### PR TITLE
Add 2006/stewart/try.sh

### DIFF
--- a/2006/grothe/README.md
+++ b/2006/grothe/README.md
@@ -14,20 +14,14 @@ make
 
 ## Try:
 
+Put on your "electronic ears" and then try:
+
 ```sh
-./grothe 65000000 10000000 1344 < twinkle.txt
+./try.sh
 ```
 
-... and then put on your "electronic ears".  You may find using
+You may find using
 a tunable scanning electronic ear helps.
-
-There are other text files you may wish to try:
-
-```sh
-./grothe 65000000 10000000 1344 < arabian.txt
-./grothe 65000000 10000000 1344 < olympics.txt
-./grothe 65000000 10000000 1344 < test.txt
-```
 
 
 ## Judges' remarks:

--- a/2006/grothe/try.sh
+++ b/2006/grothe/try.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2006/grothe
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+resume()
+{
+    echo 1>&2
+    read -r -n 1 -p "Do you wish to continue (Y/N)? "
+    if [[ "$REPLY" != "y" && "$REPLY" != "Y" ]]; then
+	exit 0
+    fi
+}
+
+read -r -n 1 -p "Press any key to run: ./grothe 65000000 10000000 1344 < twinkle.txt: "
+echo 1>&2
+./grothe 65000000 10000000 1344 < twinkle.txt
+resume
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./grothe 65000000 10000000 1344 < arabian.txt: "
+echo 1>&2
+./grothe 65000000 10000000 1344 < arabian.txt
+resume
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./grothe 65000000 10000000 1344 < olympics.txt: "
+echo 1>&2
+./grothe 65000000 10000000 1344 < olympics.txt
+resume
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./grothe 65000000 10000000 1344 < test.txt: "
+echo 1>&2
+./grothe 65000000 10000000 1344 < test.txt
+echo 1>&2

--- a/2006/hamre/try.sh
+++ b/2006/hamre/try.sh
@@ -17,17 +17,18 @@ clear
 
 
 
-echo "$ ./hamre '-1*42/3*(42*42*42)/42'" 1>&2
+read -r -n 1 -p "Press any key to run: ./hamre '-1*42/3*(42*42*42)/42': "
+echo 1>&2
 ./hamre '-1*42/3*(42*42*42)/42'
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
-echo "$ ./hamre '-1+4/3*(2+1/(3/2*(7/2-7/3+1/6)))/2'" 1>&2
+read -r -n 1 -p "Press any key to run: ./hamre '-1+4/3*(2+1/(3/2*(7/2-7/3+1/6)))/2': "
+echo 1>&2
 ./hamre '-1+4/3*(2+1/(3/2*(7/2-7/3+1/6)))/2'
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
-echo "$ ./hamre '1/0' 1>&2" 1>&2
+read -r -n 1 -p "Press any key to run: ./hamre '1/0': "
+echo 1>&2
 ./hamre '1/0' 1>&2
 echo 1>&2
 echo "...why did you not get an answer?" 1>&2
@@ -37,21 +38,33 @@ LIFE=12
 UNIVERSE=15
 EVERYTHING=15
 read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo "For the next two notice how similar they are: why do they give different answers?" 1>&2
 
 echo "$ LIFE=12; UNIVERSE=15; EVERYTHING=15; ./hamre \"\$LIFE/\$UNIVERSE/\$EVERYTHING\"" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./hamre "$LIFE/$UNIVERSE/$EVERYTHING"
+echo 1>&2
 
 echo "$ LIFE=12; UNIVERSE=15; EVERYTHING=15; ./hamre \"\$LIFE / \$UNIVERSE / \$EVERYTHING\"" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./hamre "$LIFE / $UNIVERSE / $EVERYTHING"
 
 echo 1>&2
 read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 echo "And why do these next two give different answers?" 1>&2
 echo "$ LIFE=12; UNIVERSE=15; EVERYTHING=15; ./hamre \"\$LIFE + \$UNIVERSE + \$EVERYTHING\"" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./hamre "$LIFE + $UNIVERSE + $EVERYTHING"
 echo "$ LIFE=12; UNIVERSE=15; EVERYTHING=15; ./hamre \"\$LIFE+\$UNIVERSE+\$EVERYTHING\"" 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
 ./hamre "$LIFE+$UNIVERSE+$EVERYTHING"
+echo 1>&2
 
 echo "As it turns out, \$LIFE+\$UNIVERSE+\$EVERYTHING == 42/1 == 42!" 1>&2
 

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -28,21 +28,15 @@ For more detailed information see [2006 monge in bugs.md](/bugs.md#2006-monge).
 ./monge expression ...
 ```
 
+Incorrect formulas will ungracefully crash the program.
+
 
 ## Try:
 
 ```sh
-./monge "z = 0" "z = z*z*z + c; Abs2(z) < 4"
+./try.sh
 ```
 
-Incorrect formulas will ungracefully crash the program.
-
-This is supposed to happen.  As is written in the
-[The Jargon File](http://catb.org/jargon/html/F/feature.html):
-
-```
-That's not a bug, that's a feature.
-```
 
 
 ## Alternate code:
@@ -78,13 +72,20 @@ make clobber ITERATIONS=512 alt
 If you specify a value less than 1 for any of these it sets it back to the
 default. The value 1 was selected arbitrarily and such a small number as 1 will
 not do anything useful but as long as it's at least 1 it'll not be redefined.
-Does not try taking care of overflows but such large values would be impractical
+It does not try taking care of overflows but such large values would be impractical
 anyway.
 
 
 ### Alternate use:
 
 Use `monge.alt` exactly as you would `monge` above.
+
+
+### Alternate try:
+
+```sh
+./try.alt.sh
+```
 
 
 ## Judges' remarks:

--- a/2006/monge/try.alt.sh
+++ b/2006/monge/try.alt.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 2006/monge alt code
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" alt >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./monge.alt \"z = 0\" \"z = z*z*z + c; Abs2(z) < 4\": "
+echo 1>&2
+./monge.alt "z = 0" "z = z*z*z + c; Abs2(z) < 4"
+echo 1>&2
+
+read -r -n 1 -p "Press any key to change the width/height/iterations to 500/500/1024: "
+echo 1>&2
+make clobber WIDTH=500 HEIGHT=500 ITERATIONS=1024 alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./monge.alt \"z = 0\" \"z = z*z*z + c; Abs2(z) < 4\": "
+echo 1>&2
+./monge.alt "z = 0" "z = z*z*z + c; Abs2(z) < 4"
+echo 1>&2

--- a/2006/monge/try.sh
+++ b/2006/monge/try.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2006/monge
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+
+read -r -n 1 -p "Press any key to run: ./monge \"z = 0\" \"z = z*z*z + c; Abs2(z) < 4\": "
+echo 1>&2
+./monge "z = 0" "z = z*z*z + c; Abs2(z) < 4"
+echo 1>&2
+
+

--- a/2006/stewart/README.md
+++ b/2006/stewart/README.md
@@ -30,17 +30,18 @@ NOTE: `convert(1)` belongs to [ImageMagick](https://imagemagick.org/index.php).
 ## Try:
 
 ```sh
-./stewart 400 1000000 maze > maze.xbm
-convert maze.xbm maze.png
-
-./stewart 1024 1000000 gasket > gasket.xbm
-convert gasket.xbm gasket.png
-
-./stewart 1024 1500000 dragon3 > dragon3.xbm
-convert dragon3.xbm dragon3.png
+./try.sh
 ```
 
-Now open the images in your favourite graphics viewer or a web browser.
+After running the program on a few files it will ask you if you wish to run it
+on the remaining files.
+
+The script will try converting the xbm files created by the program to png
+files. If it does it will list those that exist in the directory, at the end of
+the script. If you do not have `convert(1)` it will warn you once. In that case
+you'll have to open the xbm files in a graphics viewer capable of viewing xbm
+images. In any case choose your favourite graphics viewer to look at the images
+created.
 
 
 ## Judges' remarks:

--- a/2006/stewart/try.sh
+++ b/2006/stewart/try.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2006/stewart
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# try and find convert(1) from ImageMagick
+CONVERT="$(type -P convert)"
+# keep track if we converted anything
+CONVERTED=""
+FAILED_CONVERT=""
+
+stewart()
+{
+    if [[ "$#" != 3 ]]; then
+	echo "$0: stewart() expects 3 args, got: $#" 1>&2
+	return
+    fi
+
+    if [[ ! -f "$3" || ! -r "$3" ]]; then
+	echo "$0: file does not exist or not readable: $3" 1>&2
+	return
+    fi
+
+    if [[ -f "$3.xbm" ]]; then
+	rm -f "$3.xbm"
+    fi
+
+    read -r -n 1 -p "Press any key to run: ./stewart $1 $2 $3 > $3.xbm: "
+    echo 1>&2
+    ./stewart "$1" "$2" "$3" > "$3.xbm"
+    echo 1>&2
+
+    if [[ -n "$CONVERT" ]]; then
+	read -r -n 1 -p "Press any key to run: $CONVERT $3.xbm $3.png: "
+	echo 1>&2
+	"$CONVERT" "$3.xbm" "$3.png"
+	if [[ "$?" = 0 && -f "$3.png" ]]; then
+	    echo "Converted $3.xbm to $3.png for you to view." 1>&2
+	    CONVERTED="true"
+	else
+	    FAILED_CONVERT="true"
+	fi
+	echo 1>&2
+    fi
+}
+
+# we only warn them once if they do not have convert
+if [[ -z "$CONVERT" ]]; then
+    echo "$0: convert(1) not found: you will have to find a viewer of xbm images." 1>&2
+fi
+
+stewart 400 1000000 maze
+stewart 1024 1000000 gasket
+stewart 1024 1500000 dragon3
+
+read -r -p "Do you want to run this on the remaining files (Y/N)? "
+echo 1>&2
+if [[ "$REPLY" = "Y" || "$REPLY" = "y" ]]; then
+    for f in altar box box2 box3 carpet circles cross cross2 cross3 crystal curve \
+	diamonds diamonds2 dragon dragon2 fern gasket_mod gasket_mod2 ioccc \
+	octagon pentagon pentagons rings rings2 spirals spirals2 spirals3 spirals4 \
+	squares stars stars2 tree tree2 tree3 tree4 triangle; do
+
+	    stewart 1024 1000000 "$f"
+    done
+fi
+
+if [[ -n "$FAILED_CONVERT" ]]; then
+    echo "Failed to convert one or more files to png." 1>&2
+fi
+
+if [[ -n "$CONVERTED" ]]; then
+    echo "The following png files exist: "
+    ls -1 ./*.png
+else
+    echo "The following xbm files exist: "
+    ls -1 ./*.xbm
+fi

--- a/bin/ioccc-status.sh
+++ b/bin/ioccc-status.sh
@@ -24,7 +24,7 @@
 #
 # The -G option lets one set the path to grep(1).
 #
-export IOCCC_STATUS_SCRIPT_VERSION="0.0.4-0 2024-01-22" # major.minor.release-patch YYYY-MM-DD
+export IOCCC_STATUS_SCRIPT_VERSION="0.0.5-0 2024-01-22" # major.minor.release-patch YYYY-MM-DD
 
 SED="$(type -P sed)"
 GREP="$(type -P grep)"
@@ -129,11 +129,15 @@ if [[ ! -e $STATUS_JSON_FILE ]]; then
     exit 1
 fi
 if [[ ! -f $STATUS_JSON_FILE ]]; then
-    echo "$0: ERROR: status.json not a file: $STATUS_JSON_FILE" 1>&2
+    echo "$0: ERROR: status.json not a regular file: $STATUS_JSON_FILE" 1>&2
     exit 1
 fi
 if [[ ! -r $STATUS_JSON_FILE ]]; then
     echo "$0: ERROR: status.json not a readable file: $STATUS_JSON_FILE" 1>&2
+    exit 1
+fi
+if [[ ! -w $STATUS_JSON_FILE ]]; then
+    echo "$0: ERROR: status.json is not a writable file: $STATUS_JSON_FILE" 1>&2
     exit 1
 fi
 
@@ -238,3 +242,4 @@ if [[ -n "$STATUS_FLAG" ]]; then
 	echo "$0: updated contest status to: \"$STATUS\"" 1>&2
     fi
 fi
+exit 0

--- a/bin/ioccc-status.sh
+++ b/bin/ioccc-status.sh
@@ -110,7 +110,7 @@ shift $(( OPTIND - 1 ));
 # verify arg count
 #
 if [[ $# != 1 ]]; then
-    echo "$0: ERROR: expected no more than 1 arg, found: $#" 1>&2
+    echo "$0: ERROR: expected exactly one arg, got: $#" 1>&2
     echo 1>&2
     echo "$USAGE" 1>&2
     exit 3

--- a/bin/ioccc-status.sh
+++ b/bin/ioccc-status.sh
@@ -24,7 +24,7 @@
 #
 # The -G option lets one set the path to grep(1).
 #
-export IOCCC_STATUS_SCRIPT_VERSION="0.0.3-0 2024-01-15" # major.minor.release-patch YYYY-MM-DD
+export IOCCC_STATUS_SCRIPT_VERSION="0.0.4-0 2024-01-22" # major.minor.release-patch YYYY-MM-DD
 
 SED="$(type -P sed)"
 GREP="$(type -P grep)"
@@ -109,8 +109,9 @@ shift $(( OPTIND - 1 ));
 
 # verify arg count
 #
-if [[ $# -gt 1 ]]; then
+if [[ $# != 1 ]]; then
     echo "$0: ERROR: expected no more than 1 arg, found: $#" 1>&2
+    echo 1>&2
     echo "$USAGE" 1>&2
     exit 3
 fi

--- a/man/man1/ioccc-status.1
+++ b/man/man1/ioccc-status.1
@@ -1,0 +1,150 @@
+.\" section 1 man page for ioccc-status.sh
+.\"
+.\" This man page was first written by Cody Boone Ferguson for the IOCCC
+.\" in 2024.
+.\"
+.\" "Share and Enjoy!"
+.\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
+.\"
+.TH ioccc-status.sh 1 "22 January 2024" "ioccc-status.sh" "IOCCC website tools"
+.SH NAME
+.B ioccc-status.sh
+\- update the
+.B status.json
+file
+.SH SYNOPSIS
+.B ioccc-status.sh
+.RB [\| \-h \|]
+.RB [\| \-V \|]
+.RB [\| \-v
+.IR level \|]
+.RB [\| \-s
+.IR status \|]
+.RB [\| \-d \|]
+.RB [\| \-n \|]
+.RB [\| \-i
+.IR status_ver \|]
+.RB [\| \-N \|]
+.RB [\| \-S
+.IR sed \|]
+.RB [\| -G
+.IR grep \|]
+.IR status.json
+.SH DESCRIPTION
+.B ioccc-status.sh
+will update the IOCCC
+.B status.json
+file that shows the contest status (\fI"open"\fP or \fI"closed"\fP), the status date (when the
+.B status
+was last updated), the news date (when the
+.B news
+was last updated) and/or the
+.B status version\c
+, unless the dry\-mode (\c
+.BR \-N )
+option is specified. If dry\-mode is used then it will only show what would have changed.
+.SH OPTIONS
+.TP
+.B \-h
+Print help and exit.
+.TP
+.B \-V
+Print version and exit.
+.TP
+.BI \-v\  level
+Set verbosity level to
+.I level
+(def: 0). If level is 1 or higher it will show what file will be touched and what values will be updated, based on the options specified, assuming dry mode is not set and an option to update the file is used.
+.TP
+.BI \-s\  status
+Set
+.I status
+to \fB"open"\fP or \fB"closed"\fP. Any other value is an error.
+.TP
+.B \-d
+Update status date to the value of the shell command
+.BR date .
+.TP
+.B \-n
+Update latest news date to the value of the shell command
+.BR date .
+.TP
+.BI \-i\  status_version
+Update the status version. The version must match the regexp: '\fB^[0\-9]+\\\.[0\-9]+ [0\-9]{4}\-[0\-9]{2}\-[0\-9]{2}$\fP' and if it does not it is an error.
+.TP
+.BI \-S\  sed
+Set path to
+.BR sed (1).
+The default is from the command \fBtype -P sed\fP.
+.TP
+.BI \-G\  grep
+Set path to
+.BR grep (1).
+The default is from the command \fBtype -P grep\fP.
+.SH EXIT STATUS
+.TP
+0
+dry\-mode used or successfully updated the
+.B status.json
+file (or no update requested)
+.TQ
+1
+status.json file does not exist or is not a regular readable and writable file
+.TQ
+2
+help mode exit or print version mode exit
+.TQ
+3
+invalid command line (including
+.BR sed (1)
+or
+.BR grep (1)
+not being regular executable files)
+.SH NOTES
+.PP
+.B ioccc\-status.sh
+was written by
+.B Cody Boone Ferguson
+in 2023 to update/maintain the
+.B status.json
+file suggested to the IOCCC judges by \fBToni Mikkola (@Virtaava@home.social)\fP.
+.SH BUGS
+.PP
+A human wrote it? :\-)
+.PP
+Nevertheless, if you feel there is an issue with this tool you may open an issue at the GitHub issues page.
+.SH EXAMPLES
+.PP
+Run script to get help:
+.sp
+.RS
+.ft B
+ ./ioccc-status.sh
+
+ ./ioccc-status.sh \-h
+.ft R
+.RE
+.PP
+Dry\-mode run of updating the latest news date:
+.sp
+.RS
+.ft B
+ ./ioccc-status.sh \-n \-N ../status.json
+.ft R
+.RE
+.PP
+Update the latest news date:
+.sp
+.RS
+.ft B
+ ./ioccc-status.sh \-n ../status.json
+.ft R
+.RE
+.PP
+Set contest status to open with a new status version of \fB0.3 2024\-01\-22\fP:
+.sp
+.RS
+.ft B
+ ./ioccc-status.sh -s open -i '0.3 2024-01-22' ../status.json
+.ft R
+.RE

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3436,6 +3436,9 @@ Cody also added the [try.sh](/2006/hamre/try.sh) script.
 [Cody](#cody) added the [alternate code](/2006/monge/README.md#alternate-code) that lets
 one resize the image and redefine the number of iterations.
 
+Cody also added the [try.sh](/2006/monge/try.sh) and
+[try.alt.sh](/2006/monge/try.alt.sh) scripts.
+
 Cody also fixed the Makefile to use `sdl-config` (which is what the author
 stated too though that was noticed later), not `sdl2-config` as two functions
 that are used were removed from [SDL2](https://www.libsdl.org),

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3488,8 +3488,11 @@ program in some systems he also added `-include ...` to the Makefile as well.
 
 ## <a name="2006_stewart"></a>[2006/stewart](/2006/stewart/stewart.c) ([README.md](/2006/stewart/README.md]))
 
-[Cody](#cody) fixed it so that if the file cannot be opened it exits rather than trying
-to read from the file.
+[Cody](#cody) added the [try.sh](/2006/stewart/try.sh) script.
+
+Cody also fixed it so that if the file cannot be opened it exits rather than trying
+to read from the file. This was done at a time when it was considered to be a
+bug to fix.
 
 
 ## <a name="2006_sykes1"></a>[2006/sykes1](/2006/sykes1/sykes1.c) ([README.md](/2006/sykes1/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3418,6 +3418,11 @@ Cody also added the [try.sh](/2006/birken/try.sh) script.
 implicitly linked in.
 
 
+## <a name="2006_grothe"></a>[2006/grothe](/2006/grothe/grothe.c) ([README.md](/2006/grothe/README.md))
+
+[Cody](#cody) added the [try.sh](/2006/grothe/try.sh) script.
+
+
 ## <a name="2006_hamre"></a>[2006/hamre](/2006/hamre/hamre.c) ([README.md](/2006/hamre/README.md))
 
 [Cody](#cody) fixed this so that it will not crash without an arg after it was suggested


### PR DESCRIPTION

It will run the program on a few files but before it runs it on the
remaining files (as there are quite a lot) it will ask you if you wish
to do so. It only asks once. If convert is found it will run convert on
the xbm images to convert to png. If it's not installed it will only
warn the user once so as to not spam them. If convert fails (say because
the convert is not convert from ImageMagick) it will warn once at the
end of the script. In any event if any files were converted it will list
the png files that exist at the end of the script. Otherwise it'll list
the xbm files. It does not first check if any of those file types exist
as it is presumed that at least a few will exist. If none do it is 
likely an error in the program or a corrupted data file.
