### PR TITLE
Update todo file

### DIFF
--- a/2018/ferguson/weasel.spec
+++ b/2018/ferguson/weasel.spec
@@ -7,7 +7,7 @@ Summary:        Implementation of Richard Dawkins's Weasel program
 
 License:        Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
 URL:            http://ioccc.xexyl.net/weasel
-Source0:        weasel.tar.bz2
+Source0:        2018_ferguson.tar.bz2
 
 BuildRequires:  gcc make
 AutoReq:	1
@@ -34,11 +34,10 @@ AutoReq:	1
     string amongst others. See weasel(1) for more information.
 
 %prep
-%setup -n weasel
+%setup -n 2018/ferguson
 
 %build
 make weasel weasel.alt
-mv -f README.md README.md 2>/dev/null || :
 
 %install
 rm -rf $RPM_BUILD_ROOT
@@ -53,9 +52,7 @@ install -m 644 Makefile -D $RPM_BUILD_ROOT%{_usrsrc}/weasel
 install -m 644 prog.alt.c -D $RPM_BUILD_ROOT%{_usrsrc}/weasel/weasel.alt.c
 ln -s weasel.alt.c $RPM_BUILD_ROOT%{_usrsrc}/weasel/prog.alt.c
 install -m 644 weasel.1 -D $RPM_BUILD_ROOT%{_mandir}/man1/weasel.1
-install -m 644 hint.html -D $RPM_BUILD_ROOT%{_docdir}/weasel/weasel.html
-install -m 644 README.md -D $RPM_BUILD_ROOT%{_docdir}/weasel/weasel.markdown
-install -m 644 hint.css -D $RPM_BUILD_ROOT%{_docdir}/weasel/hint.css
+install -m 644 README.md -D $RPM_BUILD_ROOT%{_docdir}/weasel/weasel.md
 install -m 644 FILES -D $RPM_BUILD_ROOT%{_docdir}/weasel/FILES
 
 %files

--- a/tmp/things-todo.md
+++ b/tmp/things-todo.md
@@ -1,5 +1,5 @@
 # A todo list of known things to check and/or do
-*Last updated: Sun 04 Feb 2024 17:30:08 UTC*
+*Last updated: Tue 27 Feb 2024 16:16:25 UTC*
 
 This document is for [Cody Boone Ferguson](/authors.html#Cody_Boone_Ferguson) as
 he (that is I :-) ) wanted a way to keep track of things in a way that did not
@@ -24,13 +24,15 @@ completed.
     changes that might be required in those years too so a pass over all of them
     will have to be done at the time the files are to be reviewed.
 
-- Check the [GitHub issue #3 comment
-1615962832](https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1615962832)
-for links about the todo items wrt the [FAQ](/faq.md).
+- Check that the following todo tasks at:
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583842154>,
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583836962>,
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583834979>,
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583833132>,
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583832622>,
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583829356>
+    and
+    <https://github.com/ioccc-src/temp-test-ioccc/issues/3#issuecomment-1583828473>
 
-- Check for video links in README.md files and see if the videos can be
-embedded into the README.md files themselves. An entry that the video file is
-downloaded already is 2006/sykes1. There are others that I need to look at once
-the rest of the entries are done, assuming that it's possible.
-
-- Test and fix as and if necessary 2018/ferguson/weasel.spec.
+    have been finished. It is quite possible that some or all of these have been
+    corrected by now but this has not yet been determined.


### PR DESCRIPTION

The task of weasel.spec was removed as it's complete.

Rather than have to open a link to find the links to check (many if not
all are probably done already but they have to be confirmed yet) at
issue 3 I have just put the direct links in the file.

Also removed the embed video task. It might be useful but it's probably
not worth delaying things more.