### PR TITLE
Improve 2012/deckmyn/try.sh

### DIFF
--- a/2012/blakely/.gitignore
+++ b/2012/blakely/.gitignore
@@ -3,14 +3,8 @@
 blakely
 blakely.orig
 *.dSYM
-empty.gif
-flat.gif
+*.gif
 indent
 indent.c
 indent.o
-output.gif
-paraboloid.gif
-pic.gif
 prog.orig
-ripple.gif
-saddle.gif

--- a/2012/blakely/try.sh
+++ b/2012/blakely/try.sh
@@ -15,21 +15,31 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./blakely "xx*yy*+" 64 > paraboloid.gif" 1>&2
+read -r -n 1 -p "Press any key to run: ./blakely "xx*yy*+" 64 > paraboloid.gif: "
+echo 1>&2
 ./blakely "xx*yy*+" 64 > paraboloid.gif
+echo 1>&2
 
-echo "$ ./blakely 9 32 > empty.gif 1>&2"
+read -r -n 1 -p "Press any key to run: ./blakely 9 32 > empty.gif: "
+echo 1>&2
 ./blakely 9 32 > empty.gif
+echo 1>&2
 
-echo "$ ./blakely xy* 32 > saddle.gif" 1>&2
+read -r -n 1 -p "Press any key to run: ./blakely xy* 32 > saddle.gif: "
+echo 1>&2
 ./blakely xy* 32 > saddle.gif
+echo 1>&2
 
-echo "$ ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif" 1>&2
+read -r -n 1 -p "Press any key to run: ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif: "
+echo 1>&2
 ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif
+echo 1>&2
 
-echo "This might take a bit of time:" 1>&2
-echo "$ time ./blakely 0 250 > flat.gif" 1>&2
+read -r -n 1 -p "Press any key to run: time ./blakely 0 250 > flat.gif: "
+echo 1>&2
+echo "This might take a bit of time, please be patient." 1>&2
 time ./blakely 0 250 > flat.gif
+echo 1>&2
 
 echo "Now open paraboloid.gif, empty.gif, saddle.gif, ripple.gif and flat.gif in a" 1>&2
-echo "viewer that shows animated GIFs." 1>&2
+echo "graphics viewer that ANIMATES ANIMATED GIFs." 1>&2

--- a/2012/blakely/try.sh
+++ b/2012/blakely/try.sh
@@ -15,9 +15,10 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to run: ./blakely "xx*yy*+" 64 > paraboloid.gif: "
+read -r -n 1 -p "Press any key to run: ./blakely 'xx*yy*+' 64 > paraboloid.gif: "
 echo 1>&2
-./blakely "xx*yy*+" 64 > paraboloid.gif
+echo "This might take a bit of time, please be patient." 1>&2
+./blakely 'xx*yy*+' 64 > paraboloid.gif
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./blakely 9 32 > empty.gif: "
@@ -25,19 +26,21 @@ echo 1>&2
 ./blakely 9 32 > empty.gif
 echo 1>&2
 
-read -r -n 1 -p "Press any key to run: ./blakely xy* 32 > saddle.gif: "
+read -r -n 1 -p "Press any key to run: ./blakely 'xy*' 32 > saddle.gif: "
 echo 1>&2
-./blakely xy* 32 > saddle.gif
+echo "This might take a little bit of time, please be patient." 1>&2
+./blakely 'xy*' 32 > saddle.gif
 echo 1>&2
 
-read -r -n 1 -p "Press any key to run: ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif: "
+read -r -n 1 -p "Press any key to run: ./blakely 'xx*yy*1++d5*ct/' 64 > ripple.gif: "
 echo 1>&2
-./blakely xx*yy*1++d5*ct/ 64 > ripple.gif
+echo "This might take a bit of time, please be patient." 1>&2
+./blakely 'xx*yy*1++d5*ct/' 64 > ripple.gif
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: time ./blakely 0 250 > flat.gif: "
 echo 1>&2
-echo "This might take a bit of time, please be patient." 1>&2
+echo "This might take a while, please be patient." 1>&2
 time ./blakely 0 250 > flat.gif
 echo 1>&2
 

--- a/2012/deckmyn/.gitignore
+++ b/2012/deckmyn/.gitignore
@@ -1,15 +1,12 @@
 #
 # sort with: sort -d -u
-beethoven.pbm
-blank.pbm
 *.dSYM
 deckmyn
 deckmyn.orig
 example_greensleeves
-greensleeves.pbm
 indent
 indent.c
 indent.o
-output.pbm
+*.pbm
+*.png
 prog.orig
-sheetmusic.pbm

--- a/2012/deckmyn/try.sh
+++ b/2012/deckmyn/try.sh
@@ -15,26 +15,67 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to run deckmyn.c through less (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to show deckmyn.c (space = next page, q = quit): "
 echo 1>&2
-less deckmyn.c
+less -rEXF deckmyn.c
 echo 1>&2
+
 echo "$ ./deckmyn "\$\(cat deckmyn.c\)" "\$\(cat example_greensleeves\)" 2>/dev/null > greensleeves.pbm" 1>&2
-./deckmyn "$(cat deckmyn.c)" "$(cat example_greensleeves)" 2>/dev/null > greensleeves.pbm
+read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
-echo "Now open greensleeves.pbm in your image viewer of choice." 1>&2
+./deckmyn "$(cat deckmyn.c)" "$(cat example_greensleeves)" 2>/dev/null > greensleeves.pbm
 echo 1>&2
 
 echo "$ ./deckmyn "\$\(cat deckmyn.c\)" "\$\(cat example_beethoven\)" 2>/dev/null > beethoven.pbm" 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 ./deckmyn "$(cat deckmyn.c)" "$(cat example_beethoven)" 2>/dev/null > beethoven.pbm
-echo "Now open beethoven.pbm in your image viewer of choice." 1>&2
 echo 1>&2
 
 echo "$ ./deckmyn "\$\(cat deckmyn.c\)" \"sz sa x  s1 x  s1 x  s1 x  s1 x  s1 \" 2>/dev/null > blank.pbm" 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 ./deckmyn "$(cat deckmyn.c)" "sz sa x  s1 x  s1 x  s1 x  s1 x  s1 " 2>/dev/null > blank.pbm
-echo "Now open blank.pbm in your image viewer of choice." 1>&2
+echo 1>&2
 
+# Convert pbm files to png files if convert(1) is found in case the user does
+# not have a viewer of pbm files. At the end we will check for png files to ake
+# sure that there was at least one conversion. If that does not happen as long
+# as there are pbm files those will be listed instead. Otherwise something went
+# wrong and we warn the user about it.
+CONVERT="$(type -P convert)"
+if [[ -n "$CONVERT" && -f "$CONVERT" && -x "$CONVERT" ]]; then
+    if [[ -f "greensleeves.pbm" ]]; then
+	if "$CONVERT" greensleeves.pbm greensleeves.png; then
+	    echo "Converted greensleeves.pbm to greensleeves.png." 1>&2
+	fi
+    fi
+    if [[ -f "beethoven.pbm" ]]; then
+	if "$CONVERT" beethoven.pbm beethoven.png; then
+	    echo "Converted beethoven.pbm to beethoven.png." 1>&2
+	fi
+    fi
+    if [[ -f "blank.pbm" ]]; then
+	if "$CONVERT" blank.pbm blank.png; then
+	    echo "Converted blank.pbm to blank.png." 1>&2
+	fi
+    fi
+fi
+
+# Now tell the user to look at png files if any exist and otherwise any pbm
+# files if any exist. If no files exist then something went wrong so show a
+# warning message.
+if [[ ! "$(find . -name '*.png')" ]]; then
+    echo "Now open the following files with your image viewer of choice:" 1>&2
+    echo 1>&2
+    find . -name '*.png' -printf "   %p\n"
+elif [[ ! "$(find . -name '*.pbm')" ]]; then
+    echo "Now open the following files with your image viewer of choice:" 1>&2
+    echo 1>&2
+    find . -name '*.pbm' -printf "   %p\n"
+else
+    echo "-=-=-" 1>&2
+    echo "Notice: failed to write any image files. Free free to fix and open a" 1>&2
+    echo "pull request against the GitHub repo." 1>&2
+    echo "-=-=-" 1>&2
+fi


### PR DESCRIPTION

Improve less(1) options so that the screen is not cleared (to keep the 
source visible after it's seen) and to exit at EOF.

Try converting image files to png files. If this fails then as long as 
pbm files exist it will print those (telling the user to open them in 
their graphics viewer of choice). Otherwise if png files exist it lists
the png files (with the same message). If no png and no pbm files exist
it warns them that something went wrong and they are free to fix and 
open a pull request. This handling of convert(1) checks should probably
be done in other scripts where I neglected to do this (it's entirely 
possible though unlikely that a convert program exists that returns
success but does not do what we expect).

Updated .gitignore.
