### PR TITLE
Fix 2005/persano make clobber, .gitignore, try.sh

### DIFF
--- a/2005/klausler/try.sh
+++ b/2005/klausler/try.sh
@@ -74,3 +74,18 @@ read -r -n 1 -p "Press any key to run: ./klausler werewolf vampire | head -n 10:
 echo 1>&2
 ./klausler werewolf vampire | head -n 10
 echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./klausler dennis ritchie | head -n 10: "
+echo 1>&2
+./klausler dennis ritchie | head -n 10
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./klausler ken thompson | head -n 10: "
+echo 1>&2
+./klausler ken thompson | head -n 10
+echo 1>&2
+
+read -r -n 1 -p "Press any key to run: ./klausler Linus Torvalds | head -n 10: "
+echo 1>&2
+./klausler linus torvalds | head -n 10
+echo 1>&2

--- a/2005/mikeash/try.sh
+++ b/2005/mikeash/try.sh
@@ -18,21 +18,19 @@ clear
 
 read -r -n 1 -p "Press any key to run: ./mikeash < mikeash.c (space = next page, q = quit): "
 echo 1>&2
-./mikeash < mikeash.c
+./mikeash < mikeash.c | less -rEXFK
 echo 1>&2
 
 echo 1>&2
-echo "The next command should print nothing." 1>&2
-read -r -n 1 -p "Press any key to run: ./mikeash < mikeash.c | diff - mikeash.c: "
+read -r -n 1 -p "Press any key to run: ./mikeash < mikeash.c | diff -s - mikeash.c: "
 echo 1>&2
-# ShellCheck is incorrect here:
+
+# We're not reading and writing to the same file at all.
 #
-#   SC2094 (info): Make sure not to read and write the same file in the same pipeline.
-#
-# so we disable it.
-#
+# SC2094 (info): Make sure not to read and write the same file in the same pipeline.
+# https://www.shellcheck.net/wiki/SC2094
 # shellcheck disable=SC2094
-./mikeash < mikeash.c | diff - mikeash.c
+./mikeash < mikeash.c | diff -s - mikeash.c
 echo 1>&2
 
 echo "For the next two commands we will add a newline after the command's output" 1>&2
@@ -45,15 +43,7 @@ echo '(format t "~s" (+ 2 2 ))' | ./mikeash
 echo 1>&2
 
 echo "The next command will evaluate the expression: (2+2) * (5 - 9/3), giving 8\"." 1>&2
-
-# ShellCheck warns:
-#
-#   SC2140 (warning): Word is of the form "A"B"C" (B indicated). Did you mean "ABC" or "A\"B\"C"?
-#
-# ShellCheck is wrong.
-#
-# shellcheck disable=SC2140
-read -r -n 1 -p "Press any key to run: echo '(format t "~s" (* (+ 2 2 ) (- 5 (/ 9 3 ))))' | ./mikeash: "
+read -r -n 1 -p "Press any key to run: echo '(format t \"~s\" (* (+ 2 2 ) (- 5 (/ 9 3 ))))' | ./mikeash: "
 echo 1>&2
 echo '(format t "~s" (* (+ 2 2 ) (- 5 (/ 9 3 ))))' | ./mikeash
 echo 1>&2

--- a/2005/persano/.gitignore
+++ b/2005/persano/.gitignore
@@ -1,11 +1,10 @@
 #
 # sort with: ../../bin/sgi
 *.dSYM
-foo.gif
+*.gif
 indent
 indent.c
 indent.o
 persano
 persano.orig
 prog.orig
-seal.gif

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -207,7 +207,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM
+	${RM} -rf *.dSYM *.gif
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2005/persano/try.sh
+++ b/2005/persano/try.sh
@@ -24,6 +24,7 @@ if [[ -f knot3-16.gif ]]; then
     echo "Now open the file knot3-16.gif in a GIF viewer capable of viewing animated" 1>&2
     echo "GIFs. See the README.md for details on a tool to manipulate it, if you wish." 1>&2
 fi
+echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./persano 3 2 1 > foo.gif: "
 echo 1>&2
@@ -33,6 +34,7 @@ if [[ -f foo.gif ]]; then
     echo "Now open the file foo.gif in a GIF viewer capable of viewing animated" 1>&2
     echo "GIFs. See the README.md for details on a tool to manipulate it, if you wish." 1>&2
 fi
+echo 1>&2
 
 read -r -n 1 -p "Press any key to run: ./persano 5 2 > seal.gif: "
 echo 1>&2
@@ -43,3 +45,4 @@ if [[ -f seal.gif ]]; then
     echo "Now open seal.gif (Solomon's Seal knot) in a GIF viewer capable of viewing" 1>&2
     echo "animated GIFs. See the README.md for details on a tool to manipulate it, if you wish." 1>&2
 fi
+echo 1>&2


### PR DESCRIPTION

The make clobber fix is important for updating the manifest. The 
.gitignore left a .gif file out but now it just ignores '*.gif'. The
script was updated with some newlines to separate commands.