### PR TITLE
Remove hyphenation at end of lines in ioccc.css

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -21,7 +21,7 @@ p {
     -moz-hyphens: none;
     -ms-hyphens: none;
     -webkit-hyphens: none;
-    hyphens: none;
+    hyphens: manual;
 }
 
 /* Sections ========================================================================== */


### PR DESCRIPTION
In other words we won't see text like:

    ... See also the IOCCC FAQ for ad-
    ditional information on the IOCCC.

As I am not sure of the formatting of comments and the organisation of the different html elements it might be that the CSS for 'p' might need new comments or it might need to be moved to another section in the file (which I believe but do not know).