### PR TITLE
Silence another warning in 1986/marshall

### DIFF
--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype -Wno-pointer-to-int-cast -Wno-return-type \
           -Wno-strict-prototypes -Wno-uninitialized -Wno-unused-parameter \
 	  -Wno-address -Wno-builtin-declaration-mismatch -Wno-sequence-point \
-	  -Wno-unknown-warning-option
+	  -Wno-unknown-warning-option -Wno-int-to-pointer-cast
 
 # Common C compiler warning flags
 #

--- a/1986/marshall/marshall.alt.c
+++ b/1986/marshall/marshall.alt.c
@@ -10,5 +10,5 @@ x  ;if    (P(  !        i              )        |  cc[  !      j ]
 &  P(j    )>2  ?        j              :        i  ){*  argv[i++ +!-i]
 ;              for    (i=              0;;    i++                   );
 _exit(argv[(int)*argc-2/cc[1*(int)*argc]|-1<<4]);printf("%d",P(""));}}
-  P  (    a  )   char a   ;  {    a  ;   while(    a  >      "  B   "
+  P  (    a  )   char a   ;  {    a  ;   while((char *)a  >   "  B   "
   /* -    by E            ricM    arsh             all-      */);    }

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-unused-value -Wno-implicit-fallthrough -Wno-parentheses \
 	  -Wno-binding-in-condition -Wno-binding-in-condition \
-	  -Wno-misleading-indentation \Wno-unknown-warning-option \
+	  -Wno-misleading-indentation -Wno-unknown-warning-option \
 	  -Wno-comment -Wno-implicit-function-declaration \
           -Wno-misleading-indentation -Wno-unused-value
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -494,6 +494,27 @@ args to <code>main()</code> and the third arg was an
 href="1986/marshall/compilers.html">compilers.html</a> file to see how
 odd this problem was and what Cody did to fix it, if nothing else but
 for entertainment!</p>
+<p>Also, after all warnings but one that could not be silenced were
+disabled, Cody changed the alt code (which was not the same as the
+original - see above for details or try <code>make diff_orig_alt</code>
+in the directory) slightly so that it was possible to silence it. In
+particular:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>  P  <span class="op">(</span>    a  <span class="op">)</span>   <span class="dt">char</span> a   <span class="op">;</span>  <span class="op">{</span>    a  <span class="op">;</span>   <span class="cf">while</span><span class="op">(</span>    a  <span class="op">&gt;</span>      <span class="st">&quot;  B   &quot;</span></span></code></pre></div>
+<p>which gave:</p>
+<pre><code>marshall.alt.c:13:55: warning: ordered comparison between pointer and integer (&#39;char&#39; and &#39;char *&#39;)
+  P  (    a  )   char a   ;  {    a  ;   while(    a  &gt;      &quot;  B   &quot;
+                                                   ~  ^      ~~~~~~~~
+1 warning generated.</code></pre>
+<p>was changed to:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>  P  <span class="op">(</span>    a  <span class="op">)</span>   <span class="dt">char</span> a   <span class="op">;</span>  <span class="op">{</span>    a  <span class="op">;</span>   <span class="cf">while</span><span class="op">((</span><span class="dt">char</span> <span class="op">*)</span>a  <span class="op">&gt;</span>   <span class="st">&quot;  B   &quot;</span></span></code></pre></div>
+<p>which gave:</p>
+<pre><code>marshall.alt.c:13:48: warning: cast to &#39;char *&#39; from smaller integer type &#39;char&#39; [-Wint-to-pointer-cast]
+  P  (    a  )   char a   ;  {    a  ;   while((char *)a  &gt;   &quot;  B   &quot;
+                                               ^~~~~~~~~
+1 warning generated.
+</code></pre>
+<p>which can be disabled. It results in the same behaviour but this way
+no warnings are produced.</p>
 <h2 id="pawka-index.html"><a name="1986_pawka"></a><a
 href="1986/pawka/pawka.c">1986/pawka</a> (<a
 href="1986/pawka/index.html">index.html</a>)</h2>
@@ -525,7 +546,8 @@ was in 1986, as well as below.</p>
 it still required <code>-traditional-cpp</code>.</p>
 <p>If you’d like to see the difference between the version that requires
 <code>-traditional-cpp</code> and the fixed version, try:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> 1986/wall <span class="kw">;</span> <span class="fu">make</span> diff_orig_prog</span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> 1986/wall <span class="kw">;</span> <span class="fu">make</span> diff_orig_prog</span></code></pre></div>
 <p>Some of the changes required:</p>
 <ul>
 <li><p>Instead of using the <code>c_</code>, defined as
@@ -683,49 +705,49 @@ well, however.</p>
 <code>-traditional-cpp</code> (which <strike>not all compilers
 support</strike> <code>clang</code> does not support). It needed that
 option in modern systems because of two things it did:</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define a</span><span class="op">(</span><span class="pp">x</span><span class="op">)</span><span class="pp">get</span><span class="co">/***/</span><span class="pp">x</span><span class="co">/***/</span><span class="pp">id</span><span class="op">())</span></span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span>
-<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb21-5"><a href="#cb21-5" aria-hidden="true" tabindex="-1"></a>p Z<span class="op">=</span>chroot<span class="op">(</span><span class="st">&quot;/&quot;</span><span class="op">);</span>L<span class="op">(!</span>a<span class="op">(</span>u<span class="op">)</span>execv<span class="op">((</span>q<span class="op">(</span>v<span class="op">=</span><span class="st">&quot;/ipu6ljov&quot;</span><span class="op">),</span>v<span class="op">),</span>C<span class="op">);</span>Z<span class="op">-=</span>kill<span class="op">(</span>l<span class="op">);</span></span>
-<span id="cb21-6"><a href="#cb21-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb21-7"><a href="#cb21-7" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span>
-<span id="cb21-8"><a href="#cb21-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb21-9"><a href="#cb21-9" aria-hidden="true" tabindex="-1"></a>case_2<span class="op">:</span>L<span class="op">(!--</span>V<span class="op">){</span>O<span class="co">/*/*/</span>c<span class="op">*</span>c<span class="op">+</span>c<span class="op">);</span>wait<span class="op">(</span>A<span class="op">+</span>c<span class="op">*</span>c<span class="op">-</span>c<span class="op">);</span>L<span class="op">(!</span>Z<span class="op">)</span>f<span class="op">(</span>A<span class="op">,</span><span class="st">&quot;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span>c<span class="op">);</span><span class="cf">return</span><span class="op">(</span>A<span class="op">*</span>getgid<span class="op">());};</span>C<span class="op">++;</span></span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define a</span><span class="op">(</span><span class="pp">x</span><span class="op">)</span><span class="pp">get</span><span class="co">/***/</span><span class="pp">x</span><span class="co">/***/</span><span class="pp">id</span><span class="op">())</span></span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>p Z<span class="op">=</span>chroot<span class="op">(</span><span class="st">&quot;/&quot;</span><span class="op">);</span>L<span class="op">(!</span>a<span class="op">(</span>u<span class="op">)</span>execv<span class="op">((</span>q<span class="op">(</span>v<span class="op">=</span><span class="st">&quot;/ipu6ljov&quot;</span><span class="op">),</span>v<span class="op">),</span>C<span class="op">);</span>Z<span class="op">-=</span>kill<span class="op">(</span>l<span class="op">);</span></span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span>
+<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>case_2<span class="op">:</span>L<span class="op">(!--</span>V<span class="op">){</span>O<span class="co">/*/*/</span>c<span class="op">*</span>c<span class="op">+</span>c<span class="op">);</span>wait<span class="op">(</span>A<span class="op">+</span>c<span class="op">*</span>c<span class="op">-</span>c<span class="op">);</span>L<span class="op">(!</span>Z<span class="op">)</span>f<span class="op">(</span>A<span class="op">,</span><span class="st">&quot;</span><span class="sc">\n</span><span class="st">&quot;</span><span class="op">,</span>c<span class="op">);</span><span class="cf">return</span><span class="op">(</span>A<span class="op">*</span>getgid<span class="op">());};</span>C<span class="op">++;</span></span></code></pre></div>
 <p>This macro, <code>a</code>, formed the functions (the names)
 <code>getuid()</code> and <code>getgid()</code>, but this no longer
 works. The code still uses the macro <code>a</code> to form the names
 but it’s done differently, using the C token paste operator
 <code>##</code>. It’s done like thus:</p>
-<div class="sourceCode" id="cb22"><pre
-class="sourceCode diff"><code class="sourceCode diff"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="kw">--- i/1988/dale/dale.c</span></span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="dt">+++ w/1988/dale/dale.c</span></span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a><span class="dt">@@ -9,18 +9,18 @@</span></span>
-<span id="cb22-4"><a href="#cb22-4" aria-hidden="true" tabindex="-1"></a> #define L if</span>
-<span id="cb22-5"><a href="#cb22-5" aria-hidden="true" tabindex="-1"></a> #define I goto</span>
-<span id="cb22-6"><a href="#cb22-6" aria-hidden="true" tabindex="-1"></a> #define l 1</span>
-<span id="cb22-7"><a href="#cb22-7" aria-hidden="true" tabindex="-1"></a> #define f write</span>
-<span id="cb22-8"><a href="#cb22-8" aria-hidden="true" tabindex="-1"></a> #define J else</span>
-<span id="cb22-9"><a href="#cb22-9" aria-hidden="true" tabindex="-1"></a><span class="st">-#define a(x)get/***/x/***/id())</span></span>
-<span id="cb22-10"><a href="#cb22-10" aria-hidden="true" tabindex="-1"></a><span class="va">+#define a(x)get##x##id())</span></span></code></pre></div>
+<div class="sourceCode" id="cb26"><pre
+class="sourceCode diff"><code class="sourceCode diff"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">--- i/1988/dale/dale.c</span></span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="dt">+++ w/1988/dale/dale.c</span></span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a><span class="dt">@@ -9,18 +9,18 @@</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a> #define L if</span>
+<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a> #define I goto</span>
+<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a> #define l 1</span>
+<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a> #define f write</span>
+<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a> #define J else</span>
+<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a><span class="st">-#define a(x)get/***/x/***/id())</span></span>
+<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a><span class="va">+#define a(x)get##x##id())</span></span></code></pre></div>
 <p>The second is that</p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span><span class="co">/*/(;;);/*/</span>k<span class="op">()){</span>O<span class="co">/*/*/</span>c<span class="op">);</span></span></code></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span><span class="co">/*/(;;);/*/</span>k<span class="op">()){</span>O<span class="co">/*/*/</span>c<span class="op">);</span></span></code></pre></div>
 <p>cannot form <code>fork())</code> in modern C compilers. Since it was
 not done through a macro it was simply changed to be
 <code>fork()</code>, rather than adding a new macro.</p>
 <p>The other problem that could not be resolved by the
 <code>-traditional-cpp</code> was that modern compilers do not allow
 directives like:</p>
-<div class="sourceCode" id="cb24"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define _ define</span></span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">_ P char</span></span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">_ p int</span></span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">_ O close(</span></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span></code></pre></div>
+<div class="sourceCode" id="cb28"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define _ define</span></span>
+<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">_ P char</span></span>
+<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">_ p int</span></span>
+<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">_ O close(</span></span>
+<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span></code></pre></div>
 <p>so Cody changed the lines to be in the form of:</p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define P </span><span class="dt">char</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define p </span><span class="dt">int</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#define O close</span><span class="op">(</span></span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span></code></pre></div>
+<div class="sourceCode" id="cb29"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define P </span><span class="dt">char</span></span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define p </span><span class="dt">int</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#define O close</span><span class="op">(</span></span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a><span class="co">/* ... */</span></span></code></pre></div>
 <p>However, to keep the entry as close to as possible in look, Cody kept
 the <code>_</code> macro in place it’s just no longer used.</p>
 <p>See the index.html file for details on the original code, provided as
@@ -815,22 +837,22 @@ was also fixed in <a href="1989/fubar/fubar.sh">fubar.sh</a>.</p>
 <p>A strange problem occurred where if one made modifications to the C
 file it might end up failing to work even after changing it back. This
 was resolved by:</p>
-<div class="sourceCode" id="cb26"><pre
-class="sourceCode diff"><code class="sourceCode diff"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="kw">--- i/1989/fubar/fubar.sh</span></span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="dt">+++ w/1989/fubar/fubar.sh</span></span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a><span class="dt">@@ -7,13 +7,12 @@ if [[ $# -ne 1 ]]; then</span></span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>     exit 1</span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a> fi</span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a> </span>
-<span id="cb26-7"><a href="#cb26-7" aria-hidden="true" tabindex="-1"></a> # run/compile it</span>
-<span id="cb26-8"><a href="#cb26-8" aria-hidden="true" tabindex="-1"></a> rm -f ouroboros.c x1 x</span>
-<span id="cb26-9"><a href="#cb26-9" aria-hidden="true" tabindex="-1"></a><span class="st">-ex - &lt;&lt;EOF</span></span>
-<span id="cb26-10"><a href="#cb26-10" aria-hidden="true" tabindex="-1"></a><span class="st">-r fubar.c</span></span>
-<span id="cb26-11"><a href="#cb26-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ex fubar.c &lt;&lt;EOF</span></span>
-<span id="cb26-12"><a href="#cb26-12" aria-hidden="true" tabindex="-1"></a> 8,9j</span>
-<span id="cb26-13"><a href="#cb26-13" aria-hidden="true" tabindex="-1"></a> w ouroboros.c</span>
-<span id="cb26-14"><a href="#cb26-14" aria-hidden="true" tabindex="-1"></a> EOF</span>
-<span id="cb26-15"><a href="#cb26-15" aria-hidden="true" tabindex="-1"></a> chmod +x ouroboros.c</span></code></pre></div>
+<div class="sourceCode" id="cb30"><pre
+class="sourceCode diff"><code class="sourceCode diff"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="kw">--- i/1989/fubar/fubar.sh</span></span>
+<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a><span class="dt">+++ w/1989/fubar/fubar.sh</span></span>
+<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a><span class="dt">@@ -7,13 +7,12 @@ if [[ $# -ne 1 ]]; then</span></span>
+<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>     exit 1</span>
+<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a> fi</span>
+<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a> </span>
+<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a> # run/compile it</span>
+<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a> rm -f ouroboros.c x1 x</span>
+<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a><span class="st">-ex - &lt;&lt;EOF</span></span>
+<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a><span class="st">-r fubar.c</span></span>
+<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a><span class="va">+ex fubar.c &lt;&lt;EOF</span></span>
+<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a> 8,9j</span>
+<span id="cb30-13"><a href="#cb30-13" aria-hidden="true" tabindex="-1"></a> w ouroboros.c</span>
+<span id="cb30-14"><a href="#cb30-14" aria-hidden="true" tabindex="-1"></a> EOF</span>
+<span id="cb30-15"><a href="#cb30-15" aria-hidden="true" tabindex="-1"></a> chmod +x ouroboros.c</span></code></pre></div>
 <p>Cody also ‘modernised’ the script to use <code>bash</code> and fixed
 for ShellCheck. The <code>if [ .. ]</code> was changed in the C code as
 well as the script.</p>
@@ -860,11 +882,11 @@ href="1989/jar.2/jar.2.c">1989/jar.2</a> (<a
 href="1989/jar.2/index.html%5D">index.html</a>)</h2>
 <p><a href="#cody">Cody</a> fixed this to work with modern compilers.
 Modern compilers do not allow code like:</p>
-<div class="sourceCode" id="cb27"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define D define</span></span>
-<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define a include</span></span>
-<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">D foo bar</span></span>
-<span id="cb27-5"><a href="#cb27-5" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">a &lt;stdio.h&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb31"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define D define</span></span>
+<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define a include</span></span>
+<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">D foo bar</span></span>
+<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">a &lt;stdio.h&gt;</span></span></code></pre></div>
 <p>He notes that there <em>is</em> a way to get it (or something close
 to it) to work. Do you know how?</p>
 <p>Cody also provided the <a href="1989/jar.2/try.sh">try.sh</a> script
@@ -910,8 +932,8 @@ href="1989/robison/robison.c">1989/robison</a> (<a
 href="1989/robison/index.html%5D">index.html</a>)</h2>
 <p><a href="#yusuke">Yusuke Endoh</a> fixed this to compile under modern
 systems. To see the changes made, try:</p>
-<div class="sourceCode" id="cb28"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> 1989/robison <span class="kw">;</span> <span class="fu">make</span> diff_orig_prog</span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> 1989/robison <span class="kw">;</span> <span class="fu">make</span> diff_orig_prog</span></code></pre></div>
 <p>(It adds the C token pasting operator <code>##</code> instead of
 <code>/**/</code>.)</p>
 <p>Cody also added the <a href="1989/robison/try.sh">try.sh</a>
@@ -1071,11 +1093,11 @@ href="1990/dg/index.html%5D">index.html</a>)</h2>
 <p><a href="#cody">Cody</a> fixed this for modern systems. There were
 two problems to be resolved.</p>
 <p>One can no longer do:</p>
-<div class="sourceCode" id="cb29"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define d define</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">d b12(x) 12 x</span></span>
-<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a><span class="co">/* etc. */</span></span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define d define</span></span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a><span class="pp">#</span><span class="er">d b12(x) 12 x</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a><span class="co">/* etc. */</span></span></code></pre></div>
 <p>so the use of <code>#d</code> is now instead <code>#define</code>
 (the macro was originally deleted but later Cody added it back to make
 it more like the original).</p>
@@ -1150,7 +1172,7 @@ segfault prevention was added here). He also fixed some array addressing
 (some of which might not be strictly necessary but as he was testing the
 <code>fibonacci.c</code> bug he ended up changing it anyway).</p>
 <p>BTW: why can’t the fix:</p>
-<div class="sourceCode" id="cb30"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>a<span class="op">[</span><span class="dv">1</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">2</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">3</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">4</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">5</span><span class="op">]==</span>NULL<span class="op">)</span> <span class="cf">return</span> <span class="dv">1</span><span class="op">;</span></span></code></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>a<span class="op">[</span><span class="dv">1</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">2</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">3</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">4</span><span class="op">]==</span>NULL<span class="op">||</span>a<span class="op">[</span><span class="dv">5</span><span class="op">]==</span>NULL<span class="op">)</span> <span class="cf">return</span> <span class="dv">1</span><span class="op">;</span></span></code></pre></div>
 <p>be changed to just test the value of <code>A</code> when
 <code>a</code> is argv and <code>A</code> is argc?</p>
 <p>Cody also changed the code to use <code>fgets(3)</code>.</p>
@@ -1278,10 +1300,10 @@ fix the segfault was changed from <code>char*s</code> to
 <code>char s[]</code>):</p>
 <pre><code>!.Xop.fssps!.Xop.sfuvso.uzqf!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo</code></pre>
 <p>and then the call to <code>system()</code> had to be changed to:</p>
-<div class="sourceCode" id="cb32"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a>system<span class="op">(</span>q<span class="op">-</span><span class="dv">69</span><span class="op">);</span></span></code></pre></div>
+<div class="sourceCode" id="cb36"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a>system<span class="op">(</span>q<span class="op">-</span><span class="dv">69</span><span class="op">);</span></span></code></pre></div>
 <p>An important point is that the placement of this string in the
 <code>s</code> array does matter. This is because of the code:</p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="op">*</span>o<span class="op">=</span>fopen<span class="op">(</span>q<span class="op">-</span><span class="dv">3</span><span class="op">,</span><span class="st">&quot;w&quot;</span><span class="op">);</span></span></code></pre></div>
+<div class="sourceCode" id="cb37"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="op">*</span>o<span class="op">=</span>fopen<span class="op">(</span>q<span class="op">-</span><span class="dv">3</span><span class="op">,</span><span class="st">&quot;w&quot;</span><span class="op">);</span></span></code></pre></div>
 <p>which means the file name that translates to <code>a.c</code> has to
 be at the end of the string. Thus the end of the string actually looks
 like:</p>
@@ -1290,11 +1312,11 @@ like:</p>
 <code>fgets(3)</code>. As can be seen above it’s not as simple as
 changing <code>gets(3)</code> to <code>fgets(3)</code>. This was more
 magic characters that had to be updated and some added. The C code:</p>
-<div class="sourceCode" id="cb35"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a>atoi<span class="op">(</span>gets<span class="op">(</span>b<span class="op">))</span></span></code></pre></div>
+<div class="sourceCode" id="cb39"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a>atoi<span class="op">(</span>gets<span class="op">(</span>b<span class="op">))</span></span></code></pre></div>
 <p>is in the string:</p>
 <pre><code>bupj)hfut)c**</code></pre>
 <p>which was changed to be (in C):</p>
-<div class="sourceCode" id="cb37"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a>atoi<span class="op">(</span>fgets<span class="op">(</span>b<span class="op">,</span><span class="dv">99</span><span class="op">,</span>stdin<span class="op">))</span></span></code></pre></div>
+<div class="sourceCode" id="cb41"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a>atoi<span class="op">(</span>fgets<span class="op">(</span>b<span class="op">,</span><span class="dv">99</span><span class="op">,</span>stdin<span class="op">))</span></span></code></pre></div>
 <p>which in the program is:</p>
 <pre><code>bupj)ghfut)c-::-tuejo**</code></pre>
 <p>That’s fine and well but since the code does not include
@@ -1316,16 +1338,16 @@ updated again and the <code>system(q-86)</code> had to be changed to
 correct code, the generated code was changed to <code>return 1;</code>
 rather than just <code>return;</code>. Thus in full the string
 became:</p>
-<div class="sourceCode" id="cb41"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="dt">char</span> s<span class="op">[]=</span><span class="st">&quot;Qjou!s</span><span class="sc">\\</span><span class="st">311^-g</span><span class="sc">\\</span><span class="st">311^-n</span><span class="sc">\\</span><span class="st">311^-c</span><span class="sc">\\</span><span class="st">::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q&lt;n</span><span class="op">\</span></span>
-<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a><span class="st">bjo)*|gps)&lt;&lt;*txjudi)m*|aQdbtf!::::;sfuvso!2&lt;aQefgbvmu;aQ&lt;m,,a%CQ&lt;csfbla</span><span class="sc">%b</span><span class="st">Q&lt;a</span><span class="op">\</span></span>
-<span id="cb41-3"><a href="#cb41-3" aria-hidden="true" tabindex="-1"></a><span class="st">N2!Q</span><span class="sc">\n</span><span class="st">dbtf!aP2Q;m&gt;aP2Q&lt;a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4</span><span class="sc">\n</span><span class="st">JUJT%UQm&gt;aP4</span><span class="op">\</span></span>
-<span id="cb41-4"><a href="#cb41-4" aria-hidden="true" tabindex="-1"></a><span class="st">HC%TQs</span><span class="sc">\\</span><span class="st">q,,^&gt;m,2&lt;m&gt;aP4HC%SD12N1</span><span class="sc">\n</span><span class="st">JNQm&gt;s</span><span class="sc">\\</span><span class="st">..q^aHC%NHb</span><span class="sc">%G</span><span class="st">N1!D32P3%RN1UP1D12JPQU</span><span class="op">\</span></span>
-<span id="cb41-5"><a href="#cb41-5" aria-hidden="true" tabindex="-1"></a><span class="st">aP1HR%PN4</span><span class="sc">\n</span><span class="st">Q&lt;g</span><span class="sc">\\</span><span class="st">(aP3Q(^&gt;aP2Q,2&lt;n</span><span class="sc">\\</span><span class="st">(aP3Q(^&gt;aP4Hb%OD12D12N2!N3</span><span class="sc">\n</span><span class="st">JVP3Q,,&lt;jg)aP3</span><span class="op">\</span></span>
-<span id="cb41-6"><a href="#cb41-6" aria-hidden="true" tabindex="-1"></a><span class="st">Q=&gt;n</span><span class="sc">\\</span><span class="st">(aP3Q(^*m&gt;g</span><span class="sc">\\</span><span class="st">(aP3Q(^&lt;fmtf!m,,aHC%QN1!N1</span><span class="sc">\n</span><span class="st">J#Qqsjoug)#&amp;e]o#-aP1Q*aHb%#Qq</span><span class="op">\</span></span>
-<span id="cb41-7"><a href="#cb41-7" aria-hidden="true" tabindex="-1"></a><span class="st">vut)aP1Q*aHb</span><span class="sc">%F</span><span class="st">N1</span><span class="sc">\n</span><span class="st">Qm&gt;::::aHC%VP3Q&gt;bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%</span><span class="op">\</span></span>
-<span id="cb41-8"><a href="#cb41-8" aria-hidden="true" tabindex="-1"></a><span class="st">LN1UP1D12JIQUaP1HL%IQ*m&gt;aN2!N2</span><span class="sc">\n</span><span class="st">P2Q&lt;fmtf!m,,aHC%MN1!N2&gt;P2Q&gt;aN2</span><span class="sc">\n</span><span class="st">P2Hbdd!.Xop.</span><span class="op">\</span></span>
-<span id="cb41-9"><a href="#cb41-9" aria-hidden="true" tabindex="-1"></a><span class="st">fssps!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jodmvef!tuejp/i!</span><span class="op">\</span></span>
-<span id="cb41-10"><a href="#cb41-10" aria-hidden="true" tabindex="-1"></a><span class="st">b/d&quot;</span><span class="op">;</span></span></code></pre></div>
+<div class="sourceCode" id="cb45"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="dt">char</span> s<span class="op">[]=</span><span class="st">&quot;Qjou!s</span><span class="sc">\\</span><span class="st">311^-g</span><span class="sc">\\</span><span class="st">311^-n</span><span class="sc">\\</span><span class="st">311^-c</span><span class="sc">\\</span><span class="st">::^-q-ma%mO1JBHm%BQ-aP1J[O1HB%[Q&lt;n</span><span class="op">\</span></span>
+<span id="cb45-2"><a href="#cb45-2" aria-hidden="true" tabindex="-1"></a><span class="st">bjo)*|gps)&lt;&lt;*txjudi)m*|aQdbtf!::::;sfuvso!2&lt;aQefgbvmu;aQ&lt;m,,a%CQ&lt;csfbla</span><span class="sc">%b</span><span class="st">Q&lt;a</span><span class="op">\</span></span>
+<span id="cb45-3"><a href="#cb45-3" aria-hidden="true" tabindex="-1"></a><span class="st">N2!Q</span><span class="sc">\n</span><span class="st">dbtf!aP2Q;m&gt;aP2Q&lt;a%!D12J!JGJHJOJQJFJSJJJMHS%HD12D12N3!N4</span><span class="sc">\n</span><span class="st">JUJT%UQm&gt;aP4</span><span class="op">\</span></span>
+<span id="cb45-4"><a href="#cb45-4" aria-hidden="true" tabindex="-1"></a><span class="st">HC%TQs</span><span class="sc">\\</span><span class="st">q,,^&gt;m,2&lt;m&gt;aP4HC%SD12N1</span><span class="sc">\n</span><span class="st">JNQm&gt;s</span><span class="sc">\\</span><span class="st">..q^aHC%NHb</span><span class="sc">%G</span><span class="st">N1!D32P3%RN1UP1D12JPQU</span><span class="op">\</span></span>
+<span id="cb45-5"><a href="#cb45-5" aria-hidden="true" tabindex="-1"></a><span class="st">aP1HR%PN4</span><span class="sc">\n</span><span class="st">Q&lt;g</span><span class="sc">\\</span><span class="st">(aP3Q(^&gt;aP2Q,2&lt;n</span><span class="sc">\\</span><span class="st">(aP3Q(^&gt;aP4Hb%OD12D12N2!N3</span><span class="sc">\n</span><span class="st">JVP3Q,,&lt;jg)aP3</span><span class="op">\</span></span>
+<span id="cb45-6"><a href="#cb45-6" aria-hidden="true" tabindex="-1"></a><span class="st">Q=&gt;n</span><span class="sc">\\</span><span class="st">(aP3Q(^*m&gt;g</span><span class="sc">\\</span><span class="st">(aP3Q(^&lt;fmtf!m,,aHC%QN1!N1</span><span class="sc">\n</span><span class="st">J#Qqsjoug)#&amp;e]o#-aP1Q*aHb%#Qq</span><span class="op">\</span></span>
+<span id="cb45-7"><a href="#cb45-7" aria-hidden="true" tabindex="-1"></a><span class="st">vut)aP1Q*aHb</span><span class="sc">%F</span><span class="st">N1</span><span class="sc">\n</span><span class="st">Qm&gt;::::aHC%VP3Q&gt;bupj)ghfut)c-::-tuejo**aHb%JD12JON1!Qjg)a%</span><span class="op">\</span></span>
+<span id="cb45-8"><a href="#cb45-8" aria-hidden="true" tabindex="-1"></a><span class="st">LN1UP1D12JIQUaP1HL%IQ*m&gt;aN2!N2</span><span class="sc">\n</span><span class="st">P2Q&lt;fmtf!m,,aHC%MN1!N2&gt;P2Q&gt;aN2</span><span class="sc">\n</span><span class="st">P2Hbdd!.Xop.</span><span class="op">\</span></span>
+<span id="cb45-9"><a href="#cb45-9" aria-hidden="true" tabindex="-1"></a><span class="st">fssps!.Xop.jnqmjdju.gvodujpo.efdmbsbujpo!.Xop.jnqmjdju.jou!.jodmvef!tuejp/i!</span><span class="op">\</span></span>
+<span id="cb45-10"><a href="#cb45-10" aria-hidden="true" tabindex="-1"></a><span class="st">b/d&quot;</span><span class="op">;</span></span></code></pre></div>
 <p>and it now is <code>system(q-87);</code>.</p>
 <p>It is hoped that this is the last time the string has to be updated
 to work with all versions of clang but if not the above is how it
@@ -1424,19 +1446,19 @@ added. Then it was noticed that the problem is that
 it was never fixed in any of the files, not the code or the
 documentation, and thus was entirely incorrect code. A fun fact is that
 one can do:</p>
-<div class="sourceCode" id="cb42"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a>W<span class="op">=</span> fopen<span class="op">(</span>wc<span class="op">&gt;=</span> <span class="dv">2</span> <span class="op">?</span> V<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">:</span> __FILE__<span class="op">,</span><span class="st">&quot;rt&quot;</span><span class="op">);</span><span class="cf">if</span><span class="op">(!</span>W<span class="op">)</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span></code></pre></div>
+<div class="sourceCode" id="cb46"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a>W<span class="op">=</span> fopen<span class="op">(</span>wc<span class="op">&gt;=</span> <span class="dv">2</span> <span class="op">?</span> V<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">:</span> __FILE__<span class="op">,</span><span class="st">&quot;rt&quot;</span><span class="op">);</span><span class="cf">if</span><span class="op">(!</span>W<span class="op">)</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span></code></pre></div>
 <p>but one <em>CANNOT</em> do:</p>
-<div class="sourceCode" id="cb43"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb43-1"><a href="#cb43-1" aria-hidden="true" tabindex="-1"></a>W<span class="op">=</span> fopen<span class="op">(</span>wc<span class="op">&gt;=</span> <span class="dv">2</span> <span class="op">?</span> V<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">:</span> __FILE__<span class="op">,</span><span class="st">&quot;rt&quot;</span><span class="op">);</span><span class="cf">if</span><span class="op">(!</span>W<span class="op">)</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span>
-<span id="cb43-2"><a href="#cb43-2" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>W<span class="op">==</span>NULL<span class="op">)</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span></code></pre></div>
+<div class="sourceCode" id="cb47"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb47-1"><a href="#cb47-1" aria-hidden="true" tabindex="-1"></a>W<span class="op">=</span> fopen<span class="op">(</span>wc<span class="op">&gt;=</span> <span class="dv">2</span> <span class="op">?</span> V<span class="op">[</span><span class="dv">1</span><span class="op">]</span> <span class="op">:</span> __FILE__<span class="op">,</span><span class="st">&quot;rt&quot;</span><span class="op">);</span><span class="cf">if</span><span class="op">(!</span>W<span class="op">)</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span>
+<span id="cb47-2"><a href="#cb47-2" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="op">(</span>W<span class="op">==</span>NULL<span class="op">)</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span></span></code></pre></div>
 <p>because <code>adwc.c</code> will be empty! The difference is it is on
 a newline, the check. This is an example of how a simple change in code
 can break it and this is also true of another change as further
 below.</p>
 <p>Cody also restored a slightly more obscure line of code that had been
 changed:</p>
-<div class="sourceCode" id="cb44"><pre
-class="sourceCode diff"><code class="sourceCode diff"><span id="cb44-1"><a href="#cb44-1" aria-hidden="true" tabindex="-1"></a><span class="st">-   putc(&quot;}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR&quot;[i]+i-9,stderr);</span></span>
-<span id="cb44-2"><a href="#cb44-2" aria-hidden="true" tabindex="-1"></a><span class="va">+   putc(i[&quot;}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR&quot;]+i-9,stderr);</span></span></code></pre></div>
+<div class="sourceCode" id="cb48"><pre
+class="sourceCode diff"><code class="sourceCode diff"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="st">-   putc(&quot;}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR&quot;[i]+i-9,stderr);</span></span>
+<span id="cb48-2"><a href="#cb48-2" aria-hidden="true" tabindex="-1"></a><span class="va">+   putc(i[&quot;}|uutsrq`_^bji`[Zkediml[PO]a_M__]ISOYIRGTNR&quot;]+i-9,stderr);</span></span></code></pre></div>
 <p>though it’s questionable how much more (if at all) obscure that is
 :-)</p>
 <p>Cody also changed the location that it used <code>gets()</code> to be
@@ -1463,7 +1485,7 @@ operator or a <code>&amp;&amp;</code>) as this, as might be expected
 from the above, caused compilation errors with another generated file
 (<code>adwc.c</code>)! Thus after the <code>gets(3)</code> call in the
 line that looks like:</p>
-<div class="sourceCode" id="cb45"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb45-1"><a href="#cb45-1" aria-hidden="true" tabindex="-1"></a><span class="cf">while</span><span class="op">(</span> gets<span class="op">(</span>Y<span class="op">)</span> <span class="op">){</span> Y<span class="op">[</span>strlen<span class="op">(</span>Y<span class="op">)-</span><span class="dv">1</span><span class="op">]=</span><span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span><span class="op">;</span> <span class="cf">if</span><span class="op">(</span>A<span class="op">(</span>Y<span class="op">))</span> puts<span class="op">(</span>Y<span class="op">);</span> <span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb49"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="cf">while</span><span class="op">(</span> gets<span class="op">(</span>Y<span class="op">)</span> <span class="op">){</span> Y<span class="op">[</span>strlen<span class="op">(</span>Y<span class="op">)-</span><span class="dv">1</span><span class="op">]=</span><span class="ch">&#39;</span><span class="sc">\0</span><span class="ch">&#39;</span><span class="op">;</span> <span class="cf">if</span><span class="op">(</span>A<span class="op">(</span>Y<span class="op">))</span> puts<span class="op">(</span>Y<span class="op">);</span> <span class="op">}</span></span></code></pre></div>
 <p>one must keep the <code>Y[strlen(Y)-1]='\0';</code> part and keep it
 there.</p>
 <p>These fixes are complex changes due to the way the program and
@@ -1718,8 +1740,8 @@ this so that it will work with modern systems. Yusuke provided some
 fixes of the X code and Cody fixed the C pre-processor directives so
 that it would compile. It used to be that you could get away with code
 like:</p>
-<div class="sourceCode" id="cb46"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb46-1"><a href="#cb46-1" aria-hidden="true" tabindex="-1"></a>G        <span class="dt">int</span> i<span class="op">,</span>j</span>
-<span id="cb46-2"><a href="#cb46-2" aria-hidden="true" tabindex="-1"></a>K        <span class="cf">case</span></span></code></pre></div>
+<div class="sourceCode" id="cb50"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb50-1"><a href="#cb50-1" aria-hidden="true" tabindex="-1"></a>G        <span class="dt">int</span> i<span class="op">,</span>j</span>
+<span id="cb50-2"><a href="#cb50-2" aria-hidden="true" tabindex="-1"></a>K        <span class="cf">case</span></span></code></pre></div>
 <p>and expect <code>G;</code> to equate to <code>int i, j;</code>
 (though it’s now a long) and <code>K</code> to mean <code>case</code>
 but that’s no longer the case so the offending lines had
@@ -2311,7 +2333,7 @@ point since the author stated it has no <code>while</code>,
 <code>do...while</code>, <code>for</code>, <code>if/else</code>,
 <code>switch</code>, <code>?:</code> Cody removed the if statement by
 doing:</p>
-<div class="sourceCode" id="cb48"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb48-1"><a href="#cb48-1" aria-hidden="true" tabindex="-1"></a><span class="op">((</span>V<span class="op">[</span><span class="dv">1</span><span class="op">]&amp;&amp;((</span>atoi<span class="op">(</span>V<span class="op">[</span><span class="dv">1</span><span class="op">])&gt;</span><span class="dv">0</span><span class="op">&amp;&amp;</span>atoi<span class="op">(</span>V<span class="op">[</span><span class="dv">1</span><span class="op">])&lt;</span><span class="dv">27</span><span class="op">))||(</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">),</span><span class="dv">1</span><span class="op">)));</span></span></code></pre></div>
+<div class="sourceCode" id="cb52"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb52-1"><a href="#cb52-1" aria-hidden="true" tabindex="-1"></a><span class="op">((</span>V<span class="op">[</span><span class="dv">1</span><span class="op">]&amp;&amp;((</span>atoi<span class="op">(</span>V<span class="op">[</span><span class="dv">1</span><span class="op">])&gt;</span><span class="dv">0</span><span class="op">&amp;&amp;</span>atoi<span class="op">(</span>V<span class="op">[</span><span class="dv">1</span><span class="op">])&lt;</span><span class="dv">27</span><span class="op">))||(</span>exit<span class="op">(</span><span class="dv">1</span><span class="op">),</span><span class="dv">1</span><span class="op">)));</span></span></code></pre></div>
 <p>Cody also added the <a href="1998/schnitzi/try.sh">try.sh</a> script
 to help users try the commands that we recommended as well as some added
 by him.</p>
@@ -2343,7 +2365,7 @@ because it’s almost certain that some files will not exist, it would
 dereference a NULL pointer and very likely crash or halt and catch fire
 :-), preventing the entry from working. Notice how <code>H</code> is a
 funny macro defined as:</p>
-<div class="sourceCode" id="cb49"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb49-1"><a href="#cb49-1" aria-hidden="true" tabindex="-1"></a><span class="pp">%:define H</span><span class="op">(</span><span class="pp">x</span><span class="op">)</span><span class="pp"> </span><span class="op">&lt;</span><span class="pp">st</span><span class="op">%:%:</span><span class="pp">x</span><span class="op">##.</span><span class="pp">h</span><span class="op">&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb53"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb53-1"><a href="#cb53-1" aria-hidden="true" tabindex="-1"></a><span class="pp">%:define H</span><span class="op">(</span><span class="pp">x</span><span class="op">)</span><span class="pp"> </span><span class="op">&lt;</span><span class="pp">st</span><span class="op">%:%:</span><span class="pp">x</span><span class="op">##.</span><span class="pp">h</span><span class="op">&gt;</span></span></code></pre></div>
 <p>and yet the <code>FILE *</code> can be called <code>H</code>! This
 might or might not make sense to you but if it doesn’t can you figure
 out why?</p>
@@ -2626,9 +2648,9 @@ error.</p>
 matter</em>!</p>
 <p>To get this to compile with clang, <code>main()</code> had to change
 from:</p>
-<div class="sourceCode" id="cb54"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a>main <span class="op">(</span><span class="dt">char</span> <span class="op">*</span>ck<span class="op">,</span> <span class="dt">char</span> <span class="op">**</span>k<span class="op">)</span></span></code></pre></div>
+<div class="sourceCode" id="cb58"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a>main <span class="op">(</span><span class="dt">char</span> <span class="op">*</span>ck<span class="op">,</span> <span class="dt">char</span> <span class="op">**</span>k<span class="op">)</span></span></code></pre></div>
 <p>to:</p>
-<div class="sourceCode" id="cb55"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a>main <span class="op">(</span><span class="dt">int</span> cka<span class="op">,</span> <span class="dt">char</span> <span class="op">**</span>k<span class="op">)</span> <span class="op">{</span> <span class="dt">char</span> <span class="op">*</span>ck <span class="op">=</span> <span class="op">(</span><span class="dt">char</span> <span class="op">*)</span>cka<span class="op">;</span> <span class="co">/* ... */</span> <span class="op">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb59"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a>main <span class="op">(</span><span class="dt">int</span> cka<span class="op">,</span> <span class="dt">char</span> <span class="op">**</span>k<span class="op">)</span> <span class="op">{</span> <span class="dt">char</span> <span class="op">*</span>ck <span class="op">=</span> <span class="op">(</span><span class="dt">char</span> <span class="op">*)</span>cka<span class="op">;</span> <span class="co">/* ... */</span> <span class="op">}</span></span></code></pre></div>
 <p>The following change was also made to be more portable, in case the
 constants <code>PROT_READ</code> and/or <code>PROT_WRITE</code> are not
 standardised or some platform does not follow it:</p>
@@ -2639,19 +2661,19 @@ be equal in both macOS and Linux).</p>
 <p>NOTE: there might be educational value to see the progress of this
 fix; if you wish to see, try the following commands from the
 <code>2001/anonymous</code> directory:</p>
-<div class="sourceCode" id="cb56"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..93aa8d79f208dcccc3c5a2370a727b5cf64e9c53 anonymous.c</span>
-<span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff 93aa8d79f208dcccc3c5a2370a727b5cf64e9c53..c48629017117379a52b1a512ef8f2593ca9569c8 anonymous.c</span>
-<span id="cb56-3"><a href="#cb56-3" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff c48629017117379a52b1a512ef8f2593ca9569c8..efdee208a2bc650256637b9357ddfd0de82d2f41 anonymous.c</span>
-<span id="cb56-4"><a href="#cb56-4" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff efdee208a2bc650256637b9357ddfd0de82d2f41..e9a3f77ea3b209e63ac3f9c06bb84ad86e5ea706 anonymous.c</span>
-<span id="cb56-5"><a href="#cb56-5" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..2159caec4677e0f25ad704a74e04c8196fd6c343 anonymous.c</span>
-<span id="cb56-6"><a href="#cb56-6" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff 2159caec4677e0f25ad704a74e04c8196fd6c343..4bc03de321612869aebf855850c6500df95cb6ef anonymous.c</span></code></pre></div>
+<div class="sourceCode" id="cb60"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..93aa8d79f208dcccc3c5a2370a727b5cf64e9c53 anonymous.c</span>
+<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff 93aa8d79f208dcccc3c5a2370a727b5cf64e9c53..c48629017117379a52b1a512ef8f2593ca9569c8 anonymous.c</span>
+<span id="cb60-3"><a href="#cb60-3" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff c48629017117379a52b1a512ef8f2593ca9569c8..efdee208a2bc650256637b9357ddfd0de82d2f41 anonymous.c</span>
+<span id="cb60-4"><a href="#cb60-4" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff efdee208a2bc650256637b9357ddfd0de82d2f41..e9a3f77ea3b209e63ac3f9c06bb84ad86e5ea706 anonymous.c</span>
+<span id="cb60-5"><a href="#cb60-5" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..2159caec4677e0f25ad704a74e04c8196fd6c343 anonymous.c</span>
+<span id="cb60-6"><a href="#cb60-6" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff 2159caec4677e0f25ad704a74e04c8196fd6c343..4bc03de321612869aebf855850c6500df95cb6ef anonymous.c</span></code></pre></div>
 <p>Finally to see from start to finish:</p>
-<div class="sourceCode" id="cb57"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..4bc03de321612869aebf855850c6500df95cb6ef anonymous.c</span></code></pre></div>
+<div class="sourceCode" id="cb61"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a><span class="fu">git</span> diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..4bc03de321612869aebf855850c6500df95cb6ef anonymous.c</span></code></pre></div>
 <p>or to not use <code>git</code>:</p>
-<div class="sourceCode" id="cb58"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="fu">make</span> diff_orig_prog</span></code></pre></div>
+<div class="sourceCode" id="cb62"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a><span class="fu">make</span> diff_orig_prog</span></code></pre></div>
 <p>Cody also added a <a href="anonymous.bed.c">program</a> like <a
 href="anonymous.ten.c">anonymous.ten.c</a> <a
 href="https://en.wikipedia.org/wiki/Ten_Green_Bottles">Ten Green
@@ -2722,12 +2744,12 @@ href="2001/coupard/index.html%5D">index.html</a>)</h2>
 <code>main()</code> to make it more portable.</p>
 <p>Cody fixed this to compile with clang in Linux. The problem was C99
 does not support implicit int:</p>
-<div class="sourceCode" id="cb59"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a>coupard<span class="op">.</span>c<span class="op">:</span><span class="dv">31</span><span class="op">:</span><span class="dv">10</span><span class="op">:</span> error<span class="op">:</span> parameter <span class="ch">&#39;h&#39;</span> was not declared<span class="op">,</span> defaults to <span class="ch">&#39;i</span><span class="er">nt</span><span class="ch">&#39;</span><span class="op">;</span> ISO C99 and later <span class="cf">do</span> not support implicit <span class="dt">int</span> <span class="op">[-</span>Wimplicit<span class="op">-</span><span class="dt">int</span><span class="op">]</span></span>
-<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> e<span class="op">(</span>n<span class="op">,</span>h<span class="op">){</span></span>
-<span id="cb59-3"><a href="#cb59-3" aria-hidden="true" tabindex="-1"></a>         <span class="op">^</span></span>
-<span id="cb59-4"><a href="#cb59-4" aria-hidden="true" tabindex="-1"></a>coupard<span class="op">.</span>c<span class="op">:</span><span class="dv">31</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> parameter <span class="ch">&#39;n&#39;</span> was not declared<span class="op">,</span> defaults to <span class="ch">&#39;i</span><span class="er">nt</span><span class="ch">&#39;</span><span class="op">;</span> ISO C99 and later <span class="cf">do</span> not support implicit <span class="dt">int</span> <span class="op">[-</span>Wimplicit<span class="op">-</span><span class="dt">int</span><span class="op">]</span></span>
-<span id="cb59-5"><a href="#cb59-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> e<span class="op">(</span>n<span class="op">,</span>h<span class="op">){</span></span>
-<span id="cb59-6"><a href="#cb59-6" aria-hidden="true" tabindex="-1"></a>       <span class="op">^</span></span></code></pre></div>
+<div class="sourceCode" id="cb63"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a>coupard<span class="op">.</span>c<span class="op">:</span><span class="dv">31</span><span class="op">:</span><span class="dv">10</span><span class="op">:</span> error<span class="op">:</span> parameter <span class="ch">&#39;h&#39;</span> was not declared<span class="op">,</span> defaults to <span class="ch">&#39;i</span><span class="er">nt</span><span class="ch">&#39;</span><span class="op">;</span> ISO C99 and later <span class="cf">do</span> not support implicit <span class="dt">int</span> <span class="op">[-</span>Wimplicit<span class="op">-</span><span class="dt">int</span><span class="op">]</span></span>
+<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> e<span class="op">(</span>n<span class="op">,</span>h<span class="op">){</span></span>
+<span id="cb63-3"><a href="#cb63-3" aria-hidden="true" tabindex="-1"></a>         <span class="op">^</span></span>
+<span id="cb63-4"><a href="#cb63-4" aria-hidden="true" tabindex="-1"></a>coupard<span class="op">.</span>c<span class="op">:</span><span class="dv">31</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> parameter <span class="ch">&#39;n&#39;</span> was not declared<span class="op">,</span> defaults to <span class="ch">&#39;i</span><span class="er">nt</span><span class="ch">&#39;</span><span class="op">;</span> ISO C99 and later <span class="cf">do</span> not support implicit <span class="dt">int</span> <span class="op">[-</span>Wimplicit<span class="op">-</span><span class="dt">int</span><span class="op">]</span></span>
+<span id="cb63-5"><a href="#cb63-5" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> e<span class="op">(</span>n<span class="op">,</span>h<span class="op">){</span></span>
+<span id="cb63-6"><a href="#cb63-6" aria-hidden="true" tabindex="-1"></a>       <span class="op">^</span></span></code></pre></div>
 <p>and for some reason it was being reported as an error. This was not
 really worth a thanks per se but it was originally done by adding
 <code>int</code>. The better solution is to disable the warning which is
@@ -2943,20 +2965,20 @@ href="2004/jdalbec/index.html">index.html</a>)</h2>
 with clang). The problem was the cpp being unable to parse the generated
 code (see the index.html for details) and this ended up with a number of
 errors like:</p>
-<div class="sourceCode" id="cb61"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a>jdalbec<span class="op">.</span>c<span class="op">:</span><span class="dv">64</span><span class="op">:</span><span class="dv">5</span><span class="op">:</span> error<span class="op">:</span> stray <span class="ch">&#39;#</span><span class="er">#</span><span class="ch">&#39;</span> in program</span>
-<span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a>   <span class="dv">64</span> <span class="op">|</span> B N##B <span class="op">(</span>I<span class="op">)</span> <span class="op">;</span> \</span>
-<span id="cb61-3"><a href="#cb61-3" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">^~</span></span>
-<span id="cb61-4"><a href="#cb61-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb61-5"><a href="#cb61-5" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb61-6"><a href="#cb61-6" aria-hidden="true" tabindex="-1"></a><span class="op">..</span></span>
-<span id="cb61-7"><a href="#cb61-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb61-8"><a href="#cb61-8" aria-hidden="true" tabindex="-1"></a>jdalbec<span class="op">.</span>c<span class="op">:</span><span class="dv">65</span><span class="op">:</span><span class="dv">5</span><span class="op">:</span> error<span class="op">:</span> stray <span class="ch">&#39;#</span><span class="er">#</span><span class="ch">&#39;</span> in program</span>
-<span id="cb61-9"><a href="#cb61-9" aria-hidden="true" tabindex="-1"></a>   <span class="dv">65</span> <span class="op">|</span> V F##B <span class="op">(</span>B<span class="op">)</span> <span class="op">;</span> \</span>
-<span id="cb61-10"><a href="#cb61-10" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">^~</span></span>
-<span id="cb61-11"><a href="#cb61-11" aria-hidden="true" tabindex="-1"></a>jdalbec<span class="op">.</span>c<span class="op">:</span><span class="dv">65</span><span class="op">:</span><span class="dv">5</span><span class="op">:</span> error<span class="op">:</span> expected <span class="ch">&#39;;&#39;</span> before <span class="ch">&#39;B&#39;</span></span>
-<span id="cb61-12"><a href="#cb61-12" aria-hidden="true" tabindex="-1"></a>   <span class="dv">65</span> <span class="op">|</span> V F##B <span class="op">(</span>B<span class="op">)</span> <span class="op">;</span> \</span>
-<span id="cb61-13"><a href="#cb61-13" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">^</span> <span class="op">~</span></span>
-<span id="cb61-14"><a href="#cb61-14" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">;</span></span></code></pre></div>
+<div class="sourceCode" id="cb65"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a>jdalbec<span class="op">.</span>c<span class="op">:</span><span class="dv">64</span><span class="op">:</span><span class="dv">5</span><span class="op">:</span> error<span class="op">:</span> stray <span class="ch">&#39;#</span><span class="er">#</span><span class="ch">&#39;</span> in program</span>
+<span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a>   <span class="dv">64</span> <span class="op">|</span> B N##B <span class="op">(</span>I<span class="op">)</span> <span class="op">;</span> \</span>
+<span id="cb65-3"><a href="#cb65-3" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">^~</span></span>
+<span id="cb65-4"><a href="#cb65-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-5"><a href="#cb65-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-6"><a href="#cb65-6" aria-hidden="true" tabindex="-1"></a><span class="op">..</span></span>
+<span id="cb65-7"><a href="#cb65-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb65-8"><a href="#cb65-8" aria-hidden="true" tabindex="-1"></a>jdalbec<span class="op">.</span>c<span class="op">:</span><span class="dv">65</span><span class="op">:</span><span class="dv">5</span><span class="op">:</span> error<span class="op">:</span> stray <span class="ch">&#39;#</span><span class="er">#</span><span class="ch">&#39;</span> in program</span>
+<span id="cb65-9"><a href="#cb65-9" aria-hidden="true" tabindex="-1"></a>   <span class="dv">65</span> <span class="op">|</span> V F##B <span class="op">(</span>B<span class="op">)</span> <span class="op">;</span> \</span>
+<span id="cb65-10"><a href="#cb65-10" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">^~</span></span>
+<span id="cb65-11"><a href="#cb65-11" aria-hidden="true" tabindex="-1"></a>jdalbec<span class="op">.</span>c<span class="op">:</span><span class="dv">65</span><span class="op">:</span><span class="dv">5</span><span class="op">:</span> error<span class="op">:</span> expected <span class="ch">&#39;;&#39;</span> before <span class="ch">&#39;B&#39;</span></span>
+<span id="cb65-12"><a href="#cb65-12" aria-hidden="true" tabindex="-1"></a>   <span class="dv">65</span> <span class="op">|</span> V F##B <span class="op">(</span>B<span class="op">)</span> <span class="op">;</span> \</span>
+<span id="cb65-13"><a href="#cb65-13" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">^</span> <span class="op">~</span></span>
+<span id="cb65-14"><a href="#cb65-14" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>     <span class="op">;</span></span></code></pre></div>
 <p>and various other problems.</p>
 <p>Cody also added <a href="2004/jdalbec/index.html#alternate-code">alt
 code</a> which allows one to control how many numbers after the
@@ -3016,41 +3038,41 @@ href="2004/vik2/index.html">index.html</a>)</h2>
 <p><a href="#cody">Cody</a> fixed this to compile in Linux. Although it
 compiled cleanly in macOS (and BSD?) the code failed to compile at all
 in Linux due to:</p>
-<div class="sourceCode" id="cb62"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a>cc <span class="op">-</span>E vik2_1<span class="op">.</span>c <span class="op">&gt;</span> vik2_2<span class="op">.</span>c</span>
-<span id="cb62-2"><a href="#cb62-2" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">945</span><span class="op">,</span></span>
-<span id="cb62-3"><a href="#cb62-3" aria-hidden="true" tabindex="-1"></a>                 from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">959</span><span class="op">,</span></span>
-<span id="cb62-4"><a href="#cb62-4" aria-hidden="true" tabindex="-1"></a>                 from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">972</span><span class="op">,</span></span>
-<span id="cb62-5"><a href="#cb62-5" aria-hidden="true" tabindex="-1"></a>                 from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1025</span><span class="op">:</span></span>
-<span id="cb62-6"><a href="#cb62-6" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
-<span id="cb62-7"><a href="#cb62-7" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
-<span id="cb62-8"><a href="#cb62-8" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
-<span id="cb62-9"><a href="#cb62-9" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">946</span><span class="op">:</span></span>
-<span id="cb62-10"><a href="#cb62-10" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
-<span id="cb62-11"><a href="#cb62-11" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
-<span id="cb62-12"><a href="#cb62-12" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
-<span id="cb62-13"><a href="#cb62-13" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">947</span><span class="op">:</span></span>
-<span id="cb62-14"><a href="#cb62-14" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
-<span id="cb62-15"><a href="#cb62-15" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
-<span id="cb62-16"><a href="#cb62-16" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
-<span id="cb62-17"><a href="#cb62-17" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">948</span><span class="op">:</span></span>
-<span id="cb62-18"><a href="#cb62-18" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
-<span id="cb62-19"><a href="#cb62-19" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
-<span id="cb62-20"><a href="#cb62-20" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
-<span id="cb62-21"><a href="#cb62-21" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb62-22"><a href="#cb62-22" aria-hidden="true" tabindex="-1"></a><span class="op">...</span></span>
-<span id="cb62-23"><a href="#cb62-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb62-24"><a href="#cb62-24" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">182</span><span class="op">:</span></span>
-<span id="cb62-25"><a href="#cb62-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb62-26"><a href="#cb62-26" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">992</span><span class="op">:</span><span class="dv">85</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">201</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-27"><a href="#cb62-27" aria-hidden="true" tabindex="-1"></a>  <span class="dv">992</span> <span class="op">|</span> I</span>
-<span id="cb62-28"><a href="#cb62-28" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>                                                                                     <span class="op">^</span></span>
-<span id="cb62-29"><a href="#cb62-29" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1497</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-30"><a href="#cb62-30" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1498</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-31"><a href="#cb62-31" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1499</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-32"><a href="#cb62-32" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1500</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-33"><a href="#cb62-33" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1501</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-34"><a href="#cb62-34" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1504</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
-<span id="cb62-35"><a href="#cb62-35" aria-hidden="true" tabindex="-1"></a>make<span class="op">:</span> <span class="op">***</span> <span class="op">[</span>Makefile<span class="op">:</span><span class="dv">133</span><span class="op">:</span> vik2<span class="op">]</span> Error <span class="dv">1</span></span></code></pre></div>
+<div class="sourceCode" id="cb66"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a>cc <span class="op">-</span>E vik2_1<span class="op">.</span>c <span class="op">&gt;</span> vik2_2<span class="op">.</span>c</span>
+<span id="cb66-2"><a href="#cb66-2" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">945</span><span class="op">,</span></span>
+<span id="cb66-3"><a href="#cb66-3" aria-hidden="true" tabindex="-1"></a>                 from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">959</span><span class="op">,</span></span>
+<span id="cb66-4"><a href="#cb66-4" aria-hidden="true" tabindex="-1"></a>                 from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">972</span><span class="op">,</span></span>
+<span id="cb66-5"><a href="#cb66-5" aria-hidden="true" tabindex="-1"></a>                 from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1025</span><span class="op">:</span></span>
+<span id="cb66-6"><a href="#cb66-6" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
+<span id="cb66-7"><a href="#cb66-7" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
+<span id="cb66-8"><a href="#cb66-8" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
+<span id="cb66-9"><a href="#cb66-9" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">946</span><span class="op">:</span></span>
+<span id="cb66-10"><a href="#cb66-10" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
+<span id="cb66-11"><a href="#cb66-11" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
+<span id="cb66-12"><a href="#cb66-12" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
+<span id="cb66-13"><a href="#cb66-13" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">947</span><span class="op">:</span></span>
+<span id="cb66-14"><a href="#cb66-14" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
+<span id="cb66-15"><a href="#cb66-15" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
+<span id="cb66-16"><a href="#cb66-16" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
+<span id="cb66-17"><a href="#cb66-17" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">948</span><span class="op">:</span></span>
+<span id="cb66-18"><a href="#cb66-18" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">383</span><span class="op">:</span><span class="dv">8</span><span class="op">:</span> error<span class="op">:</span> no macro name given in #ifdef directive</span>
+<span id="cb66-19"><a href="#cb66-19" aria-hidden="true" tabindex="-1"></a>  <span class="dv">383</span> <span class="op">|</span> O  \</span>
+<span id="cb66-20"><a href="#cb66-20" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>        <span class="op">^</span></span>
+<span id="cb66-21"><a href="#cb66-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb66-22"><a href="#cb66-22" aria-hidden="true" tabindex="-1"></a><span class="op">...</span></span>
+<span id="cb66-23"><a href="#cb66-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb66-24"><a href="#cb66-24" aria-hidden="true" tabindex="-1"></a>In file included from vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">182</span><span class="op">:</span></span>
+<span id="cb66-25"><a href="#cb66-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb66-26"><a href="#cb66-26" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">992</span><span class="op">:</span><span class="dv">85</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">201</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-27"><a href="#cb66-27" aria-hidden="true" tabindex="-1"></a>  <span class="dv">992</span> <span class="op">|</span> I</span>
+<span id="cb66-28"><a href="#cb66-28" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span>                                                                                     <span class="op">^</span></span>
+<span id="cb66-29"><a href="#cb66-29" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1497</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-30"><a href="#cb66-30" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1498</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-31"><a href="#cb66-31" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1499</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-32"><a href="#cb66-32" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1500</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-33"><a href="#cb66-33" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1501</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-34"><a href="#cb66-34" aria-hidden="true" tabindex="-1"></a>vik2<span class="op">.</span>c<span class="op">:</span><span class="dv">1504</span><span class="op">:</span><span class="dv">21</span><span class="op">:</span> error<span class="op">:</span> #include nested depth <span class="dv">200</span> exceeds maximum of <span class="dv">200</span> <span class="op">(</span>use <span class="op">-</span>fmax<span class="op">-</span>include<span class="op">-</span>depth<span class="op">=</span>DEPTH to increase the maximum<span class="op">)</span></span>
+<span id="cb66-35"><a href="#cb66-35" aria-hidden="true" tabindex="-1"></a>make<span class="op">:</span> <span class="op">***</span> <span class="op">[</span>Makefile<span class="op">:</span><span class="dv">133</span><span class="op">:</span> vik2<span class="op">]</span> Error <span class="dv">1</span></span></code></pre></div>
 <p>Unfortunately the fix required heavy modification to the original
 file (see below) and also inclusion of what used to be generated by the
 <a href="2004/vik2/Makefile">Makefile</a> but now it at least works for
@@ -3121,7 +3143,7 @@ that the <code>long*E</code> is now <code>int*E</code>. This solves a
 specific problem for Linux (32-bit, 64-bit) and macOS (arm64).</p>
 <p>To get the self-test feature to work it was required to remove from
 the code:</p>
-<div class="sourceCode" id="cb63"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a>O<span class="op">-</span>b<span class="op">-</span>f<span class="op">-</span>u <span class="op">-</span>s<span class="op">-</span>c<span class="op">-</span>a<span class="op">-</span>t<span class="op">-</span>e<span class="op">;</span></span></code></pre></div>
+<div class="sourceCode" id="cb67"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a>O<span class="op">-</span>b<span class="op">-</span>f<span class="op">-</span>u <span class="op">-</span>s<span class="op">-</span>c<span class="op">-</span>a<span class="op">-</span>t<span class="op">-</span>e<span class="op">;</span></span></code></pre></div>
 <p>as it caused a compilation error in some of the generated code but
 served no purpose, didn’t affect the output of the puzzle and since the
 ‘string’ is already in the code there is no problem omitting it.</p>
@@ -3133,20 +3155,20 @@ change might also not have been necessary if using different flags to
 <code>cc</code> but this is less portable and caused other problems.
 This was a complicated fix as it’s in the comments but in a funny way;
 the final result to get the test feature to work is:</p>
-<div class="sourceCode" id="cb64"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="op">;;</span> <span class="co">/*echo/Line/%d;sed/-n/-e/ %d,%dp/%s/|sed*/</span></span>
-<span id="cb64-2"><a href="#cb64-2" aria-hidden="true" tabindex="-1"></a><span class="co">/*-e/&#39;s,intZ,int/ Z,g&#39;&gt;c.c;make/c;/ rm/-f/c*/</span></span>
-<span id="cb64-3"><a href="#cb64-3" aria-hidden="true" tabindex="-1"></a><span class="op">;;</span></span></code></pre></div>
+<div class="sourceCode" id="cb68"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb68-1"><a href="#cb68-1" aria-hidden="true" tabindex="-1"></a><span class="op">;;</span> <span class="co">/*echo/Line/%d;sed/-n/-e/ %d,%dp/%s/|sed*/</span></span>
+<span id="cb68-2"><a href="#cb68-2" aria-hidden="true" tabindex="-1"></a><span class="co">/*-e/&#39;s,intZ,int/ Z,g&#39;&gt;c.c;make/c;/ rm/-f/c*/</span></span>
+<span id="cb68-3"><a href="#cb68-3" aria-hidden="true" tabindex="-1"></a><span class="op">;;</span></span></code></pre></div>
 <p>changed from:</p>
-<div class="sourceCode" id="cb65"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a><span class="op">;;</span> <span class="co">/*echo/Line/%d;sed/-n/-e/ %d,%dp/%s&gt;*/</span></span>
-<span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a><span class="co">/*c.c;cc/c.c /-c*/</span><span class="op">;;</span></span></code></pre></div>
+<div class="sourceCode" id="cb69"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a><span class="op">;;</span> <span class="co">/*echo/Line/%d;sed/-n/-e/ %d,%dp/%s&gt;*/</span></span>
+<span id="cb69-2"><a href="#cb69-2" aria-hidden="true" tabindex="-1"></a><span class="co">/*c.c;cc/c.c /-c*/</span><span class="op">;;</span></span></code></pre></div>
 <p>or as a diff:</p>
-<div class="sourceCode" id="cb66"><pre
-class="sourceCode diff"><code class="sourceCode diff"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a><span class="st">-(t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s&gt;*/</span></span>
-<span id="cb66-2"><a href="#cb66-2" aria-hidden="true" tabindex="-1"></a><span class="st">-/*c.c;cc/c.c /-c*/;;char*A=0,*_,*R,*Q, D[9999],*r,l</span></span>
-<span id="cb66-3"><a href="#cb66-3" aria-hidden="true" tabindex="-1"></a><span class="st">-[9999],T=42, M,V=32;long*E,k[9999],B[1 &lt;&lt;+21],*N=B+</span></span>
-<span id="cb66-4"><a href="#cb66-4" aria-hidden="true" tabindex="-1"></a><span class="va">+(t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s/|sed*/</span></span>
-<span id="cb66-5"><a href="#cb66-5" aria-hidden="true" tabindex="-1"></a><span class="va">+/*-e/&#39;s,intZ,int/ Z,g&#39;&gt;c.c;make/c;/ rm/-f/c*/</span></span>
-<span id="cb66-6"><a href="#cb66-6" aria-hidden="true" tabindex="-1"></a><span class="va">+;;char*A=0,*_,*R,*Q, D[9999],*r,l[9999],T=42, M,V=32;int *E,k[9999],B[1 &lt;&lt;+21],*N=B+</span></span></code></pre></div>
+<div class="sourceCode" id="cb70"><pre
+class="sourceCode diff"><code class="sourceCode diff"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="st">-(t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s&gt;*/</span></span>
+<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a><span class="st">-/*c.c;cc/c.c /-c*/;;char*A=0,*_,*R,*Q, D[9999],*r,l</span></span>
+<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a><span class="st">-[9999],T=42, M,V=32;long*E,k[9999],B[1 &lt;&lt;+21],*N=B+</span></span>
+<span id="cb70-4"><a href="#cb70-4" aria-hidden="true" tabindex="-1"></a><span class="va">+(t(m),(0));; /*echo/Line/%d;sed/-n/-e/ %d,%dp/%s/|sed*/</span></span>
+<span id="cb70-5"><a href="#cb70-5" aria-hidden="true" tabindex="-1"></a><span class="va">+/*-e/&#39;s,intZ,int/ Z,g&#39;&gt;c.c;make/c;/ rm/-f/c*/</span></span>
+<span id="cb70-6"><a href="#cb70-6" aria-hidden="true" tabindex="-1"></a><span class="va">+;;char*A=0,*_,*R,*Q, D[9999],*r,l[9999],T=42, M,V=32;int *E,k[9999],B[1 &lt;&lt;+21],*N=B+</span></span></code></pre></div>
 <p>Cody also added the <a href="2005/giljade/try.sh">try.sh</a> script
 which also lets one see the beauty of the entry without having to use
 vi(m), should they be afraid of getting stuck in it (and for ease of
@@ -3176,12 +3198,12 @@ href="2005/mikeash/index.html">index.html</a>)</h2>
 <p><a href="#cody">Cody</a> fixed this to work in Linux. The problem was
 an unknown escape sequence, <code>\N</code>, which caused a funny
 compiler error:</p>
-<div class="sourceCode" id="cb67"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="op">};</span>n b<span class="op">[</span><span class="dv">2048</span><span class="op">];</span><span class="dt">int</span> i</span>
-<span id="cb67-2"><a href="#cb67-2" aria-hidden="true" tabindex="-1"></a>mikeash<span class="op">.</span>c<span class="op">:</span> In function <span class="ch">&#39;R&#39;</span><span class="op">:</span></span>
-<span id="cb67-3"><a href="#cb67-3" aria-hidden="true" tabindex="-1"></a>mikeash<span class="op">.</span>c<span class="op">:</span><span class="dv">7</span><span class="op">:</span><span class="dv">1</span><span class="op">:</span> error<span class="op">:</span> <span class="ch">&#39;\</span><span class="er">N</span><span class="ch">&#39;</span> not followed by <span class="ch">&#39;{&#39;</span></span>
-<span id="cb67-4"><a href="#cb67-4" aria-hidden="true" tabindex="-1"></a>    <span class="dv">7</span> <span class="op">|</span> <span class="op">;</span>C<span class="op">!=</span><span class="ch">&#39;</span><span class="sc">\n</span><span class="ch">&#39;</span><span class="op">;</span>A<span class="op">()</span></span>
-<span id="cb67-5"><a href="#cb67-5" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span> <span class="op">^</span></span>
-<span id="cb67-6"><a href="#cb67-6" aria-hidden="true" tabindex="-1"></a>mikeash<span class="op">.</span>c<span class="op">:</span><span class="dv">7</span><span class="op">:</span><span class="dv">1</span><span class="op">:</span> error<span class="op">:</span> incomplete universal character name \Ne</span></code></pre></div>
+<div class="sourceCode" id="cb71"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="op">};</span>n b<span class="op">[</span><span class="dv">2048</span><span class="op">];</span><span class="dt">int</span> i</span>
+<span id="cb71-2"><a href="#cb71-2" aria-hidden="true" tabindex="-1"></a>mikeash<span class="op">.</span>c<span class="op">:</span> In function <span class="ch">&#39;R&#39;</span><span class="op">:</span></span>
+<span id="cb71-3"><a href="#cb71-3" aria-hidden="true" tabindex="-1"></a>mikeash<span class="op">.</span>c<span class="op">:</span><span class="dv">7</span><span class="op">:</span><span class="dv">1</span><span class="op">:</span> error<span class="op">:</span> <span class="ch">&#39;\</span><span class="er">N</span><span class="ch">&#39;</span> not followed by <span class="ch">&#39;{&#39;</span></span>
+<span id="cb71-4"><a href="#cb71-4" aria-hidden="true" tabindex="-1"></a>    <span class="dv">7</span> <span class="op">|</span> <span class="op">;</span>C<span class="op">!=</span><span class="ch">&#39;</span><span class="sc">\n</span><span class="ch">&#39;</span><span class="op">;</span>A<span class="op">()</span></span>
+<span id="cb71-5"><a href="#cb71-5" aria-hidden="true" tabindex="-1"></a>      <span class="op">|</span> <span class="op">^</span></span>
+<span id="cb71-6"><a href="#cb71-6" aria-hidden="true" tabindex="-1"></a>mikeash<span class="op">.</span>c<span class="op">:</span><span class="dv">7</span><span class="op">:</span><span class="dv">1</span><span class="op">:</span> error<span class="op">:</span> incomplete universal character name \Ne</span></code></pre></div>
 <p>The problem was that in the string above there was a
 <code>\Newline</code> but this is invalid C. This was changed to be
 <code>\nNewline</code> and then, because the code is supposed to output
@@ -3884,14 +3906,14 @@ really just a decompressor to generate the real source of the program.
 So the source of the entry has to be compiled and then run, and the
 output has to be compiled to be <code>hou</code>. This allows the real
 program to be used. Thus the Makefile rule looks like:</p>
-<div class="sourceCode" id="cb70"><pre
-class="sourceCode makefile"><code class="sourceCode makefile"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="dv">${PROG}:</span><span class="dt"> </span><span class="ch">${</span><span class="dt">PROG</span><span class="ch">}</span><span class="dt">.c</span></span>
-<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a><span class="er">    </span><span class="ch">${</span><span class="dt">CC</span><span class="ch">}</span> <span class="ch">${</span><span class="dt">CFLAGS</span><span class="ch">}</span> <span class="ch">$&lt;</span> -o <span class="ch">$@</span> <span class="ch">${</span><span class="dt">LDFLAGS</span><span class="ch">}</span></span>
-<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a>    ./<span class="ch">${</span><span class="dt">PROG</span><span class="ch">}</span> | <span class="ch">${</span><span class="dt">CC</span><span class="ch">}</span> <span class="ch">${</span><span class="dt">CFLAGS</span><span class="ch">}</span> -xc - -o <span class="ch">$@</span> <span class="ch">${</span><span class="dt">LDFLAGS</span><span class="ch">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb74"><pre
+class="sourceCode makefile"><code class="sourceCode makefile"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a><span class="dv">${PROG}:</span><span class="dt"> </span><span class="ch">${</span><span class="dt">PROG</span><span class="ch">}</span><span class="dt">.c</span></span>
+<span id="cb74-2"><a href="#cb74-2" aria-hidden="true" tabindex="-1"></a><span class="er">    </span><span class="ch">${</span><span class="dt">CC</span><span class="ch">}</span> <span class="ch">${</span><span class="dt">CFLAGS</span><span class="ch">}</span> <span class="ch">$&lt;</span> -o <span class="ch">$@</span> <span class="ch">${</span><span class="dt">LDFLAGS</span><span class="ch">}</span></span>
+<span id="cb74-3"><a href="#cb74-3" aria-hidden="true" tabindex="-1"></a>    ./<span class="ch">${</span><span class="dt">PROG</span><span class="ch">}</span> | <span class="ch">${</span><span class="dt">CC</span><span class="ch">}</span> <span class="ch">${</span><span class="dt">CFLAGS</span><span class="ch">}</span> -xc - -o <span class="ch">$@</span> <span class="ch">${</span><span class="dt">LDFLAGS</span><span class="ch">}</span></span></code></pre></div>
 <p>which then compiles like:</p>
-<div class="sourceCode" id="cb71"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="fu">cc</span> <span class="at">-std</span><span class="op">=</span>gnu11 <span class="at">-Wall</span> <span class="at">-Wextra</span> <span class="at">-pedantic</span> <span class="at">-Wno-sign-compare</span> <span class="at">-Wno-strict-prototypes</span>    <span class="at">-O3</span> hou.c <span class="at">-o</span> hou <span class="at">-lm</span></span>
-<span id="cb71-2"><a href="#cb71-2" aria-hidden="true" tabindex="-1"></a><span class="ex">./hou</span> <span class="kw">|</span> <span class="fu">cc</span> <span class="at">-std</span><span class="op">=</span>gnu11 <span class="at">-Wall</span> <span class="at">-Wextra</span> <span class="at">-pedantic</span> <span class="at">-Wno-sign-compare</span> <span class="at">-Wno-strict-prototypes</span>    <span class="at">-O3</span> <span class="at">-xc</span> <span class="at">-</span> <span class="at">-o</span> hou <span class="at">-lm</span></span></code></pre></div>
+<div class="sourceCode" id="cb75"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb75-1"><a href="#cb75-1" aria-hidden="true" tabindex="-1"></a><span class="fu">cc</span> <span class="at">-std</span><span class="op">=</span>gnu11 <span class="at">-Wall</span> <span class="at">-Wextra</span> <span class="at">-pedantic</span> <span class="at">-Wno-sign-compare</span> <span class="at">-Wno-strict-prototypes</span>    <span class="at">-O3</span> hou.c <span class="at">-o</span> hou <span class="at">-lm</span></span>
+<span id="cb75-2"><a href="#cb75-2" aria-hidden="true" tabindex="-1"></a><span class="ex">./hou</span> <span class="kw">|</span> <span class="fu">cc</span> <span class="at">-std</span><span class="op">=</span>gnu11 <span class="at">-Wall</span> <span class="at">-Wextra</span> <span class="at">-pedantic</span> <span class="at">-Wno-sign-compare</span> <span class="at">-Wno-strict-prototypes</span>    <span class="at">-O3</span> <span class="at">-xc</span> <span class="at">-</span> <span class="at">-o</span> hou <span class="at">-lm</span></span></code></pre></div>
 <p>The <code>LDFLAGS</code> were updated to have <code>-lm</code> as the
 author suggested it uses the <code>math.h</code> library which not all
 systems link in by default (Linux for instance does not).</p>
@@ -4084,15 +4106,15 @@ href="2015/burton/index.html%5D">index.html</a>)</h2>
 echo feature, where the first character of the filename starts with
 <code>e</code>. The only way it would work before that is if one did
 something like:</p>
-<div class="sourceCode" id="cb72"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb72-1"><a href="#cb72-1" aria-hidden="true" tabindex="-1"></a><span class="fu">ln</span> <span class="at">-sf</span> prog eprog</span>
-<span id="cb72-2"><a href="#cb72-2" aria-hidden="true" tabindex="-1"></a><span class="va">PATH</span><span class="op">=</span><span class="va">$PATH</span>:. <span class="kw">;</span> <span class="ex">eprog</span> <span class="st">&#39;...&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb76"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb76-1"><a href="#cb76-1" aria-hidden="true" tabindex="-1"></a><span class="fu">ln</span> <span class="at">-sf</span> prog eprog</span>
+<span id="cb76-2"><a href="#cb76-2" aria-hidden="true" tabindex="-1"></a><span class="va">PATH</span><span class="op">=</span><span class="va">$PATH</span>:. <span class="kw">;</span> <span class="ex">eprog</span> <span class="st">&#39;...&#39;</span></span></code></pre></div>
 <p>since otherwise the first character would not be <code>e</code> but
 rather a dot (<code>./eprog</code>). This was done by adding to the
 Makefile <code>-include libgen.h</code> and adding to
 <code>main()</code> after the variable declaration (<code>V*A;</code>)
 the code:</p>
-<div class="sourceCode" id="cb73"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb73-1"><a href="#cb73-1" aria-hidden="true" tabindex="-1"></a><span class="op">*</span>K<span class="op">=</span>basename<span class="op">(*</span>K<span class="op">);</span></span></code></pre></div>
+<div class="sourceCode" id="cb77"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb77-1"><a href="#cb77-1" aria-hidden="true" tabindex="-1"></a><span class="op">*</span>K<span class="op">=</span>basename<span class="op">(*</span>K<span class="op">);</span></span></code></pre></div>
 <p>This was done for both the <a href="2015/burton/prog.c">prog.c</a>
 and <a href="2015/burton/prog.alt.c">prog.alt.c</a>. The Makefile was
 also updated to build <code>eprog</code> and <code>eprog.alt</code> to
@@ -4578,9 +4600,9 @@ href="2020/endoh3/index.html">index.html</a>)</h2>
 <p><a href="#cody">Cody</a> fixed the script <a
 href="2020/endoh3/run_clock.sh">run_clock.sh</a> which gave a funny
 error when running it:</p>
-<div class="sourceCode" id="cb74"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> ./run_clock.sh</span>
-<span id="cb74-2"><a href="#cb74-2" aria-hidden="true" tabindex="-1"></a><span class="ex">-bash:</span> ./run_clock.sh: cannot execute: required file not found</span></code></pre></div>
+<div class="sourceCode" id="cb78"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb78-1"><a href="#cb78-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> ./run_clock.sh</span>
+<span id="cb78-2"><a href="#cb78-2" aria-hidden="true" tabindex="-1"></a><span class="ex">-bash:</span> ./run_clock.sh: cannot execute: required file not found</span></code></pre></div>
 <p>If run from within vim a different error message occurred:</p>
 <pre><code>/bin/bash: ./run_clock.sh: /usr/bin/end: bad interpreter: No such file or directory</code></pre>
 <p>though this was only noticed later on after it was fixed.</p>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -392,6 +392,43 @@ We encourage you to read the [compilers.html](1986/marshall/compilers.html) file
 see how odd this problem was and what Cody did to fix it, if nothing else but
 for entertainment!
 
+Also, after all warnings but one that could not be silenced were disabled,
+Cody changed the alt code (which was not the same as the original - see above
+for details or try `make diff_orig_alt` in the directory) slightly so that it
+was possible to silence it. In particular:
+
+```c
+  P  (    a  )   char a   ;  {    a  ;   while(    a  >      "  B   "
+```
+
+which gave:
+
+```
+marshall.alt.c:13:55: warning: ordered comparison between pointer and integer ('char' and 'char *')
+  P  (    a  )   char a   ;  {    a  ;   while(    a  >      "  B   "
+                                                   ~  ^      ~~~~~~~~
+1 warning generated.
+```
+
+was changed to:
+
+```c
+  P  (    a  )   char a   ;  {    a  ;   while((char *)a  >   "  B   "
+```
+
+which gave:
+
+```
+marshall.alt.c:13:48: warning: cast to 'char *' from smaller integer type 'char' [-Wint-to-pointer-cast]
+  P  (    a  )   char a   ;  {    a  ;   while((char *)a  >   "  B   "
+                                               ^~~~~~~~~
+1 warning generated.
+
+```
+
+which can be disabled. It results in the same behaviour but this way no warnings
+are produced.
+
 
 ## <a name="1986_pawka"></a>[1986/pawka](1986/pawka/pawka.c) ([index.html](1986/pawka/index.html))
 


### PR DESCRIPTION

This warning was previously not possible to silence but by changing the
(alt) code slightly (with same functionality including indeed the 
problem I documented in compilers.md) it now is.
