### PR TITLE
Improve and add 2012/endoh1 try scripts

### DIFF
--- a/1986/bright/try.sh
+++ b/1986/bright/try.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# try.sh - demonstrate IOCCC winner 2000/tomx
+# try.sh - demonstrate IOCCC winner 1986/bright
 #
 
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it

--- a/2012/blakely/.gitignore
+++ b/2012/blakely/.gitignore
@@ -3,14 +3,8 @@
 blakely
 blakely.orig
 *.dSYM
-empty.gif
-flat.gif
+*.gif
 indent
 indent.c
 indent.o
-output.gif
-paraboloid.gif
-pic.gif
 prog.orig
-ripple.gif
-saddle.gif

--- a/2012/blakely/try.sh
+++ b/2012/blakely/try.sh
@@ -15,21 +15,31 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./blakely "xx*yy*+" 64 > paraboloid.gif" 1>&2
+read -r -n 1 -p "Press any key to run: ./blakely "xx*yy*+" 64 > paraboloid.gif: "
+echo 1>&2
 ./blakely "xx*yy*+" 64 > paraboloid.gif
+echo 1>&2
 
-echo "$ ./blakely 9 32 > empty.gif 1>&2"
+read -r -n 1 -p "Press any key to run: ./blakely 9 32 > empty.gif: "
+echo 1>&2
 ./blakely 9 32 > empty.gif
+echo 1>&2
 
-echo "$ ./blakely xy* 32 > saddle.gif" 1>&2
+read -r -n 1 -p "Press any key to run: ./blakely xy* 32 > saddle.gif: "
+echo 1>&2
 ./blakely xy* 32 > saddle.gif
+echo 1>&2
 
-echo "$ ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif" 1>&2
+read -r -n 1 -p "Press any key to run: ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif: "
+echo 1>&2
 ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif
+echo 1>&2
 
-echo "This might take a bit of time:" 1>&2
-echo "$ time ./blakely 0 250 > flat.gif" 1>&2
+read -r -n 1 -p "Press any key to run: time ./blakely 0 250 > flat.gif: "
+echo 1>&2
+echo "This might take a bit of time, please be patient." 1>&2
 time ./blakely 0 250 > flat.gif
+echo 1>&2
 
 echo "Now open paraboloid.gif, empty.gif, saddle.gif, ripple.gif and flat.gif in a" 1>&2
-echo "viewer that shows animated GIFs." 1>&2
+echo "graphics viewer that ANIMATES ANIMATED GIFs." 1>&2

--- a/2012/blakely/try.sh
+++ b/2012/blakely/try.sh
@@ -15,9 +15,10 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to run: ./blakely "xx*yy*+" 64 > paraboloid.gif: "
+read -r -n 1 -p "Press any key to run: ./blakely 'xx*yy*+' 64 > paraboloid.gif: "
 echo 1>&2
-./blakely "xx*yy*+" 64 > paraboloid.gif
+echo "This might take a bit of time, please be patient." 1>&2
+./blakely 'xx*yy*+' 64 > paraboloid.gif
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./blakely 9 32 > empty.gif: "
@@ -25,19 +26,21 @@ echo 1>&2
 ./blakely 9 32 > empty.gif
 echo 1>&2
 
-read -r -n 1 -p "Press any key to run: ./blakely xy* 32 > saddle.gif: "
+read -r -n 1 -p "Press any key to run: ./blakely 'xy*' 32 > saddle.gif: "
 echo 1>&2
-./blakely xy* 32 > saddle.gif
+echo "This might take a little bit of time, please be patient." 1>&2
+./blakely 'xy*' 32 > saddle.gif
 echo 1>&2
 
-read -r -n 1 -p "Press any key to run: ./blakely xx*yy*1++d5*ct/ 64 > ripple.gif: "
+read -r -n 1 -p "Press any key to run: ./blakely 'xx*yy*1++d5*ct/' 64 > ripple.gif: "
 echo 1>&2
-./blakely xx*yy*1++d5*ct/ 64 > ripple.gif
+echo "This might take a bit of time, please be patient." 1>&2
+./blakely 'xx*yy*1++d5*ct/' 64 > ripple.gif
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: time ./blakely 0 250 > flat.gif: "
 echo 1>&2
-echo "This might take a bit of time, please be patient." 1>&2
+echo "This might take a while, please be patient." 1>&2
 time ./blakely 0 250 > flat.gif
 echo 1>&2
 

--- a/2012/deckmyn/.gitignore
+++ b/2012/deckmyn/.gitignore
@@ -1,15 +1,12 @@
 #
 # sort with: sort -d -u
-beethoven.pbm
-blank.pbm
 *.dSYM
 deckmyn
 deckmyn.orig
 example_greensleeves
-greensleeves.pbm
 indent
 indent.c
 indent.o
-output.pbm
+*.pbm
+*.png
 prog.orig
-sheetmusic.pbm

--- a/2012/deckmyn/try.sh
+++ b/2012/deckmyn/try.sh
@@ -15,26 +15,67 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to run deckmyn.c through less (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to show deckmyn.c (space = next page, q = quit): "
 echo 1>&2
-less deckmyn.c
+less -rEXF deckmyn.c
 echo 1>&2
+
 echo "$ ./deckmyn "\$\(cat deckmyn.c\)" "\$\(cat example_greensleeves\)" 2>/dev/null > greensleeves.pbm" 1>&2
-./deckmyn "$(cat deckmyn.c)" "$(cat example_greensleeves)" 2>/dev/null > greensleeves.pbm
+read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
-echo "Now open greensleeves.pbm in your image viewer of choice." 1>&2
+./deckmyn "$(cat deckmyn.c)" "$(cat example_greensleeves)" 2>/dev/null > greensleeves.pbm
 echo 1>&2
 
 echo "$ ./deckmyn "\$\(cat deckmyn.c\)" "\$\(cat example_beethoven\)" 2>/dev/null > beethoven.pbm" 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 ./deckmyn "$(cat deckmyn.c)" "$(cat example_beethoven)" 2>/dev/null > beethoven.pbm
-echo "Now open beethoven.pbm in your image viewer of choice." 1>&2
 echo 1>&2
 
 echo "$ ./deckmyn "\$\(cat deckmyn.c\)" \"sz sa x  s1 x  s1 x  s1 x  s1 x  s1 \" 2>/dev/null > blank.pbm" 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 ./deckmyn "$(cat deckmyn.c)" "sz sa x  s1 x  s1 x  s1 x  s1 x  s1 " 2>/dev/null > blank.pbm
-echo "Now open blank.pbm in your image viewer of choice." 1>&2
+echo 1>&2
 
+# Convert pbm files to png files if convert(1) is found in case the user does
+# not have a viewer of pbm files. At the end we will check for png files to ake
+# sure that there was at least one conversion. If that does not happen as long
+# as there are pbm files those will be listed instead. Otherwise something went
+# wrong and we warn the user about it.
+CONVERT="$(type -P convert)"
+if [[ -n "$CONVERT" && -f "$CONVERT" && -x "$CONVERT" ]]; then
+    if [[ -f "greensleeves.pbm" ]]; then
+	if "$CONVERT" greensleeves.pbm greensleeves.png; then
+	    echo "Converted greensleeves.pbm to greensleeves.png." 1>&2
+	fi
+    fi
+    if [[ -f "beethoven.pbm" ]]; then
+	if "$CONVERT" beethoven.pbm beethoven.png; then
+	    echo "Converted beethoven.pbm to beethoven.png." 1>&2
+	fi
+    fi
+    if [[ -f "blank.pbm" ]]; then
+	if "$CONVERT" blank.pbm blank.png; then
+	    echo "Converted blank.pbm to blank.png." 1>&2
+	fi
+    fi
+fi
+
+# Now tell the user to look at png files if any exist and otherwise any pbm
+# files if any exist. If no files exist then something went wrong so show a
+# warning message.
+if [[ ! "$(find . -name '*.png')" ]]; then
+    echo "Now open the following files with your image viewer of choice:" 1>&2
+    echo 1>&2
+    find . -name '*.png' -printf "   %p\n"
+elif [[ ! "$(find . -name '*.pbm')" ]]; then
+    echo "Now open the following files with your image viewer of choice:" 1>&2
+    echo 1>&2
+    find . -name '*.pbm' -printf "   %p\n"
+else
+    echo "-=-=-" 1>&2
+    echo "Notice: failed to write any image files. Free free to fix and open a" 1>&2
+    echo "pull request against the GitHub repo." 1>&2
+    echo "-=-=-" 1>&2
+fi

--- a/2012/endoh1/.gitignore
+++ b/2012/endoh1/.gitignore
@@ -5,7 +5,9 @@ configuration.txt
 endoh1
 endoh1.alt
 endoh1.alt2
+endoh1.alt3
 endoh1_color
+endoh1_color2
 endoh1_color.alt
 endoh1_color.alt2
 endoh1.orig

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -115,8 +115,8 @@ DATA= column.txt column2.txt column3.txt corners.txt dripping-pan.txt \
 	funnel3.txt leidenfrost.txt logo.txt pour-out.txt tanada.txt
 TARGET= ${PROG} ${PROG}_color
 #
-ALT_OBJ= ${PROG}.alt.o ${PROG}_color.alt.o
-ALT_TARGET= ${PROG}.alt ${PROG}_color.alt
+ALT_OBJ= ${PROG}.alt.o ${PROG}_color.alt.o ${PROG}.alt2.o
+ALT_TARGET= ${PROG}.alt ${PROG}_color.alt ${PROG}.alt2
 
 # The factor of gravity
 #
@@ -167,9 +167,7 @@ ${PROG}.alt: ${PROG}.alt.c
 ${PROG}_color.alt: ${PROG}_color.alt.c
 	${CC} ${CFLAGS} -DS=${SLEEP} -DA=${TIMER} $< -o $@ ${LDFLAGS}
 
-alt2: ${PROG}.alt2
-	@${TRUE}
-
+# deobfuscated version:
 ${PROG}.alt2: ${PROG}.alt2.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/2012/endoh1/README.md
+++ b/2012/endoh1/README.md
@@ -6,30 +6,35 @@ make
 There are two alt versions that let you control the compile time variables that
 control the fluid behaviour and the added variables to speed up or slow down the
 fluid as well as setting a timeout (if not 0): one for the original black and
-white and the colour one added by the author at the request of the judges.
-Another version is the deobfuscated version provided by the author as well.  See
-[alternate code](#alternate-code) below for more details.
+white and one for the colour one added by the author (at the request of the
+judges at the time of the contest).  Another version is the deobfuscated version
+provided by the author as well.  See the [Alternate code](#alternate-code)
+section below for more details.
 
 
 ## To use:
 
 ```sh
-./endoh1 < configuration.txt
+./endoh1 < file
 ```
+
+WARNING: if you're sensitive to/don't like flashing colours/text or just want to
+see what this looks like not going so fast then you might wish to try the
+[Alternate code](#alternate-code) instead.
 
 
 ## Try:
 
 ```sh
-./endoh1 < endoh1.c
+./try.bw.sh endoh1.c
+./try.sh endoh1.c
 
-./endoh1 < pour-out.txt
+./try.bw.sh pour-out.txt
+./try.sh pour-out.txt
 
-./endoh1 < fountain.txt
+./try.bw.sh fountain.txt
+./try.sh fountain.txt
 ```
-
-Also try using `endoh1_color` as you would `endoh1` above. `make` will compile
-this by default.
 
 
 ## Alternate code:
@@ -46,46 +51,19 @@ the fluid and change the behaviour of the fluid. The file
 For the default values, try:
 
 ```sh
-make alt alt2
+make alt
 ```
-
-The `alt2` is only necessary if you wish to compile the deobfuscated version but
-it is equivalent in function to the original entry, [endoh1.c](endoh1.c).
 
 In the `alt` versions a default time of 10 seconds is set as an alarm so that
-one can more easily go through the list of files to see them all in succession
-for fun. That is controlled by the variable `A`; 0 disables it.
-
-If you wish to change the speed you should do:
-
-```sh
-make clobber SLEEP=N alt
-```
-
-where `N` is number or the letter `I`.
-
-WARNING: if you're sensitive to flashing colours or any flashing at all do make
-sure you don't decrease the value of `S`, the sleep time passed to `usleep(3)`,
-too much.
-
-If however you wish to change the gravity factor, pressure factor and/or
-viscosity factor, you should redefine the values `G`, `P` and/or `V` macros,
-respectively, with the same caveat about numbers for `S` above. For instance if
-you wish to change the viscosity and pressure factors but leave the other macros
-alone:
+one can more easily go through the list of files to see them all in succession,
+for fun. That is controlled by the variable `TIMER` at compilation.
+For instance if you wish to change the value to 5:
 
 ```sh
-make clobber VISCOSITY=X PRESSURE=Y alt
+make clobber TIMER=5 alt
 ```
 
-where `X` and `Y` are numbers or the letter `I` and which are, respectively, the
-viscosity and pressure factors.
-
-There is no restriction on what the number is because doing so prevents the
-macros from being defined to `I` which would prevent the author's remarks about
-it from being done.
-
-If you want to disable the alarm time, set `A` to 0:
+If you want to disable the alarm time, set it to 0:
 
 ```sh
 make clobber TIMER=0 alt
@@ -93,26 +71,41 @@ make clobber TIMER=0 alt
 
 It cannot be < 0 or > 60 (arbitrarily selected).
 
-Try slowing down the display by increasing the sleep time from `12321` to
-`50000`:
+The `SLEEP` variable is to delay the time between updates to make it easier to
+see and to not flash too quickly. The code protects against a value < 0 and
+defaults to 12321 but you can change it to. For instance to slow it down you
+could increase the sleep time from `12321` to `50000`:
 
 ```sh
 make clobber SLEEP=50000 alt
 ```
 
-Now try using both `endoh1.alt` and `endoh1_color.alt` as you would `endoh1` above.
 
-Also try speeding up the display by decreasing the sleep time from `12321` to
+If you wish to speed it up you might decrease the sleep time from `12321` to
 `9999`:
 
 ```sh
-make clobber SLEEP=9999 alt2
+make clobber SLEEP=9999 alt
 ```
 
-WARNING: again, be careful with too low a value if you're sensitive to flashing
-colours or anything at all.
+WARNING: the lower the value the faster it will flash so be careful if you're
+sensitive to this.
 
-Now try using both `endoh1.alt` and `endoh1_color.alt` as you would `endoh1` above.
+
+If you wish to change the gravity factor, pressure factor and/or
+viscosity factor, you should redefine the values `GRAVITY`, `PRESSURE` and/or
+`VISCOSITY` macros, respectively. For instance if you wish to change the
+viscosity and pressure factors but leave the other values alone:
+
+```sh
+make clobber VISCOSITY=X PRESSURE=Y alt
+```
+
+where `X` and `Y` are numbers or the letter `I` and which are, respectively, the
+viscosity and pressure factors. There is no attempt to check the value or type
+because doing so prevents the macros from being defined to `I` which would
+prevent the author's remarks about it from being done.
+
 
 You might also wish to try redefining the macros `G`, `P` and/or `V`. For
 instance:
@@ -128,7 +121,13 @@ You might try even:
 make clobber GRAVITY=I alt
 ```
 
-See the author's remarks for details on these macros.
+See the author's remarks for details on these macros where:
+
+```
+G = GRAVITY
+P = PRESSURE
+V = VISCOSITY
+```
 
 
 ### Alternate use:
@@ -147,6 +146,12 @@ try:
 ```
 
 The second run of each will be with the gravity factor set to `I`.
+
+To see the same thing but in the original uncoloured version, try:
+
+```sh
+./try.alt.bw.sh
+```
 
 
 ## Judges' remarks:

--- a/2012/endoh1/endoh1.alt.c
+++ b/2012/endoh1/endoh1.alt.c
@@ -3,7 +3,7 @@
 #  include<complex.h>  //||||                     ,____.              IOCCC-  #
 #  ifndef	       S
 #  define              S 12321
-#  elif                S < 1
+#  elif                S < 0
 #  undef               S
 #  define              S 12321
 #  endif

--- a/2012/endoh1/try.alt.bw.sh
+++ b/2012/endoh1/try.alt.bw.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# try.alt.sh - demonstrate IOCCC winner 2012/endoh1 alt code with colour
+# try.alt.bw.sh - demonstrate IOCCC winner 2012/endoh1 alt code w/o colour
 #
 
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
@@ -42,33 +42,33 @@ echo "$ make clobber CC=$CC TIMER=$TIMER SLEEP=$SLEEP GRAVITY=I VISCOSITY=$VISCO
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 make clobber CC="$CC" TIMER="$TIMER" SLEEP="$SLEEP" GRAVITY=I VISCOSITY="$VISCOSITY" PRESSURE="$PRESSURE" alt >/dev/null || exit 1
-# we have to move the endoh1_color.alt to endoh1_color.alt3, not alt2, because
-# we have to use make clobber which would wipe out endoh1_color.alt2.
-read -r -n 1 -p "Press any key to move endoh1_color.alt to endoh1_color.alt3: "
+# we have to move the endoh1.alt to endoh1.alt3, not alt2, because
+# we have to use make clobber which would wipe out endoh1.alt2.
+read -r -n 1 -p "Press any key to move endoh1.alt to endoh1.alt3: "
 echo 1>&2
-mv -v endoh1_color.alt endoh1_color.alt3
+mv -v endoh1.alt endoh1.alt3
 echo 1>&2
 echo "$ make clobber CC=$CC TIMER=$TIMER SLEEP=$SLEEP GRAVITY=$GRAVITY VISCOSITY=$VISCOSITY PRESSURE=$PRESSURE alt" 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 make clobber CC="$CC" TIMER="$TIMER" SLEEP="$SLEEP" GRAVITY="$GRAVITY" VISCOSITY="$VISCOSITY" PRESSURE="$PRESSURE" alt >/dev/null || exit 1
-read -r -n 1 -p "Press any key to move endoh1_color.alt3 to endoh1_color.alt2: "
+read -r -n 1 -p "Press any key to move endoh1.alt3 to endoh1.alt2: "
 echo 1>&2
-mv -v endoh1_color.alt3 endoh1_color.alt2
+mv -v endoh1.alt3 endoh1.alt2
 # clear screen before continuing
 clear
 
 # now that we have both binaries we can run each one on the data files, first
 # the source file.
-read -r -n 1 -p "Press any key to run: ./endoh1_color.alt < endoh1_color.alt.c 2>/dev/null: "
+read -r -n 1 -p "Press any key to run: ./endoh1.alt < endoh1.alt.c 2>/dev/null: "
 echo 1>&2
-./endoh1_color.alt < endoh1_color.alt.c 2>/dev/null
+./endoh1.alt < endoh1.alt.c 2>/dev/null
 echo 1>&2
 # reset terminal sanity
 reset
-read -r -n 1 -p "Press any key to run: ./endoh1_color.alt2 < endoh1_color.alt.c 2>/dev/null: "
+read -r -n 1 -p "Press any key to run: ./endoh1.alt2 < endoh1.alt.c 2>/dev/null: "
 echo 1>&2
-./endoh1_color.alt2 < endoh1_color.alt.c 2>/dev/null
+./endoh1.alt2 < endoh1.alt.c 2>/dev/null
 # reset terminal sanity
 reset
 
@@ -81,11 +81,11 @@ for i in clock.txt column.txt column2.txt column3.txt corners.txt \
 
     # to make it more 'fluid' :-) we only prompt once per file even though the
     # second command is a different file in that the gravity factor is set to I.
-    read -r -n 1 -p "Press any key to run: ./endoh1_color.alt < $i: "
+    read -r -n 1 -p "Press any key to run: ./endoh1.alt < $i: "
     clear
-    ./endoh1_color.alt < "$i" 2>/dev/null
+    ./endoh1.alt < "$i" 2>/dev/null
     clear
-    ./endoh1_color.alt2 < "$i" 2>/dev/null
+    ./endoh1.alt2 < "$i" 2>/dev/null
     # reset terminal sanity
     reset
 done

--- a/2012/endoh1/try.bw.sh
+++ b/2012/endoh1/try.bw.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# try.bw.sh - demonstrate IOCCC winner 2012/endoh1 w/o colour
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+if [[ "$#" -ne 1 ]]; then
+    echo "usage: $0 file" 1>&2
+    exit 1
+fi
+
+read -r -n 1 -p "Press any key to run: ./endoh1 < $1 (ctrl-c/intr to end program): "
+./endoh1 < "$1"

--- a/2012/endoh1/try.sh
+++ b/2012/endoh1/try.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2012/endoh1 with colour
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+if [[ "$#" -ne 1 ]]; then
+    echo "usage: $0 file" 1>&2
+    exit 1
+fi
+
+read -r -n 1 -p "Press any key to run: ./endoh1_color < $1 (ctrl-c/intr to end program): "
+./endoh1_color < "$1"

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3727,8 +3727,16 @@ with the default, and which is run on the source file and each of the text files
 supplied by the author. This code has an alarm set at 10 seconds so that one
 need not hit ctrl-c/intr in between .. say to make it more fluid :-)
 
-The [endoh1.alt2.c](/2012/endoh1/endoh1.alt.c) was provided by Yusuke as a
-de-obfuscated version.
+Cody also added the [try.alt.bw.sh](/2012/endoh1/try.alt.bw.sh) which is the
+same as the `try.alt.sh` except it does not use the coloured version.
+
+Finally Cody added the [try.sh](/2012/endoh1/try.sh) and
+[try.bw.sh](/2012/endoh1/try.bw.sh) which correspond to the coloured version
+[endoh1_color.c](/2012/endoh1/endoh1_color.c) and the original submitted
+version without colour, [endoh1.c](/2012/endoh1/endoh1.c).
+
+The [endoh1.alt2.c](/2012/endoh1/endoh1.alt2.c) was provided by the author,
+[Yusuke](#yusuke), at the time of the contest as a de-obfuscated version.
 
 
 ## <a name="2012_endoh2"></a>[2012/endoh2](/2012/endoh2/endoh2.c) ([README.md](/2012/endoh2/README.md))


### PR DESCRIPTION

The new try.sh and try.bw.sh scripts run the program on one file (passed 
to the script) in colour and without colour respectively. One file
because one has to terminate the program.

The new try.alt.bw.sh is like try.alt.sh but uses the black and white
(original submitted entry) version.

The scripts for the alt code allow one to set the different variables
that can be redefined. The use is the same variable names as in the
Makefile. For instance:
   
   TIMER=5 SLEEP=5000 GRAVITY=I VISCOSITY=4 PRESSURE=1 ./try.alt.sh
   TIMER=5 SLEEP=5000 GRAVITY=I VISCOSITY=4 PRESSURE=1 ./try.bw.alt.sh

for the gravity 'I' and:
   
   TIMER=5 SLEEP=5000 GRAVITY=N VISCOSITY=4 PRESSURE=1 ./try.alt.sh
   TIMER=5 SLEEP=5000 GRAVITY=N VISCOSITY=4 PRESSURE=1 ./try.bw.alt.sh

where 'N' is some number. Obviously the other values can have different
values than given above. Some of these values are protected against in
code (to an extent - if the user wants to set them to strings that's on
them) but not all are and the scripts do not try and check for the user
either.

The endoh1.alt.c file was changed in that one can now define SLEEP (S in
the code) to 0 like the original, should they want to see the original
but with other values specified. That will make it flash much more
quickly which can be a problem of course but that's up to each user.