### PR TITLE
Add 2011/vik/try.sh

### DIFF
--- a/2011/vik/.gitignore
+++ b/2011/vik/.gitignore
@@ -1,6 +1,7 @@
 #
 # sort with: sort -d -u
 audio_file.raw
+
 *.dSYM
 indent
 indent.c
@@ -9,3 +10,4 @@ prog.orig
 vik
 vik.alt
 vik.orig
+*.wav

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -25,21 +25,35 @@ For more detailed information see [2011 vik in bugs.md](/bugs.md#2011-vik).
 ./vik file.mod > audio_file.raw
 ```
 
+If you have `mplayer(1)`:
 
-## Try:
 
 ```sh
-./vik randowan.mod | mplayer -demuxer rawaudio -
-./vik mad_world.mod | mplayer -demuxer rawaudio -
+./vik file.mod | mplayer -demuxer rawaudio -
 ```
 
-Alternatively, you can use:
+Alternatively, you can convert the file to a WAV:
 
 ```sh
 ./vik file.mod > file.raw; ./raw2wav file.raw > file.wav
 ```
 
-It is possible to download a number of music module files from [The Mod
+and then play `file.wav` with a program that can play WAV files.
+
+
+## Try:
+
+```sh
+./try.sh
+```
+
+The script checks that you have `mplayer(1)` installed and if it is it will pipe
+`vik` to `mplayer`. In this case it will also use `raw2wav` to convert the file
+to a WAV file. If `mplayer(1)` cannot be found it will just use `raw2wav`. This
+way even if one has an `mplayer(1)` that fails or is for some reason not what is
+expected they can at least play the WAV file manually.
+
+It is also possible to download a number of music module files from [The Mod
 Archive](http://modarchive.org).
 
 
@@ -54,7 +68,6 @@ Assuming that `make` is similar enough try:
 
 ```sh
 make alt
-
 ```
 
 

--- a/2011/vik/try.sh
+++ b/2011/vik/try.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2011/vik
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+# in this case we won't fail if we can't compile the code because we can still
+# run the supplementary program.
+make CC="$CC" all >/dev/null
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# fine mplayer
+MPLAYER="$(type -P mplayer)"
+
+raw2wav()
+{
+    if [[ "$#" != 2 ]]; then
+	echo "$0: raw2wav() expects two args, got: $#" 1>&2
+	return
+    fi
+
+    read -r -n 1 -p "Press any key to run: ./vik $1 > $2: "
+    echo 1>&2
+    ./vik "$1" > "$2"
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to run: ./raw2wav $1 > $2: "
+    echo 1>&2
+    ./raw2wav "$1" > "$2"
+    echo 1>&2
+    echo "Converted $1 to $2." 1>&2
+    echo 1>&2
+}
+
+if [[ -n "$MPLAYER" && -f "$MPLAYER" && -x "$MPLAYER" ]]; then
+    # If we have mplayer we'll try playing the sounds directly. If however it
+    # fails for some reason we will run the alternate procedure, creating WAV
+    # files.
+    read -r -n 1 -p "Press any key to run: ./vik randowan.mod | $MPLAYER -demuxer rawaudio -: "
+    echo 1>&2
+    ./vik randowan.mod | mplayer -demuxer rawaudio -
+    raw2wav randowan.mod randowan.wav
+
+    read -r -n 1 -p "Press any key to run: ./vik mad_world.mod | mplayer -demuxer rawaudio -: "
+    echo 1>&2
+    ./vik mad_world.mod | mplayer -demuxer rawaudio -
+    raw2wav mad_world.mod mad_world.wav
+    echo 1>&2
+else
+    raw2wav randowan.mod randowan.wav
+    [[ -f randowan.wav ]] && echo "Now try playing randowan.wav with a program that can play WAV files." 1>&2
+
+    raw2wav mad_world.mod mad_world.wav
+    [[ -f mad_world.wav ]] && echo "Now try playing mad_world.wav with a program that can play WAV files." 1>&2
+fi

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3669,7 +3669,9 @@ controls, width and height.
 
 ## <a name="2011_vik"></a>[2011/vik](/2011/vik/vik.c) ([README.md](/2011/vik/README.md]))
 
-[Cody](#cody) added an [alternate version](/2011/vik/README.md#alternate-code) for Windows
+[Cody](#cody) added the [try.sh](/2011/vik/try.sh) script.
+
+Cody also added an [alternate version](/2011/vik/README.md#alternate-code) for Windows
 based on the author's comments (along with looking up the function for the right
 header files). To build try the alt rule of the Makefile.
 


### PR DESCRIPTION
The script will check that mplayer(1) is installed. If it is it will pipe vik to mplayer. In that case it will still use the raw2wav program just in case something goes wrong (or for some reason mplayer is not what is expected). If mplayer cannot be found or is not a regular executable file then it will just use raw2wav. The raw2wav function in the script tells you the name of the converted file. In the case that mplayer cannot be found the script also suggests that you play the WAV files with a program that can play WAV files.