### PR TITLE
Improvements to build and script of 2013/endoh4 

### DIFF
--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -24,7 +24,7 @@ download one or both before exiting.
 ## Try:
 
 ```sh
-cat jpeg.c
+less jpeg.c
 ```
 
 Next look at `jpeg.jpg` in an image viewer program.

--- a/2013/endoh3/.gitignore
+++ b/2013/endoh3/.gitignore
@@ -7,3 +7,4 @@ indent
 indent.c
 indent.o
 prog.orig
+*.wav

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
-	-Wno-main -Wno-deprecated-non-prototype
+	-Wno-main -Wno-deprecated-non-prototype -Wno-unused-parameter
 
 # Common C compiler warning flags
 #

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -22,21 +22,32 @@ For more detailed information see [2013 endoh3 in bugs.md](/bugs.md#2013-endoh3)
 ./endoh3
 ```
 
+This program plays sound. See [FAQ 3.10 - How do I compile and use an IOCCC
+winner that requires sound?](/faq.md#faq3_10) if you do not know how to set your
+system up for this or if you want to verify that everything is oky.
+
 
 ## Try:
 
-Trying this out will depend on how your system can play sounds. The author's
-remarks include some options for different operating systems.
-
-The simplest way is to create a .wav file and have your system play that.
-
 ```sh
-echo 'CDEFGABc' | ./endoh3 | ruby wavify.rb > cde.wav
+./try.sh
+
+./try.sh ABC
+
+./try.sh test.abc yankee.abc
+
+./try.sh *.abc
 ```
 
-Observe how you will need ruby installed.
+The script will check for SoX first and next `padsp` from `PulseAudio` and
+finally if neither are found if you have `ruby(1)` installed it'll use the
+included ruby script to convert it to a WAV file for you to play.
 
-There are also some other musical samples, twinkle.abc and menuet.abc.
+If no args are passed to the script it will play [twinkle.abc](twinkle.abc) and
+the string `ABC`. Otherwise while there's a remaining arg if it's a file it will
+run the program on the file. If it's not a file it'll run it as a string.
+
+The `*.abc` files are provided as music samples.
 
 
 ## Judges' remarks:

--- a/2013/endoh3/endoh3.c
+++ b/2013/endoh3/endoh3.c
@@ -1,1 +1,1 @@
-char a;float b,c;main(d){for(;d>2e3*c?c=1,scanf(" %c%f",&a,&c),d=55-a%32*9/5,b=d>9,d=d%13-a/32*12:1;a=2)++d<24?b*=89/84.:putchar(a=b*d);}
+char a;float b,c;main(d,e)char**e;{for(;d>2e3*c?c=1,scanf(" %c%f",&a,&c),d=55-a%32*9/5,b=d>9,d=d%13-a/32*12:1;a=2)++d<24?b*=89/84.:putchar(a=b*d);}

--- a/2013/endoh3/try.sh
+++ b/2013/endoh3/try.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2013/endoh3
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# Because there are numerous ways to run this entry we check for different tools
+# being installed in order to determine how to proceed. Even so /dev/dsp seems
+# to be uninstalled in modern systems so we check for what the author suggested
+# with that but only if the other options won't work (like SoX not installed).
+#
+SOX="$(type -P sox)"
+PADSP="$(type -P padsp)"
+RUBY="$(type -P ruby)"
+
+endoh3()
+{
+    if [[ "$#" -ne 1 ]]; then
+	echo "$0: endoh3() requires one arg, got: $#" 1>&2
+	return
+    fi
+    if [[ -f "$1" && -r "$1" ]]; then
+	if [[ -n "$SOX" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    echo 1>&2
+	elif [[ -n "$PADSP" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    echo 1>&2
+	elif [[ -n "$RUBY" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
+	    echo 1>&2
+	else
+	    echo "Please install either SoX, ruby or padsp (from PulseAudio)." 1>&2
+	    exit 1
+	fi
+    else # no file
+	if [[ -n "$SOX" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    echo 1>&2
+	elif [[ -n "$PADSP" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    echo 1>&2
+	elif [[ -n "$RUBY" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
+	    echo 1>&2
+	else
+	    echo "Please install either SoX, ruby or padsp (from PulseAudio)." 1>&2
+	    exit 1
+	fi
+    fi
+}
+
+if [[ "$#" -lt 1 ]]; then
+    # if we have no arg just run endoh3 with twinkle.abc and the string ABC.
+    endoh3 twinkle.abc
+    endoh3 ABC
+    endoh3 CDEFGABc
+else
+    # otherwise while we have an arg run endoh3 on it as a file or string
+    while [[ "$#" -gt 0 ]]; do
+	endoh3 "$1"
+	shift 1
+    done
+fi

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -55,9 +55,13 @@ CSTD= -std=gnu11
 #
 ARCH=
 
+# Variable to simplify redefining size
+#
+SIZE= 70,23
+
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DS=${SIZE}
 
 # Include files that are needed to compile
 #

--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -4,23 +4,45 @@
 make
 ```
 
+If you wish to change the size (see the [Author's remarks](#authors-remarks)
+below) you can do so with the `SIZE` variable. For instance you can do:
+
+
+```sh
+make clobber SIZE=50,50 all
+```
+
+but you can also do this directly with the [endoh4.sh](endoh4.sh) script as
+described below.
+
+
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2013 endoh4 in bugs.md](/bugs.md#2013-endoh4).
+
 
 ## To use:
 
 ```sh
 ./endoh4 < file
-./run.sh file
+./endoh4.sh file
 ```
 
 The second form is preferable as it will temporarily make the cursor invisible
-as recommended by the author. If no file is specified in `run.sh` command line
-it will feed to the program [endoh4.c](endoh4.c).
+as recommended by the author. If no file is specified in the `./endoh4.sh` command
+line it will feed to the program [endoh4.c](endoh4.c).
 
 
 ## Try:
 
 ```sh
-./run.sh cube.txt
+./endoh4.sh cube.txt
 ```
 
 Hit ctrl-c to end the program.
@@ -30,14 +52,31 @@ The author recommends the use of xterm.
 For an example, if you are a football/soccer fan, try:
 
 ```sh
-./run.sh solids/archimedian-solid/a11-truncated-icosahedron.txt
+./endoh4.sh solids/archimedian-solid/a11-truncated-icosahedron.txt
 ```
+
+You can provide more than one file:
+
+```sh
+./endoh4.sh solids/archimedian-solid/a11-truncated-icosahedron.txt cube.txt
+```
+
+Hit ctrl-c/intr to go to the next file.
+
+If you wish to change the size to `50,50` without passing any arg:
+
+
+```sh
+SIZE=50,50 ./endoh4.sh
+```
+
+Not specifying a file feeds [endoh4.c](endoh4.c) to the program.
 
 
 ## Judges' remarks:
 
 This program is formatted as the net for a tetrahedron (hint: try feeding the
-program it's own source code like `./run.sh`).  When it runs there is an
+program it's own source code like `./endoh4.sh`).  When it runs there is an
 animation for the computation to work out the convex hull.
 
 
@@ -69,7 +108,7 @@ This simple spec involves many details.
 ### Portability
 
 I think it conforms with both C89 and C99.  I confirmed that it worked on gcc,
-clang, and tcc.  It should not be warned with `-pedantic` and `-Wextra`.
+clang, and tcc.  It should not trigger warnings with `-pedantic` and `-Wextra`.
 
 
 ### Tips
@@ -85,7 +124,7 @@ tput cnorm
 or
 
 ```sh
-./run.sh cube.txt
+./endoh4.sh cube.txt
 ```
 
 ### Bonuses
@@ -100,7 +139,7 @@ The shape of this code is the geometric net of a regular tetrahedron.
 So, try:
 
 ```sh
-./endoh4 < endoh4.c # or ./run.sh
+./endoh4 < endoh4.c # or ./endoh4.sh
 ```
 
 The [solids/](solids/) directory includes various solid data:

--- a/2013/endoh4/endoh4.sh
+++ b/2013/endoh4/endoh4.sh
@@ -6,11 +6,13 @@
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
 # this way allows us to have the user specify a different compiler in an easy
 # way.
-if [[ -z "$CC" ]]; then
-    CC="cc"
-fi
+[[ -z "$CC" ]] && CC="cc"
 
-make CC="$CC" all >/dev/null || exit 1
+# let user redefine size. This requires that we clobber so that they can change
+# it each time.
+[[ -z "$SIZE" ]] && SIZE=70,23
+
+make clobber CC="$CC" SIZE="$SIZE" all >/dev/null || exit 1
 
 # clear screen after compilation so that only the entry is shown
 clear
@@ -23,11 +25,20 @@ trap "tput cnorm;echo" 0 1 2 3 15
 tput civis
 
 # run program attempting to feed it a file, if specified
-if [[ "$#" -eq 1 ]]; then
-    ./endoh4 < "$1"
+if [[ "$#" -gt 0 ]]; then
+    while [[ "$#" -gt 0 ]]; do
+	read -r -n 1 -p "Press any key to run: ./endoh4 < $1: "
+	echo 1>&2
+	./endoh4 < "$1"
+	echo 1>&2
+	shift 1
+    done
 else
     # otherwise feed the source code of the program to the program
+    read -r -n 1 -p "Press any key to run: ./endoh4 < endoh4.c: "
+    echo 1>&2
     ./endoh4 < endoh4.c
+    echo 1>&2
 fi
 
 # explicitly set cursor back just in case it's not terminated through one of the

--- a/bugs.md
+++ b/bugs.md
@@ -3114,6 +3114,15 @@ A workaround is inserting a whitespace: `C2 E2`.
 --
 
 
+## 2013 endoh4
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2013/endoh4/endoh4.c](2013/endoh4/endoh4.c)
+### Information: [2013/endoh4/README.md](2013/endoh4/README.md)
+
+Invalid input files will very likely crash the program.
+
+
 
 ## 2013 hou
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3977,6 +3977,14 @@ not found.
 The entry can still be enjoyed if you do not have these tools, however.
 
 
+## <a name="2013_endoh3"></a>[2013/endoh3](/2013/endoh3/endoh3.c) ([README.md](/2013/endoh3/README.md))
+
+[Cody](#cody) added the [try.sh](/2013/endoh3/try.sh) script.
+
+Cody also (out of an abundance of caution for `clang(1)` which is strict with
+arg type and count to `main()`) added a second (unused) arg to `main()`.
+
+
 ## <a name="2013_endoh4"></a>[2013/endoh4](/2013/endoh4/endoh4.c) ([README.md](/2013/endoh4/README.md))
 
 [Cody](#cody) added the [try.sh](/2013/endoh4/try.sh) script which temporarily

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3987,11 +3987,16 @@ arg type and count to `main()`) added a second (unused) arg to `main()`.
 
 ## <a name="2013_endoh4"></a>[2013/endoh4](/2013/endoh4/endoh4.c) ([README.md](/2013/endoh4/README.md))
 
-[Cody](#cody) added the [try.sh](/2013/endoh4/try.sh) script which temporarily
+[Cody](#cody) added the [endoh4.sh](/2013/endoh4/endoh4.sh) script which temporarily
 turns off the cursor as suggested by the author, with the addition that if no
 file is specified it will feed the source code [endoh4.c](/2013/endoh4/endoh4.c)
 to the program rather than the file specified. It does not try and detect if the
-file exists or can be read as that will be handled by the shell/program.
+file exists or can be read as that will be handled by the shell/program. One may
+pass more than one file to the script.
+
+Cody also made it easier to redefine the size at compilation time (see the
+author's remarks for more details on what this means). The `endoh4.sh` script
+allows one to redefine it as well.
 
 
 ## <a name="2013_hou"></a>[2013/hou](/2013/hou/hou.c) ([README.md](/2013/hou/README.md))


### PR DESCRIPTION
 
The Makefile was modified in such a way that allows one to easily
redefine the size (in the code the S macro). For instance:

    make clobber SIZE=50,50 all

The try.sh was renamed to endoh4.sh as it's more of a wrapper to the
program rather than things to try. Also it now lets one specify more
than one file to feed to the program (in sequence).
 
The bugs.md was updated - added INABIAF. If the file format is invalid
it will very likely crash.