### PR TITLE
Remove ambiguity in 2005/jetro/README.md

### DIFF
--- a/2005/aidan/try.alt.sh
+++ b/2005/aidan/try.alt.sh
@@ -23,16 +23,16 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./$AIDAN < blank.sudoku (space = next page, q = quit): "
 echo 1>&2
-./"$AIDAN" < blank.sudoku | less -rEXF
+./"$AIDAN" < blank.sudoku | less -rEXFK
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: echo IOCCC | ./$AIDAN (space = next page, q = quit): "
-echo IOCCC | ./"$AIDAN" | less -rEXF
+echo IOCCC | ./"$AIDAN" | less -rEXFK
 echo "What just happened?" 1>&2
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: echo IOCCC | ./$AIDAN 42 (space = next page, q = quit): "
-echo IOCCC | ./"$AIDAN" 42 1>&2 | less -rEXF
+echo IOCCC | ./"$AIDAN" 42 1>&2 | less -rEXFK
 echo 1>&2
 echo "Seeing that, was the 'echo IOCCC' relevant?" 1>&2
 echo 1>&2

--- a/2005/aidan/try.sh
+++ b/2005/aidan/try.sh
@@ -20,12 +20,12 @@ AIDAN="aidan"
 echo "$ ./$AIDAN < blank.sudoku" 1>&2
 read -r -n 1 -p "Press any key to run: ./$AIDAN < blank.sudoku (space = next page, q = quit): "
 echo 1>&2
-./"$AIDAN" < blank.sudoku | less -rEXF
+./"$AIDAN" < blank.sudoku | less -rEXFK
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./$AIDAN U < blank.sudoku (space = next page, q = quit): "
 echo 1>&2
-./"$AIDAN" U < blank.sudoku | less -rEXF
+./"$AIDAN" U < blank.sudoku | less -rEXFK
 echo 1>&2
 echo "What was the difference between the previous command?" 1>&2
 echo "More specifically, what did it do?" 1>&2
@@ -33,7 +33,7 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: echo IOCCC | ./$AIDAN (space = next page, q = quit): "
 echo 1>&2
-echo IOCCC | ./"$AIDAN" | less -rEXF
+echo IOCCC | ./"$AIDAN" | less -rEXFK
 echo 1>&2
 echo "What just happened?" 1>&2
 echo 1>&2
@@ -41,18 +41,18 @@ echo 1>&2
 
 read -r -n 1 -p "Press any key to run: echo IOCCC | ./$AIDAN 42 (space = next page, q = quit): "
 echo 1>&2
-echo IOCCC | ./"$AIDAN" 42 | less -rEXF
+echo IOCCC | ./"$AIDAN" 42 | less -rEXFK
 echo 1>&2
 echo "Seeing that, was the 'echo IOCCC' relevant?" 1>&2
 echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./$AIDAN < insane1.sudoku (space = next page, q = quit): "
-./"$AIDAN" < insane1.sudoku | less -rEXF
+./"$AIDAN" < insane1.sudoku | less -rEXFK
 
 read -r -n 1 -p "Do you with to run the test suite (y/n)? "
 if [[ "$REPLY" = "y" || "$REPLY" = "Y" ]]; then
     echo 1>&2
     read -r -n 1 -p "Press any key to run: make test (space = next page, q = quit): "
     echo 1>&2
-    make test | less -rEXF
+    make test | less -rEXFK
 fi

--- a/2005/chia/chia.c
+++ b/2005/chia/chia.c
@@ -1,6 +1,6 @@
 /*
  * Sun's Java is often touted as being "portable", even though my code won't
- * suddenly become über-portable if it's in Java. Truth is, Java's one of
+ * suddenly become uber-portable if it's in Java. Truth is, Java's one of
  * the most ugly, slow, and straitjacketed languages ever. It's popular
  * mainly because people hear the word "portable" and go "ewww".
  *

--- a/2005/jetro/README.md
+++ b/2005/jetro/README.md
@@ -1,9 +1,8 @@
 ## To build:
 
-This entry requires SDL to be installed.
-
-See [3.8  - How do I compile an IOCCC winner that requires SDL1 or
-SDL2?](/faq.md#SDL) for information on how to install it if you haven't already.
+This entry requires SDL. See [3.8  - How do I compile an IOCCC winner that
+requires SDL1 or SDL2?](/faq.md#SDL) for information on how to install it if you
+haven't already.
 
 If you have SDL installed:
 

--- a/2005/jetro/README.md
+++ b/2005/jetro/README.md
@@ -2,8 +2,8 @@
 
 This entry requires SDL to be installed.
 
-See the [FAQ](/faq.md) for information on how to install it if you haven't
-already.
+See [3.8  - How do I compile an IOCCC winner that requires SDL1 or
+SDL2?](/faq.md#SDL) for information on how to install it if you haven't already.
 
 If you have SDL installed:
 


### PR DESCRIPTION

The wording 'this entry requires SDL to be installed' has more than one
interpretation: 'it requires SDL to install the entry' (which seems more
likely even though it's incorrect) or 'it requires SDL to be built' 
(less likely as that is not what it said). Now it just says 'this entry
requires SDL'. Now it's monosemic and it says exactly what it should 
(okay - it could say something else like 'it requires SDL to compile' 
but that's bordering on unnecessary semantics).