### PR TITLE
Improve 1994/westley alt + to use etc.

### DIFF
--- a/1994/westley/.gitignore
+++ b/1994/westley/.gitignore
@@ -1,6 +1,5 @@
 #
 # sort with: sort -d -u
-a.out
 *.dSYM
 indent
 indent.c

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -131,7 +131,14 @@ ${PROG}: ${PROG}.c
 	@echo "=-=-=-=-="
 	@echo "NOTE: this entry has different compiler errors based on compilation line."
 	@echo "The purpose is to find the right error message to win the game!"
+	@echo
 	@echo "NOTE: your terminal should be set to 80 columns, 8 character tabs, and wraparound."
+	@echo "If you wish to avoid these restrictions try the alternate code with:"
+	@echo
+	@echo "	    make alt"
+	@echo
+	@echo "for the default messages and the specific cc -D options for the rest of the game."
+	@echo "See the README.md for details or the try.sh and try.alt.sh scripts."
 	@echo "=-=-=-=-="
 	-${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/1994/westley/README.md
+++ b/1994/westley/README.md
@@ -5,27 +5,44 @@ make alt
 ```
 
 We recommend that you try the alternate version first as the original entry
-requires (for good display) 80 columns and 8 character tabs with wraparound. The
-alt code is the same as the original except that the original code used
-`#include`s of files that do not exist to generate the messages (as compiler
-errors) whereas the alt code uses `printf(3)`. The purpose of the game is to
-escape the dungeon. For the original entry see [Original code](#original-code)
-below.
+requires (for better display) 80 columns and 8 character tabs with wraparound.
+
+The alt code uses the same logic as the original code except that the original
+code used `#include`s of files that do not exist to generate the messages (as
+compiler errors) whereas the alt code uses `printf(3)`. For the original entry
+see [Original code](#original-code) below.
 
 
 ## To use:
 
-There is no running as such. See below.
+
+```sh
+./westley.alt
+```
+
+The purpose of the game is to escape the dungeon. Depending on the compiler line
+you will get a different message when you run the program. One compiler line
+will make you win the game (escape the dungeon) and others will show something
+else.
+
+_This is independent of the previous (if there are any previous) compiler
+invocations_ specified. That means with the right compiler invocation you can
+'win' the game on the first go.
+
+There are a variety of different `-D` flags you give to `cc` that change the
+message you get. You might wish to look at the [source code](westley.alt.c) to
+get a better idea or see below in the [Try](#try) section for running the game
+from start to finish.
 
 
 ### Try:
 
-For something more interesting try compiling it with
-different cc arguments and then run the program each time.  For example:
+For something more interesting try compiling it with different `cc -D` arguments
+and then run the program each time.  For example:
 
 ```sh
-cc -Describe -Door westley.alt.c && ./a.out
-cc -Describe -Drain westley.alt.c && ./a.out
+cc -Describe -Door westley.alt.c -o westley.alt && ./westley.alt
+cc -Describe -Drain westley.alt.c -o westley.alt && ./westley.alt
 ```
 
 To see the game from start to finish, try:
@@ -37,8 +54,8 @@ To see the game from start to finish, try:
 
 ## Original code:
 
-NOTE: the purpose of this entry is to escape the dungeon via the compiler line
-where you **get messages as compiler errors**. Depending on the compiler line you
+The purpose of the game is to escape the dungeon **via the compiler line
+where you get _messages as compiler errors_**. Depending on the compiler line you
 will get different error messages and one compiler line will make you win the
 game!
 
@@ -53,19 +70,31 @@ reason that we recommend you try it first.
 make all
 ```
 
-Depending on the compilation line you will get different messages (as errors)
-which let you play the game.
+There are a variety of different `-D` flags you can give to `cc` that change the
+message you get. You might wish to look at the [source code](westley.c) to get a
+better idea or see below in the [Original try](#original-try) section for
+running the game from start to finish.
 
 
 ## Original use:
 
-There is no running as such. See below.
+There is no running of this program directly as it is supposed to fail to
+compile: the purpose of the game is to escape the dungeon but depending on the
+compiler line you will get a different message (**as compiler errors** due to
+`#include` files not existing). One compiler line will make you win the game
+(escape the dungeon) and others will show something else.
+
+_This is independent of the previous (if there are any previous) compiler
+invocations_ specified. That means with the right compiler invocation you can
+'win' the game on the first go. But unlike the [alternate code](westley.alt.c),
+you do not run this program as it will not compile: instead it will be compiler
+error messages; there is no running the program.
 
 
 ## Original try:
 
-For something more interesting try compiling it with
-different cc arguments.  For example:
+For something more interesting try compiling it with different `cc -D`
+arguments:
 
 ```sh
 cc -Describe -Door westley.c

--- a/1994/westley/try.alt.sh
+++ b/1994/westley/try.alt.sh
@@ -9,55 +9,55 @@ if [[ -z "$CC" ]]; then
     CC="cc"
 fi
 
-rm -f a.out
-"${CC}" -Describe -Door westley.alt.c && ./a.out
+rm -f westley.alt
+"${CC}" -Describe -Door westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Drain westley.alt.c && ./a.out
+"${CC}" -Describe -Drain westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Dwarf westley.alt.c && ./a.out
+"${CC}" -Describe -Dwarf westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Debris westley.alt.c && ./a.out # or -Dungeon
+"${CC}" -Describe -Debris westley.alt.c -o westley.alt && ./westley.alt # or -Dungeon
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Desk westley.alt.c && ./a.out
+"${CC}" -Describe -Desk westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Dime westley.alt.c && ./a.out
+"${CC}" -Describe -Dime westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Directory westley.alt.c && ./a.out
+"${CC}" -Describe -Directory westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Dial -DUNgeon0614 westley.alt.c && ./a.out
+"${CC}" -Dial -DUNgeon0614 westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Drink -Daiquiri westley.alt.c && ./a.out
+"${CC}" -Drink -Daiquiri westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Drop -Daiquiri westley.alt.c && ./a.out
+"${CC}" -Drop -Daiquiri westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Drop -Dwarf -Daiquiri westley.alt.c && ./a.out # or -Drop -Down -Daiquiri
+"${CC}" -Drop -Dwarf -Daiquiri westley.alt.c -o westley.alt && ./westley.alt # or -Drop -Down -Daiquiri
 sleep 1
 echo 1>&2
-"${CC}" -Describe -Document westley.alt.c && ./a.out
+"${CC}" -Describe -Document westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Depress -Dotted -Dog westley.alt.c && ./a.out
+"${CC}" -Depress -Dotted -Dog westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Depress -Dalmatian westley.alt.c && ./a.out # also accepts "Dalmation" [sic]
+"${CC}" -Depress -Dalmatian westley.alt.c -o westley.alt && ./westley.alt # also accepts "Dalmation" [sic]
 sleep 1
 echo 1>&2
-"${CC}" -Deposit -Dime westley.alt.c && ./a.out
+"${CC}" -Deposit -Dime westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Drop -Donut westley.alt.c && ./a.out
+"${CC}" -Drop -Donut westley.alt.c -o westley.alt && ./westley.alt
 sleep 1
 echo 1>&2
-"${CC}" -Drop -Donut -Down -Drain westley.alt.c && ./a.out # or -Drop -Dwarf -Donut
+"${CC}" -Drop -Donut -Down -Drain westley.alt.c -o westley.alt && ./westley.alt # or -Drop -Dwarf -Donut
 echo 1>&2
-rm -f a.out
+rm -f westley.alt

--- a/1994/westley/westley.alt.c
+++ b/1994/westley/westley.alt.c
@@ -1,4 +1,5 @@
-#include <stdio.h>
+#include<stdio.h>
+#include<stdlib.h>
 int main()
 {
 #if rop&onut&((own&rain)|warf)
@@ -7,46 +8,46 @@ printf("The orc scrambles to the drain,\n"
 "run out the door and escape!\n"
 "\n"
 "             The End\n");
-return 0;
+exit(0);
 #else
 #if escribe
 #if ocument
 printf("It reads:\n"
 "    Depress Dotted Dog\n");
-return 0;
+exit(0);
 #else
 #if oor
 printf("The door is decorated with relief\n"
 "figures of various dog breeds.\n");
-return 0;
+exit(0);
 #else
 #if rain
 printf("Through the drain you see a dwarf\n"
 "in another cell.\n");
-return 0;
+exit(0);
 #else
 #if warf
 printf("The gnarled dwarf looks thirsty.\n");
-return 0;
+exit(0);
 #else
 #if ungeon|ebris
 printf("You notice a desk, a phone, and\n"
 "a phone directory among the clutter.\n");
-return 0;
+exit(0);
 #else
 #if esk
 printf("There are some dimes on the desk.\n");
-return 0;
+exit(0);
 #else
 #if irectory
 printf("It reads:\n"
 "    Pixie's Pub -\n"
 "    instant service -\n"
 "    Dial DUNgeon0614\n");
-return 0;
+exit(0);
 #else
 printf("You notice nothing unusual.\n");
-return 0;
+exit(0);
 #endif
 #endif
 #endif
@@ -59,13 +60,13 @@ return 0;
 printf("Pixie takes your order, and\n"
 "magically, the room is filled\n"
 "with banana daiquiris.\n");
-return 0;
+exit(0);
 #endif
 #if rink&aiquiri
 printf("As you drink, a voice from\n"
 "below says 'Could you drop\n"
 "one down here?'\n");
-return 0;
+exit(0);
 #endif
 #if rop&aiquiri
 #if warf|own
@@ -74,11 +75,11 @@ printf("The dwarf eagerly accepts\n"
 "I found this, but I can't\n"
 "understand it.'  He hands\n"
 "you a document.\n");
-return 0;
+exit(0);
 #else
 printf("You drop the drink\n"
 "on the floor.\n");
-return 0;
+exit(0);
 #endif
 #endif
 #if epress&(almatian|almation)
@@ -87,33 +88,29 @@ printf("As you press the dalmatian\n"
 "to reveal a menacing orc by\n"
 "a vending machine (with a\n"
 "sign reading 'DEPOSIT MONEY').\n");
-return 0;
+exit(0);
 #endif
 #if eposit&(ime|imes)
 printf("Donuts spill out; you get\n"
 "some, the orc hungrily eats\n"
 "the rest.\n");
-return 0;
-
+exit(0);
 #endif
 #if rop&onut
-
 printf("The orc quickly eats the\n"
 "donut; he still bars the\n"
 "way.\n");
-
-return 0;
+exit(0);
 #endif
 #if rop+epress+ime+eposit+rink+aiquiri+onut==1
-
 printf("Be more specific.\n");
-return 0;
+exit(0);
 #endif
 printf("You are in a debris-filled\n"
 "dungeon; a door bars the\n"
 "way, and sludge trickles into\n"
 "a floor drain.\n");
-return 0;
+exit(0);
 #endif
 #endif
 }


### PR DESCRIPTION
The to build/original build, to use/original use and try/original try sections have been changed in the README.md to be much more consistent and clearer (and detailed in some ways).

The to run section (not the original run section as that one is not supposed to be compilable and is not compilable either) has './westley.alt' now as that will give you a message even right after running 'make clobber alt'.

The alt code was changed in that blank lines were removed and (as a cosmetic change) the 'return 0;'s were changed to 'exit(0);'s. Originally the idea was to have 'int main()' be 'main()' (like the original in the #if 0..#else..#endif block) but this will trigger -Wimplicit-int and since one would not want to run a more complicated 'make' invocation (instead of a simple 'cc' invocation or at least a simpler one) it means the output is messed up with a warning. But using exit(0); is fine albeit with an additional #include.

The try.alt.sh script now has an -o westley.alt and instead of running ./a.out it runs ./westley.alt. This makes it more like normal 'make alt' targets.

The Makefile all target now has information about the alt build as it does not have the restrictions of column width, character tab length and wraparound.

The .gitignore no longer has a.out in it.