### PR TITLE
Improve bash version notes in bin/*.sh

### DIFF
--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -131,7 +131,7 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: This entry is likely to fail and/or dump core on any computer other"
+	@echo "Warning: this entry is likely to fail and/or dump core on any computer other"
 	@echo "than a Vax-11 or pdp-11."
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/bin/all-run.sh
+++ b/bin/all-run.sh
@@ -64,8 +64,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -73,16 +73,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -90,11 +92,12 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
+
 
 # setup bash file matching
 #

--- a/bin/all-years.sh
+++ b/bin/all-years.sh
@@ -63,8 +63,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -72,16 +72,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -89,9 +91,9 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/chk-entry.sh
+++ b/bin/chk-entry.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,9 +63,9 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/gen-authors.sh
+++ b/bin/gen-authors.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,9 +63,9 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/gen-location.sh
+++ b/bin/gen-location.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,11 +63,12 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
+
 
 # setup bash file matching
 #

--- a/bin/gen-other-html.sh
+++ b/bin/gen-other-html.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,11 +63,12 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
+
 
 # setup bash file matching
 #

--- a/bin/gen-sitemap.sh
+++ b/bin/gen-sitemap.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,11 +63,12 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
+
 
 # setup bash file matching
 #

--- a/bin/gen-status.sh
+++ b/bin/gen-status.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,11 +63,12 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
+
 
 # setup bash file matching
 #

--- a/bin/gen-top-html.sh
+++ b/bin/gen-top-html.sh
@@ -39,8 +39,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -48,16 +48,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -65,9 +67,9 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/gen-year-index.sh
+++ b/bin/gen-year-index.sh
@@ -37,8 +37,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -46,16 +46,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -63,9 +65,9 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/gen-years.sh
+++ b/bin/gen-years.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,16 +44,18 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
@@ -61,9 +63,9 @@ if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/md2html.sh
+++ b/bin/md2html.sh
@@ -87,8 +87,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -96,27 +96,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/output-index-author.sh
+++ b/bin/output-index-author.sh
@@ -41,8 +41,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -50,27 +50,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/output-index-inventory.sh
+++ b/bin/output-index-inventory.sh
@@ -41,8 +41,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -50,27 +50,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/output-year-index.sh
+++ b/bin/output-year-index.sh
@@ -7,7 +7,7 @@
 #
 # It is usually invoked by:
 #
-#	-a bin/output-year-index.sh
+#	bin/output-year-index.sh
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
@@ -42,8 +42,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -51,27 +51,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/pandoc-wrapper.sh
+++ b/bin/pandoc-wrapper.sh
@@ -42,8 +42,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -51,27 +51,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/quick-readme2index.sh
+++ b/bin/quick-readme2index.sh
@@ -44,8 +44,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -53,27 +53,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/readme2index.sh
+++ b/bin/readme2index.sh
@@ -38,8 +38,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -47,27 +47,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/sort.gitignore.sh
+++ b/bin/sort.gitignore.sh
@@ -50,8 +50,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -59,29 +59,31 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
+
 
 # setup bash file matching
 #

--- a/bin/status2html.sh
+++ b/bin/status2html.sh
@@ -39,8 +39,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -48,27 +48,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/subst.default.sh
+++ b/bin/subst.default.sh
@@ -44,8 +44,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -53,27 +53,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/subst.entry-index.sh
+++ b/bin/subst.entry-index.sh
@@ -44,8 +44,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -53,27 +53,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/subst.year-index.sh
+++ b/bin/subst.year-index.sh
@@ -44,8 +44,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -53,27 +53,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/tar-all.sh
+++ b/bin/tar-all.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,27 +44,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/tar-entry.sh
+++ b/bin/tar-entry.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,27 +44,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 

--- a/bin/tar-year.sh
+++ b/bin/tar-year.sh
@@ -35,8 +35,8 @@
 # of bash between 4.2 and 5.1.7 might work.  However, to be safe, we will require
 # bash version 5.1.8 or later.
 #
-# WHY 5.1.8 and not 4.2?  This safely is done because macOS homebrew bash we
-# often use it "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
+# WHY 5.1.8 and not 4.2?  This safely is done because macOS Homebrew bash we
+# often use is "version 5.2.26(1)-release" or later, and the RHEL Linux bash we
 # use often use is "version 5.1.8(1)-release" or later.  These versions are what
 # we initially tested.  We recommend you either upgrade bash or install a newer
 # version of bash and adjust your $PATH so that "/usr/bin/env bash" finds a bash
@@ -44,27 +44,28 @@
 #
 # NOTE: The macOS shipped, as of 2024 March 15, a version of bash is something like
 #	bash "version 3.2.57(1)-release".  That macOS shipped version of bash
-#	will NOT work.  For users of macOS we recommend you install homebrew,
-#	(see https://brew.sh), and then install homebrew bash (/opt/homebrew/bin/bash),
-#	and then arrange your $PATH so that "/opt/homebrew/bin" is ahead of "/bin".
+#	will NOT work.  For users of macOS we recommend you install Homebrew,
+#	(see https://brew.sh), and then run "brew install bash" which will
+#	typically install it into /opt/homebrew/bin/bash, and then arrange your $PATH
+#	so that "/usr/bin/env bash" finds "/opt/homebrew/bin" (or whatever the
+#	Homebrew bash is).
 #
 # NOTE: And while MacPorts might work, we noticed a number of subtle differences
 #	with some of their ported tools to suggest you might be better off
-#	with installing homebrew (see https://brew.sh).  No disrespect is intended
+#	with installing Homebrew (see https://brew.sh).  No disrespect is intended
 #	to the MacPorts team as they do a commendable job.  Nevertheless we ran
 #	into enough differences with MacPorts environments to suggest you
-#	might find a better experience with this tool under homebrew instead.
+#	might find a better experience with this tool under Homebrew instead.
 #
 if [[ -z ${BASH_VERSINFO[0]} ||
 	 ${BASH_VERSINFO[0]} -lt 5 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -lt 1 ||
 	 ${BASH_VERSINFO[0]} -eq 5 && ${BASH_VERSINFO[1]} -eq 1 && ${BASH_VERSINFO[2]} -lt 8 ]]; then
-
     echo "$0: ERROR: bash version needs to be >= 5.1.8: $BASH_VERSION" 1>&2
     echo "$0: Warning: bash version >= 4.2 might work but 5.1.8 was the minimum we tested" 1>&2
-    echo "$0: Notice: For macOS users: install homebrew (see https://brew.sh)," \
-	 "then install homebrew bash (brew install bash), and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
-	 "finds the homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
+    echo "$0: Notice: For macOS users: install Homebrew (see https://brew.sh), then run" \
+	 ""brew install bash" and then modify your \$PATH so that \"#!/usr/bin/env bash\"" \
+	 "finds the Homebrew installed (usually /opt/homebrew/bin/bash) version of bash" 1>&2
     exit 4
 fi
 


### PR DESCRIPTION

The wording in the comments and the error message (in particular for
macOS) should now be clearer. Now in both places it shows how to install
bash in Homebrew. In commands I surrounded them like what was already
used, with " rather than 's, to make it consistent. There were other
cosmetic consistency changes as well.
 
Except in paths 'homebrew' was changed to 'Homebrew'.

In bin/output-year-index.sh there was a typo fix: it said to use it one
typically would do: 

    -a bin/output-year-index.sh

which obviously is not correct.