### PR TITLE
Typo and format fixes 1984/mullender/README.md

### DIFF
--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -19,10 +19,6 @@ like:
 
 ``` <!---sh-->
     ./try.sh
-
-    ./laman 4
-    ./laman 9
-    ./laman 16
 ```
 
 This code should run you in circles.

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -147,11 +147,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h2 id="try">Try:</h2>
 <p>The program accepts ONE POSITIVE number. Seeing is believing, so try things
 like:</p>
-<pre class="&lt;!---sh--&gt;"><code>    ./try.sh
-
-    ./laman 4
-    ./laman 9
-    ./laman 16</code></pre>
+<pre class="&lt;!---sh--&gt;"><code>    ./try.sh</code></pre>
 <p>This code should run you in circles.</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>Some new compilers (in 1984) dislike lines 6 and 10 of the source, so we changed
@@ -191,12 +187,12 @@ them from:</p>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/Makefile">Makefile</a> - entry Makefile</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.orig.c">laman.orig.c</a> - original source</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/try.sh">try.sh</a> - how to run</li>
-<li><a href="1984_laman.tar.bz2">1984_laman.tar.bz2</a> - download entry</li>
+<li><a href="1984_laman.tar.bz2">1984_laman.tar.bz2</a> - download entry tarball</li>
 </ul>
 <h2 id="secondary-files">Secondary files</h2>
 <ul>
 <li><a href="index.html">index.html</a> - this web page</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/README.md">README.md</a> - markdown source for index.html</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/README.md">README.md</a> - markdown source for this web page</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/.entry.json">.entry.json</a> - description of entry in JSON</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/.gitignore">.gitignore</a> - list of files that should not be committed under git</li>
 <li><a href=".path">.path</a> - directory path from top directory</li>

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -168,8 +168,8 @@ article for the quote! For a more detailed analysis, taken from the book Obfusca
 and Other Mysteries, see below. We hope that this is okay with the author of the
 book. Considering that the analysis is entirely the authors' comments we don't
 think this will be a problem. Unfortunately the excerpt was PDF and it did not
-copy paste well. We had to go back and forth to type so it's possible he made a
-typo though he also fixed some typos found in the extract. As for the other
+copy paste well. We had to go back and forth to type so it's possible we made a
+typo though we also fixed some typos found in the extract. As for the other
 comments:
 
 ### Remarks from the author:
@@ -194,7 +194,7 @@ We decided for fun to create an
 [obfuscated](https://en.wikipedia.org/wiki/Obfuscation_(software)) set of
 programs, only for the
 [PDP](https://en.wikipedia.org/wiki/Programmed_Data_Processor), to do this, but
-circumventing the channel (i.e. cheating, hence the needed obfuscation.). Our
+circumventing the channel (i.e. cheating, hence the needed obfuscation). Our
 programs worked and we handed them in.
 
 Of course, the teacher had a good laugh and then rejected our submission. (We
@@ -207,12 +207,12 @@ there](https://groups.google.com/g/net.lang.c/c/lx-TAuEyeRI/m/HdOOnNx6LC0J) and 
 it.
 
 Since we had just recently created these [obfuscated
-programs](https://en.wikipedia.org/wiki/Obfuscation_(software))) we decided we could
+programs](https://en.wikipedia.org/wiki/Obfuscation_(software)) we decided we could
 use the same technique for an obfuscated C program. We upped the ante a bit by
 making it "portable".
 
 To add to the
-[obfuscation](https://en.wikipedia.org/wiki/Obfuscation_(software))), we used
+[obfuscation](https://en.wikipedia.org/wiki/Obfuscation_(software)), we used
 different formats for the integers in the array: some in decimal, some in octal,
 some in hexadecimal, and when the value would fit, some as an ASCII character.
 
@@ -312,11 +312,11 @@ program counter points at the second
 [instruction](https://en.wikipedia.org/wiki/Instruction_set_architecture#Instructions),
 we subtract 2 from the scratch register in the second instruction. Then we
 subtract the length of the string and store the result in the location with
-label 0. This has to do with the calling sequence of [system
+label `0`. This has to do with the calling sequence of [system
 calls](https://en.wikipedia.org/wiki/System_call) on the
 [PDP](https://en.wikipedia.org/wiki/Programmed_Data_Processor). Following the
 `sys` instruction is the system call number (4 for `write()`), the address of
-the buffer (pointed to by label 0), and the length of the buffer (9). The [file
+the buffer (pointed to by label `0`), and the length of the buffer (9). The [file
 descriptor](https://en.wikipedia.org/wiki/File_descriptor) is in register `r0`.
 The rest of the code implements a delay loop. In each iteration, a non-existing
 system call (55) slows things down.
@@ -358,18 +358,18 @@ The first word (after the label `vax`) is the
 [PDP](https://en.wikipedia.org/wiki/Programmed_Data_Processor) [branch
 instruction](https://en.wikipedia.org/wiki/Branch_(computer_science)).
 [PDP](https://en.wikipedia.org/wiki/Programmed_Data_Processor) branch
-instructions are octal `400+` the distance divided by 2.  The string that both
+instructions are octal `400` + the distance divided by `2`.  The string that both
 the [PDP](https://en.wikipedia.org/wiki/Programmed_Data_Processor) and
 [VAX](https://en.wikipedia.org/wiki/VAX)
 programs use is after the `str` label, and the
 [PDP](https://en.wikipedia.org/wiki/Programmed_Data_Processor) code is after the
-pdp label.
+`pdp` label.
 
 On the [VAX](https://en.wikipedia.org/wiki/VAX), the program
 [pushes](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)) 9 (the length
 of the string), the address of the string and 1 (the [file
 descriptor](https://en.wikipedia.org/wiki/File_descriptor) on the
-[stack](https://en.wikipedia.org/wiki/Stack_(abstract_data_type)) and calls
+[stack](https://en.wikipedia.org/wiki/Stack_(abstract_data_type))) and calls
 `write(2)`. Since we didn't know the exact calling sequence for [system
 calls](https://en.wikipedia.org/wiki/System_call), we just copied the source for
 the `write(2)` system call stub into our program. After `write(2)` finishes, the
@@ -445,7 +445,8 @@ compiled in modern systems.
     }
 ```
 
-As can be seen, there is a slight preference for decimal, and also a character
+As can be seen, there is a slight preference for
+[decimal](https://en.wikipedia.org/wiki/Decimal), and also a character
 format is sometimes used, but only if the data is a printable ASCII character.
 
 When we ran this program, we were almost completely satisfied with the result.
@@ -455,9 +456,10 @@ Since everybody knows what a [PDP-11](https://en.wikipedia.org/wiki/PDP-11)
 branch instruction looks like (everyone knows that the traditional magic word
 for an executable, `0407`, is a [PDP-11](https://en.wikipedia.org/wiki/PDP-11)
 [branch](https://en.wikipedia.org/wiki/Branch_(computer_science))), we changed
-that to decimal. After checking the size of the resulting program we saw that it
-was one byte too long. The limit was 512 bytes, and our program was 513 bytes.
-So we changed the word `and` in the comment to `&&`.
+that to [decimal](https://en.wikipedia.org/wiki/Decimal). After checking the
+size of the resulting program we saw that it was one byte too long. The limit
+was 512 bytes, and our program was 513 bytes.  So we changed the word `and` in
+the comment to `&&`.
 
 
 <!--

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -241,8 +241,8 @@ article for the quote! For a more detailed analysis, taken from the book Obfusca
 and Other Mysteries, see below. We hope that this is okay with the author of the
 book. Considering that the analysis is entirely the authors’ comments we don’t
 think this will be a problem. Unfortunately the excerpt was PDF and it did not
-copy paste well. We had to go back and forth to type so it’s possible he made a
-typo though he also fixed some typos found in the extract. As for the other
+copy paste well. We had to go back and forth to type so it’s possible we made a
+typo though we also fixed some typos found in the extract. As for the other
 comments:</p>
 <h3 id="remarks-from-the-author">Remarks from the author:</h3>
 <p>I have never known a lot about the <a href="https://en.wikipedia.org/wiki/VAX">VAX</a>
@@ -263,7 +263,7 @@ channel. This channel was simulated with a pair of
 <a href="https://en.wikipedia.org/wiki/Obfuscation_(software)">obfuscated</a> set of
 programs, only for the
 <a href="https://en.wikipedia.org/wiki/Programmed_Data_Processor">PDP</a>, to do this, but
-circumventing the channel (i.e. cheating, hence the needed obfuscation.). Our
+circumventing the channel (i.e. cheating, hence the needed obfuscation). Our
 programs worked and we handed them in.</p>
 <p>Of course, the teacher had a good laugh and then rejected our submission. (We
 knew him well, so we could get away with this.)</p>
@@ -273,11 +273,11 @@ where we read a bunch of newsgroups. I’m sure it was <a href="https://groups.g
 there</a> and we saw
 it.</p>
 <p>Since we had just recently created these <a href="https://en.wikipedia.org/wiki/Obfuscation_(software)">obfuscated
-programs</a>) we decided we could
+programs</a> we decided we could
 use the same technique for an obfuscated C program. We upped the ante a bit by
 making it “portable”.</p>
 <p>To add to the
-<a href="https://en.wikipedia.org/wiki/Obfuscation_(software)">obfuscation</a>), we used
+<a href="https://en.wikipedia.org/wiki/Obfuscation_(software)">obfuscation</a>, we used
 different formats for the integers in the array: some in decimal, some in octal,
 some in hexadecimal, and when the value would fit, some as an ASCII character.</p>
 <p>The rest is history.</p>
@@ -357,11 +357,11 @@ program counter points at the second
 <a href="https://en.wikipedia.org/wiki/Instruction_set_architecture#Instructions">instruction</a>,
 we subtract 2 from the scratch register in the second instruction. Then we
 subtract the length of the string and store the result in the location with
-label 0. This has to do with the calling sequence of <a href="https://en.wikipedia.org/wiki/System_call">system
+label <code>0</code>. This has to do with the calling sequence of <a href="https://en.wikipedia.org/wiki/System_call">system
 calls</a> on the
 <a href="https://en.wikipedia.org/wiki/Programmed_Data_Processor">PDP</a>. Following the
 <code>sys</code> instruction is the system call number (4 for <code>write()</code>), the address of
-the buffer (pointed to by label 0), and the length of the buffer (9). The <a href="https://en.wikipedia.org/wiki/File_descriptor">file
+the buffer (pointed to by label <code>0</code>), and the length of the buffer (9). The <a href="https://en.wikipedia.org/wiki/File_descriptor">file
 descriptor</a> is in register <code>r0</code>.
 The rest of the code implements a delay loop. In each iteration, a non-existing
 system call (55) slows things down.</p>
@@ -397,17 +397,17 @@ program that we came up with is as follows:</p>
 <a href="https://en.wikipedia.org/wiki/Programmed_Data_Processor">PDP</a> <a href="https://en.wikipedia.org/wiki/Branch_(computer_science)">branch
 instruction</a>.
 <a href="https://en.wikipedia.org/wiki/Programmed_Data_Processor">PDP</a> branch
-instructions are octal <code>400+</code> the distance divided by 2. The string that both
+instructions are octal <code>400</code> + the distance divided by <code>2</code>. The string that both
 the <a href="https://en.wikipedia.org/wiki/Programmed_Data_Processor">PDP</a> and
 <a href="https://en.wikipedia.org/wiki/VAX">VAX</a>
 programs use is after the <code>str</code> label, and the
 <a href="https://en.wikipedia.org/wiki/Programmed_Data_Processor">PDP</a> code is after the
-pdp label.</p>
+<code>pdp</code> label.</p>
 <p>On the <a href="https://en.wikipedia.org/wiki/VAX">VAX</a>, the program
 <a href="https://en.wikipedia.org/wiki/Stack_(abstract_data_type)">pushes</a> 9 (the length
 of the string), the address of the string and 1 (the <a href="https://en.wikipedia.org/wiki/File_descriptor">file
 descriptor</a> on the
-<a href="https://en.wikipedia.org/wiki/Stack_(abstract_data_type)">stack</a> and calls
+<a href="https://en.wikipedia.org/wiki/Stack_(abstract_data_type)">stack</a>) and calls
 <code>write(2)</code>. Since we didn’t know the exact calling sequence for <a href="https://en.wikipedia.org/wiki/System_call">system
 calls</a>, we just copied the source for
 the <code>write(2)</code> system call stub into our program. After <code>write(2)</code> finishes, the
@@ -479,7 +479,8 @@ compiled in modern systems.</p>
             printf(&quot;};\n&quot;);
         }
     }</code></pre>
-<p>As can be seen, there is a slight preference for decimal, and also a character
+<p>As can be seen, there is a slight preference for
+<a href="https://en.wikipedia.org/wiki/Decimal">decimal</a>, and also a character
 format is sometimes used, but only if the data is a printable ASCII character.</p>
 <p>When we ran this program, we were almost completely satisfied with the result.
 The only problem we had was that the program had chosen an
@@ -488,9 +489,10 @@ Since everybody knows what a <a href="https://en.wikipedia.org/wiki/PDP-11">PDP-
 branch instruction looks like (everyone knows that the traditional magic word
 for an executable, <code>0407</code>, is a <a href="https://en.wikipedia.org/wiki/PDP-11">PDP-11</a>
 <a href="https://en.wikipedia.org/wiki/Branch_(computer_science)">branch</a>), we changed
-that to decimal. After checking the size of the resulting program we saw that it
-was one byte too long. The limit was 512 bytes, and our program was 513 bytes.
-So we changed the word <code>and</code> in the comment to <code>&amp;&amp;</code>.</p>
+that to <a href="https://en.wikipedia.org/wiki/Decimal">decimal</a>. After checking the
+size of the resulting program we saw that it was one byte too long. The limit
+was 512 bytes, and our program was 513 bytes. So we changed the word <code>and</code> in
+the comment to <code>&amp;&amp;</code>.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.
@@ -518,14 +520,14 @@ So we changed the word <code>and</code> in the comment to <code>&amp;&amp;</code
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/Makefile">Makefile</a> - entry Makefile</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.alt.c">mullender.alt.c</a> - alternative source</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.orig.c">mullender.orig.c</a> - original source</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/a.out.h">a.out.h</a> - header file for gentab.c for compatibility with 1984 systems</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/gentab.c">gentab.c</a> - author tool to generate code</li>
-<li><a href="1984_mullender.tar.bz2">1984_mullender.tar.bz2</a> - download entry</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/a.out.h">a.out.h</a> - header file for gentab.c for compatibility with 1984 systems</li>
+<li><a href="1984_mullender.tar.bz2">1984_mullender.tar.bz2</a> - download entry tarball</li>
 </ul>
 <h2 id="secondary-files">Secondary files</h2>
 <ul>
 <li><a href="index.html">index.html</a> - this web page</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/README.md">README.md</a> - markdown source for index.html</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/README.md">README.md</a> - markdown source for this web page</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/.entry.json">.entry.json</a> - description of entry in JSON</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/.gitignore">.gitignore</a> - list of files that should not be committed under git</li>
 <li><a href=".path">.path</a> - directory path from top directory</li>

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -283,6 +283,7 @@ clobber: clean
 	${RM} -rf *.dSYM
 	${RM} -f misaka2.c misaka3.c misaka4.c misaka5.c
 	${RM} -f misaka6.c misaka7.c misaka8.c misaka9.c
+	${RM} -f same_as_long_cat.txt long_cat.txt
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/faq.html
+++ b/faq.html
@@ -916,7 +916,7 @@ judging the IOCCC. A Unix man page for <code>cb</code>
 usually away with <code>stty echo</code>. Sometimes you can also get away with <code>stty sane</code>.
 <code>reset</code> does the most but note that it will clear the screen (obviously <code>clear</code>
 will too but it won’t reset the terminal).</p>
-<h3 id="faq-3.7-how-do-i-run-an-ioccc-entry-that-requires-x11"><a name="faq3_7"></a><a name="X11macos"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC entry that requires X11?</h3>
+<h3 id="faq-3.7-how-do-i-run-an-ioccc-entry-that-requires-x11"><a name="faq3_7"></a><a name="X11macOS"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC entry that requires X11?</h3>
 <h4 id="generally-to-compile-and-run-an-ioccc-entry-that-requires-x11"><a name="X11_general"></a>Generally, to compile and run an IOCCC entry that requires X11:</h4>
 <p>You must have the X11 related include files and X11 libraries in order to
 compile the IOCCC entry. In order to do this you will need to install Xorg and
@@ -987,7 +987,7 @@ shell</a>.</p>
 <p>As an example we will use <a href="1993/jonth/index.html">1993/jonth</a> which works
 with macOS 14.2.1 (macOS Sonoma).</p>
 <p>First of all you will need to install the <a href="https://www.xquartz.org">most recent
-XQuartz</a>, preferably on an <a href="https://support.apple.com/macos">Apple supported version of
+XQuartz</a>, preferably on an <a href="https://support.apple.com/macOS">Apple supported version of
 macOS, preferably the most recent version</a>.
 After it is installed, open the “XQuartz” application (usually located in
 <code>/Applications/Utilities/XQuartz.app</code>) by typing at the command line:</p>
@@ -1033,7 +1033,7 @@ may be helpful:</p>
 <pre class="&lt;!---sh--&gt;"><code>    sudo yum install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
 <p><strong>IMPORTANT NOTE</strong>: The <a href="#Xorg_deprecated">X.org server has been deprecated</a>.
 See the above note for details.</p>
-<h4 id="package-website">package website</h4>
+<h4 id="package-website">Package website</h4>
 <p>First, see the above note on <a href="#X11_general">installing and starting Xorg</a>.</p>
 <p>See the <a href="https://x.org/wiki/">X.org</a> foundation web site.</p>
 <p><strong>IMPORTANT NOTE</strong>: The <a href="#Xorg_deprecated">X.org server has been deprecated</a>.
@@ -1063,7 +1063,7 @@ the package website.</p>
 <p>Then to install SDL and SDL2, execute the following command:</p>
 <pre class="&lt;!---sh--&gt;"><code>    brew install sdl2 sdl12-compat
     eval &quot;$(opt/homebrew/bin/brew shellenv)&quot;</code></pre>
-<h5 id="macos-via-macports">macos via MacPorts</h5>
+<h5 id="macos-via-macports">macOS via MacPorts</h5>
 <p>If you haven’t already, install
 <a href="https://www.macports.org/install.php">MacPorts</a>. Then run:</p>
 <pre class="&lt;!---sh--&gt;"><code>    sudo port install libsdl libsdl2</code></pre>
@@ -1082,7 +1082,7 @@ the package website.</p>
 feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.</p>
-<h4 id="package-website-1">package website</h4>
+<h4 id="package-website-1">Package website</h4>
 <p>Go to the <a href="https://www.libsdl.org">SDL website</a> and follow their instructions
 for downloading, installing and using SDL.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>
@@ -1105,7 +1105,7 @@ macOS with alternative methods for macOS and different package managers with Lin
 <p>and agree to the terms and conditions and proceed with the install.</p>
 <h5 id="macos-via-homebrew-1">macOS via Homebrew</h5>
 <p>Not applicable, see above.</p>
-<h5 id="macos-via-macports-1">macos via MacPorts</h5>
+<h5 id="macos-via-macports-1">macOS via MacPorts</h5>
 <p>Not applicable, see above.</p>
 <h4 id="debian-based-linux-2">Debian based Linux</h4>
 <p>Execute the following as root or via sudo:</p>
@@ -1116,7 +1116,7 @@ macOS with alternative methods for macOS and different package managers with Lin
 feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.</p>
-<h4 id="package-website-2">package website</h4>
+<h4 id="package-website-2">Package website</h4>
 <p>Go to the <a href="https://invisible-island.net/ncurses/">ncurses website</a> and follow their instructions
 for downloading, installing and using ncurses.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>
@@ -1141,7 +1141,7 @@ install depends on your OS.</p>
 <h4 id="debian-based-linux-3">Debian based Linux</h4>
 <p>Usually the index.html file will explain how to use it under Debian so we do not
 include this here, at least for now.</p>
-<h4 id="package-website-3">package website</h4>
+<h4 id="package-website-3">Package website</h4>
 <p>Not applicable, see above.</p>
 <h4 id="other-linux-distributions-3">Other Linux distributions</h4>
 <p>Usually the index.html file will explain how to use it under Linux so we do not
@@ -1294,7 +1294,7 @@ the package website.</p>
 <p>If you have not already done so, install <a href="https://brew.sh">Homebrew</a>.</p>
 <p>Then to install netpbm, execute the following command:</p>
 <pre class="&lt;!---sh--&gt;"><code>    brew install netpbm</code></pre>
-<h5 id="macos-via-macports-3">macos via MacPorts</h5>
+<h5 id="macos-via-macports-3">macOS via MacPorts</h5>
 <p>If you haven’t already, install
 <a href="https://www.macports.org/install.php">MacPorts</a>. Then run:</p>
 <pre class="&lt;!---sh--&gt;"><code>    sudo port install libnetpbm netpbm</code></pre>
@@ -1307,7 +1307,7 @@ the package website.</p>
 feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.</p>
-<h4 id="package-website-4">package website</h4>
+<h4 id="package-website-4">Package website</h4>
 <p>Go to the <a href="https://netpbm.sourceforge.net">netpbm website</a> and follow their instructions
 for downloading, installing and using netpbm.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>
@@ -1328,7 +1328,7 @@ the package website.</p>
 <p>If you have not already done so, install <a href="https://brew.sh">Homebrew</a>.</p>
 <p>Then to install libjpeg-turbo, execute the following command:</p>
 <pre class="&lt;!---sh--&gt;"><code>    brew install libjpeg-turbo</code></pre>
-<h5 id="macos-via-macports-4">macos via MacPorts</h5>
+<h5 id="macos-via-macports-4">macOS via MacPorts</h5>
 <p>If you haven’t already, install
 <a href="https://www.macports.org/install.php">MacPorts</a>. Then run:</p>
 <pre class="&lt;!---sh--&gt;"><code>    sudo port install libjpeg-turbo libjpeg-turbo-devel</code></pre>
@@ -1341,7 +1341,7 @@ the package website.</p>
 feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.</p>
-<h4 id="package-website-5">package website</h4>
+<h4 id="package-website-5">Package website</h4>
 <p>Go to the <a href="https://www.libjpeg-turbo.org">libjpeg-turbo website</a> and follow their instructions
 for downloading, installing and using libjpeg-turbo.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>
@@ -1362,7 +1362,7 @@ the package website.</p>
 <p>If you have not already done so, install <a href="https://brew.sh">Homebrew</a>.</p>
 <p>Then to install ImageMagick, execute the following command:</p>
 <pre class="&lt;!---sh--&gt;"><code>    brew install ImageMagick</code></pre>
-<h5 id="macos-via-macports-5">macos via MacPorts</h5>
+<h5 id="macos-via-macports-5">macOS via MacPorts</h5>
 <p>If you haven’t already, install
 <a href="https://www.macports.org/install.php">MacPorts</a>. Then run:</p>
 <pre class="&lt;!---sh--&gt;"><code>    sudo port install ImageMagick</code></pre>
@@ -1375,7 +1375,7 @@ the package website.</p>
 feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.</p>
-<h4 id="package-website-6">package website</h4>
+<h4 id="package-website-6">Package website</h4>
 <p>Go to the <a href="https://imagemagick.org">ImageMagick website</a> and follow their instructions
 for downloading, installing and using ImageMagick.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>
@@ -1411,7 +1411,7 @@ you might look to install OpenGL via Homebrew or MacPorts.</p>
 feature of the package manager to determine which packages you need to install.
 Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.</p>
-<h4 id="package-website-7">package website</h4>
+<h4 id="package-website-7">Package website</h4>
 <p>Go to the <a href="https://vulkan.org">Vulkan website</a> and follow their instructions
 for downloading, installing and using OpenGL.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>

--- a/faq.md
+++ b/faq.md
@@ -1039,7 +1039,7 @@ usually away with `stty echo`. Sometimes you can also get away with `stty sane`.
 will too but it won't reset the terminal).
 
 
-### <a name="faq3_7"></a><a name="X11macos"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC entry that requires X11?
+### <a name="faq3_7"></a><a name="X11macOS"></a><a name="X11"></a>FAQ 3.7: How do I run an IOCCC entry that requires X11?
 
 
 #### <a name="X11_general"></a>Generally, to compile and run an IOCCC entry that requires X11:
@@ -1138,7 +1138,7 @@ with macOS 14.2.1 (macOS Sonoma).
 
 First of all you will need to install the [most recent
 XQuartz](https://www.xquartz.org), preferably on an [Apple supported version of
-macOS, preferably the most recent version](https://support.apple.com/macos).
+macOS, preferably the most recent version](https://support.apple.com/macOS).
 After it is installed, open the "XQuartz" application (usually located in
 `/Applications/Utilities/XQuartz.app`) by typing at the command line:
 
@@ -1216,7 +1216,7 @@ For systems that have the `yum(1)` command:
 See the above note for details.
 
 
-#### package website
+#### Package website
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
@@ -1280,7 +1280,7 @@ Then to install SDL and SDL2, execute the following command:
 ```
 
 
-##### macos via MacPorts
+##### macOS via MacPorts
 
 If you haven't already, install
 [MacPorts](https://www.macports.org/install.php). Then run:
@@ -1325,7 +1325,7 @@ Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
 
-#### package website
+#### Package website
 
 Go to the [SDL website](https://www.libsdl.org) and follow their instructions
 for downloading, installing and using SDL.
@@ -1375,7 +1375,7 @@ and agree to the terms and conditions and proceed with the install.
 Not applicable, see above.
 
 
-##### macos via MacPorts
+##### macOS via MacPorts
 
 Not applicable, see above.
 
@@ -1399,7 +1399,7 @@ Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
 
-#### package website
+#### Package website
 
 Go to the [ncurses website](https://invisible-island.net/ncurses/) and follow their instructions
 for downloading, installing and using ncurses.
@@ -1454,7 +1454,7 @@ Usually the index.html file will explain how to use it under Debian so we do not
 include this here, at least for now.
 
 
-#### package website
+#### Package website
 
 Not applicable, see above.
 
@@ -1700,7 +1700,7 @@ Then to install netpbm, execute the following command:
 ```
 
 
-##### macos via MacPorts
+##### macOS via MacPorts
 
 If you haven't already, install
 [MacPorts](https://www.macports.org/install.php). Then run:
@@ -1730,7 +1730,7 @@ Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
 
-#### package website
+#### Package website
 
 Go to the [netpbm website](https://netpbm.sourceforge.net) and follow their instructions
 for downloading, installing and using netpbm.
@@ -1777,7 +1777,7 @@ Then to install libjpeg-turbo, execute the following command:
 ```
 
 
-##### macos via MacPorts
+##### macOS via MacPorts
 
 If you haven't already, install
 [MacPorts](https://www.macports.org/install.php). Then run:
@@ -1808,7 +1808,7 @@ Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
 
-#### package website
+#### Package website
 
 Go to the [libjpeg-turbo website](https://www.libjpeg-turbo.org) and follow their instructions
 for downloading, installing and using libjpeg-turbo.
@@ -1853,7 +1853,7 @@ Then to install ImageMagick, execute the following command:
 ```
 
 
-##### macos via MacPorts
+##### macOS via MacPorts
 
 If you haven't already, install
 [MacPorts](https://www.macports.org/install.php). Then run:
@@ -1883,7 +1883,7 @@ Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
 
-#### package website
+#### Package website
 
 Go to the [ImageMagick website](https://imagemagick.org) and follow their instructions
 for downloading, installing and using ImageMagick.
@@ -1955,7 +1955,7 @@ Note that you might have to install both the library and the developmental
 packages: one for compiling and one for linking / running.
 
 
-#### package website
+#### Package website
 
 Go to the [Vulkan website](https://vulkan.org) and follow their instructions
 for downloading, installing and using OpenGL.


### PR DESCRIPTION

Numerous typo fixes (like in links with an extraneous ')') and format fixes
were done.

Rebuilt index.html.