### PR TITLE
Add 2014/vik/try.sh, update bugs.md, fix clobber

### DIFF
--- a/2013/endoh3/try.sh
+++ b/2013/endoh3/try.sh
@@ -32,43 +32,22 @@ endoh3()
     fi
     if [[ -f "$1" && -r "$1" ]]; then
 	if [[ -n "$SOX" ]]; then
-	    echo "$ cat $1 | ./endoh3 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+	    echo "$ ./endoh3 < $1 | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
 	    read -r -n 1 -p "Press any key to continue: "
 	    echo 1>&2
-	    # The author suggested the form below and it simplifies the command
-	    # as well so we disable the supposed useless cat (there are no
-	    # useless cats).
-	    #
-	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-	    # https://www.shellcheck.net/wiki/SC2002
-	    # shellcheck disable=SC2002
-	    cat "$1" | ./endoh3 | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+	    ./endoh3 < "$1" | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
 	    echo 1>&2
 	elif [[ -n "$PADSP" ]]; then
-	    echo "$ cat $1 | ./endoh3 | $PADSP tee /dev/dsp > /dev/null" 1>&2
+	    echo "$ ./endoh3 < $1 | $PADSP tee /dev/dsp > /dev/null" 1>&2
 	    read -r -n 1 -p "Press any key to continue: "
 	    echo 1>&2
-	    # The author suggested the form below and it simplifies the command
-	    # as well so we disable the supposed useless cat (there are no
-	    # useless cats).
-	    #
-	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-	    # https://www.shellcheck.net/wiki/SC2002
-	    # shellcheck disable=SC2002
-	    cat "$1" | ./endoh3 | "$PADSP" tee /dev/dsp > /dev/null
+	    ./endoh3 < "$1" | "$PADSP" tee /dev/dsp > /dev/null
 	    echo 1>&2
 	elif [[ -n "$RUBY" ]]; then
-	    echo "$ cat $1 | ./endoh3 | $RUBY wavify.rb > $1.wav" 1>&2
+	    echo "$ ./endoh3 < $1 | $RUBY wavify.rb > $1.wav" 1>&2
 	    read -r -n 1 -p "Press any key to continue: "
 	    echo 1>&2
-	    # The author suggested the form below and it simplifies the command
-	    # as well so we disable the supposed useless cat (there are no
-	    # useless cats).
-	    #
-	    # SC2002 (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
-	    # https://www.shellcheck.net/wiki/SC2002
-	    # shellcheck disable=SC2002
-	    cat "$1" | ./endoh3 | "$RUBY" wavify.rb > "$1".wav
+	    ./endoh3 < "$1" | "$RUBY" wavify.rb > "$1".wav
 	    echo "Now try playing $1.wav in a program that plays WAV files." 1>&2
 	    echo 1>&2
 	else

--- a/2014/vik/.gitignore
+++ b/2014/vik/.gitignore
@@ -8,4 +8,4 @@ indent.o
 prog
 prog.alt
 prog.orig
-prog.raw
+*.raw

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -203,7 +203,7 @@ clean:
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
 	${RM} -rf *.dSYM
-	${RM} -f audio_file.raw prog.raw
+	${RM} -f *.raw
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -23,16 +23,16 @@ For more detailed information see [2014 vik in bugs.md](/bugs.md#2014-vik).
 ## To use:
 
 ```sh
-./prog > foo.c
+echo foo | ./prog > audio_file.raw
+
+echo foo | ./prog | mplayer -demuxer rawaudio -
 ```
 
 
 ## Try:
 
 ```sh
-echo 'Want to hear me beep?' | ./prog > audio_file.raw
-
-echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio -
+./try.sh
 ```
 
 

--- a/2014/vik/try.sh
+++ b/2014/vik/try.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2014/vik
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+if [[ -z "$CC" ]]; then
+    CC="cc"
+fi
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# remove target files for saving them
+rm -f beep.raw chocolate.raw
+
+write_to_raw()
+{
+    if [[ "$#" -ne 2 ]]; then
+	echo "$0: usage: write_to_raw file arg" 1>&2
+	return
+    fi
+
+    read -r -n 1 -p "Press any key to run: echo $2 | ./prog > $1.raw: "
+    echo "$2" | ./prog > "$1".raw
+}
+
+# now determine if we have mplayer(1)
+MPLAYER="$(type -P mplayer)"
+if [[ -n "$MPLAYER" ]]; then
+    read -r -n 1 -p "Press any key to play: 'Want to hear me beep?': "
+    echo 1>&2
+    echo "$ echo 'Want to hear me beep?' | ./prog | mplayer -demuxer rawaudio -" 1>&2
+    echo 'Want to hear me beep?' | ./prog | mplayer -demuxer rawaudio -
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run: ./prog e < beep.raw: "
+    echo 1>&2
+    ./prog e < beep.raw
+    echo 1>&2
+
+    read -r -n 1 -p "Press any key to play: 'No. I want chocolate!': "
+    echo 1>&2
+    echo "$ echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio - | tee chocolate.raw" 1>&2
+    echo 'No. I want chocolate!' | ./prog | mplayer -demuxer rawaudio - | tee chocolate.raw
+    read -r -n 1 -p "Press any key to run: ./prog e < chocolate.raw: "
+    echo 1>&2
+fi
+
+read -r -n 1 -p "Press any key to run: echo 'Want to hear me beep?' | ./prog > beep.raw: "
+echo 1>&2
+echo 'Want to hear me beep?' | ./prog > beep.raw
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog e < beep.raw: "
+echo 1>&2
+./prog e < beep.raw
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: echo 'No. I want chocolate!' | ./prog > chocolate.raw: "
+echo 1>&2
+echo 'No. I want chocolate!' | ./prog > chocolate.raw
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog e < chocolate.raw: "
+echo 1>&2
+./prog e < chocolate.raw

--- a/bugs.md
+++ b/bugs.md
@@ -3199,17 +3199,50 @@ This program will very likely crash if no arg is given.
 ### Source code: [2014/vik/prog.c](2014/vik/prog.c)
 ### Information: [2014/vik/README.md](2014/vik/README.md)
 
-[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) discovered a bug that
-shows itself in some cases (it works in others) when working on his winning
-[2020 Enigma machine](2020/ferguson2/prog.c) ('Most enigmatic') entry. See his
-[README.md](2020/ferguson2/README.md) for details (search for `vik` in the
-file).
+[Cody Boone Ferguson](/winners.html#Cody_Boone_Ferguson) discovered a bug to do
+with translating sound to text that shows itself in some cases (it works in
+others) when working on his winning [2020 Enigma machine](2020/ferguson2/prog.c)
+('Most enigmatic') entry. See his [README.md](2020/ferguson2/README.md) for
+details (search for `vik` in the file). This one might be more of a limitation
+but this is not known.
 
 He provides a tip in testing the problem: it might help to use his Enigma
 machine to find problems as it will allow you to verify what is correct and what
-is not. Again see his README.md for details!
+is not. Again see his README.md for details. However it is also possible to not
+rely on the entry as the below shows. One should be able to do:
 
-If you want to try and fix this (mis)feature, you are welcome to try.
+
+```sh
+echo 'No. I want chocolate!' | ./prog > chocolate.raw
+
+./prog e < chocolate.raw
+```
+
+and get:
+
+```
+No. I want some chocolate!
+```
+
+but instead we get:
+
+```
+IT FHOCOLITE!
+```
+
+which is very wrong. If however one does:
+
+```
+echo IOCCC | ./prog > ioccc.raw
+
+./prog e < ioccc.raw
+```
+
+they will properly get:
+
+```
+IOCCC
+```
 
 
 # 2015

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4182,7 +4182,11 @@ clean`) removes those files and so that they are ignored by `.gitignore`.
 
 ## <a name="2014_vik"></a>[2014/vik](/2014/vik/prog.c) ([README.md](/2014/vik/README.md))
 
-[Cody](#cody) added an alternate version that is based on the author's remarks that will
+[Cody](#cody) added the [try.sh](/2014/vik/try.sh) script. Cody notes that there
+is a bug that will show itself as one of the features does not work right. The
+translation of the raw audio to text is buggy in some cases.
+
+Cody also added an alternate version that is based on the author's remarks that will
 theoretically work for Microsoft Windows compilers (if anything works in Windows
 :-) ). We have no way of testing this and if anything has changed since 2014
 that would break it we do not know.


### PR DESCRIPTION

The bugs.md has more details on the bug I discovered when working on
2020/ferguson2. Even the usage in the try section (now in try.sh)
resulted in files that cannot be translated to English right.

The make clobber rule now removes *.raw instead of specific raw files.
This is important for clean up prior to updating the manifest.

Updated .gitignore.
