### PR TITLE
Typo fix in index.{md,html}

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@ href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc
 GitHub repo</a>.</p>
 <h1 id="suggestion-for-visitors">Suggestion for visitors</h1>
 <p>Explore the <a href="years.html">Winning Entries</a> sorted by year,
-or sort by <a href="authors.html">People who have won</a>.</p>
+or sorted by <a href="authors.html">People who have won</a>.</p>
 <h1 id="obfuscate-defined">Obfuscate defined:</h1>
 <p>tr.v. -cated, -cating, -cates. <BR><BR> <strong>1a.</strong> To
 render obscure.<BR> <strong>1b.</strong> To darken. <BR><BR>

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ then consider making pull requests against the [temp-test-ioccc GitHub repo](htt
 
 # Suggestion for visitors
 
-Explore the [Winning Entries](years.html) sorted by year, or sort by [People who have won](authors.html).
+Explore the [Winning Entries](years.html) sorted by year, or sorted by [People who have won](authors.html).
 
 
 # Obfuscate defined:

--- a/news.html
+++ b/news.html
@@ -102,7 +102,7 @@
 <!-- END: this line ends content from: inc/before-content.default.html -->
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
-<h1 id="section">2023-02-29</h1>
+<h1 id="section">2024-02-29</h1>
 <p>We continue to make good progress on web site. In the <a
 href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc
 GitHub repo</a> we have made nearly 4600 changes to date!</p>

--- a/news.md
+++ b/news.md
@@ -1,4 +1,4 @@
-# 2023-02-29
+# 2024-02-29
 
 We continue to make good progress on web site.  In the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc) we have made nearly 4600 changes to date!
 


### PR DESCRIPTION

'sort' -> 'sorted'. This is because the former CAN suggests that one 
might be able to sort the list when actually the list is sorted (it is
also synchronous with the previous list where it says sorted, not sort).