### PR TITLE
Mass typo fix in YYYY/README.md files, rebuild www

### DIFF
--- a/1984/README.md
+++ b/1984/README.md
@@ -20,7 +20,7 @@ post](https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J).
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1984/index.html
+++ b/1984/index.html
@@ -141,7 +141,7 @@ post</a>.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1985/README.md
+++ b/1985/README.md
@@ -18,7 +18,7 @@ since we were unable to select only the best 4.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1985/index.html
+++ b/1985/index.html
@@ -140,7 +140,7 @@ since we were unable to select only the best 4.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1986/README.md
+++ b/1986/README.md
@@ -30,7 +30,7 @@ started this year.  A notice was posted to net.announce.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1986/index.html
+++ b/1986/index.html
@@ -150,7 +150,7 @@ started this year. A notice was posted to net.announce.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1987/README.md
+++ b/1987/README.md
@@ -28,7 +28,7 @@ fly that danced all over the foils.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1987/index.html
+++ b/1987/index.html
@@ -149,7 +149,7 @@ fly that danced all over the foils.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1988/README.md
+++ b/1988/README.md
@@ -26,7 +26,7 @@ also available on a wide number of USENET archive sites.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1988/index.html
+++ b/1988/index.html
@@ -145,7 +145,7 @@ also available on a wide number of USENET archive sites.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1989/README.md
+++ b/1989/README.md
@@ -31,7 +31,7 @@ Journal](https://www.vintage-computer.com/publications.php?microsystemsjournal).
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1989/index.html
+++ b/1989/index.html
@@ -149,7 +149,7 @@ Journal</a>.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1990/README.md
+++ b/1990/README.md
@@ -28,7 +28,7 @@ available on a wide number of USENET archive sites such as uunet.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1990/index.html
+++ b/1990/index.html
@@ -146,7 +146,7 @@ available on a wide number of USENET archive sites such as uunet.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1991/README.md
+++ b/1991/README.md
@@ -91,7 +91,7 @@ judges@toad.com
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 ## Credits:

--- a/1991/index.html
+++ b/1991/index.html
@@ -193,7 +193,7 @@ judges@toad.com</code></pre>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <h2 id="credits">Credits:</h2>
 <p>We would like to thank Barbara Frezza for her role as official chef
 of the contest. Landon Noll appreciated the opportunity to serve

--- a/1992/README.md
+++ b/1992/README.md
@@ -83,7 +83,7 @@ us a line.  We enjoy seeing who, where and how the contest is used.
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 ## Credits:

--- a/1992/index.html
+++ b/1992/index.html
@@ -188,7 +188,7 @@ us a line. We enjoy seeing who, where and how the contest is used.</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <h2 id="credits">Credits:</h2>
 <p>We would like to thank Barbara Frezza for her role as official chef of
 the contest. Landon Noll and Larry Bassel appreciated the opportunity

--- a/1993/README.md
+++ b/1993/README.md
@@ -54,7 +54,7 @@ us a line.  We enjoy seeing who, where and how the contest is used.
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 ### Credits:

--- a/1993/index.html
+++ b/1993/index.html
@@ -164,7 +164,7 @@ us a line. We enjoy seeing who, where and how the contest is used.</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <h3 id="credits">Credits:</h3>
 <p>We would like to thank Barbara Frezza for her role as official chef
 of the contest. Landon Curt Noll and Larry Bassel appreciated the opportunity

--- a/1994/README.md
+++ b/1994/README.md
@@ -122,7 +122,7 @@ as well as details on how to provide fixes to any of the entries.
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 ## Credits

--- a/1994/index.html
+++ b/1994/index.html
@@ -215,7 +215,7 @@ as well as details on how to provide fixes to any of the entries.</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <h2 id="credits">Credits</h2>
 <p>We would like to thank Barbara Frezza for her role as official chef
 of the contest. Landon Curt Noll and Larry Bassel appreciated the opportunity

--- a/1995/README.md
+++ b/1995/README.md
@@ -70,7 +70,7 @@ us a line.  We enjoy seeing who, where and how the contest is used.
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 ## Credits

--- a/1995/index.html
+++ b/1995/index.html
@@ -177,7 +177,7 @@ us a line. We enjoy seeing who, where and how the contest is used.</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <h2 id="credits">Credits</h2>
 <p>We would like to thank Barbara Frezza for her role as official chef of
 the contest. Landon Noll, Larry Bassel and Sriram Srinivasan

--- a/1996/README.md
+++ b/1996/README.md
@@ -91,7 +91,7 @@ us a line.  We enjoy seeing who, where and how the contest is used.
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/1996/index.html
+++ b/1996/index.html
@@ -188,7 +188,7 @@ us a line. We enjoy seeing who, where and how the contest is used.</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1998/README.md
+++ b/1998/README.md
@@ -115,7 +115,7 @@ questions@ioccc.org
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 If you use, distribute or publish these entries in some way, please drop
 us a line.  We enjoy seeing who, where and how the contest is used.

--- a/1998/index.html
+++ b/1998/index.html
@@ -212,7 +212,7 @@ Send such email to:</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <p>If you use, distribute or publish these entries in some way, please drop
 us a line. We enjoy seeing who, where and how the contest is used.</p>
 <p>You must include the words ‘ioccc question’ in the subject of your email

--- a/2000/README.md
+++ b/2000/README.md
@@ -91,7 +91,7 @@ questions@ioccc.org
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2000/index.html
+++ b/2000/index.html
@@ -189,7 +189,7 @@ Send such email to:</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2001/README.md
+++ b/2001/README.md
@@ -73,7 +73,7 @@ questions@ioccc.org
 purposes only, and should not be used today.  See
 [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2001/index.html
+++ b/2001/index.html
@@ -177,7 +177,7 @@ Send such email to:</p>
 purposes only, and should not be used today. See
 <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2004/README.md
+++ b/2004/README.md
@@ -58,7 +58,7 @@ them for the next IOCCC.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2004/index.html
+++ b/2004/index.html
@@ -168,7 +168,7 @@ them for the next IOCCC.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2005/README.md
+++ b/2005/README.md
@@ -89,7 +89,7 @@ them for the next IOCCC.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2005/index.html
+++ b/2005/index.html
@@ -184,7 +184,7 @@ them for the next IOCCC.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2006/README.md
+++ b/2006/README.md
@@ -55,7 +55,7 @@ of the submitter).
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2006/index.html
+++ b/2006/index.html
@@ -164,7 +164,7 @@ of the submitter).</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2011/README.md
+++ b/2011/README.md
@@ -54,7 +54,7 @@ the identity of the submitter).
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2011/index.html
+++ b/2011/index.html
@@ -163,7 +163,7 @@ the identity of the submitter).</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2012/README.md
+++ b/2012/README.md
@@ -105,7 +105,7 @@ in some particularly impressive way.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2012/index.html
+++ b/2012/index.html
@@ -199,7 +199,7 @@ in some particularly impressive way.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2013/README.md
+++ b/2013/README.md
@@ -90,7 +90,7 @@ excel over similar previous winning entry in some particularly impressive way.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/2013/index.html
+++ b/2013/index.html
@@ -185,7 +185,7 @@ excel over similar previous winning entry in some particularly impressive way.</
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2018/README.md
+++ b/2018/README.md
@@ -95,7 +95,7 @@ the idea was limited in scope.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 <!--
 

--- a/2018/index.html
+++ b/2018/index.html
@@ -191,7 +191,7 @@ the idea was limited in scope.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2019/README.md
+++ b/2019/README.md
@@ -75,7 +75,7 @@ the idea was limited in scope.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 <!--
 

--- a/2019/index.html
+++ b/2019/index.html
@@ -172,7 +172,7 @@ the idea was limited in scope.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/2020/README.md
+++ b/2020/README.md
@@ -71,7 +71,7 @@ One more thing that feels dated is digraphs and trigraphs.
 
 **IMPORTANT NOTE**: See [contact.html](../contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](../faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](../faq.html) for additional information on the IOCCC.
 
 <!--
 

--- a/2020/index.html
+++ b/2020/index.html
@@ -173,7 +173,7 @@ perhaps re-submit them for the next IOCCC.</p>
 <p>One more thing that feels dated is digraphs and trigraphs.</p>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="../faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/README.html
+++ b/README.html
@@ -279,7 +279,7 @@ official entries that won the <strong>International Obfuscated C Code Contest (I
 Internet’s oldest ongoing contest.</p>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also <a href="faq.html">the IOCCC FAQ</a> for addition information on the IOCCC.</p>
+See also <a href="faq.html">the IOCCC FAQ</a> for additional information on the IOCCC.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Internet's oldest ongoing contest.
 
 **IMPORTANT NOTE**: See [contact.html](contact.html) for up to date contact details
 as well as details on how to provide fixes to any of the entries.
-See also [the IOCCC FAQ](faq.html) for addition information on the IOCCC.
+See also [the IOCCC FAQ](faq.html) for additional information on the IOCCC.
 
 
 <!--

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -7,7 +7,7 @@ maintain the [official IOCCC web site](https://www.ioccc.org).
 
 Currently these tools maintain the [experimental web site](https://ioccc-src.github.io/temp-test-ioccc/)
 by default, via the  [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc).
-These tools will redefault to using the temp-test-ioccc repo and the experimental web site
+These tools will default to using the temp-test-ioccc repo and the experimental web site
 until the [official IOCCC web site](https://www.ioccc.org), via the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) is ready for the mass pull request/merge.
 


### PR DESCRIPTION

'For addition information' should be 'For additional information'.