### PR TITLE
Fix 1993/lmfjyh/Makefile

### DIFF
--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -132,7 +132,6 @@ ${PROG}: ${PROG}.c
 	@echo "it relies on a compiler bug which was fixed in gcc 2.3.3 a very"
 	@echo "long time ago."
 	@echo
-	${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	${CP} lmfjyh.c \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
 	@echo ${CC} ${CFLAGS} \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c -o $@ ${LDFLAGS}
 	@${CC} ${CFLAGS} \
@@ -145,6 +144,8 @@ ${PROG}: ${PROG}.c
 	    echo "and then run the alternate program:" && \
 	    echo && \
 	    echo "    ./${ALT_TARGET}"
+	@${RM} -f \"\;main\(\)\{puts\(\"Hello\ World!\"\)\;\}char\*C=\".c
+	    
 
 # alternative executable
 #

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -1299,9 +1299,7 @@ files for functions.</p>
 <p><a href="#cody">Cody</a> added an <a href="1993/lmfjyh/index.html#alternate-code">alternate
 version</a> which does what the program did
 with gcc &lt; 2.3.3. See the index.html file for details and for why this was made
-the alternate version, not the actual entry. This alternate version will compile
-automatically (as <code>lmfjyh</code> itself) in the very likely case (if you don’t have
-gcc &lt; 2.3.3) that the entry fails to compile.</p>
+the alternate version, not the actual entry.</p>
 <p>Cody also made the Makefile delete the very unsafe filename that is compiled (or
 would be compiled if gcc &lt; 2.3.3) whether or not compilation succeeds (which is
 highly unlikely).</p>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1809,9 +1809,7 @@ files for functions.
 [Cody](#cody) added an [alternate
 version](1993/lmfjyh/index.html#alternate-code) which does what the program did
 with gcc < 2.3.3. See the index.html file for details and for why this was made
-the alternate version, not the actual entry. This alternate version will compile
-automatically (as `lmfjyh` itself) in the very likely case (if you don't have
-gcc < 2.3.3) that the entry fails to compile.
+the alternate version, not the actual entry.
 
 Cody also made the Makefile delete the very unsafe filename that is compiled (or
 would be compiled if gcc < 2.3.3) whether or not compilation succeeds (which is


### PR DESCRIPTION
The problem it had is that it was reverted back to trying to compile the very unsafe file name without deleting it after the ${CC} line. Thus the ${RM} part was moved back to the end of the rule. I added the file (or a glob that will match the file) to .gitignore a long time ago possibly when I added the alt code.

The thanks file was fixed to account for the fact that the Makefile no longer automatically builds the alt version if the code fails to compile.