### PR TITLE
Fixes and improvements in 1980s index.html files

### DIFF
--- a/1984/README.md
+++ b/1984/README.md
@@ -9,8 +9,9 @@ source and try to figure how it does what it does!  This year we only had
 remarks from two authors but these came years later.
 
 Restrictions against machine dependent code were not in the [rules](rules.txt)
-in 1984. The source file size restriction was only 512 bytes.  Rules and results
-were posted to [net.lang.c](https://groups.google.com/g/net.lang.c) and
+in 1984. The source file size restriction was only 512 bytes.
+[Rules](rules.txt) and [results](../years.html#1984) were posted to
+[net.lang.c](https://groups.google.com/g/net.lang.c) and
 [net.unix-wizards](https://groups.google.com/g/net.unix-wizards). The contest
 was announced in a [net.lang.c
 post](https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J).

--- a/1984/index.html
+++ b/1984/index.html
@@ -133,8 +133,9 @@ to compile it and how to run the winning program. Look at the winning
 source and try to figure how it does what it does! This year we only had
 remarks from two authors but these came years later.</p>
 <p>Restrictions against machine dependent code were not in the <a href="rules.txt">rules</a>
-in 1984. The source file size restriction was only 512 bytes. Rules and results
-were posted to <a href="https://groups.google.com/g/net.lang.c">net.lang.c</a> and
+in 1984. The source file size restriction was only 512 bytes.
+<a href="rules.txt">Rules</a> and <a href="../years.html#1984">results</a> were posted to
+<a href="https://groups.google.com/g/net.lang.c">net.lang.c</a> and
 <a href="https://groups.google.com/g/net.unix-wizards">net.unix-wizards</a>. The contest
 was announced in a <a href="https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J">net.lang.c
 post</a>.</p>

--- a/1987/README.md
+++ b/1987/README.md
@@ -15,13 +15,12 @@ this year.
 [Rules](rules.txt) and results were posted to comp.lang.c and comp.unix.wizards
 with an announcement in news.announce.important.
 [Micro/Systems Journal](https://www.vintage-computer.com/publications.php?microsystemsjournal)
-published the 1987 winning entries.  [Mark R.
-Horton](https://www.amazon.com/stores/Mark-R.-Horton/author/B001HPGRB8) included
-a version of the [1987 winning entries](../years.html#1987) in an appendix of his C book
-[Portable C Software International
+published the 1987 winning entries.  [Mary Ann Horton](../authors.html#Mary_Ann_Horton) included
+a version of the [1987 winning entries](../years.html#1987) in an appendix of
+her C book [Portable C Software International
 Edition](https://www.amazon.com/Portable-Software-Mark-R-Horton/dp/0138680507).
-The first announcement of winning entries at the Summer 87 USENIX was helped by a small
-fly that danced all over the foils.
+The first announcement of winning entries at the Summer 87 USENIX was helped by
+a small fly that danced all over the foils.
 
 
 ## Final Comments

--- a/1987/index.html
+++ b/1987/index.html
@@ -139,13 +139,12 @@ this year.</p>
 <p><a href="rules.txt">Rules</a> and results were posted to comp.lang.c and comp.unix.wizards
 with an announcement in news.announce.important.
 <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems Journal</a>
-published the 1987 winning entries. <a href="https://www.amazon.com/stores/Mark-R.-Horton/author/B001HPGRB8">Mark R.
-Horton</a> included
-a version of the <a href="../years.html#1987">1987 winning entries</a> in an appendix of his C book
-<a href="https://www.amazon.com/Portable-Software-Mark-R-Horton/dp/0138680507">Portable C Software International
+published the 1987 winning entries. <a href="../authors.html#Mary_Ann_Horton">Mary Ann Horton</a> included
+a version of the <a href="../years.html#1987">1987 winning entries</a> in an appendix of
+her C book <a href="https://www.amazon.com/Portable-Software-Mark-R-Horton/dp/0138680507">Portable C Software International
 Edition</a>.
-The first announcement of winning entries at the Summer 87 USENIX was helped by a small
-fly that danced all over the foils.</p>
+The first announcement of winning entries at the Summer 87 USENIX was helped by
+a small fly that danced all over the foils.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.

--- a/1988/README.md
+++ b/1988/README.md
@@ -7,13 +7,14 @@ You may then wish to look at the Author's remarks for even more details.
 
 The maximum size of entries was raised from 1024 to 1536 bytes, however smaller
 entries were encouraged.  Due to the ["Best Abuse of the Rules" entry of
-1987](/1987/biggar/index.html), a limit of 160 chars in the compile line was introduced.
+1987](../1987/biggar/index.html), a limit of 160 chars in the compile line was introduced.
 
 This year, the Grand Prize was given to the most unusual entry and best
 abuse of the C Preprocessor rather than the most well rounded entry.
 
-[Rules](rules.txt) and results were posted to comp.lang.c, comp.sources.unix and
-alt.sources.  The 1988 winning entries will be published in the [Micro/Systems
+[Rules](rules.txt) and [results](../years.html#1988) were posted to comp.lang.c,
+comp.sources.unix and alt.sources.  The 1988 winning entries will be published
+in the [Micro/Systems
 Journal](https://www.vintage-computer.com/publications.php?microsystemsjournal).
 
 Winning entries for previous years were repackaged with each year

--- a/1988/index.html
+++ b/1988/index.html
@@ -131,12 +131,13 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
 <p>The maximum size of entries was raised from 1024 to 1536 bytes, however smaller
-entries were encouraged. Due to the <a href="/1987/biggar/index.html">“Best Abuse of the Rules” entry of
+entries were encouraged. Due to the <a href="../1987/biggar/index.html">“Best Abuse of the Rules” entry of
 1987</a>, a limit of 160 chars in the compile line was introduced.</p>
 <p>This year, the Grand Prize was given to the most unusual entry and best
 abuse of the C Preprocessor rather than the most well rounded entry.</p>
-<p><a href="rules.txt">Rules</a> and results were posted to comp.lang.c, comp.sources.unix and
-alt.sources. The 1988 winning entries will be published in the <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
+<p><a href="rules.txt">Rules</a> and <a href="../years.html#1988">results</a> were posted to comp.lang.c,
+comp.sources.unix and alt.sources. The 1988 winning entries will be published
+in the <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
 Journal</a>.</p>
 <p>Winning entries for previous years were repackaged with each year
 being in its own directory. Makefiles and hints were also provided.

--- a/1989/README.md
+++ b/1989/README.md
@@ -8,7 +8,7 @@ You may then wish to look at the Author's remarks for even more details.
 Instructions for use: Run `make` to compile entries (it is possible that on
 System V or non-Unix systems the Makefile needs to be changed).
 
-This year, the Grand Prize was given to the most useful program.
+This year, the [Best of Show](jar.2/index.html) was given to the most useful program.
 
 The ["Strangest abuse of the rules"](jar.1/indx.html) award was given this year
 to stress the fact that starting in 1990, compiling entries must result a
@@ -20,7 +20,7 @@ using it.  In the case of the ["Best game"](tromp/README) entry, however, some
 functionality is lost in the portable version and so the Makefile uses
 the original program.
 
-[Rules](rules.txt) and results were posted to comp.lang.c, comp.sources.unix, and
+[Rules](rules.txt) and [results](../years.html#1989) were posted to comp.lang.c, comp.sources.unix, and
 alt.sources.  They have been made available on a wide number of USENET
 archive sites such as uunet.  The 1989 winning entries will be published in the
 [Micro/Systems

--- a/1989/index.html
+++ b/1989/index.html
@@ -132,7 +132,7 @@ Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Instructions for use: Run <code>make</code> to compile entries (it is possible that on
 System V or non-Unix systems the Makefile needs to be changed).</p>
-<p>This year, the Grand Prize was given to the most useful program.</p>
+<p>This year, the <a href="jar.2/index.html">Best of Show</a> was given to the most useful program.</p>
 <p>The <a href="jar.1/indx.html">“Strangest abuse of the rules”</a> award was given this year
 to stress the fact that starting in 1990, compiling entries must result a
 regular executable file.</p>
@@ -141,7 +141,7 @@ self modifying program”</a> because there is no loss of functionality in
 using it. In the case of the <a href="tromp/README">“Best game”</a> entry, however, some
 functionality is lost in the portable version and so the Makefile uses
 the original program.</p>
-<p><a href="rules.txt">Rules</a> and results were posted to comp.lang.c, comp.sources.unix, and
+<p><a href="rules.txt">Rules</a> and <a href="../years.html#1989">results</a> were posted to comp.lang.c, comp.sources.unix, and
 alt.sources. They have been made available on a wide number of USENET
 archive sites such as uunet. The 1989 winning entries will be published in the
 <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems


### PR DESCRIPTION
A point of interest is that in 1987 the README.md referred to Mark R Horton but it is now Mary Ann Horton so I changed it to that. Also as she has won I linked to not the Amazon author page but rather the authors.html link. It's important to note though that the author page on Amazon says Mark still, perhaps because that is how the book was published (I guess - I didn't look). Still it seems right to change it to how she identifies, rather than not.

Links were added for entries where referred to. Links were added to results where not linked to. It is unclear if links to USENET groups should be kept (besides the ones where the direct posts are known) or removed so I have not added any that have missing links even those that were already in other README.md files.

What remains to be done for the 1980s README.md files depends on whether the USENET group links that are there should be removed or if those missing should be added.

The rendered html files were tested on my web server and all appears okay.