### PR TITLE
Fix 1992/westley/whereami scripts if tput fails

### DIFF
--- a/1992/westley/whereami.alt.sh
+++ b/1992/westley/whereami.alt.sh
@@ -23,16 +23,18 @@ fi
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
 # this way allows us to have the user specify a different compiler in an easy
 # way.
-if [[ -z "$CC" ]]; then
-    CC="cc"
-fi
+[[ -z "$CC" ]] && CC="cc"
 
 # try getting the columns the simple way first: tput cols
-COLUMNS="$(tput cols)"
-
-if [[ "$?" -ne 0 ]]; then
-    # if tput failed for any reason try stty(1) with awk(1):
-    COLUMNS="$(stty size|awkf '{print $NF}')"
+if ! COLUMNS="$(tput cols)"; then
+    # if tput failed for any reason try stty(1) with awk(1).
+    #
+    # Disable this warning of shellcheck as it's wrong: awk needs single quotes.
+    #
+    # SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.
+    # https://www.shellcheck.net/wiki/SC2016
+    # shellcheck disable=SC2016
+    COLUMNS="$(stty size|awk '{print $NF}')"
 fi
 
 if [[ "$COLUMNS" -lt 80 ]]; then

--- a/1992/westley/whereami.sh
+++ b/1992/westley/whereami.sh
@@ -23,15 +23,18 @@ fi
 # make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
 # this way allows us to have the user specify a different compiler in an easy
 # way.
-if [[ -z "$CC" ]]; then
-    CC="cc"
-fi
+[[ -z "$CC" ]] && CC="cc"
 
 # try getting the columns the simple way first: tput cols
-COLUMNS="$(tput cols)"
-if [[ "$?" -ne 0 ]]; then
-    # if tput failed for any reason try stty(1) with awk(1):
-    COLUMNS="$(stty size|awkf '{print $NF}')"
+if ! COLUMNS="$(tput cols)"; then
+    # if tput failed for any reason try stty(1) with awk(1).
+    #
+    # Disable this warning of shellcheck as it's wrong: awk needs single quotes.
+    #
+    # SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.
+    # https://www.shellcheck.net/wiki/SC2016
+    # shellcheck disable=SC2016
+    COLUMNS="$(stty size|awk '{print $NF}')"
 fi
 
 if [[ "$COLUMNS" -lt 80 ]]; then

--- a/2001/coupard/README.md
+++ b/2001/coupard/README.md
@@ -14,19 +14,8 @@ make
 
 ## Try:
 
-If you have access to `/dev/audio` or `/dev/sound/dsp`:
-
 ```sh
-./coupard > /dev/audio
-./coupard > /dev/sound/dsp
-```
-
-If you do not, first install [sox](https://en.wikipedia.org/wiki/SoX). If you
-use macOS you might install it from [MacPorts](https://www.macports.org) or
-[Homebrew](https://brew.sh). Then you can try:
-
-```sh
-./coupard | sox -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+./try.sh
 ```
 
 

--- a/2001/coupard/try.sh
+++ b/2001/coupard/try.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# try.sh - demonstrate IOCCC winner 2001/coupard
+#
+
+# make sure CC is set so that when we do make CC="$CC" it isn't empty. Doing it
+# this way allows us to have the user specify a different compiler in an easy
+# way.
+[[ -z "$CC" ]] && CC="cc"
+
+# in this case we won't fail if we can't compile the code because we can still
+# run the supplementary program.
+make CC="$CC" everything >/dev/null
+
+# clear screen after compilation so that only the entry is shown
+clear
+
+# hopefully sox(1) is installed but we check for it just in case that it's not
+SOX="$(type -P sox)"
+AUDIO="/dev/audio"
+DSP="/dev/sound/dsp"
+
+if [[ -n "$SOX" ]]; then
+    echo "$ ./coupard | $SOX -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio" 1>&2
+    read -r -n 1 -p "Press any key to continue: "
+    echo 1>&2
+    ./coupard | "$SOX" -q -traw -r8000 -b8 -e unsigned-integer - -tcoreaudio
+    echo 1>&2
+elif [[ -S "$AUDIO" ]]; then
+    ./coupard > "$AUDIO"
+elif [[ -S "$DSP" ]]; then
+    ./coupard > "$DSP"
+else
+    echo "SoX not installed. Please install it and try again." 1>&2
+    echo "Tip: see https://github.com/ioccc-src/temp-test-ioccc/blob/master/faq.md#sox." 1>&2
+fi

--- a/2001/ollinger/try.sh
+++ b/2001/ollinger/try.sh
@@ -19,25 +19,25 @@ clear
 
 read -r -n 1 -p "Press any key to run: ./ollinger 1000 | cut -c -200 (space = next page, q = quit): "
 echo 1>&2
-./ollinger 1000 | cut -c -200 | less -rEXF
+./ollinger 1000 | cut -c -200 | less -rEXFK
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./ollinger 1000 | cut -c -100 (space = next page, q = quit): "
 echo 1>&2
-./ollinger 1000 | cut -c -100 | less -rEXF
+./ollinger 1000 | cut -c -100 | less -rEXFK
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./ollinger 42 (space = next page, q = quit): "
 echo 1>&2
-./ollinger 42 | less -rEXF
+./ollinger 42 | less -rEXFK
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./ollinger 42 | cut -c -100 (space = next page, q = quit): "
 echo 1>&2
-./ollinger 42 | cut -c -100 | less -rEXF
+./ollinger 42 | cut -c -100 | less -rEXFK
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./ollinger 42 | cut -c -200 (space = next page, q = quit): "
 echo 1>&2
-./ollinger 42 | cut -c -200 | less -rEXF
+./ollinger 42 | cut -c -200 | less -rEXFK
 echo 1>&2

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2808,13 +2808,18 @@ void e(n,h){
 
 ```
 
-This was not really worth a thanks per se but it was originally done by adding
-`int`. The better solution is to disable the warning which is what was done
-later on to make it more like the original.
+and for some reason it was being reported as an error. This was not really worth
+a thanks per se but it was originally done by adding `int`. The better solution
+is to disable the warning which is what was done later on to make it more like
+the original.
 
-Yusuke provided a proper command line for macOS (to do with sound; see his
+[Yusuke](#yusuke) provided a proper command line for those without `/dev/audio`
+or `/dev/sound/dsp` (which is most everyone nowadays, it seems, and especially
+those with macOS) (to do with sound; see his
 [/2013/endoh3/README.md](/2013/endoh3/README.md) entry where he also refers to
 sound devices in macOS).
+
+Cody added the [try.sh](/2001/coupard/try.sh).
 
 
 ## <a name="2001_ctk"></a>[2001/ctk](/2001/ctk/ctk.c) ([README.md](/2001/ctk/README.md]))


### PR DESCRIPTION

There was a typo: awkf instead of awk.

ShellCheck fix as well.