### PR TITLE
Add 2013/endoh3/try.sh

### DIFF
--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -24,7 +24,7 @@ download one or both before exiting.
 ## Try:
 
 ```sh
-cat jpeg.c
+less jpeg.c
 ```
 
 Next look at `jpeg.jpg` in an image viewer program.

--- a/2013/endoh3/.gitignore
+++ b/2013/endoh3/.gitignore
@@ -7,3 +7,4 @@ indent
 indent.c
 indent.o
 prog.orig
+*.wav

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
-	-Wno-main -Wno-deprecated-non-prototype
+	-Wno-main -Wno-deprecated-non-prototype -Wno-unused-parameter
 
 # Common C compiler warning flags
 #

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -22,21 +22,32 @@ For more detailed information see [2013 endoh3 in bugs.md](/bugs.md#2013-endoh3)
 ./endoh3
 ```
 
+This program plays sound. See [FAQ 3.10 - How do I compile and use an IOCCC
+winner that requires sound?](/faq.md#faq3_10) if you do not know how to set your
+system up for this or if you want to verify that everything is oky.
+
 
 ## Try:
 
-Trying this out will depend on how your system can play sounds. The author's
-remarks include some options for different operating systems.
-
-The simplest way is to create a .wav file and have your system play that.
-
 ```sh
-echo 'CDEFGABc' | ./endoh3 | ruby wavify.rb > cde.wav
+./try.sh
+
+./try.sh ABC
+
+./try.sh test.abc yankee.abc
+
+./try.sh *.abc
 ```
 
-Observe how you will need ruby installed.
+The script will check for SoX first and next `padsp` from `PulseAudio` and
+finally if neither are found if you have `ruby(1)` installed it'll use the
+included ruby script to convert it to a WAV file for you to play.
 
-There are also some other musical samples, twinkle.abc and menuet.abc.
+If no args are passed to the script it will play [twinkle.abc](twinkle.abc) and
+the string `ABC`. Otherwise while there's a remaining arg if it's a file it will
+run the program on the file. If it's not a file it'll run it as a string.
+
+The `*.abc` files are provided as music samples.
 
 
 ## Judges' remarks:

--- a/2013/endoh3/endoh3.c
+++ b/2013/endoh3/endoh3.c
@@ -1,1 +1,1 @@
-char a;float b,c;main(d){for(;d>2e3*c?c=1,scanf(" %c%f",&a,&c),d=55-a%32*9/5,b=d>9,d=d%13-a/32*12:1;a=2)++d<24?b*=89/84.:putchar(a=b*d);}
+char a;float b,c;main(d,e)char**e;{for(;d>2e3*c?c=1,scanf(" %c%f",&a,&c),d=55-a%32*9/5,b=d>9,d=d%13-a/32*12:1;a=2)++d<24?b*=89/84.:putchar(a=b*d);}

--- a/2013/endoh3/try.sh
+++ b/2013/endoh3/try.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2013/endoh3
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# Because there are numerous ways to run this entry we check for different tools
+# being installed in order to determine how to proceed. Even so /dev/dsp seems
+# to be uninstalled in modern systems so we check for what the author suggested
+# with that but only if the other options won't work (like SoX not installed).
+#
+SOX="$(type -P sox)"
+PADSP="$(type -P padsp)"
+RUBY="$(type -P ruby)"
+
+endoh3()
+{
+    if [[ "$#" -ne 1 ]]; then
+	echo "$0: endoh3() requires one arg, got: $#" 1>&2
+	return
+    fi
+    if [[ -f "$1" && -r "$1" ]]; then
+	if [[ -n "$SOX" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    echo 1>&2
+	elif [[ -n "$PADSP" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    echo 1>&2
+	elif [[ -n "$RUBY" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
+	    echo 1>&2
+	else
+	    echo "Please install either SoX, ruby or padsp (from PulseAudio)." 1>&2
+	    exit 1
+	fi
+    else # no file
+	if [[ -n "$SOX" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    echo 1>&2
+	elif [[ -n "$PADSP" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    echo 1>&2
+	elif [[ -n "$RUBY" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
+	    echo 1>&2
+	else
+	    echo "Please install either SoX, ruby or padsp (from PulseAudio)." 1>&2
+	    exit 1
+	fi
+    fi
+}
+
+if [[ "$#" -lt 1 ]]; then
+    # if we have no arg just run endoh3 with twinkle.abc and the string ABC.
+    endoh3 twinkle.abc
+    endoh3 ABC
+    endoh3 CDEFGABc
+else
+    # otherwise while we have an arg run endoh3 on it as a file or string
+    while [[ "$#" -gt 0 ]]; do
+	endoh3 "$1"
+	shift 1
+    done
+fi

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3977,6 +3977,14 @@ not found.
 The entry can still be enjoyed if you do not have these tools, however.
 
 
+## <a name="2013_endoh3"></a>[2013/endoh3](/2013/endoh3/endoh3.c) ([README.md](/2013/endoh3/README.md))
+
+[Cody](#cody) added the [try.sh](/2013/endoh3/try.sh) script.
+
+Cody also (out of an abundance of caution for `clang(1)` which is strict with
+arg type and count to `main()`) added a second (unused) arg to `main()`.
+
+
 ## <a name="2013_endoh4"></a>[2013/endoh4](/2013/endoh4/endoh4.c) ([README.md](/2013/endoh4/README.md))
 
 [Cody](#cody) added the [try.sh](/2013/endoh4/try.sh) script which temporarily


### PR DESCRIPTION

The script checks for SoX, padsp and otherwise ruby. It allows one to
pass in args: each one is first checked to be a readable file and if
it is it'll be processed as a file; otherwise it'll be processed as a
string. If no arg is specified it runs the program on twinkle.abc and
the strings ABC and CDEFGABc (the latter suggested by the author).

If none of the three tools noted above are installed it tells the user
to install one of them first. I was not able to test the padsp(1) one
but the invocation matches the author's remarks. /dev/dsp seems to not
be installed in modern linux systems so it would be useful to have
padsp(1) if not SoX (which is preferable in general for entries that
play sound). The ruby script wavify.rb provided by the author is the
last resort which turns the output to a WAV file.