### PR TITLE
Fix 2020/ferguson1/Makefile from silence commit

### DIFF
--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-unused-value -Wno-implicit-fallthrough -Wno-parentheses \
 	  -Wno-binding-in-condition -Wno-binding-in-condition \
-	  -Wno-misleading-indentation \Wno-unknown-warning-option \
+	  -Wno-misleading-indentation -Wno-unknown-warning-option \
 	  -Wno-comment -Wno-implicit-function-declaration \
           -Wno-misleading-indentation -Wno-unused-value
 


### PR DESCRIPTION
There was a \ instead of a - which broke compilation.