### PR TITLE
Add 2020/otterness/try.sh

### DIFF
--- a/2020/kurdyukov1/try.sh
+++ b/2020/kurdyukov1/try.sh
@@ -26,6 +26,11 @@ echo 1>&2
 echo IOCCC | ./prog
 echo 1>&2
 
+read -r -n 1 -p "Press any key to show prog.c (space = next page, q = quit): "
+echo 1>&2
+less -rEXFK prog.c
+echo 1>&2
+
 read -r -n 1 -p "Press any key to run: ./prog < prog.c: "
 echo 1>&2
 ./prog < prog.c
@@ -44,22 +49,28 @@ echo 1>&2
 read -r -n 1 -p "Press any key to run: ./prog < prog.x86_64.asm: "
 echo 1>&2
 ./prog < prog.x86_64.asm
+echo 1>&2
 
-rm -f md5.txt prog.md5.txt
+# remove output files first
+rm -vf md5.txt prog.md5.txt
+
 if [[ -n "$MD5SUM" ]]; then
-    if [[ "$(basename $MD5SUM)" == "openssl" ]]; then
-	echo "$ $MD5SUM md5 prog.c | cut -f 2 -d' ' > md5.txt" 1>&2
-	"$MD5SUM" md5 prog.c | cut -f 2 -d' ' > md5.txt
-	echo "$ ./prog < prog.c > prog.md5.txt" 1>&2
-	./prog < prog.c > prog.md5.txt
+    if [[ "$(basename "$MD5SUM")" == "openssl" ]]; then
+	read -r -n 1 -p "Press any key to run: $MD5SUM md5 prog.c | cut -f 2 -d' ' | tee md5.txt: "
+	"$MD5SUM" md5 prog.c | cut -f 2 -d' ' | tee md5.txt
+	read -r -n 1 -p "Press any key to run: ./prog < prog.c | tee prog.md5.txt: "
+	./prog < prog.c | tee prog.md5.txt
     else
-	echo "$ $MD5SUM prog.c | cut -f1 -d' ' > md5.txt" 1>&2
-	"$MD5SUM" prog.c | cut -f1 -d' ' > md5.txt
-	echo "$ ./prog < prog.c > prog.md5.txt" 1>&2
+	read -r -n 1 -p "Press any key to run: $MD5SUM prog.c | cut -f1 -d' ' | tee md5.txt: "
+	"$MD5SUM" prog.c | cut -f1 -d' ' | tee md5.txt
+	read -r -n 1 -p "Press any key to run: ./prog < prog.c > prog.md5.txt: "
+	echo 1>&2
 	./prog < prog.c > prog.md5.txt
     fi
-    read -r -n 1 -p "Press any key to compare the two files md5.txt and prog.md5.txt: "
+    echo 1>&2
+    read -r -n 1 -p "Press any key to run: diff -s md5.txt prog.md5.txt: "
     echo 1>&2
     diff -s md5.txt prog.md5.txt
+    echo 1>&2
 fi
-rm -f md5.txt prog.md5.txt
+rm -vf md5.txt prog.md5.txt

--- a/2020/kurdyukov2/.gitignore
+++ b/2020/kurdyukov2/.gitignore
@@ -1,6 +1,9 @@
 #
 # sort with: sort -d -u
 *.dSYM
+*.jpg
+*.gif
+*.ppm
 indent
 indent.c
 indent.o

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -212,7 +212,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM
+	${RM} -rf *.dSYM *.gif *.ppm out*.jpg
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -212,7 +212,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM *.gif *.ppm out*.jpg
+	${RM} -rf *.dSYM *.gif *.ppm out*.jpg gif/
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2020/kurdyukov2/README.md
+++ b/2020/kurdyukov2/README.md
@@ -19,6 +19,7 @@ make
 ./prog 1000 selfie.jpg output.jpg
 # Admire your portrait in cubist style
 
+# Also try:
 ./try.sh
 ```
 
@@ -98,7 +99,7 @@ After that’s installed you need to run make with these options:
 make LDFLAGS="-I/opt/local/include -L/opt/local/lib"
 ```
 
-### Building on macOS with HomeBrew
+### Building on macOS with Homebrew
 
 First, make sure you have the compiler tools installed e.g. by:
 
@@ -106,7 +107,7 @@ First, make sure you have the compiler tools installed e.g. by:
 sudo xcode-select --install
 ```
 
-Make sure you install [HomeBrew](https://brew.sh).
+Make sure you install [Homebrew](https://brew.sh).
 
 Then:
 
@@ -139,8 +140,10 @@ You can use this command to make a GIF from output images (uses ImageMagick).
 For instance after running the command suggested by the judges:
 
 ```sh
-convert -delay 10 -dither none -loop 0 $(ls out*.jpg | sort -V) $(ls out*.jpg | sort -rV) +map out.gif
+convert -delay 10 -dither none -loop 0 $(find . -maxdepth 1 -type f -name '*jpg' | sort -V) $(find . -maxdepth 1 -type f -name '*jpg' | sort -rV) +map out.gif
 ```
+
+NOTE: the above is done in the [try.sh](try.sh) script.
 
 Also provided `makegif.sh` to aid with GIF creation.
 

--- a/2020/kurdyukov2/makegif.sh
+++ b/2020/kurdyukov2/makegif.sh
@@ -4,28 +4,63 @@ output=${2:-"output.gif"}
 prog=${3:-"./prog"}
 ext="${image##*.}"
 dir="gif"
-[ $# -lt 3 ] && [ "$ext" = "png" -o "$ext" = "ppm" ] && prog="./prog_$ext"
-[ -f "$image" ] || {
+[[ $# -lt 3 ]] && [[ "$ext" = "png" || "$ext" = "ppm" ]] && prog="./prog_$ext"
+[[ -f "$image" ]] || {
 	echo "Usage: $0 image.jpg output.gif ./prog"
 	echo "Dependencies: ImageMagick, bc (basic calculator)"
 	echo "Note: don't use large images (dimensions above 1000), ImageMagick may fail."
 	echo "Uses \"gif\" directory for temporary files."
 	exit 1
 }
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+[[ -z "$CC" || ! -f "$CC" || ! -x "$CC" ]] && CC="cc"
+make CC="$CC" all >/dev/null || exit 1
+
 mkdir -p "$dir"
+
 i=8 ; x=$i ; j=0
-while [ $x -le 16000 ]; do
+while [[ $x -le 16000 ]]; do
 	x="$(echo "a=$i*e(l(2)/4*$j)+0.5;scale=0;a/1" | bc -l)"
 	echo "### $j : $x"
 	list[j]="$dir/out$j.$ext"
 	"$prog" "$x" "$image" "$dir/out$j.$ext" ; j=$((j+1))
 done
 i=$j ; j=$((j-2))
-while [ $j -ge 1 ]; do
-### Uncomment the following line if you want to make a GIF in an image editor such as GIMP
-#	cp "$dir/out$j.$ext" "$dir/out$i.$ext"
-	list[i]="$dir/out$j.$ext"
-	i=$((i+1)) ; j=$((j-1))
-done
-convert -delay 10 -dither none -loop 0 "${list[@]}" +map "$output"
+while [[ $j -ge 1 ]]; do
+    ### Uncomment the following line if you want to make a GIF in an image editor such as GIMP
+    # cp "$dir/out$j.$ext" "$dir/out$i.$ext"
 
+    list[i]="$dir/out$j.$ext"
+    i=$((i+1)) ; j=$((j-1))
+done
+
+# try finding convert(1) from ImageMagick if CONVERT not passed to script or is
+# not an executable file
+convert_error()
+{
+    echo 1>&2
+    echo "Warning: $CONVERT failed to generate out.gif. Is $CONVERT convert(1) from ImageMagick?" 1>&2
+    echo "See: https://github.com/ioccc-src/temp-test-ioccc/blob/master/faq.md#imagemagick." 1>&2
+    echo 1>&2
+    echo "Tip: if you have it in a different path, try: CONVERT=path ./try.sh" 1>&2
+    echo 1>&2
+}
+[[ -z "$CONVERT" || ! -f "$CONVERT" || ! -x "$CONVERT" ]] && CONVERT="$(type -P convert)"
+if [[ -z "$CONVERT" || ! -f "$CONVERT" || ! -x "$CONVERT" ]]; then
+    echo 1>&2
+    echo "Could not fine convert(1) from ImageMagick." 1>&2
+    echo "See: https://github.com/ioccc-src/temp-test-ioccc/blob/master/faq.md#imagemagick." 1>&2
+    echo 1>&2
+else
+    "$CONVERT" -delay 10 -dither none -loop 0 "${list[@]}" +map "$output"
+    if [[ ! -f "$output" ]]; then
+	convert_error
+    else
+	echo 1>&2
+	echo "Now look at $output with a graphics viewer that can show animated GIFs." 1>&2
+	echo "Warning: includes flashing colours." 1>&2
+	echo 1>&2
+    fi
+fi

--- a/2020/kurdyukov2/try.sh
+++ b/2020/kurdyukov2/try.sh
@@ -27,6 +27,8 @@ convert_error()
     echo 1>&2
 }
 
+# remove ppm files that we create
+rm -f random.ppm output.ppm
 echo "$ (echo P6 1024 1024 255; dd if=/dev/urandom bs=3M count=1) > random.ppm" 1>&2
 (echo P6 1024 1024 255; dd if=/dev/urandom bs=3M count=1) > random.ppm
 echo "Look at random.ppm. Do you see any patterns?" 1>&2
@@ -54,8 +56,13 @@ if [[ -n "$CONVERT" ]]; then
     echo 1>&2
     read -r -n 1 -p "Press any key to create GIF: "
     echo 1>&2
-    echo "$ $CONVERT -delay 10 -dither none -loop 0 $(ls out*.jpg | sort -V) $(ls out*.jpg | sort -rV) +map out.gif" 1>&2
-    "$CONVERT" -delay 10 -dither none -loop 0 $(ls out*.jpg | sort -V) $(ls out*.jpg | sort -rV) +map out.gif
+    echo "$ $CONVERT -delay 10 -dither none -loop 0 $(find . -maxdepth 1 -type f -name '*jpg' | sort -V) $(find . -maxdepth 1 -type f -name '*jpg' | sort -rV) +map out.gif" 1>&2
+    # We want word splitting here so disable shellcheck warning SC2046.
+    #
+    # SC2046 (warning): Quote this to prevent word splitting.
+    # https://www.shellcheck.net/wiki/SC2046
+    # shellcheck disable=SC2046
+    "$CONVERT" -delay 10 -dither none -loop 0 $(find . -maxdepth 1 -type f -name '*jpg' | sort -V) $(find . -maxdepth 1 -type f -name '*jpg' | sort -rV) +map out.gif
     if [[ ! -f out.gif ]]; then
 	convert_error
     else
@@ -63,6 +70,11 @@ if [[ -n "$CONVERT" ]]; then
 	echo "Now look at out.gif with a graphics viewer that can show animated GIFs." 1>&2
 	echo "Warning: includes flashing colours." 1>&2
     fi
+
+    read -r -n 1 -p "Press any key to run: ./makegif.sh sample.jpg kurdyukov2.gif ./prog: "
+    echo 1>&2
+    ./makegif.sh sample.jpg kurdyukov2.gif ./prog
+    echo 1>&2
 else
     echo 1>&2
     echo "Could not fine convert(1) from ImageMagick." 1>&2

--- a/2020/kurdyukov4/try.sh
+++ b/2020/kurdyukov4/try.sh
@@ -15,35 +15,39 @@ make CC="$CC" all >/dev/null || exit 1
 # clear screen after compilation so that only the entry is shown
 clear
 
-read -r -n 1 -p "Press any key to run: ./prog Shakespeare.txt 2000 10 1: "
+read -r -n 1 -p "Press any key to run: time ./prog Shakespeare.txt 2000 10 1: "
 echo 1>&2
-./prog Shakespeare.txt 2000 10 1
-echo 1>&2
-
-read -r -n 1 -p "Press any key to run: ./prog Shakespeare.txt 2000 9 1: "
-echo 1>&2
-./prog Shakespeare.txt 2000 9 1
+time ./prog Shakespeare.txt 2000 10 1
 echo 1>&2
 
-read -r -n 1 -p "Press any key to run: ./prog Shakespeare.txt 2000 8 1: "
+read -r -n 1 -p "Press any key to run: time ./prog Shakespeare.txt 2000 9 1: "
 echo 1>&2
-./prog Shakespeare.txt 2000 8 1
-
-read -r -n 1 -p "Press any key to run: ./prog Eugene_Onegin.txt 2000 10 1: "
+time ./prog Shakespeare.txt 2000 9 1
 echo 1>&2
-./prog Eugene_Onegin.txt 2000 10 1
 
-echo "$ echo "00000000000000000000 01 02 02 02 02 02 02" > test.txt" 1>&2
+read -r -n 1 -p "Press any key to run: time ./prog Shakespeare.txt 2000 8 1: "
+echo 1>&2
+time ./prog Shakespeare.txt 2000 8 1
+
+read -r -n 1 -p "Press any key to run: time ./prog Eugene_Onegin.txt 2000 10 1: "
+echo 1>&2
+time ./prog Eugene_Onegin.txt 2000 10 1
+
+read -r -n 1 -p "Press any key to run: echo 00000000000000000000 01 02 02 02 02 02 02 > test.txt: "
+echo 1>&2
 echo "00000000000000000000 01 02 02 02 02 02 02" > test.txt
 echo 1>&2
-make rand >/dev/null || exit 0
 
-read -r -n 1 -p "Press any key to run: ./prog test.txt 1000 2 123: "
+read -r -n 1 -p "Press any key to run: time ./prog test.txt 1000 2 123: "
 echo 1>&2
-./prog test.txt 1000 2 123
+time ./prog test.txt 1000 2 123
 echo 1>&2
-read -r -n 1 -p "Press any key to run: ./rand test.txt 1000 2 123" 1>&2
+
+read -r -n 1 -p "Press any key to run: make rand >/dev/null: "
 echo 1>&2
-./rand test.txt 1000 2 123
+make rand >/dev/null || exit 0
+read -r -n 1 -p "Press any key to run: time ./rand test.txt 1000 2 123" 1>&2
+echo 1>&2
+time ./rand test.txt 1000 2 123
 
 exit 0

--- a/2020/otterness/.gitignore
+++ b/2020/otterness/.gitignore
@@ -1,8 +1,12 @@
 #
-# sort with: sort -d -u
+# Don't sort because of the exclusion of *.mid with the exception
+# of the cvikl.mid and the entertainer.mid.
 *.dSYM
 indent
 indent.c
 indent.o
 prog
 prog.orig
+*.mid
+!cvikl.mid
+!entertainer.mid

--- a/2020/otterness/README.md
+++ b/2020/otterness/README.md
@@ -26,12 +26,11 @@ For more detailed information see [2020 otterness in bugs.md](/bugs.md#2020-otte
 ## Try:
 
 ```sh
-./prog < cvikl.mid > output.mid
-# Play output.mid with your favorite player
-
-./prog < entertainer.mid > output2.mid
-# Play output2.mid with your favorite player
+./try.sh
 ```
+
+Now play `output.mid` and `output2.mid` in an audio player that can play MIDI
+files.
 
 
 ## Judges' remarks:

--- a/2020/otterness/try.sh
+++ b/2020/otterness/try.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2020/otterness
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+[[ -z "$CC" || ! -f "$CC" || ! -x "$CC" ]] && CC="cc"
+
+make CC="$CC" all >/dev/null || exit 1
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+read -r -n 1 -p "Press any key to run: ./prog < cvikl.mid > output.mid: "
+echo 1>&2
+./prog < cvikl.mid > output.mid
+echo "Now play output.wav in an audio player that can play MIDI files." 1>&2
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./prog < entertainer.mid > output2.mid: "
+echo 1>&2
+./prog < entertainer.mid > output2.mid
+echo "Now play output2.wav in an audio player that can play MIDI files." 1>&2
+echo 1>&2

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4833,6 +4833,12 @@ the user has installed the appropriate library with
 [MacPorts](https://www.macports.org) (with the default MacPorts prefix
 `/opt/local`).
 
+Cody also fixed the script [makegif.sh](2020/kurdyukov2/makegif.sh) in a variety
+of ways: shellcheck(1), make sure the program is compiled first (allowing one to
+specify which compiler to use with `CC=foo ./makegif.sh ...`), checking that
+`convert(1)` is found and that it worked properly (linking to the proper FAQ
+entry if not installed or it fails).
+
 
 ## <a name="2020_kurdyukov3"></a>[2020/kurdyukov3](/2020/kurdyukov3/prog.c) ([README.md](/2020/kurdyukov3/README.md))
 

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4872,6 +4872,8 @@ J.R.R. Tolkien).
 that one need not download them and to make sure they can always be obtained
 even if the domain or link goes dead.
 
+Cody also added the [try.sh](/2020/otterness/try.sh) script.
+
 
 ## <a name="2020_tsoj"></a>[2020/tsoj](/2020/tsoj/prog.c) ([README.md](/2020/tsoj/README.md))
 


### PR DESCRIPTION

The .gitignore was updated but it cannot be sorted because it excludes
'*.mid' but then negates the .mid files in the repo, cvikl.mid and
entertainer.mid. These have to come after the exclusion of '*.mid'. This
is important as one might use the entry to create a .mid file that is 
not done in the try script. The make clobber rule does not remove 
'*.mid' files as doing so would remove the ones we want to keep.