### PR TITLE
Fix make genfilelist to use var.mk variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,13 +294,13 @@ genpath:
 
 # generate YYYY level .filelist
 #
-# IMPORTANT: This file assumes that make clobber was previously done.
+# IMPORTANT: .filelist assumes that make clobber was previously done.
 #
 genfilelist:
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	@-for i in ${YEARS}; do \
-	    rm -f "$$i/.genfilelist.tmp"; \
-	    find "$$i" -mindepth 1 -maxdepth 1 -type f ! -path "$$i/.genfilelist.tmp" ! -name .DS_Store | \
+	    ${RM} -f "$$i/.genfilelist.tmp"; \
+	    ${FIND} "$$i" -mindepth 1 -maxdepth 1 -type f ! -path "$$i/.genfilelist.tmp" ! -name .DS_Store | \
 	      ${SORT} -f -d -u > "$$i/.genfilelist.tmp"; \
 	    if ${CMP} -s "$$i/.genfilelist.tmp" "$$i/.filelist"; then \
 		${RM} -f "$$i/.genfilelist.tmp"; \

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -4818,6 +4818,10 @@ is <code>$(MAKE)</code>.</p>
 <code>PDFLATEX</code> to the <a href="var.mk">var.mk</a> file and
 removed another that was deemed problematic or undesired. Other variable
 names had typos in them.</p>
+<p>In at least one case (like the <a href="/Makefile">top level
+Makefile</a>) where raw commands (that are in <a
+href="/var.mk">var.mk</a>) were used, Cody updated them to use the
+variables.</p>
 <p>A comment was missing for the <code>diff_alt_orig</code> rule in all
 the Makefiles and this, along with many other fixes and changes to the
 Makefiles were made by Cody’s <a
@@ -4830,16 +4834,17 @@ improvements</h2>
 officer :-) (and a fine one at that, we think :-) ), made many, many
 typ0 (… :-) ) fixes throughout the index.html files, scripts, other data
 files, Makefiles (see above) etc.</p>
-<p>He also updated the formatting of the index.html files (after
-renaming the old files to index.html) to proper markdown.</p>
+<p>He also updated the formatting of the README.md, used to generate the
+index.html files, after renaming the old files to README.md, to proper
+markdown.</p>
 <p>Where possible he made the presentation of the entries much more
 consistent across the entries of all the years as well as other files.
 This is not possible for everything (the remarks of authors, for
 instance, cannot be and should not be made consistent but adding
 markdown where necessary in the remarks is).</p>
 <p>A lot of these fixes were done with his <a
-href="https://github.com/xexyl/sgit">sgit tool</a> as well but many were
-done manually too.</p>
+href="https://github.com/xexyl/sgit">sgit tool</a> as well but probably
+most were done manually.</p>
 <h2 id="thank-you-honor-roll"><a name="thank_you_honor_roll"></a>Thank
 you honor roll</h2>
 <p>There are a number of people who have contributed to several thousand

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -5016,6 +5016,10 @@ Cody also added missing variables like `BASH` and `PDFLATEX` to the
 [var.mk](var.mk) file and removed another that was deemed problematic or
 undesired. Other variable names had typos in them.
 
+In at least one case (like the [top level Makefile](/Makefile)) where raw
+commands (that are in [var.mk](/var.mk)) were used, Cody updated them to use the
+variables.
+
 A comment was missing for the `diff_alt_orig` rule in all the Makefiles and
 this, along with many other fixes and changes to the Makefiles were made by
 Cody's [sgit tool](https://github.com/xexyl/sgit) but many other changes he did
@@ -5028,8 +5032,8 @@ manually.
 that, we think :-) ), made many, many typ0 (... :-) ) fixes throughout the
 index.html files, scripts, other data files, Makefiles (see above) etc.
 
-He also updated the formatting of the index.html files (after renaming the old
-files to index.html) to proper markdown.
+He also updated the formatting of the README.md, used to generate the index.html
+files, after renaming the old files to README.md, to proper markdown.
 
 Where possible he made the presentation of the entries much more consistent
 across the entries of all the years as well as other files. This is not possible
@@ -5037,7 +5041,7 @@ for everything (the remarks of authors, for instance, cannot be and should not
 be made consistent but adding markdown where necessary in the remarks is).
 
 A lot of these fixes were done with his [sgit
-tool](https://github.com/xexyl/sgit) as well but many were done manually too.
+tool](https://github.com/xexyl/sgit) as well but probably most were done manually.
 
 
 ## <a name="thank_you_honor_roll"></a>Thank you honor roll


### PR DESCRIPTION
Also the thanks file had some fixes in them including a consistency problem: a place that refers to markdown had been updated to refer to index.html when it should have remained README.md.