### PR TITLE
Fix make clobber in 2013/endoh3

### DIFF
--- a/1998/schweikh3/.gitignore
+++ b/1998/schweikh3/.gitignore
@@ -10,6 +10,7 @@ indent.c
 indent.o
 prog.orig
 samefile
+samefile.alt
 schweikh3
 schweikh3.alt
 schweikh3.orig

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -211,7 +211,7 @@ clean:
 	fi
 
 clobber: clean
-	${RM} -f ${TARGET} ${ALT_TARGET}
+	${RM} -f ${TARGET} ${ALT_TARGET} samefile.alt
 	${RM} -rf *.dSYM
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \

--- a/2013/endoh2/README.md
+++ b/2013/endoh2/README.md
@@ -24,7 +24,7 @@ download one or both before exiting.
 ## Try:
 
 ```sh
-cat jpeg.c
+less jpeg.c
 ```
 
 Next look at `jpeg.jpg` in an image viewer program.

--- a/2013/endoh3/.gitignore
+++ b/2013/endoh3/.gitignore
@@ -7,3 +7,4 @@ indent
 indent.c
 indent.o
 prog.orig
+*.wav

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
-	-Wno-main -Wno-deprecated-non-prototype
+	-Wno-main -Wno-deprecated-non-prototype -Wno-unused-parameter
 
 # Common C compiler warning flags
 #

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -204,7 +204,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM
+	${RM} -rf *.dSYM *.wav
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -22,21 +22,32 @@ For more detailed information see [2013 endoh3 in bugs.md](/bugs.md#2013-endoh3)
 ./endoh3
 ```
 
+This program plays sound. See [FAQ 3.10 - How do I compile and use an IOCCC
+winner that requires sound?](/faq.md#faq3_10) if you do not know how to set your
+system up for this or if you want to verify that everything is oky.
+
 
 ## Try:
 
-Trying this out will depend on how your system can play sounds. The author's
-remarks include some options for different operating systems.
-
-The simplest way is to create a .wav file and have your system play that.
-
 ```sh
-echo 'CDEFGABc' | ./endoh3 | ruby wavify.rb > cde.wav
+./try.sh
+
+./try.sh ABC
+
+./try.sh test.abc yankee.abc
+
+./try.sh *.abc
 ```
 
-Observe how you will need ruby installed.
+The script will check for SoX first and next `padsp` from `PulseAudio` and
+finally if neither are found if you have `ruby(1)` installed it'll use the
+included ruby script to convert it to a WAV file for you to play.
 
-There are also some other musical samples, twinkle.abc and menuet.abc.
+If no args are passed to the script it will play [twinkle.abc](twinkle.abc) and
+the string `ABC`. Otherwise while there's a remaining arg if it's a file it will
+run the program on the file. If it's not a file it'll run it as a string.
+
+The `*.abc` files are provided as music samples.
 
 
 ## Judges' remarks:

--- a/2013/endoh3/endoh3.c
+++ b/2013/endoh3/endoh3.c
@@ -1,1 +1,1 @@
-char a;float b,c;main(d){for(;d>2e3*c?c=1,scanf(" %c%f",&a,&c),d=55-a%32*9/5,b=d>9,d=d%13-a/32*12:1;a=2)++d<24?b*=89/84.:putchar(a=b*d);}
+char a;float b,c;main(d,e)char**e;{for(;d>2e3*c?c=1,scanf(" %c%f",&a,&c),d=55-a%32*9/5,b=d>9,d=d%13-a/32*12:1;a=2)++d<24?b*=89/84.:putchar(a=b*d);}

--- a/2013/endoh3/try.sh
+++ b/2013/endoh3/try.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2013/endoh3
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# Because there are numerous ways to run this entry we check for different tools
+# being installed in order to determine how to proceed. Even so /dev/dsp seems
+# to be uninstalled in modern systems so we check for what the author suggested
+# with that but only if the other options won't work (like SoX not installed).
+#
+SOX="$(type -P sox)"
+PADSP="$(type -P padsp)"
+RUBY="$(type -P ruby)"
+
+endoh3()
+{
+    if [[ "$#" -ne 1 ]]; then
+	echo "$0: endoh3() requires one arg, got: $#" 1>&2
+	return
+    fi
+    if [[ -f "$1" && -r "$1" ]]; then
+	if [[ -n "$SOX" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    echo 1>&2
+	elif [[ -n "$PADSP" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    echo 1>&2
+	elif [[ -n "$RUBY" ]]; then
+	    echo "$ cat $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    # The author suggested the form below and it simplifies the command
+	    # as well so we disable the supposed useless cat (there are no
+	    # useless cats).
+	    #
+	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
+	    # https://www.shellcheck.net/wiki/SC2002
+	    # shellcheck disable=SC2002
+	    cat "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
+	    echo 1>&2
+	else
+	    echo "Please install either SoX, ruby or padsp (from PulseAudio)." 1>&2
+	    exit 1
+	fi
+    else # no file
+	if [[ -n "$SOX" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    echo 1>&2
+	elif [[ -n "$PADSP" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    echo 1>&2
+	elif [[ -n "$RUBY" ]]; then
+	    echo "$ echo $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    read -r -n 1 -p "Press any key to continue: "
+	    echo 1>&2
+	    echo "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
+	    echo 1>&2
+	else
+	    echo "Please install either SoX, ruby or padsp (from PulseAudio)." 1>&2
+	    exit 1
+	fi
+    fi
+}
+
+if [[ "$#" -lt 1 ]]; then
+    # if we have no arg just run endoh3 with twinkle.abc and the string ABC.
+    endoh3 twinkle.abc
+    endoh3 ABC
+    endoh3 CDEFGABc
+else
+    # otherwise while we have an arg run endoh3 on it as a file or string
+    while [[ "$#" -gt 0 ]]; do
+	endoh3 "$1"
+	shift 1
+    done
+fi

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -55,9 +55,13 @@ CSTD= -std=gnu11
 #
 ARCH=
 
+# Variable to simplify redefining size
+#
+SIZE= 70,23
+
 # Defines that are needed to compile
 #
-CDEFINE=
+CDEFINE= -DS=${SIZE}
 
 # Include files that are needed to compile
 #

--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -4,23 +4,45 @@
 make
 ```
 
+If you wish to change the size (see the [Author's remarks](#authors-remarks)
+below) you can do so with the `SIZE` variable. For instance you can do:
+
+
+```sh
+make clobber SIZE=50,50 all
+```
+
+but you can also do this directly with the [endoh4.sh](endoh4.sh) script as
+described below.
+
+
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2013 endoh4 in bugs.md](/bugs.md#2013-endoh4).
+
 
 ## To use:
 
 ```sh
 ./endoh4 < file
-./run.sh file
+./endoh4.sh file
 ```
 
 The second form is preferable as it will temporarily make the cursor invisible
-as recommended by the author. If no file is specified in `run.sh` command line
-it will feed to the program [endoh4.c](endoh4.c).
+as recommended by the author. If no file is specified in the `./endoh4.sh` command
+line it will feed to the program [endoh4.c](endoh4.c).
 
 
 ## Try:
 
 ```sh
-./run.sh cube.txt
+./endoh4.sh cube.txt
 ```
 
 Hit ctrl-c to end the program.
@@ -30,14 +52,31 @@ The author recommends the use of xterm.
 For an example, if you are a football/soccer fan, try:
 
 ```sh
-./run.sh solids/archimedian-solid/a11-truncated-icosahedron.txt
+./endoh4.sh solids/archimedian-solid/a11-truncated-icosahedron.txt
 ```
+
+You can provide more than one file:
+
+```sh
+./endoh4.sh solids/archimedian-solid/a11-truncated-icosahedron.txt cube.txt
+```
+
+Hit ctrl-c/intr to go to the next file.
+
+If you wish to change the size to `50,50` without passing any arg:
+
+
+```sh
+SIZE=50,50 ./endoh4.sh
+```
+
+Not specifying a file feeds [endoh4.c](endoh4.c) to the program.
 
 
 ## Judges' remarks:
 
 This program is formatted as the net for a tetrahedron (hint: try feeding the
-program it's own source code like `./run.sh`).  When it runs there is an
+program it's own source code like `./endoh4.sh`).  When it runs there is an
 animation for the computation to work out the convex hull.
 
 
@@ -69,7 +108,7 @@ This simple spec involves many details.
 ### Portability
 
 I think it conforms with both C89 and C99.  I confirmed that it worked on gcc,
-clang, and tcc.  It should not be warned with `-pedantic` and `-Wextra`.
+clang, and tcc.  It should not trigger warnings with `-pedantic` and `-Wextra`.
 
 
 ### Tips
@@ -85,7 +124,7 @@ tput cnorm
 or
 
 ```sh
-./run.sh cube.txt
+./endoh4.sh cube.txt
 ```
 
 ### Bonuses
@@ -100,7 +139,7 @@ The shape of this code is the geometric net of a regular tetrahedron.
 So, try:
 
 ```sh
-./endoh4 < endoh4.c # or ./run.sh
+./endoh4 < endoh4.c # or ./endoh4.sh
 ```
 
 The [solids/](solids/) directory includes various solid data:

--- a/2013/endoh4/endoh4.sh
+++ b/2013/endoh4/endoh4.sh
@@ -6,11 +6,13 @@
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
 # this way allows us to have the user specify a different compiler in an easy
 # way.
-if [[ -z "$CC" ]]; then
-    CC="cc"
-fi
+[[ -z "$CC" ]] && CC="cc"
 
-make CC="$CC" all >/dev/null || exit 1
+# let user redefine size. This requires that we clobber so that they can change
+# it each time.
+[[ -z "$SIZE" ]] && SIZE=70,23
+
+make clobber CC="$CC" SIZE="$SIZE" all >/dev/null || exit 1
 
 # clear screen after compilation so that only the entry is shown
 clear
@@ -23,11 +25,20 @@ trap "tput cnorm;echo" 0 1 2 3 15
 tput civis
 
 # run program attempting to feed it a file, if specified
-if [[ "$#" -eq 1 ]]; then
-    ./endoh4 < "$1"
+if [[ "$#" -gt 0 ]]; then
+    while [[ "$#" -gt 0 ]]; do
+	read -r -n 1 -p "Press any key to run: ./endoh4 < $1: "
+	echo 1>&2
+	./endoh4 < "$1"
+	echo 1>&2
+	shift 1
+    done
 else
     # otherwise feed the source code of the program to the program
+    read -r -n 1 -p "Press any key to run: ./endoh4 < endoh4.c: "
+    echo 1>&2
     ./endoh4 < endoh4.c
+    echo 1>&2
 fi
 
 # explicitly set cursor back just in case it's not terminated through one of the

--- a/2013/hou/README.md
+++ b/2013/hou/README.md
@@ -30,17 +30,14 @@ effects should be more or less recognizable when you see 16.
 ## Try:
 
 ```sh
-./hou BIG
-./hou old_default.scene BIG
-./hou otherroom.scene
-./hou otherroom.scene NAIVE
+./try.sh
 ```
 
-Try opening the file and then let the program run a while and every so often
-reopen the file, to see how it changes. The author suggests that you leave the
-program running overnight to see what happens. If however you do not have all
-night :-) then the following JPEG files should show you what happens with some
-of the invocations above:
+Try opening the file noted by the program then let the program run a while and
+every so often reopen the file, to see how it changes. The author suggests that
+you leave the program running overnight to see what happens. If however you do
+not have all night :-) then the following JPEG files should show you what
+happens with some of the invocations above:
 
 ![./hou BIG - Luna](luna.jpg)
 

--- a/2013/hou/try.sh
+++ b/2013/hou/try.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2013/hou
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+echo "2013/hou menu" 1>&2
+echo 1>&2
+echo "(0) BIG (luna.ppm)" 1>&2
+echo "(1) old_default.scene BIG (old_default.ppm)" 1>&2
+echo "(2) otherroom (otherroom.ppm)" 1>&2
+echo "(3) NAIVE otherroom (otherroom.ppm)" 1>&2
+echo 1>&2
+read -rp "Make your selection (0 - 3, anything else to quit): " mode
+
+case "$mode" in
+    0)  # BIG
+	echo "$ ./hou BIG" 1>&2
+	./hou BIG
+	;;
+    1)  # old_default BIG
+	echo "$ ./hou old_default.scene BIG" 1>&2
+	./hou old_default.scene BIG
+	;;
+    2)  # otherroom
+	echo "$ ./hou otherroom.scene" 1>&2
+	./hou otherroom.scene
+	;;
+    3)  # otherroom NAIVE
+	echo "$ ./hou otherroom.scene NAIVE" 1>&2
+	./hou otherroom.scene NAIVE
+	;;
+    *)	exit 0	
+	;;
+esac

--- a/2013/misaka/try.sh
+++ b/2013/misaka/try.sh
@@ -26,13 +26,13 @@ echo 1>&2
 echo 1>&2
 
 rm -f long_cat.txt same_as_long_cat.txt
-read -r -n 1 -p "Press any key to run: ./long_cat > long_cat.txt: "
+read -r -n 1 -p "Press any key to run: ./long_cat | tee long_cat.txt: "
 echo 1>&2
-./long_cat > long_cat.txt
+./long_cat | tee long_cat.txt
 echo 1>&2
-read -r -n 1 -p "Press any key to run: ./same_as_long_cat > same_as_long_cat.txt: "
+read -r -n 1 -p "Press any key to run: ./same_as_long_cat | tee same_as_long_cat.txt: "
 echo 1>&2
-./same_as_long_cat > same_as_long_cat.txt
+./same_as_long_cat | tee same_as_long_cat.txt
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: diff -s long_cat.txt same_as_long_cat.txt: "
@@ -65,8 +65,8 @@ echo 1>&2
 ./loooooooong_cat | less -EX
 echo 1>&2
 
-echo "Press any key to run: seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c"
-read -r -n 1 -p "(space = next page, q = quit): "
+echo "$ seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c"
+read -r -n 1 -p "Press any key to continue (space = next page, q = quit): "
 echo 1>&2
-seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c | less -EX
+seq -f '%.0f  ' 45 | ./horizontal_cat - misaka.c | less -rEXFK
 echo 1>&2

--- a/2013/morgan1/README.md
+++ b/2013/morgan1/README.md
@@ -8,20 +8,17 @@ make
 ## To use:
 
 ```sh
-echo "2013/10/03" | ./morgan1
+echo "YYYY/MM/DD" | ./morgan1
 ```
+
+where `YYYY` is the four digit year, `MM` is the two digit month and `DD` is two
+digit day of the month.
 
 
 ## Try:
 
 ```sh
-echo "1985/10/28" | ./morgan1
-
-echo "1996/12/31" | ./morgan1
-
-echo "1986/03/31" | ./morgan1 # Comet Halley (look for 'Ha')
-
-echo "1997/04/01" | ./morgan1 # Comet Hale-Bopp (look for 'Hb')
+./try.sh
 ```
 
 Try pressing the arrow keys when your focus is in the window.

--- a/2013/morgan1/try.sh
+++ b/2013/morgan1/try.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2013/morgan1
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: echo 1985/10/28 | ./morgan1: "
+echo 1>&2
+echo "1985/10/28" | ./morgan1
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo 1996/12/31 | ./morgan1: "
+echo 1>&2
+echo "1996/12/31" | ./morgan1
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo 1986/03/31 | ./morgan1 # Comet Halley (look for 'Ha'): "
+echo 1>&2
+echo "1986/03/31" | ./morgan1 # Comet Halley (look for 'Ha')
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo 1997/04/01 | ./morgan1 # Comet Hale-Bopp (look for 'Hb'): "
+echo 1>&2
+echo "1997/04/01" | ./morgan1 # Comet Hale-Bopp (look for 'Hb')
+echo 1>&2

--- a/bin/all-run.sh
+++ b/bin/all-run.sh
@@ -42,7 +42,7 @@ fi
 shopt -s nullglob	# enable expanded to nothing rather than remaining unexpanded
 shopt -u failglob	# disable error message if no matches are found
 shopt -u dotglob	# disable matching files starting with .
-shopt -s globskipdots	# enable never matching . nor ..
+shopt -s globskipdots	# enable never matching . or ..
 shopt -u nocaseglob	# disable strict case matching
 shopt -u extglob	# enable extended globbing patterns
 shopt -s globstar	# enable ** to match all files and zero or more directories and subdirectories

--- a/bugs.md
+++ b/bugs.md
@@ -3114,6 +3114,15 @@ A workaround is inserting a whitespace: `C2 E2`.
 --
 
 
+## 2013 endoh4
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2013/endoh4/endoh4.c](2013/endoh4/endoh4.c)
+### Information: [2013/endoh4/README.md](2013/endoh4/README.md)
+
+Invalid input files will very likely crash the program.
+
+
 
 ## 2013 hou
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4031,6 +4031,8 @@ Further, after the file `2013/hou/doc/example.markdown` was moved to
 [2013/hou/doc/example.md](/2013/hou/doc/example.md) to match the rest of the repo
 this broke `make` which Cody also fixed.
 
+Cody also added the [try.sh](/2013/hou/try.sh) script.
+
 
 ## <a name="2013_mills"></a>[2013/mills](/2013/mills/mills.c) ([README.md)[2013/mills/README.md))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3977,6 +3977,14 @@ not found.
 The entry can still be enjoyed if you do not have these tools, however.
 
 
+## <a name="2013_endoh3"></a>[2013/endoh3](/2013/endoh3/endoh3.c) ([README.md](/2013/endoh3/README.md))
+
+[Cody](#cody) added the [try.sh](/2013/endoh3/try.sh) script.
+
+Cody also (out of an abundance of caution for `clang(1)` which is strict with
+arg type and count to `main()`) added a second (unused) arg to `main()`.
+
+
 ## <a name="2013_endoh4"></a>[2013/endoh4](/2013/endoh4/endoh4.c) ([README.md](/2013/endoh4/README.md))
 
 [Cody](#cody) added the [try.sh](/2013/endoh4/try.sh) script which temporarily

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3987,11 +3987,16 @@ arg type and count to `main()`) added a second (unused) arg to `main()`.
 
 ## <a name="2013_endoh4"></a>[2013/endoh4](/2013/endoh4/endoh4.c) ([README.md](/2013/endoh4/README.md))
 
-[Cody](#cody) added the [try.sh](/2013/endoh4/try.sh) script which temporarily
+[Cody](#cody) added the [endoh4.sh](/2013/endoh4/endoh4.sh) script which temporarily
 turns off the cursor as suggested by the author, with the addition that if no
 file is specified it will feed the source code [endoh4.c](/2013/endoh4/endoh4.c)
 to the program rather than the file specified. It does not try and detect if the
-file exists or can be read as that will be handled by the shell/program.
+file exists or can be read as that will be handled by the shell/program. One may
+pass more than one file to the script.
+
+Cody also made it easier to redefine the size at compilation time (see the
+author's remarks for more details on what this means). The `endoh4.sh` script
+allows one to redefine it as well.
 
 
 ## <a name="2013_hou"></a>[2013/hou](/2013/hou/hou.c) ([README.md](/2013/hou/README.md))

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4052,6 +4052,8 @@ Firefox both had the problem.
 [Cody](#cody) added explicit linking of libm (`-lm`) as not all systems do this
 implicitly (Linux doesn't seem to but macOS does).
 
+Cody also added the [try.sh](/2013/morgan1/try.sh) script.
+
 
 ## <a name="2013_robison"></a>[2013/robison](/2013/robison/robison.c) ([README.md](/2013/robison/README.md))
 


### PR DESCRIPTION

Have to remove *.wav files. This is important for updating the manifest
if the program was run and generated wav files (because the other tools
were not found).