### PR TITLE
Improve 2012/hamano/try.sh + add helper make rules

### DIFF
--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-empty-body -Wno-format \
 	-Wno-format-security -Wno-gnu-zero-variadic-macro-arguments -Wno-main \
-	-Wno-parentheses
+	-Wno-parentheses -Wno-implicit-function-declaration -Wno-strict-prototypes
 
 # Common C compiler warning flags
 #
@@ -129,10 +129,47 @@ all: data ${TARGET}
 .PHONY: all alt data everything diff_orig_prog diff_prog_orig \
 	diff_alt_prog diff_prog_alt diff_orig_alt diff_alt_orig \
 	clean clobber install love haste waste maker easter_egg \
-	sandwich supernova deep_magic magic charon pluto
+	sandwich supernova deep_magic magic charon pluto hint hint.pdf \
+	hello hello.pdf
+
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+# hint.pdf rules to simplify use of 2012/hamano
+#
+
+# This rule generates the hint.pdf file which is the README.md obfuscated as a
+# PDF that is NOT part of the repo:
+hint.pdf: ${PROG} README.md
+	./${PROG} < README.md > hint.pdf
+	@echo
+
+# This rule, hint, depends on the hint.pdf rule. That rule generates the
+# hint.pdf file (NOT part of the repo) which is an obfuscated (as a PDF) version
+# of the README.md. This rule, in turn, COMPILES THAT PDF FILE AS C CODE!
+hint: hint.pdf
+	${CC} ${CFLAGS} -xc $< -o $@
+
+
+# hello.pdf rules to simplify use of 2012/hamano
+#
+
+# This rule generates the hello.pdf file which is a simple 'Hello World!'
+# program obfuscated as a PDF:
+hello.pdf:
+	echo 'int main(){puts("Hello World!");}' | ./${PROG} > hello.pdf
+
+# This rule, hello, depends on the hello.pdf rule. That rule generates the
+# hello.pdf file (NOT part of the repo) which is an obfuscated (as a PDF) version
+# of a simple 'Hello World!' program. This rule, in turn, COMPILES THAT PDF FILE
+# AS C CODE to hello and then pipes it to cc to compile it to hello2 which when
+# run will print 'Hello World!'.
+hello: hello.pdf
+	@echo
+	${CC} ${CFLAGS} -xc hello.pdf -o $@
+	@echo
+	./hello | ${CC} ${CFLAGS} -xc - -o hello2 
 
 # alternative executable
 #
@@ -204,7 +241,7 @@ clean:
 	fi
 
 clobber: clean
-	${RM} -f ${TARGET} ${ALT_TARGET}
+	${RM} -f ${TARGET} ${ALT_TARGET} hint.pdf hello.pdf hello hello2
 	${RM} -rf *.dSYM
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \

--- a/2012/hamano/README.md
+++ b/2012/hamano/README.md
@@ -28,15 +28,28 @@ One of the PDF files generated is this README.md file as a PDF, obfuscated, and
 the PDF file will then be compiled as C (itself!) and executed so that it shows
 README.md!
 
-Another PDF file generated is obfuscated C code. Once this is done it will
-compile the PDF as if it was C and then run it like:
+That procedure looks like:
+
+```sh
+./hamano < README.md > hint.pdf
+cc -xc hint.pdf -o hint
+./hint
+```
+
+Another PDF generated is an obfuscated `Hello World!` program (obfuscated inside
+the PDF). Once this is done it will compile the PDF as if it was C (itself!). It
+will look like:
 
 ```sh
 echo 'int main(){puts("Hello World!");}' | ./hamano > hello.pdf
-cc -Wno-implicit-function-declaration -xc hello.pdf -o hello2
-./hello2 | gcc -Wno-implicit-function-declaration -xc - -o ./hello3
-./hello3
+cc -xc hello.pdf -o hello
+./hello | cc -Wno-implicit-function-declaration -xc - -o ./hello2
+
+./hello2
 ```
+
+although the `CFLAGS` will be what is in the Makefile as it uses the helper
+rules `hint.pdf`, `hint`, `hello.pdf` and `hello` to do this.
 
 
 ## Judges' remarks:

--- a/2012/hamano/try.sh
+++ b/2012/hamano/try.sh
@@ -15,37 +15,47 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to obfuscate README.md, writing to hint.pdf: "
-echo 1>&2
-echo "$ ./hamano < README.md > hint.pdf" 1>&2
-./hamano < README.md > hint.pdf
+# delete hint.pdf
+rm -f hint.pdf
 
-echo "Now try opening it in a pdf viewer before proceeding." 1>&2
-read -r -n 1 -p "Press any key to continue: "
-
+echo "Will obfuscate README.md like:" 1>&2
 echo 1>&2
-echo "$ ${CC} -xc hint.pdf -o hint" 1>&2
-${CC} -xc hint.pdf -o hint
+echo "    ./hamano < README.md > hint.pdf" 1>&2
 echo 1>&2
-read -r -n 1 -p "Press any key to run: ./hint | less (space = next page, q = quit): "
-./hint | less
-
+echo "and then compile it as C like:" 1>&2
+echo 1>&2
+echo "    ${CC} -xc hint.pdf -o hint" 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: make hint: "
+echo 1>&2
+make hint
+echo 1>&2
+echo "Now try opening hint.pdf in a pdf viewer before proceeding." 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./hint (space = next page, q = quit): "
+echo 1>&2
+./hint | less -rEXFK
 echo 1>&2
 
 echo "Will obfuscate the following code: " 1>&2
 echo 1>&2
-echo "	    int main(){puts("Hello World!");}"
+echo "    int main(){puts("Hello World!");}"
 echo 1>&2
-echo "writing to hello.pdf" 1>&2
-echo 'int main(){puts("Hello World!");}' | ./hamano > hello.pdf
+echo "writing it to hello.pdf via:" 1>&2
 echo 1>&2
-echo "Now open hello.pdf in a pdf viewer before continuing." 1>&2
+echo "     echo 'int main(){puts("Hello World!");}' | ./hamano > hello.pdf"
 echo 1>&2
-read -r -n 1 -p "Press any key to continue to deobfuscate and compile hello.pdf: "
+echo "and then execute the following commands:" 1>&2
 echo 1>&2
-echo "$ ${CC} -Wno-implicit-function-declaration -xc hello.pdf -o hello2" 1>&2
-${CC} -Wno-implicit-function-declaration -xc hello.pdf -o hello2
-echo "$ ./hello2 | ${CC} -Wno-implicit-function-declaration -xc - -o ./hello3" 1>&2
-./hello2 | ${CC} -Wno-implicit-function-declaration -xc - -o ./hello3
-echo "$ ./hello3" 1>&2
-./hello3
+echo "    ${CC} -xc hello.pdf -o hello" 1>&2
+echo "    ./hello | ${CC} -xc - -o hello2" 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: make hello: "
+echo 1>&2
+make hello
+echo 1>&2
+echo "Now open hello.pdf in a pdf viewer to see the obfuscated source." 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./hello2: "
+echo 1>&2
+./hello2

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3769,7 +3769,9 @@ which the recipe file now links to.
 
 ## <a name="2012_hamano"></a>[2012/hamano](/2012/hamano/hamano.c) ([README.md](/2012/hamano/README.md]))
 
-[Cody](#cody) added the [try.sh](/2012/hamano/try.sh) script.
+[Cody](#cody) added the [try.sh](/2012/hamano/try.sh) script and the helper
+Makefile rules `hint.pdf`, `hint`, `hello.pdf` and `hello` to simplify the
+procedure for both `hint.pdf` and `hello.pdf` as well as compiling them as C. 
 
 
 ## <a name="2012_hou"></a>[2012/hou](/2012/hou/hou.c) ([README.md](/2012/hou/README.md]))


### PR DESCRIPTION
The Makefile rules added:

    hint.pdf
    hint

    hello.pdf
    hello

The hint rules generate the hint.pdf (which is the README.md file obfuscated in a pdf) by feeding the program README.md and then it compiles hint.pdf as C code. Running it will print the README.md file!

The hello rules generate hello.pdf which is (inside the pdf) an obfuscated 'Hello World!' program. This is done by a simple echo piped o the program which redirects it to hello.pdf. Then hello.pdf will be compiled as C code which when run (as ./hello2) will print 'Hello World!'.

The script now uses these rules to do what was once done manually. These rules are .PHONY rules as otherwise they might not always run.

The clobber rule now removes these files.