### PR TITLE
Improve 2005/giljade test.sh and fix make clobber

### DIFF
--- a/2005/giljade/.gitignore
+++ b/2005/giljade/.gitignore
@@ -9,4 +9,5 @@ indent
 indent.c
 indent.o
 out
+out.count
 prog.orig

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -215,7 +215,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM out
+	${RM} -rf *.dSYM out out.count
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -215,7 +215,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM out out.count
+	${RM} -rf *.dSYM out out.count c.c
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2005/giljade/test.sh
+++ b/2005/giljade/test.sh
@@ -24,11 +24,13 @@ EXIT_CODE=0
 # delete temporary files first to make sure that they're clean
 rm -f out out.count
 
-echo "This may take a while: please be patient." 1>&2
+# redirect stdout to 'out' (but show it to output via tee(1)) so that we can run
+# the test suite of giljade.
+./"$GILJADE" | tee out
 echo 1>&2
-
-# redirect stdout to 'out' so that we can run the test suite of giljade
-./"$GILJADE" > out
+echo 1>&2
+# warn user that this will take a while
+echo "This may take a while: please be patient:" 1>&2
 # here we want to show only the lines matching the regexp '^Line' but write
 # everything to out.count for checking (after running it all) for errors and how
 # many versions were found.
@@ -41,16 +43,17 @@ if [[ "$COUNT" != 180 ]]; then
     # if we failed to get exactly 180 versions there is a problem
     echo "FAIL: Expected 180 versions, got $COUNT" 1>&2
     EXIT_CODE=1
-elif [[ "$(grep -c '[^-]error' out.count)" -ne 0 ]]; then
-    # we have to check for '[^-]error' because the CFLAGS contain '-Wno-error'
-    # which would be a false positive.
-    echo "FAIL: Error compiling one or more versions!" 1>&2
-    echo "Try the following command to find out what problems occurred:" 1>&2
-    echo 1>&2
-    echo "	grep -C10 -E '[^-]error' out.count" 1>&2
-    echo 1>&2
-    echo "and feel free to report or fix it and make a GitHub pull request." 1>&2
-    EXIT_CODE=2
+    if [[ "$(grep -c '[^-]error' out.count)" != 0 ]]; then
+	# we have to check for '[^-]error' because the CFLAGS contain '-Wno-error'
+	# which would be a false positive.
+	echo "FAIL: Error compiling one or more versions!" 1>&2
+	echo "Try the following command to find out what problems occurred:" 1>&2
+	echo 1>&2
+	echo "	grep -C 10 -E '[^-]error' out.count | less" 1>&2
+	echo 1>&2
+	echo "and feel free to report or fix it and then make a GitHub pull request." 1>&2
+	EXIT_CODE=2
+    fi
 else
     # all good: every version could be compiled
     echo "Found and successfully compiled all 180 versions!" 1>&2
@@ -58,10 +61,21 @@ else
     EXIT_CODE=0
 fi
 
-# delete temporary files but only if no failure
-
+# delete temporary files but only if no failure and the user doesn't want to
+# look at them
 if [[ "$EXIT_CODE" = 0 ]]; then
-    rm -f out out.count
+    read -r -p "Do you wish to keep the 'out' and 'out.count' files (Y/N)? "
+    echo 1>&2
+    if [[ "$REPLY" != "Y" && "$REPLY" != "y" ]]; then
+	rm -vf out out.count
+    else
+	echo "Leaving 'out' and 'out.count' for you to look at. Remove them manually" 1>&2
+	echo "when you wish to or run 'make clobber' to remove them automatically." 1>&2
+    fi
+else
+    echo "Leaving 'out' and 'out.count' for you to look at. Remove them manually" 1>&2
+    echo "when you wish to or run 'make clobber' to remove them automatically." 1>&2
+    echo 1>&2
 fi
 
 # exit :-)


### PR DESCRIPTION
The script now lets one keep the out and out.count file even if the test suite passes. This is done because the try script does that too in case the user wants to see the out file to open in vim for fun (though the try script actually simulates this for them).

The make clobber rule needs to remove out.count too in case they decide to keep the file OR in the case before this commit the detecting errors is terminated prematurely. This is especially important for updating the manifest but even then it shouldn't leave files lying about.

Updated .gitignore with out.count added.