### PR TITLE
Fix stray and bogus file 'z' after make www

### DIFF
--- a/bin/md2html.sh
+++ b/bin/md2html.sh
@@ -2075,7 +2075,7 @@ if [[ -n $PANDOC_WRAPPER ]]; then
 	    echo "$0: debug[5]: about to execute:" \
 		 "$PERL_TOOL -0 -p -i -e $PERL_LINE -- $TMP_INDEX_HTML" 1>&2
 	fi
-	cp "$TMP_STRIPPED_MD" z
+
 	"$PERL_TOOL" -0 -p -i -e "$PERL_LINE" -- "$TMP_INDEX_HTML"
 	if [[ $status -ne 0 ]]; then
 	    echo "$0: ERROR: pandoc wrapper tool:" \

--- a/faq.html
+++ b/faq.html
@@ -1290,7 +1290,7 @@ further down for different instructions. Otherwise: in particular you must:</p>
 <ul>
 <li><a href="https://www.gnome.org">Gnome</a> terminal application</li>
 <li><a href="https://kde.org">KDE</a> terminal application</li>
-<li><code>xterm(</code>) terminal application</li>
+<li><code>xterm(1)</code> terminal application</li>
 </ul>
 <p>See below for various system related hints that may be of help.</p>
 <div id="Xorg_deprecated">

--- a/faq.md
+++ b/faq.md
@@ -1175,7 +1175,7 @@ By X11 terminal application we suggest one of:
 
 * [Gnome](https://www.gnome.org) terminal application
 * [KDE](https://kde.org) terminal application
-* `xterm(`) terminal application
+* `xterm(1)` terminal application
 
 See below for various system related hints that may be of help.
 


### PR DESCRIPTION
The problem is that bin/md2html.sh had the line:

        cp "$TMP_STRIPPED_MD" z

It did not use the file and it did not delete it either.
