### PR TITLE
More fixes in 1980s README.md files

### DIFF
--- a/1984/README.md
+++ b/1984/README.md
@@ -10,10 +10,8 @@ remarks from two authors but these came years later.
 
 Restrictions against machine dependent code were not in the [rules](rules.txt)
 in 1984. The source file size restriction was only 512 bytes.
-[Rules](rules.txt) and [results](../years.html#1984) were posted to
-[net.lang.c](https://groups.google.com/g/net.lang.c) and
-[net.unix-wizards](https://groups.google.com/g/net.unix-wizards). The contest
-was announced in a [net.lang.c
+[Rules](rules.txt) and [results](../years.html#1984) were posted to _net.lang.c_
+and _net.unix-wizards_. The contest was announced in a [net.lang.c
 post](https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J).
 
 

--- a/1984/index.html
+++ b/1984/index.html
@@ -134,10 +134,8 @@ source and try to figure how it does what it does! This year we only had
 remarks from two authors but these came years later.</p>
 <p>Restrictions against machine dependent code were not in the <a href="rules.txt">rules</a>
 in 1984. The source file size restriction was only 512 bytes.
-<a href="rules.txt">Rules</a> and <a href="../years.html#1984">results</a> were posted to
-<a href="https://groups.google.com/g/net.lang.c">net.lang.c</a> and
-<a href="https://groups.google.com/g/net.unix-wizards">net.unix-wizards</a>. The contest
-was announced in a <a href="https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J">net.lang.c
+<a href="rules.txt">Rules</a> and <a href="../years.html#1984">results</a> were posted to <em>net.lang.c</em>
+and <em>net.unix-wizards</em>. The contest was announced in a <a href="https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J">net.lang.c
 post</a>.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details

--- a/1985/README.md
+++ b/1985/README.md
@@ -7,11 +7,10 @@ Author's remarks for even more details.
 
 Hints against machine dependent code were added to the [rules](rules.txt) to
 avoid another 1984 style entry ([1984/mullender](../1984/mullender/index.html)).
-[Rules](rules.txt) and [results](../years.html#1985) were posted to
-[net.lang.c](https://groups.google.com/g/net.lang.c) and
-[net.unix-wizards](https://groups.google.com/g/net.unix-wizards).  Larry Bassel
-was invited to help in the judging.  Awards were given to 5 classes of programs
-since we were unable to select only the best 4.
+[Rules](rules.txt) and [results](../years.html#1985) were posted to _net.lang.c_
+and _net.unix-wizards_.  Larry Bassel was invited to help in the judging.
+Awards were given to 5 classes of programs since we were unable to select only
+the best 4.
 
 
 ## Final Comments

--- a/1985/index.html
+++ b/1985/index.html
@@ -132,11 +132,10 @@ and try to figure how it does what it does! You may then wish to look at the
 Author’s remarks for even more details.</p>
 <p>Hints against machine dependent code were added to the <a href="rules.txt">rules</a> to
 avoid another 1984 style entry (<a href="../1984/mullender/index.html">1984/mullender</a>).
-<a href="rules.txt">Rules</a> and <a href="../years.html#1985">results</a> were posted to
-<a href="https://groups.google.com/g/net.lang.c">net.lang.c</a> and
-<a href="https://groups.google.com/g/net.unix-wizards">net.unix-wizards</a>. Larry Bassel
-was invited to help in the judging. Awards were given to 5 classes of programs
-since we were unable to select only the best 4.</p>
+<a href="rules.txt">Rules</a> and <a href="../years.html#1985">results</a> were posted to <em>net.lang.c</em>
+and <em>net.unix-wizards</em>. Larry Bassel was invited to help in the judging.
+Awards were given to 5 classes of programs since we were unable to select only
+the best 4.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.

--- a/1986/README.md
+++ b/1986/README.md
@@ -16,14 +16,12 @@ Shell](https://en.wikipedia.org/wiki/Bourne_shell) (`/bin/sh`) won for both
 systems.  The BSD [finger](https://en.wikipedia.org/wiki/Finger_(protocol))
 program took third place.
 
-[Rules](rules.txt) and [results](../years.html#1986) were posted to
-[net.lang.c](https://groups.google.com/g/net.lang.c) and
-[net.unix-wizards](https://groups.google.com/g/net.unix-wizards).
-[Micro/Systems
+[Rules](rules.txt) and [results](../years.html#1986) were posted to _net.lang.c_
+and _net.unix-wizards_.  [Micro/Systems
 Journal](https://www.vintage-computer.com/publications.php?microsystemsjournal)
 started regular publishing of the winning entries.  The practice of making first
-announcement of the winning entries at the Summer USENIX BOF (Birds of a Feather)
-started this year.  A notice was posted to net.announce.
+announcement of the winning entries at the Summer USENIX BOF (Birds of a
+Feather) started this year.  A notice was posted to net.announce.
 
 
 ## Final Comments

--- a/1986/index.html
+++ b/1986/index.html
@@ -139,14 +139,12 @@ V</a> program. The <a href="https://en.wikipedia.org/wiki/Bourne_shell">Bourne
 Shell</a> (<code>/bin/sh</code>) won for both
 systems. The BSD <a href="https://en.wikipedia.org/wiki/Finger_(protocol)">finger</a>
 program took third place.</p>
-<p><a href="rules.txt">Rules</a> and <a href="../years.html#1986">results</a> were posted to
-<a href="https://groups.google.com/g/net.lang.c">net.lang.c</a> and
-<a href="https://groups.google.com/g/net.unix-wizards">net.unix-wizards</a>.
-<a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
+<p><a href="rules.txt">Rules</a> and <a href="../years.html#1986">results</a> were posted to <em>net.lang.c</em>
+and <em>net.unix-wizards</em>. <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
 Journal</a>
 started regular publishing of the winning entries. The practice of making first
-announcement of the winning entries at the Summer USENIX BOF (Birds of a Feather)
-started this year. A notice was posted to net.announce.</p>
+announcement of the winning entries at the Summer USENIX BOF (Birds of a
+Feather) started this year. A notice was posted to net.announce.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
 as well as details on how to provide fixes to any of the entries.

--- a/1987/README.md
+++ b/1987/README.md
@@ -18,7 +18,8 @@ with an announcement in news.announce.important.
 published the 1987 winning entries.  [Mary Ann Horton](../authors.html#Mary_Ann_Horton) included
 a version of the [1987 winning entries](../years.html#1987) in an appendix of
 her C book [Portable C Software International
-Edition](https://www.amazon.com/Portable-Software-Mark-R-Horton/dp/0138680507).
+Edition](https://www.amazon.com/Portable-Software-Mark-R-Horton/dp/0138680507)
+(published under the name _Mark R Horton_).
 The first announcement of winning entries at the Summer 87 USENIX was helped by
 a small fly that danced all over the foils.
 

--- a/1987/index.html
+++ b/1987/index.html
@@ -142,7 +142,8 @@ with an announcement in news.announce.important.
 published the 1987 winning entries. <a href="../authors.html#Mary_Ann_Horton">Mary Ann Horton</a> included
 a version of the <a href="../years.html#1987">1987 winning entries</a> in an appendix of
 her C book <a href="https://www.amazon.com/Portable-Software-Mark-R-Horton/dp/0138680507">Portable C Software International
-Edition</a>.
+Edition</a>
+(published under the name <em>Mark R Horton</em>).
 The first announcement of winning entries at the Summer 87 USENIX was helped by
 a small fly that danced all over the foils.</p>
 <h2 id="final-comments">Final Comments</h2>

--- a/1989/README.md
+++ b/1989/README.md
@@ -8,21 +8,22 @@ You may then wish to look at the Author's remarks for even more details.
 Instructions for use: Run `make` to compile entries (it is possible that on
 System V or non-Unix systems the Makefile needs to be changed).
 
+The Makefile for ["Best self modifying program"](fubar/indx.html) always uses
+the most portable version because there is no loss of functionality in
+using it.  In the case of the ["Best game"](tromp/README) entry, however, some
+functionality is lost in the portable version and so its Makefile uses
+the original program.
+
 This year, the [Best of Show](jar.2/index.html) was given to the most useful program.
 
 The ["Strangest abuse of the rules"](jar.1/indx.html) award was given this year
 to stress the fact that starting in 1990, compiling entries must result a
 regular executable file.
 
-The Makefile always uses the portable version of the ["Best
-self modifying program"](fubar/indx.html) because there is no loss of functionality in
-using it.  In the case of the ["Best game"](tromp/README) entry, however, some
-functionality is lost in the portable version and so the Makefile uses
-the original program.
-
-[Rules](rules.txt) and [results](../years.html#1989) were posted to comp.lang.c, comp.sources.unix, and
-alt.sources.  They have been made available on a wide number of USENET
-archive sites such as uunet.  The 1989 winning entries will be published in the
+[Rules](rules.txt) and [results](../years.html#1989) were posted to
+_comp.lang.c_, _comp.sources.unix_ and
+_alt.sources_.  They have been made available on a wide number of USENET
+archive sites such as _uunet_.  The 1989 winning entries will be published in the
 [Micro/Systems
 Journal](https://www.vintage-computer.com/publications.php?microsystemsjournal).
 

--- a/1989/index.html
+++ b/1989/index.html
@@ -132,18 +132,19 @@ Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Instructions for use: Run <code>make</code> to compile entries (it is possible that on
 System V or non-Unix systems the Makefile needs to be changed).</p>
+<p>The Makefile for <a href="fubar/indx.html">“Best self modifying program”</a> always uses
+the most portable version because there is no loss of functionality in
+using it. In the case of the <a href="tromp/README">“Best game”</a> entry, however, some
+functionality is lost in the portable version and so its Makefile uses
+the original program.</p>
 <p>This year, the <a href="jar.2/index.html">Best of Show</a> was given to the most useful program.</p>
 <p>The <a href="jar.1/indx.html">“Strangest abuse of the rules”</a> award was given this year
 to stress the fact that starting in 1990, compiling entries must result a
 regular executable file.</p>
-<p>The Makefile always uses the portable version of the <a href="fubar/indx.html">“Best
-self modifying program”</a> because there is no loss of functionality in
-using it. In the case of the <a href="tromp/README">“Best game”</a> entry, however, some
-functionality is lost in the portable version and so the Makefile uses
-the original program.</p>
-<p><a href="rules.txt">Rules</a> and <a href="../years.html#1989">results</a> were posted to comp.lang.c, comp.sources.unix, and
-alt.sources. They have been made available on a wide number of USENET
-archive sites such as uunet. The 1989 winning entries will be published in the
+<p><a href="rules.txt">Rules</a> and <a href="../years.html#1989">results</a> were posted to
+<em>comp.lang.c</em>, <em>comp.sources.unix</em> and
+<em>alt.sources</em>. They have been made available on a wide number of USENET
+archive sites such as <em>uunet</em>. The 1989 winning entries will be published in the
 <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
 Journal</a>.</p>
 <h2 id="final-comments">Final Comments</h2>


### PR DESCRIPTION
Where there is not a direct post when referring to a USENET group (for results etc.) it is no longer a link to the group itself but just made italic. That means only 1984 has it and only for the contest announcement.

In 1989 the point about the Makefiles for fubar and tromp have been clarified a bit. They were ambiguous before: it could have been read as the Makefile for ALL entries but it was only for that entry. Also since these points are about the Makefile (and in particular portability of the original or alt versions) I moved the paragraph to right under the part about running make to compile (this part has some additional fixes that will be applied later on).

The years: 1984, 1985, 1986, 1987 and 1989 were updated. There was nothing to do (for this commit) for 1988 but there is a change that will be made after discussion.