### PR TITLE
Silence 1992/gson/mkdict.sh shellcheck warnings

### DIFF
--- a/1992/gson/mkdict.sh
+++ b/1992/gson/mkdict.sh
@@ -1,4 +1,26 @@
 #!/usr/bin/env bash
+#
+# mkdict.sh - make a dictionary file for IOCCC winner 1992/gson
+#
+# This OBFUSCATED script was provided by the author.
+#
+
+# We disable all warnings from shellcheck(1) because this script was provided by
+# the author as an OBFUSCATED SCRIPT and not one to follow best practices.
+#
+# SC2060 (warning): Quote parameters to tr to prevent glob expansion.
+# https://www.shellcheck.net/wiki/SC2060 -- Quote parameters to tr to prevent...
+# SC2248 (style): Prefer double quoting even when variables don't contain special characters.
+# https://www.shellcheck.net/wiki/SC2248
+# SC1001 (info): This \^ will be a regular '^' in this context.
+# https://www.shellcheck.net/wiki/SC1001 -- This \^ will be a regular '^' in ...
+# SC1087 (error): Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
+# https://www.shellcheck.net/wiki/SC1087 -- Use braces when expanding arrays,...
+# SC2248 (style): Prefer double quoting even when variables don't contain special characters.
+# https://www.shellcheck.net/wiki/SC2248
+# SC1001 (info): This \^ will be a regular '^' in this context.
+# https://www.shellcheck.net/wiki/SC1001 -- This \^ will be a regular '^' in ...
+# SC2248 (style): Prefer double quoting even when variables don't contain special characters.
+# https://www.shellcheck.net/wiki/SC2248
+# shellcheck disable=SC2060,SC2248,SC1001,SC1087
 z=a-z];tr [A-Z\] \[$z|sed s/[\^$z[\^$z*/_/g|tr _ \\012|grep ..|sort -u
-
-

--- a/bin/gen-inventory.sh
+++ b/bin/gen-inventory.sh
@@ -45,13 +45,13 @@ fi
 #
 # Requires bash with a version 4.2 or later
 #
-shopt -s nullglob	# enable expanded to nothing rather than remaining unexpanded
+shopt -s nullglob	# enable expand to nothing rather than remaining unexpanded
 shopt -u failglob	# disable error message if no matches are found
-shopt -u dotglob	# disable matching files starting with .
-shopt -s globskipdots	# enable never matching . nor ..
+shopt -u dotglob	# disable matching files starting with '.'
+shopt -s globskipdots	# enable never matching '.' nor '..'
 shopt -u nocaseglob	# disable strict case matching
 shopt -u extglob	# enable extended globbing patterns
-shopt -s globstar	# enable ** to match all files and zero or more directories and subdirectories
+shopt -s globstar	# enable '**' to match all files and zero or more directories and subdirectories
 
 # set variables referenced in the usage message
 #
@@ -62,7 +62,7 @@ export V_FLAG=0
 GIT_TOOL=$(type -P git)
 export GIT_TOOL
 if [[ -z "$GIT_TOOL" ]]; then
-    echo "$0: FATAL: git tool is not installed or not in PATH" 1>&2
+    echo "$0: FATAL: git tool is not installed or is not in PATH" 1>&2
     exit 200
 fi
 "$GIT_TOOL" rev-parse --is-inside-work-tree >/dev/null 2>&1
@@ -238,7 +238,7 @@ if [[ ! -d $INC_PATH ]]; then
 fi
 export INC_DIR="inc"
 
-# verify that we have an bin subdirectory
+# verify that we have a bin subdirectory
 #
 export BIN_PATH="$TOPDIR/bin"
 if [[ ! -d $BIN_PATH ]]; then
@@ -333,7 +333,7 @@ if [[ ! -e $WINNER_JSON ]]; then
     exit 5
 fi
 if [[ ! -f $WINNER_JSON ]]; then
-    echo "$0: ERROR: .winner.json is not a file: $WINNER_JSON" 1>&2
+    echo "$0: ERROR: .winner.json is not a regular file: $WINNER_JSON" 1>&2
     exit 5
 fi
 if [[ ! -r $WINNER_JSON ]]; then
@@ -345,7 +345,7 @@ if [[ ! -e $PANDOC_WRAPPER ]]; then
     exit 6
 fi
 if [[ ! -f $PANDOC_WRAPPER ]]; then
-    echo "$0: ERROR: pandoc wrapper tool is not a file: $PANDOC_WRAPPER" 1>&2
+    echo "$0: ERROR: pandoc wrapper tool is not a regular file: $PANDOC_WRAPPER" 1>&2
     exit 6
 fi
 if [[ ! -x $PANDOC_WRAPPER ]]; then
@@ -361,7 +361,7 @@ if [[ ! -e $MANIFEST_WINNER_JSON_AWK ]]; then
     exit 6
 fi
 if [[ ! -f $MANIFEST_WINNER_JSON_AWK ]]; then
-    echo "$0: ERROR: bin/manifest.winner.json.awk is not a file: $MANIFEST_WINNER_JSON_AWK" 1>&2
+    echo "$0: ERROR: bin/manifest.winner.json.awk is not a regular file: $MANIFEST_WINNER_JSON_AWK" 1>&2
     exit 6
 fi
 if [[ ! -r $MANIFEST_WINNER_JSON_AWK ]]; then


### PR DESCRIPTION
    
As a test of the new format of disabling warnings/errors from shellcheck(1) I have done it for this script which is an important one to consider as every warning and error should be disabled as the author provided the script (that I added as a script file) as an obfuscated script and therefore to not follow best practices, not at the time or now. But this way it's just one script to see if this works well, rather than fixing all the others (which will happen later in any case).