### PR TITLE
Fix links/text in 2020/ferguson[12]

### DIFF
--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -60,7 +60,7 @@ and non-zero).
     size to grow every time you eat a bug. Default 5; negative
     values are allowed. 'Negativity' creates for fun gameplay modes with
     enough creativity. See [gameplay.html](gameplay.html)
-    GitHub) as well as [play.sh](%%REPO_URL%%/2020/ferguson1/play.sh) for some examples.
+    as well as [play.sh](%%REPO_URL%%/2020/ferguson1/play.sh) for some examples.
 
 * **SHED**<br>
     every **SHED** movements you will grow (> 0), shrink (< 0) or
@@ -578,11 +578,6 @@ the years and who I owe a great deal to. Thank you for believing in me and my
 programming abilities (and other abilities) even when I couldn't believe in
 myself! Very much appreciated especially coming from an amazing programmer who I
 have huge admiration for!
-
-I want to thank Ilya Kurdyukov for his helpful comments, suggestions and
-reporting the (undocumented) 'problem' about half-width/full-width char spacing.
-He's been playing with some versions of his own and will have them on GitHub
-after the 2020 IOCCC winning entries have been published.
 
 Finally I want to thank Leo Broukhis, Simon Cooper and Landon Curt Noll for
 continuing to hold the contest after all these years - and for having selected

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -437,7 +437,7 @@ MAXSIZE</strong> you win <em>before</em> you grow to the full size!</p></li>
 size to grow every time you eat a bug. Default 5; negative
 values are allowed. ‘Negativity’ creates for fun gameplay modes with
 enough creativity. See <a href="gameplay.html">gameplay.html</a>
-GitHub) as well as <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/play.sh">play.sh</a> for some examples.</p></li>
+as well as <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/play.sh">play.sh</a> for some examples.</p></li>
 <li><p><strong>SHED</strong><br>
 every <strong>SHED</strong> movements you will grow (&gt; 0), shrink (&lt; 0) or
 stay the same length (0) by the <strong>SHEDS</strong> (below) value. Again
@@ -864,10 +864,6 @@ the years and who I owe a great deal to. Thank you for believing in me and my
 programming abilities (and other abilities) even when I couldn’t believe in
 myself! Very much appreciated especially coming from an amazing programmer who I
 have huge admiration for!</p>
-<p>I want to thank Ilya Kurdyukov for his helpful comments, suggestions and
-reporting the (undocumented) ‘problem’ about half-width/full-width char spacing.
-He’s been playing with some versions of his own and will have them on GitHub
-after the 2020 IOCCC winning entries have been published.</p>
 <p>Finally I want to thank Leo Broukhis, Simon Cooper and Landon Curt Noll for
 continuing to hold the contest after all these years - and for having selected
 my entries. It’s a huge honour; thank you! I also happen to <strong>love</strong> your

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -115,17 +115,15 @@ There is a good deal of useful documentation that is provided with this entry:
 ```
 
 
-* [recode.html][] (or [recode.html](recode.html) if reading on GitHub)
+* [recode.html][]
     - Some useful information about [recode.c](%%REPO_URL%%/2020/ferguson2/recode.c)
 
 
-* [chocolate-cake.html][] (or [chocolate-cake.html](chocolate-cake.html) if reading on GitHub)
-    - Because most of us could use some *Double-layered Chocolate Fudge Cake*!
+* [encrypted.html][]
     - NOTE: see [recode.html][] (or [recode.html](recode.html) for details about how to decrypt this!
 
 
 [recode.html]: recode.html
-[chocolate-cake.html]: chocolate-cake.html
 
 
 ## Author's remarks:
@@ -285,14 +283,11 @@ After that you can input the string and it'll go from there.
 #### Example run
 </div>
 
-BTW: There's a much more entertaining (and delicious) challenge or exercise in
-[recode.html][] (if you're reading this on GitHub check the
-[recode.html](recode.html) file instead); this involves [chocolate-cake.html][] (if
-on GitHub, see [here](chocolate-cake.html), though one might need a different kind
-of exercise after taking up the challenge! :-) These however show the general
-program as well as how to use the two winning entries of the [Morse
+BTW: There's a much more entertaining way to explore this entry. See
+[recode.html][] for more details. There's a secret message that one might like
+to decipher. These however show the general program as well as how to use the
+two winning entries of the [Morse
 code](https://en.wikipedia.org/wiki/Morse_code) that I referred to earlier:
-
 
 ``` <!---sh-->
     $ ./prog -
@@ -443,8 +438,10 @@ I didn't think of everything. My entry was meant to be a simulator only as far
 as the ciphering goes but I thought this would make it much more interesting:
 make it more flexible by a wrapper program.
 
-For examples using it (and a delicious challenge) see [recode.html][] (or
-[recode.html](recode.html) if reading on GitHub). See also the [recode.1][] and
+For examples using it you might enjoy a fun message that I have encrypted using
+a key that you should be able to figure out (it's in a list). This might lead to
+something else fun as well but I will not say more than that. Anyway, see
+[recode.html](recode.html) for more details. See also the [recode.1][] and
 [enigma.1][] man pages.
 
 
@@ -497,8 +494,8 @@ by itself. However for the reflector I did `1A` but it only expects 1 char! So
 will that mean that the plugboard pairs are off? Yes it does seem to be so. This
 is buffering at play I believe but it's useful for allowing the `recode` program
 to easily configure the Enigma machine. In the [recode.html](recode.html) file
-(or [recode.html](recode.html) if reading on GitHub) file I give a hint as to how
-this could be fixed but the caveat is it would necessitate a need for rewriting
+file I give a hint as to how this could be fixed but the caveat is it would
+necessitate a need for rewriting
 [recode.c](%%REPO_URL%%/2020/ferguson2/recode.c).
 
 There's another thing to be aware of and that's the way the ranges are enforced.
@@ -511,13 +508,10 @@ same applies: in C 0-1 but in human it's 1-2 (technically these were reflectors 
 the Enigma machine which I display by name in [recode.c](%%REPO_URL%%/2020/ferguson2/recode.c) just like
 with the rotors).
 
-For more information see [recode.html][] (or [recode.html](recode.html) if viewing on
-GitHub).
+For more information see [recode.html][].
 
 BTW: If you need a reminder to go to the gym just do your Enigma ABCs and it
-should help you remember (though not at this time in our world it might help you
-later on?). This might become even more useful after the challenge is accepted,
-accomplished and made use of! :)
+should help you remember:
 
 ``` <!---sh-->
     $ echo ABC | ./prog
@@ -584,14 +578,7 @@ To encipher:
 The file [obfuscation.key][] is the key to decipher/encipher
 [obfuscation.txt][].
 
-For the lazy [obfuscation.html](obfuscation.html) has the deciphered version. I am afraid I'm not
-so inclined to do that for the cake recipe: the idea there is to make it a fun
-exercise that when solved unlocks a wonderful double-layered chocolate fudge
-cake recipe. But given that my ['Don't tread on me'](../ferguson1/index.html) award entry
-also has the [recipe](../ferguson1/chocolate-cake.html)
-([ferguson1/chocolate-cake.html](../ferguson1/chocolate-cake.html) if reading on
-GitHub), not enciphered, one might just go there instead. Still it's a fun way
-to explore this entry.
+For the lazy [obfuscation.html](obfuscation.html) has the deciphered version.
 
 As for the [obfuscation.key][] file if you observe the contents you'll find the
 word `OBFUSCATION`:
@@ -616,7 +603,7 @@ choose from a set of rotors and there were no duplicates. This shouldn't be a
 problem here however except that it wouldn't be a possible configuration of the
 real Enigma machine. The `recode` program *however does validate this* (except
 when reading in settings via the `-R` option which I explain in the
-[recode.html][] file ([recode.html](recode.html) on GitHub).
+[recode.html][] file.
 
 *   The way the [plugboard](https://www.cryptomuseum.com/crypto/enigma/i/sb.htm)
 \- for the machines that had them - is, if you connect A to B then no other
@@ -861,7 +848,6 @@ that.
 [enigma.1]: enigma.1
 [recode.1]: recode.1
 [recode.html]: recode.html
-[chocolate-cake.html]: chocolate-cake.html
 [recode.c]: recode.c
 [obfuscation.html]: obfuscation.html
 [obfuscation.txt]: obfuscation.txt
@@ -942,7 +928,6 @@ as well as the award titles. And yes indeed 'most of us could use
 If you wish to contact me please do so. Please contact via mastodon. You can try
 email but I'm more likely to respond to mastodon messages.
 
-[Double-layered Chocolate Fudge Cake]: chocolate-cake.html
 [Heer (army)]: https://en.wikipedia.org/wiki/German_Army_(1935%E2%80%931945)
 [Heer]: https://en.wikipedia.org/wiki/German_Army_(1935%E2%80%931945)
 [Luftwaffe]: https://en.wikipedia.org/wiki/Luftwaffe

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -464,13 +464,12 @@ out! Can you figure out why this works this way?</p>
 </ul>
 <pre><code>    man ./enigma.1</code></pre>
 <ul>
-<li><a href="recode.html">recode.html</a> (or <a href="recode.html">recode.html</a> if reading on GitHub)
+<li><a href="recode.html">recode.html</a>
 <ul>
 <li>Some useful information about <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson2/recode.c">recode.c</a></li>
 </ul></li>
-<li><a href="chocolate-cake.html">chocolate-cake.html</a> (or <a href="chocolate-cake.html">chocolate-cake.html</a> if reading on GitHub)
+<li>[encrypted.html][]
 <ul>
-<li>Because most of us could use some <em>Double-layered Chocolate Fudge Cake</em>!</li>
 <li>NOTE: see <a href="recode.html">recode.html</a> (or <a href="recode.html">recode.html</a> for details about how to decrypt this!</li>
 </ul></li>
 </ul>
@@ -597,12 +596,10 @@ pairs</a>.</p>
 <div id="example">
 <h4 id="example-run">Example run</h4>
 </div>
-<p>BTW: There’s a much more entertaining (and delicious) challenge or exercise in
-<a href="recode.html">recode.html</a> (if you’re reading this on GitHub check the
-<a href="recode.html">recode.html</a> file instead); this involves <a href="chocolate-cake.html">chocolate-cake.html</a> (if
-on GitHub, see <a href="chocolate-cake.html">here</a>, though one might need a different kind
-of exercise after taking up the challenge! :-) These however show the general
-program as well as how to use the two winning entries of the <a href="https://en.wikipedia.org/wiki/Morse_code">Morse
+<p>BTW: There’s a much more entertaining way to explore this entry. See
+<a href="recode.html">recode.html</a> for more details. There’s a secret message that one might like
+to decipher. These however show the general program as well as how to use the
+two winning entries of the <a href="https://en.wikipedia.org/wiki/Morse_code">Morse
 code</a> that I referred to earlier:</p>
 <pre><code>    $ ./prog -
     Ring 1: 3
@@ -701,8 +698,10 @@ having to type it out again every time).</p>
 I didn’t think of everything. My entry was meant to be a simulator only as far
 as the ciphering goes but I thought this would make it much more interesting:
 make it more flexible by a wrapper program.</p>
-<p>For examples using it (and a delicious challenge) see <a href="recode.html">recode.html</a> (or
-<a href="recode.html">recode.html</a> if reading on GitHub). See also the <a href="recode.1">recode.1</a> and
+<p>For examples using it you might enjoy a fun message that I have encrypted using
+a key that you should be able to figure out (it’s in a list). This might lead to
+something else fun as well but I will not say more than that. Anyway, see
+<a href="recode.html">recode.html</a> for more details. See also the <a href="recode.1">recode.1</a> and
 <a href="enigma.1">enigma.1</a> man pages.</p>
 <div id="parsersubtlety">
 <h3 id="a-parser-subtlety-that-could-cause-confusion">A parser subtlety that could cause confusion</h3>
@@ -746,8 +745,8 @@ by itself. However for the reflector I did <code>1A</code> but it only expects 1
 will that mean that the plugboard pairs are off? Yes it does seem to be so. This
 is buffering at play I believe but it’s useful for allowing the <code>recode</code> program
 to easily configure the Enigma machine. In the <a href="recode.html">recode.html</a> file
-(or <a href="recode.html">recode.html</a> if reading on GitHub) file I give a hint as to how
-this could be fixed but the caveat is it would necessitate a need for rewriting
+file I give a hint as to how this could be fixed but the caveat is it would
+necessitate a need for rewriting
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson2/recode.c">recode.c</a>.</p>
 <p>There’s another thing to be aware of and that’s the way the ranges are enforced.
 There are five rotors which obviously are in C 0-4 but in ‘natural language’
@@ -757,12 +756,9 @@ There are five rotors which obviously are in C 0-4 but in ‘natural language’
 same applies: in C 0-1 but in human it’s 1-2 (technically these were reflectors B and C in
 the Enigma machine which I display by name in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson2/recode.c">recode.c</a> just like
 with the rotors).</p>
-<p>For more information see <a href="recode.html">recode.html</a> (or <a href="recode.html">recode.html</a> if viewing on
-GitHub).</p>
+<p>For more information see <a href="recode.html">recode.html</a>.</p>
 <p>BTW: If you need a reminder to go to the gym just do your Enigma ABCs and it
-should help you remember (though not at this time in our world it might help you
-later on?). This might become even more useful after the challenge is accepted,
-accomplished and made use of! :)</p>
+should help you remember:</p>
 <pre><code>    $ echo ABC | ./prog
     GYM
     $ echo ABC | ./prog | ./prog
@@ -801,14 +797,7 @@ has some of the ways I think this entry is obfuscated. To decipher try:</p>
 <pre><code>    ./recode -Robfuscation.key -fobfuscation.md | ./prog - 2&gt;/dev/null &gt; obfuscation.txt</code></pre>
 <p>The file <a href="obfuscation.key">obfuscation.key</a> is the key to decipher/encipher
 <a href="obfuscation.txt">obfuscation.txt</a>.</p>
-<p>For the lazy <a href="obfuscation.html">obfuscation.html</a> has the deciphered version. I am afraid I’m not
-so inclined to do that for the cake recipe: the idea there is to make it a fun
-exercise that when solved unlocks a wonderful double-layered chocolate fudge
-cake recipe. But given that my <a href="../ferguson1/index.html">‘Don’t tread on me’</a> award entry
-also has the <a href="../ferguson1/chocolate-cake.html">recipe</a>
-(<a href="../ferguson1/chocolate-cake.html">ferguson1/chocolate-cake.html</a> if reading on
-GitHub), not enciphered, one might just go there instead. Still it’s a fun way
-to explore this entry.</p>
+<p>For the lazy <a href="obfuscation.html">obfuscation.html</a> has the deciphered version.</p>
 <p>As for the <a href="obfuscation.key">obfuscation.key</a> file if you observe the contents you’ll find the
 word <code>OBFUSCATION</code>:</p>
 <pre><code>    2OB5FU1SC2ATIONCDEFGHJKLMPQRYZ
@@ -826,7 +815,7 @@ choose from a set of rotors and there were no duplicates. This shouldn’t be a
 problem here however except that it wouldn’t be a possible configuration of the
 real Enigma machine. The <code>recode</code> program <em>however does validate this</em> (except
 when reading in settings via the <code>-R</code> option which I explain in the
-<a href="recode.html">recode.html</a> file (<a href="recode.html">recode.html</a> on GitHub).</p></li>
+<a href="recode.html">recode.html</a> file.</p></li>
 <li><p>The way the <a href="https://www.cryptomuseum.com/crypto/enigma/i/sb.htm">plugboard</a>
 - for the machines that had them - is, if you connect A to B then no other
 letters can connect to A or B. Earlier there wasn’t proper detection and this
@@ -1067,7 +1056,7 @@ have huge admiration for!</p>
 continuing to hold the contest after all these years - and for having selected
 my entries. It’s a huge honour; thank you! I also happen to love your comments
 as well as the award titles. And yes indeed ‘most of us could use
-<em><a href="chocolate-cake.html">Double-layered Chocolate Fudge Cake</a></em>!’</p>
+<em>[Double-layered Chocolate Fudge Cake][]</em>!’</p>
 <p>If you wish to contact me please do so. Please contact via mastodon. You can try
 email but I’m more likely to respond to mastodon messages.</p>
 <!--


### PR DESCRIPTION
Some of the removed text referred to things that no longer exist due to shortening the text (a bit).

Others were that the text used to say that one should try the markdown or html file depending on if read in GitHub or not but now it's only the html files so that reference to GitHub was removed.

Other problems were discovered and fixed as well.