### PR TITLE
Improve make help and typo fixes in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ help:
 	@echo "make gen_top_html - generate a number of the top level HTML files from markdown"
 	@echo "make quick_entry_index - build winner index.html files that might be out of date"
 	@echo "make quick_www - generate html files more quickly, checking timestamps"
-	@echo "make www - build html pages for website"
+	@echo "make www - build html pages for web site"
 	@echo
 	@echo "make untar_entry_tarball - untar all entry tarballs"
 	@echo "make untar_year_tarball - untar all year level tarballs"

--- a/Makefile
+++ b/Makefile
@@ -258,33 +258,33 @@ indent.c:
 # here!
 #
 help:
-	@echo make genpath
-	@echo make genfilelist
-	@echo make verify_entry_files
-	@echo make sort_gitignore
-	@echo make gen_authors
-	@echo make gen_location
-	@echo make gen_years
-	@echo make entry_index
-	@echo make gen_other_html
-	@echo make gen_year_index
-	@echo make gen_status
-	@echo make gen_top_html
-	@echo make quick_entry_index
-	@echo make quick_www
-	@echo make www
+	@echo "make genpath - form top level .top, YYYY level .year and winner .path files"
+	@echo "make genfilelist - generate YYYY level .filelist"
+	@echo "make verify_entry_files - check to be sure all files in all entries exist"
+	@echo "make sort_gitignore - sort .gitignore files according to rules in bin/sgi.sh"
+	@echo "make gen_authors - generate the top level authors.html page"
+	@echo "make gen_location - generate the top level location.html page"
+	@echo "make gen_years - generate the top level years.html page"
+	@echo "make entry_index - force the build of ALL winner index.html files"
+	@echo "make gen_other_html - build entry HTML files from markdown other than README.md"
+	@echo "make gen_year_index - generate year level index.html files using the"
+	@echo "make gen_status - generate status.json and status.html"
+	@echo "make gen_top_html - generate a number of the top level HTML files from markdown"
+	@echo "make quick_entry_index - build winner index.html files that might be out of date"
+	@echo "make quick_www - generate html files morem quickly, checking timestamps"
+	@echo "make www - build html pages for website"
 	@echo
-	@echo make untar_entry_tarball
-	@echo make untar_year_tarball
+	@echo "make untar_entry_tarball - untar all entry tarballs"
+	@echo "make untar_year_tarball - untar all year level tarballs"
 	@echo
-	@echo make form_entry_tarball
-	@echo make form_year_tarball
-	@echo make tar
+	@echo "make form_entry_tarball - form all entry compressed tarballs"
+	@echo "make form_year_tarball - form all IOCCC year level compressed tarballs"
+	@echo "make tar - build all tarballs"
 	@echo
-	@echo make gen_sitemap
-	@echo make timestamp
+	@echo "make gen_sitemap - generate the XML sitemap"
+	@echo "make timestamp - generate things with timestamps (status, sitemap etc.)"
 	@echo
-	@echo make update
+	@echo "make update - update everything on the web site"
 
 # form the top level .top, YYYY level .year and winner level .path files
 #
@@ -335,7 +335,7 @@ verify_entry_files: ${ALL_RUN} ${CHK_ENTRY}
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	${ALL_RUN} -v 3 ${CHK_ENTRY}
 
-# check to be sure all files in all entries exist
+# sort .gitignore files according to rules in bin/sgi.sh
 #
 sort_gitignore: ${ALL_RUN} ${SORT_GITIGNORE}
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
@@ -388,7 +388,7 @@ thanks: ${GEN_TOP_HTML} thanks-for-help.md
 	@${GEN_TOP_HTML}
 	@echo "... and thanks for all the fish :-)"
 
-# generate build entry HTML files from markdown other than README.md to index.html HTML files
+# build entry HTML files from markdown other than README.md to index.html
 #
 gen_other_html: ${GEN_OTHER_HTML}
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
@@ -471,7 +471,7 @@ untar_entry_tarball: ${ALL_RUN}
 	${MAKE} verify_entry_files
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
-# untar all entry tarballs
+# untar all year level tarballs
 #
 untar_year_tarball: ${ALL_RUN}
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
@@ -505,7 +505,7 @@ tar:
 	${MAKE} form_year_tarball
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
-# generate a status.json and status.html
+# generate status.json and status.html
 #
 gen_status: ${GEN_STATUS}
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ help:
 	@echo "make gen_status - generate status.json and status.html"
 	@echo "make gen_top_html - generate a number of the top level HTML files from markdown"
 	@echo "make quick_entry_index - build winner index.html files that might be out of date"
-	@echo "make quick_www - generate html files morem quickly, checking timestamps"
+	@echo "make quick_www - generate html files more quickly, checking timestamps"
 	@echo "make www - build html pages for website"
 	@echo
 	@echo "make untar_entry_tarball - untar all entry tarballs"


### PR DESCRIPTION
The make help rule now has a summary of each rule so that one need not check the Makefile every time. Of course for more details they still have to but it's helpful for those who know what they need to do but still might not remember all the rule names (as there are quite a few).

Typo fixes include things like incorrect statements (in comments) of what a rule does, some being yank paste errors.