### PR TITLE
Typo fix in news.{md,html}

### DIFF
--- a/news.html
+++ b/news.html
@@ -102,7 +102,7 @@
 <!-- END: this line ends content from: inc/before-content.default.html -->
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
-<h1 id="section">2023-02-29</h1>
+<h1 id="section">2024-02-29</h1>
 <p>We continue to make good progress on web site. In the <a
 href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc
 GitHub repo</a> we have made nearly 4600 changes to date!</p>

--- a/news.md
+++ b/news.md
@@ -1,4 +1,4 @@
-# 2023-02-29
+# 2024-02-29
 
 We continue to make good progress on web site.  In the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc) we have made nearly 4600 changes to date!
 


### PR DESCRIPTION
Make year 2024 not 2023.