### PR TITLE
Fix fix of 2011/akari make clobber

### DIFF
--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -226,7 +226,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM
+	${RM} -rf *.dSYM rot13.c
 	${RM} -f akari2.c akari3.c akari4.c odd_output.ppm even_output.ppm expanded_and_rot13_output.txt expanded_output.txt
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -227,7 +227,7 @@ clean:
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
 	${RM} -rf *.dSYM
-	${RM} -f akari2.c akari3.c akari4.c *.ppm
+	${RM} -f akari2.c akari3.c akari4.c odd_output.ppm even_output.ppm expanded_and_rot13_output.txt expanded_output.txt
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \


### PR DESCRIPTION
Can't remove *.ppm as that removes example.ppm. Instead specific ppm files are removed.

Also two text files have to be removed.