### PR TITLE
Improve and shellcheck fix 2012/tromp/try.sh

### DIFF
--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-empty-body -Wno-format \
 	-Wno-format-security -Wno-gnu-zero-variadic-macro-arguments -Wno-main \
-	-Wno-parentheses
+	-Wno-parentheses -Wno-implicit-function-declaration -Wno-strict-prototypes
 
 # Common C compiler warning flags
 #
@@ -129,10 +129,47 @@ all: data ${TARGET}
 .PHONY: all alt data everything diff_orig_prog diff_prog_orig \
 	diff_alt_prog diff_prog_alt diff_orig_alt diff_alt_orig \
 	clean clobber install love haste waste maker easter_egg \
-	sandwich supernova deep_magic magic charon pluto
+	sandwich supernova deep_magic magic charon pluto hint hint.pdf \
+	hello hello.pdf
+
 
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
+# hint.pdf rules to simplify use of 2012/hamano
+#
+
+# This rule generates the hint.pdf file which is the README.md obfuscated as a
+# PDF that is NOT part of the repo:
+hint.pdf: ${PROG} README.md
+	./${PROG} < README.md > hint.pdf
+	@echo
+
+# This rule, hint, depends on the hint.pdf rule. That rule generates the
+# hint.pdf file (NOT part of the repo) which is an obfuscated (as a PDF) version
+# of the README.md. This rule, in turn, COMPILES THAT PDF FILE AS C CODE!
+hint: hint.pdf
+	${CC} ${CFLAGS} -xc $< -o $@
+
+
+# hello.pdf rules to simplify use of 2012/hamano
+#
+
+# This rule generates the hello.pdf file which is a simple 'Hello World!'
+# program obfuscated as a PDF:
+hello.pdf:
+	echo 'int main(){puts("Hello World!");}' | ./${PROG} > hello.pdf
+
+# This rule, hello, depends on the hello.pdf rule. That rule generates the
+# hello.pdf file (NOT part of the repo) which is an obfuscated (as a PDF) version
+# of a simple 'Hello World!' program. This rule, in turn, COMPILES THAT PDF FILE
+# AS C CODE to hello and then pipes it to cc to compile it to hello2 which when
+# run will print 'Hello World!'.
+hello: hello.pdf
+	@echo
+	${CC} ${CFLAGS} -xc hello.pdf -o $@
+	@echo
+	./hello | ${CC} ${CFLAGS} -xc - -o hello2 
 
 # alternative executable
 #
@@ -204,7 +241,7 @@ clean:
 	fi
 
 clobber: clean
-	${RM} -f ${TARGET} ${ALT_TARGET}
+	${RM} -f ${TARGET} ${ALT_TARGET} hint.pdf hello.pdf hello hello2
 	${RM} -rf *.dSYM
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \

--- a/2012/hamano/README.md
+++ b/2012/hamano/README.md
@@ -28,15 +28,28 @@ One of the PDF files generated is this README.md file as a PDF, obfuscated, and
 the PDF file will then be compiled as C (itself!) and executed so that it shows
 README.md!
 
-Another PDF file generated is obfuscated C code. Once this is done it will
-compile the PDF as if it was C and then run it like:
+That procedure looks like:
+
+```sh
+./hamano < README.md > hint.pdf
+cc -xc hint.pdf -o hint
+./hint
+```
+
+Another PDF generated is an obfuscated `Hello World!` program (obfuscated inside
+the PDF). Once this is done it will compile the PDF as if it was C (itself!). It
+will look like:
 
 ```sh
 echo 'int main(){puts("Hello World!");}' | ./hamano > hello.pdf
-cc -Wno-implicit-function-declaration -xc hello.pdf -o hello2
-./hello2 | gcc -Wno-implicit-function-declaration -xc - -o ./hello3
-./hello3
+cc -xc hello.pdf -o hello
+./hello | cc -Wno-implicit-function-declaration -xc - -o ./hello2
+
+./hello2
 ```
+
+although the `CFLAGS` will be what is in the Makefile as it uses the helper
+rules `hint.pdf`, `hint`, `hello.pdf` and `hello` to do this.
 
 
 ## Judges' remarks:

--- a/2012/hamano/try.sh
+++ b/2012/hamano/try.sh
@@ -15,37 +15,47 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to obfuscate README.md, writing to hint.pdf: "
-echo 1>&2
-echo "$ ./hamano < README.md > hint.pdf" 1>&2
-./hamano < README.md > hint.pdf
+# delete hint.pdf
+rm -f hint.pdf
 
-echo "Now try opening it in a pdf viewer before proceeding." 1>&2
-read -r -n 1 -p "Press any key to continue: "
-
+echo "Will obfuscate README.md like:" 1>&2
 echo 1>&2
-echo "$ ${CC} -xc hint.pdf -o hint" 1>&2
-${CC} -xc hint.pdf -o hint
+echo "    ./hamano < README.md > hint.pdf" 1>&2
 echo 1>&2
-read -r -n 1 -p "Press any key to run: ./hint | less (space = next page, q = quit): "
-./hint | less
-
+echo "and then compile it as C like:" 1>&2
+echo 1>&2
+echo "    ${CC} -xc hint.pdf -o hint" 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: make hint: "
+echo 1>&2
+make hint
+echo 1>&2
+echo "Now try opening hint.pdf in a pdf viewer before proceeding." 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./hint (space = next page, q = quit): "
+echo 1>&2
+./hint | less -rEXFK
 echo 1>&2
 
 echo "Will obfuscate the following code: " 1>&2
 echo 1>&2
-echo "	    int main(){puts("Hello World!");}"
+echo "    int main(){puts("Hello World!");}"
 echo 1>&2
-echo "writing to hello.pdf" 1>&2
-echo 'int main(){puts("Hello World!");}' | ./hamano > hello.pdf
+echo "writing it to hello.pdf via:" 1>&2
 echo 1>&2
-echo "Now open hello.pdf in a pdf viewer before continuing." 1>&2
+echo "     echo 'int main(){puts("Hello World!");}' | ./hamano > hello.pdf"
 echo 1>&2
-read -r -n 1 -p "Press any key to continue to deobfuscate and compile hello.pdf: "
+echo "and then execute the following commands:" 1>&2
 echo 1>&2
-echo "$ ${CC} -Wno-implicit-function-declaration -xc hello.pdf -o hello2" 1>&2
-${CC} -Wno-implicit-function-declaration -xc hello.pdf -o hello2
-echo "$ ./hello2 | ${CC} -Wno-implicit-function-declaration -xc - -o ./hello3" 1>&2
-./hello2 | ${CC} -Wno-implicit-function-declaration -xc - -o ./hello3
-echo "$ ./hello3" 1>&2
-./hello3
+echo "    ${CC} -xc hello.pdf -o hello" 1>&2
+echo "    ./hello | ${CC} -xc - -o hello2" 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: make hello: "
+echo 1>&2
+make hello
+echo 1>&2
+echo "Now open hello.pdf in a pdf viewer to see the obfuscated source." 1>&2
+echo 1>&2
+read -r -n 1 -p "Press any key to run: ./hello2: "
+echo 1>&2
+./hello2

--- a/2012/hou/try.sh
+++ b/2012/hou/try.sh
@@ -15,14 +15,18 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to run: less hou.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to run show hou.c (space = next page, q = quit): "
 echo 1>&2
-less -X hou.c
+less -rEXFK hou.c
 echo 1>&2
 
-read -r -n 1 -p "Press any key to run: ./hou ansi.txt hou.c | less -r (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to run: ./hou ansi.txt hou.c (space = next page, q = quit): "
 echo 1>&2
-echo "$ ./hou ansi.txt hou.c | less -r"
+# Note: unlike the other try.sh/try.alt.sh scripts we don't use options that
+# don't reset the terminal and that quit less(1) when it reaches EOF. This is
+# because if we do the effect will vanish the moment they reach the EOF. Also if
+# we don't have less(1) reset things the colour of the rest of the script will
+# be wrong. Thus in this script the user must hit 'q' to finish this command.
 ./hou ansi.txt hou.c | less -r
 echo 1>&2
 

--- a/2012/kang/README.md
+++ b/2012/kang/README.md
@@ -36,8 +36,9 @@ where the sound of 'V' is 'F' and so the program had the letter be 'F'. A
 problem, however, with changing it is that it breaks other words including in
 German. Thus there is the alternate version instead which fixes a problem for
 Germans that causes problems for Germans so if you're German you'll just have to
-deal with it :-) It is, however, good as you might be able appreciate the entry
-even more.
+deal with it :-) It also breaks other words too and this happens only for one
+letter change. With this one should hopefully be able to really appreciate the
+subtlety of this entry even more.
 
 
 ### Alternate build:
@@ -50,7 +51,10 @@ make alt
 ### Alternate use:
 
 ```sh
+echo "full spelling of an English cardinal numeral less than a quadrillion" | ./kang.alt
+
 echo vier | ./kang.alt
+
 echo uno | ./kang.alt
 ```
 
@@ -58,14 +62,17 @@ echo uno | ./kang.alt
 ### Alternate try:
 
 ```sh
-./de.alt.sh # German 0 through 13 both with and without umlaut
+./try.alt.sh # try various languages
+
 ./en.alt.sh # English 0 through 13
+
+./de.alt.sh # German 0 through 13 with both umlauts and without (additional 'e')
 ```
 
 What does it get right? What does it get wrong? How does it compare to the
 original entry without the change of `f` to `v`?
 
-Finally why does it get what it gets wrong wrong? 
+Finally why does it get wrong what it gets wrong? 
 
 
 ## Judges' remarks:

--- a/2012/kang/de.alt.sh
+++ b/2012/kang/de.alt.sh
@@ -37,7 +37,8 @@ done
 j=0
 for i in Null eins zwei drei vier fünf fuenf sechs sieben acht neun zehn elf zwoelf zwölf dreizehn ; \
 do
-    echo -n "$i (${NUMBERS[$j]}): "
-	echo "$i"|"./$KANG"
-	((j++))
+    read -r -n 1 -p "Press any key to run: echo $i | ./$KANG # ${NUMBERS[$j]}: "
+    echo 1>&2
+    echo "$i" | "./$KANG"
+    ((j++))
 done

--- a/2012/kang/de.sh
+++ b/2012/kang/de.sh
@@ -37,7 +37,8 @@ done
 j=0
 for i in Null eins zwei drei vier fünf fuenf sechs sieben acht neun zehn elf zwoelf zwölf dreizehn ; \
 do
-    echo -n "$i (${NUMBERS[$j]}): "
-	echo "$i"|"./$KANG"
-	((j++))
+    read -r -n 1 -p "Press any key to run: echo $i | ./$KANG # ${NUMBERS[$j]}: "
+    echo 1>&2
+    echo "$i" | "./$KANG"
+    ((j++))
 done

--- a/2012/kang/en.alt.sh
+++ b/2012/kang/en.alt.sh
@@ -32,7 +32,8 @@ done
 j=0
 for i in zero one two three four five six seven eight nine ten eleven twelve thirteen ; \
 do
-    echo -n "$i (${NUMBERS[$j]}): "
-    echo "$i"|"./$KANG"
+    read -r -n 1 -p "Press any key to run: echo $i | ./$KANG # ${NUMBERS[$j]}: "
+    echo 1>&2
+    echo "$i" | "./$KANG"
     ((j++))
 done

--- a/2012/kang/en.sh
+++ b/2012/kang/en.sh
@@ -33,7 +33,8 @@ done
 j=0
 for i in zero one two three four five six seven eight nine ten eleven twelve thirteen ; \
 do
-    echo -n "$i (${NUMBERS[$j]}): "
-    echo "$i"|"./$KANG"
+    read -r -n 1 -p "Press any key to run: echo $i | ./$KANG # ${NUMBERS[$j]}: "
+    echo 1>&2
+    echo "$i" | "./$KANG"
     ((j++))
 done

--- a/2012/kang/try.alt.sh
+++ b/2012/kang/try.alt.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# try.alt.sh - demonstrate IOCCC winner 2012/kang alt code
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" everything >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: echo Nineteen hundred and eighty-four | ./kang.alt # 1984: "
+echo 1>&2
+echo Nineteen hundred and eighty-four | ./kang.alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo uno | ./kang.alt # 1: "
+echo 1>&2
+echo uno | ./kang.alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo trois | ./kang.alt # 3: "
+echo 1>&2
+echo trois | ./kang.alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo fier | ./kang.alt # 4, should be vier: "
+echo 1>&2
+echo fier | ./kang.alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo vier | ./kang.alt # 4: "
+echo 1>&2
+echo vier | ./kang.alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo \"shest'\" | ./kang.alt # 6: "
+echo 1>&2
+echo "shest'" | ./kang.alt
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo dos | ./kang.alt # 2: "
+echo 1>&2
+echo dos | ./kang.alt
+echo 1>&2

--- a/2012/kang/try.sh
+++ b/2012/kang/try.sh
@@ -14,20 +14,40 @@ make CC="$CC" everything >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ echo Nineteen hundred and eighty-four | ./kang" 1>&2
+read -r -n 1 -p "Press any key to run: echo Nineteen hundred and eighty-four | ./kang # 1984: "
+echo 1>&2
 echo Nineteen hundred and eighty-four | ./kang
+echo 1>&2
 
-echo "$ echo uno | ./kang" 1>&2
+read -r -n 1 -p "Press any key to run: echo uno | ./kang # 1: "
+echo 1>&2
 echo uno | ./kang
+echo 1>&2
 
-echo "$ echo trois | ./kang" 1>&2
+read -r -n 1 -p "Press any key to run: echo trois | ./kang # 3: "
+echo 1>&2
 echo trois | ./kang
+echo 1>&2
 
-echo "$ echo fier | ./kang # notice the issue here, see alternate code instead" 1>&2
+read -r -n 1 -p "Press any key to run: echo fier | ./kang # 4, should be vier: "
+echo 1>&2
 echo fier | ./kang # notice the issue here, see alternate code instead
+echo 1>&2
 
-echo "$ echo \"shest'\" | ./kang" 1>&2
+read -r -n 1 -p "Press any key to run: echo vier | ./kang # 4: "
+echo 1>&2
+echo vier | ./kang # notice the issue here, see alternate code instead
+echo 1>&2
+echo "Note: for a version that gets this one right (breaking others" 1>&2
+echo "including fier), see the alt code." 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo \"shest'\" | ./kang # 6: "
+echo 1>&2
 echo "shest'" | ./kang
+echo 1>&2
 
-echo "$ echo dos | ./kang" 1>&2
+read -r -n 1 -p "Press any key to run: echo dos | ./kang # 2: "
+echo 1>&2
 echo dos | ./kang
+echo 1>&2

--- a/2012/konno/README.md
+++ b/2012/konno/README.md
@@ -14,14 +14,18 @@ code](#alternate-code) below.
 ./konno N
 ```
 
-NOTE: N is an integer from 0 to 255.
-
 
 ## Try:
 
 ```sh
 ./try.sh
+
+# you can also specify numbers to try before the random and preselected ones:
+./try.sh 111 222 333 444 555 666 777 888 999
 ```
+
+Try running [try.sh](try.sh) a number of times as the first part randomly
+selects ten numbers to try.
 
 
 ## Alternate code:

--- a/2012/konno/try.sh
+++ b/2012/konno/try.sh
@@ -15,47 +15,71 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-echo "$ ./konno 30" 1>&2
+# let user specify args to run on program too
+while [[ "$#" -ge 1 ]]; do
+    read -r -n 1 -p "Press any key to run: ./konno $1: "
+    echo 1>&2
+    ./konno "$1"
+    echo 1>&2
+    shift 1
+done
+
+# use ten random values (in range $((RANDOM % 101)))
+i=0
+# we do it this way to prevent the annoying shellcheck warning that 'i' appears
+# to be unused (as it would be if 'for i in {0..9}; do .. done').
+while [[ "$i" -lt 10 ]]; do
+    NUM="$((RANDOM % 101))"
+    read -r -n 1 -p "Press any key to run: ./konno $NUM: "
+    echo 1>&2
+    ./konno "$NUM"
+    echo 1>&2
+    ((i++))
+done
+
+
+# finally use some preselected values
+read -r -n 1 -p "Press any key to run: ./konno 30: "
+echo 1>&2
 ./konno 30
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 90: "
 echo 1>&2
-echo "$ ./konno 90" 1>&2
 ./konno 90
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 102: "
 echo 1>&2
-echo "$ ./konno 102" 1>&2
 ./konno 102
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 109: "
 echo 1>&2
-echo "$ ./konno 109" 1>&2
 ./konno 109
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 165: "
 echo 1>&2
-echo "$ ./konno 165" 1>&2
 ./konno 165
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 42: "
 echo 1>&2
-echo "$ ./konno 42" 1>&2
 ./konno 42 
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 37: "
 echo 1>&2
-echo "$ ./konno 37" 1>&2
 ./konno 37 
 echo 1>&2
 
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: ./konno 255: "
 echo 1>&2
-echo "$ ./konno 255" 1>&2
 ./konno 255 
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./konno 10000: "
+echo 1>&2
+./konno 10000
+echo 1>&2

--- a/2012/omoikane/try.alt.sh
+++ b/2012/omoikane/try.alt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# try.sh - demonstrate IOCCC winner 2012/omoikane alternate code
+# try.alt.sh - demonstrate IOCCC winner 2012/omoikane alt code
 #
 
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
@@ -10,7 +10,7 @@ if [[ -z "$CC" ]]; then
     CC="cc"
 fi
 
-make CC="$CC" everything >/dev/null || exit 1
+make CC="$CC" alt >/dev/null || exit 1
 
 # clear screen after compilation so that only the entry is shown
 clear
@@ -23,27 +23,29 @@ PERL="$(type -P perl)"
 
 echo "$ echo \"A quick brown fox jumps over the lazy dog\" | ./nyaruko.alt > output.c" 1>&2
 echo "A quick brown fox jumps over the lazy dog" | ./nyaruko.alt > output.c
-read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to show output.c (space = next page, q = quit): "
 echo 1>&2
-less -EX output.c
+less -rEXFK output.c
 
 # perl specific stuff
-if [[ -n "$PERL" ]]; then
+if [[ -n "$PERL" && -f "$PERL" && -x "$PERL" ]]; then
     read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: " 1>&2
     echo 1>&2
     "${PERL}" output.c > data.c
-    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    read -r -n 1 -p "Press any key to show data.c (space = next page, q = quit): "
     echo 1>&2
-    less -EX data.c
-    echo "$ cc -o data data.c" 1>&2
+    less -rEXFK data.c
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run: cc -o data data.c: "
+    echo 1>&2
     cc -o data data.c
     read -r -n 1 -p "Press any key to run: ./data: "
-    echo "$ ./data" 1>&2
     echo 1>&2
     ./data
 fi
 
-echo "$ cc -o output output.c" 1>&2
+read -r -n 1 -p "Press any key to run: cc -o output output.c: "
+echo 1>&2
 cc -o output output.c
 read -r -n 1 -p "Press any key to run: ./output: "
 echo 1>&2
@@ -53,37 +55,41 @@ echo "$ ./output" 1>&2
 read -r -n 1 -p "Press any key to run: ./nyaruko.alt < output > output.c: "
 echo 1>&2
 ./nyaruko.alt < output > output.c
-read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to show output.c (space = next page, q = quit): "
 echo 1>&2
-less -EX output.c
+less -rEXFK output.c
 
 read -r -n 1 -p "Press any key to run: bash output.c > key.c: "
+echo 1>&2
 bash output.c > key.c
 echo 1>&2
-read -r -n 1 -p "Press any key to run: less -EX key.c (space = next page, q = quit): "
-less -EX key.c
+read -r -n 1 -p "Press any key to run: show key.c (space = next page, q = quit): "
+less -rEXFK key.c
 
 # more perl stuff
-if [[ -n "${PERL}" ]]; then
+if [[ -n "${PERL}" && -f "$PERL" && -x "$PERL" ]]; then
     read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: "
     echo 1>&2
     "${PERL}" output.c > data.c
-    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    read -r -n 1 -p "Press any key to show data.c (space = next page, q = quit): "
     echo 1>&2
-    less -EX data.c
+    less -rEXFK data.c
     read -r -n 1 -p "Press any key to run: cat key.c data.c > output.c: "
     echo 1>&2
     cat key.c data.c > output.c
-    read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+    read -r -n 1 -p "Press any key to show output.c (space = next page, q = quit): "
     echo 1>&2
-    less -EX output.c
-    echo "$ cc output.c -o output" 1>&2
+    less -rEXFK output.c
+    read -r -n 1 -p "Press any key to run: cc output.c -o output: "
+    echo 1>&2
     cc output.c -o output
     read -r -n 1 -p "Press any key to run: ./output > output.2: "
     echo 1>&2
     ./output > output.2
-    echo "$ chmod +x output.2" 1>&2
+    read -r -n 1 -p "Press any key to run: chmod +x output.2: "
+    echo 1>&2
     chmod +x output.2
     read -r -n 1 -p "Press any key to run: ./output.2: "
+    echo 1>&2
     ./output.2
 fi

--- a/2012/omoikane/try.sh
+++ b/2012/omoikane/try.sh
@@ -23,27 +23,29 @@ PERL="$(type -P perl)"
 
 echo "$ echo \"A quick brown fox jumps over the lazy dog\" | ./nyaruko > output.c" 1>&2
 echo "A quick brown fox jumps over the lazy dog" | ./nyaruko > output.c
-read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to show output.c (space = next page, q = quit): "
 echo 1>&2
-less -EX output.c
+less -rEXFK output.c
 
 # perl specific stuff
-if [[ -n "$PERL" ]]; then
+if [[ -n "$PERL" && -f "$PERL" && -x "$PERL" ]]; then
     read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: " 1>&2
     echo 1>&2
     "${PERL}" output.c > data.c
-    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    read -r -n 1 -p "Press any key to show data.c (space = next page, q = quit): "
     echo 1>&2
-    less -EX data.c
-    echo "$ cc -o data data.c" 1>&2
+    less -rEXFK data.c
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run: cc -o data data.c: "
+    echo 1>&2
     cc -o data data.c
     read -r -n 1 -p "Press any key to run: ./data: "
-    echo "$ ./data" 1>&2
     echo 1>&2
     ./data
 fi
 
-echo "$ cc -o output output.c" 1>&2
+read -r -n 1 -p "Press any key to run: cc -o output output.c: "
+echo 1>&2
 cc -o output output.c
 read -r -n 1 -p "Press any key to run: ./output: "
 echo 1>&2
@@ -53,37 +55,41 @@ echo "$ ./output" 1>&2
 read -r -n 1 -p "Press any key to run: ./nyaruko < output > output.c: "
 echo 1>&2
 ./nyaruko < output > output.c
-read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+read -r -n 1 -p "Press any key to show output.c (space = next page, q = quit): "
 echo 1>&2
-less -EX output.c
+less -rEXFK output.c
 
 read -r -n 1 -p "Press any key to run: bash output.c > key.c: "
+echo 1>&2
 bash output.c > key.c
 echo 1>&2
-read -r -n 1 -p "Press any key to run: less -EX key.c (space = next page, q = quit): "
-less -EX key.c
+read -r -n 1 -p "Press any key to run: show key.c (space = next page, q = quit): "
+less -rEXFK key.c
 
 # more perl stuff
-if [[ -n "${PERL}" ]]; then
+if [[ -n "${PERL}" && -f "$PERL" && -x "$PERL" ]]; then
     read -r -n 1 -p "Press any key to run: ${PERL} output.c > data.c: "
     echo 1>&2
     "${PERL}" output.c > data.c
-    read -r -n 1 -p "Press any key to run: less -EX data.c (space = next page, q = quit): "
+    read -r -n 1 -p "Press any key to show data.c (space = next page, q = quit): "
     echo 1>&2
-    less -EX data.c
+    less -rEXFK data.c
     read -r -n 1 -p "Press any key to run: cat key.c data.c > output.c: "
     echo 1>&2
     cat key.c data.c > output.c
-    read -r -n 1 -p "Press any key to run: less -EX output.c (space = next page, q = quit): "
+    read -r -n 1 -p "Press any key to show output.c (space = next page, q = quit): "
     echo 1>&2
-    less -EX output.c
-    echo "$ cc output.c -o output" 1>&2
+    less -rEXFK output.c
+    read -r -n 1 -p "Press any key to run: cc output.c -o output: "
+    echo 1>&2
     cc output.c -o output
     read -r -n 1 -p "Press any key to run: ./output > output.2: "
     echo 1>&2
     ./output > output.2
-    echo "$ chmod +x output.2" 1>&2
+    read -r -n 1 -p "Press any key to run: chmod +x output.2: "
+    echo 1>&2
     chmod +x output.2
     read -r -n 1 -p "Press any key to run: ./output.2: "
+    echo 1>&2
     ./output.2
 fi

--- a/2012/tromp/try.sh
+++ b/2012/tromp/try.sh
@@ -15,106 +15,96 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-# ^-- SC2140 (warning): Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?
-# shellcheck disable=SC2140 
-echo "$ (cat hilbert.Blc; echo -n "1") | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: (cat hilbert.Blc; echo -n \"1\") | ./tromp: "
 echo 1>&2
 (cat hilbert.Blc; echo -n "1") | ./tromp
 echo 1>&2
 
-# ^-- SC2140 (warning): Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?
-# shellcheck disable=SC2140 
-echo "$ (cat hilbert.Blc; echo -n "12") | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: (cat hilbert.Blc; echo -n \"12\") | ./tromp: "
 echo 1>&2
 (cat hilbert.Blc; echo -n "12") | ./tromp
 echo 1>&2
 
-# ^-- SC2140 (warning): Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?
-# shellcheck disable=SC2140 
-echo "$ (cat hilbert.Blc; echo -n "123") | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
-echo 1>&2
-
-# There's no such thing as a useless cat so we silence:
+# There's no such thing as a useless cat so we silence. Well okay it's also
+# because it's easier to verify that it works as this form was given by the
+# author.
 #
-#   SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-#
+# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# https://www.shellcheck.net/wiki/SC2002
 # shellcheck disable=SC2002
+read -r -n 1 -p "Press any key to run: (cat hilbert.Blc; echo -n \"123\") | ./tromp: "
+echo 1>&2
 (cat hilbert.Blc; echo -n "123") | ./tromp
 echo 1>&2
 
-echo "$ (cat hilbert.Blc; echo -n 1234) | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: (cat hilbert.Blc; echo -n 1234) | ./tromp: "
 echo 1>&2
-# There's no such thing as a useless cat so we silence:
+# There's no such thing as a useless cat so we silence. Well okay it's also
+# because it's easier to verify that it works as this form was given by the
+# author.
 #
-#   SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-#
+# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# https://www.shellcheck.net/wiki/SC2002
 # shellcheck disable=SC2002
-
 (cat hilbert.Blc; echo -n 1234) | ./tromp
 echo 1>&2
 
-echo "$ echo " Hello, world" | ./tromp"
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: echo \" Hello, world\" | ./tromp: "
 echo 1>&2
 echo " Hello, world" | ./tromp
 echo 1>&2
 
-echo "$ echo "*Hello, world" | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: echo \"*Hello, world\" | ./tromp: "
 echo 1>&2
 echo "*Hello, world" | ./tromp
 echo 1>&2
 
-echo "$ (cat uni8.Blc; echo " Ni hao") | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: (cat uni8.Blc; echo \" Ni hao\") | ./tromp: "
 echo 1>&2
-# There's no such thing as a useless cat so we silence:
-#
-#   SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-#
-# shellcheck disable=SC2002
 (cat uni8.Blc; echo " Ni hao") | ./tromp
 echo 1>&2
 
 echo "$ cat primes.blc | ./tromp -b | head -c 70" 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
-# There's no such thing as a useless cat so we silence:
+# There's no such thing as a useless cat so we silence. Well okay it's also
+# because it's easier to verify that it works as this form was given by the
+# author.
 #
-#   SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-#
+# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# https://www.shellcheck.net/wiki/SC2002
 # shellcheck disable=SC2002
 cat primes.blc | ./tromp -b | head -c 70
 echo 1>&2
 
 echo "$ (cat oddindices.Blc; echo -n " "; cat primes.blc | ./tromp -b) | ./tromp | head -c 70" 1>&2
-echo 1>&2
 read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
-# There's no such thing as a useless cat so we silence:
+
+# There's no such thing as a useless cat so we silence. Well okay it's also
+# because it's easier to verify that it works as this form was given by the
+# author.
 #
-#   SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-#
+# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# https://www.shellcheck.net/wiki/SC2002
 # shellcheck disable=SC2002
 (cat oddindices.Blc; echo -n " "; cat primes.blc | ./tromp -b) | ./tromp | head -c 70
 echo 1>&2
 
-echo "$ cat hw.bf" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+read -r -n 1 -p "Press any key to run: cat hw.bf: "
 echo 1>&2
 cat hw.bf
 echo 1>&2
-echo "$ cat bf.Blc hw.bf | ./tromp" 1>&2
-read -r -n 1 -p "Press any key to continue: "
+
+
+read -r -n 1 -p "Press any key to run: cat bf.Blc hw.bf | ./tromp: "
 echo 1>&2
-# There's no such thing as a useless cat so we silence:
+# There's no such thing as a useless cat so we silence. Well okay it's also
+# because it's easier to verify that it works as this form was given by the
+# author.
 #
-#   SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-#
+# SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+# https://www.shellcheck.net/wiki/SC2002
 # shellcheck disable=SC2002
 cat bf.Blc hw.bf | ./tromp
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3769,7 +3769,9 @@ which the recipe file now links to.
 
 ## <a name="2012_hamano"></a>[2012/hamano](/2012/hamano/hamano.c) ([README.md](/2012/hamano/README.md]))
 
-[Cody](#cody) added the [try.sh](/2012/hamano/try.sh) script.
+[Cody](#cody) added the [try.sh](/2012/hamano/try.sh) script and the helper
+Makefile rules `hint.pdf`, `hint`, `hello.pdf` and `hello` to simplify the
+procedure for both `hint.pdf` and `hello.pdf` as well as compiling them as C. 
 
 
 ## <a name="2012_hou"></a>[2012/hou](/2012/hou/hou.c) ([README.md](/2012/hou/README.md]))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3820,17 +3820,15 @@ respectively. Notice how a single letter changes so much!
 
 ## <a name="2012_omoikane"></a>[2012/omoikane](/2012/omoikane/omoikane.c) ([README.md](/2012/omoikane/README.md]))
 
-[Cody](#cody) added the [try.sh](/2012/omoikane/try.sh) script.
-
-Cody also added the [alternate code](/2012/omoikane/README.md#alternate-code)
+[Cody](#cody) added the [alternate versions](/2012/omoikane/README.md#alternate-code)
 which will, if no arg is specified, read in the program itself, rather than
 `/dev/urandom`. This is mostly useful for those without a `/dev/urandom` device
 file (the default for the entry). The second alternate version is like the first
 except that it also sets binary mode on `stdin` and `stdout` which should
 theoretically make it work in Windows.
 
-Cody also added the [try.alt.sh](/2012/omoikane/try.alt.sh) script that is like
-the `try.sh` script but which uses the (first version of the) alt code instead.
+Cody also added the [try.sh](/2012/omoikane/try.sh) and
+[try.alt.sh](/2012/omoikane/try.alt.sh) scripts.
 
 
 ## <a name="2012_tromp"></a>[2012/tromp](/2012/tromp/tromp.c) ([README.md](/2012/tromp/README.md))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3797,7 +3797,7 @@ about it. Using both, however, allows one to experience different capabilities
 and also enjoy or appreciate the entry even more, given how simple the
 difference is.
 
-Cody also added five scripts: [en.sh](/2012/kang/en.sh),
+Cody also added six scripts: [en.sh](/2012/kang/en.sh),
 [de.sh](/2012/kang/de.sh), [en.alt.sh](/2012/kang/en.alt.sh) and
 [de.alt.sh](/2012/de.alt.sh) which count from 0 through 13 in English and German
 using the original entry and the alt version respectively.
@@ -3807,8 +3807,10 @@ In the German scripts it uses the umlaut and also does it without the umlaut
 either version but the `.alt.sh` versions default to the `alt` version whereas
 the other defaults to the submitted entry. See the README.md for details.
 
-The fifth script, [try.sh](/2012/kang/try.sh), runs a sequence of commands to
-show different languages and numbers.
+The fifth and sixth scripts, [try.sh](/2012/kang/try.sh) and
+[try.alt.sh](/2012/kang/try.alt.sh), run a sequence of commands to
+show different languages and numbers with the submitted and alternate version
+respectively. Notice how a single letter changes so much!
 
 
 ## <a name="2012_konno"></a>[2012/konno](/2012/konno/konno.c) ([README.md](/2012/konno/README.md]))


### PR DESCRIPTION

As for the shellcheck warning could be fixed (missing '\' before a '"') 
and the useless cat ones had the rationale updated (it's what the author
used so it's easier to verify it's okay though I still say - and so does
the script - that there's no such thing as a useless cat) and the format
of what warning is disabled (URL included).
