### PR TITLE
Fix 2013/hou/Makefile for a.c

### DIFF
--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -51,7 +51,7 @@ source file is self documenting.  :-)
 From time to time, run `ps(1)` and look at the new processes.
 
 See [shapiro.html](shapiro.html) for more information in the internals of this program.
-The file [shapiro.alt.c](%%REPO_URL%%/1994/shapiro/shapiro.alt.c) contains a non-obfuscated version of
+The file `shapiro.alt.c` contains a non-obfuscated version of
 this program. Note that this alt file is currently missing. See
 [1994 shapiro bugs](../../bugs.html#1994_shapiro) for details.
 
@@ -71,14 +71,14 @@ My entry, [shapiro.c](%%REPO_URL%%/1994/shapiro/shapiro.c), is mostly comments, 
 clock. If you strip out the comments and look at the code you will
 quickly realize that the comments were the important part and that
 the code does very little (see pun above). It writes (to `stdout`)
-another C program ([shapiro_t2.c](%%REPO_URL%%/1994/shapiro/shapiro_t2.c). This is the first level of
+another C program (`shapiro_t2.c`). This is the first level of
 obfuscation.
 
-The second program ([shapiro_t2.c](%%REPO_URL%%/1994/shapiro/shapiro_t2.c) (use `make everything` first)
-prints a clock in the upper right hand corner of your VTxxx/ANSI display.
+The second program (`shapiro_t2.c`) prints a clock in the upper right hand
+corner of your VTxxx/ANSI display.
 
 Most of the surface obfuscation in the second program,
-[shapiro_t2.c](%%REPO_URL%%/1994/shapiro/shapiro_t2.c), was an attempt to make it as small as possible.
+`shapiro_t2.c`, was an attempt to make it as small as possible.
 You should be able to see around this with `cb(1)` and some more intelligent
 variable names.  Once you get past this you will realize that the third level of
 obfuscation is a six member client/server hierarchy.  (See the

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -421,7 +421,7 @@ bring it back to the foreground.</p>
 source file is self documenting. :-)</p>
 <p>From time to time, run <code>ps(1)</code> and look at the new processes.</p>
 <p>See <a href="shapiro.html">shapiro.html</a> for more information in the internals of this program.
-The file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.alt.c">shapiro.alt.c</a> contains a non-obfuscated version of
+The file <code>shapiro.alt.c</code> contains a non-obfuscated version of
 this program. Note that this alt file is currently missing. See
 <a href="../../bugs.html#1994_shapiro">1994 shapiro bugs</a> for details.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
@@ -432,12 +432,12 @@ this program. Note that this alt file is currently missing. See
 clock. If you strip out the comments and look at the code you will
 quickly realize that the comments were the important part and that
 the code does very little (see pun above). It writes (to <code>stdout</code>)
-another C program (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro_t2.c">shapiro_t2.c</a>. This is the first level of
+another C program (<code>shapiro_t2.c</code>). This is the first level of
 obfuscation.</p>
-<p>The second program (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro_t2.c">shapiro_t2.c</a> (use <code>make everything</code> first)
-prints a clock in the upper right hand corner of your VTxxx/ANSI display.</p>
+<p>The second program (<code>shapiro_t2.c</code>) prints a clock in the upper right hand
+corner of your VTxxx/ANSI display.</p>
 <p>Most of the surface obfuscation in the second program,
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro_t2.c">shapiro_t2.c</a>, was an attempt to make it as small as possible.
+<code>shapiro_t2.c</code>, was an attempt to make it as small as possible.
 You should be able to see around this with <code>cb(1)</code> and some more intelligent
 variable names. Once you get past this you will realize that the third level of
 obfuscation is a six member client/server hierarchy. (See the

--- a/1994/weisberg/README.md
+++ b/1994/weisberg/README.md
@@ -77,7 +77,8 @@ event of a system shutdown or reboot.
 
 ### Bugs
 
-The alternative version ([weisberg.alt.c](%%REPO_URL%%/1994/weisberg/weisberg.alt.c) source) has never actually run
+The alternative version ([weisberg.c](%%REPO_URL%%/1994/weisberg/weisberg.c)
+compiled to `weisberg.alt`) has never actually run
 to completion. After running for close to a week it had reached somewhere around
 250e6, when it became necessary to test the reboot feature (which worked
 remarkably well). As there are quite a lot of primes to be found before reaching

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -431,7 +431,8 @@ run to completion, so as an added feature, it will cease execution upon
 reception of a signal (any will do equally well), as well as in the
 event of a system shutdown or reboot.</p>
 <h3 id="bugs">Bugs</h3>
-<p>The alternative version (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.alt.c">weisberg.alt.c</a> source) has never actually run
+<p>The alternative version (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.c">weisberg.c</a>
+compiled to <code>weisberg.alt</code>) has never actually run
 to completion. After running for close to a week it had reached somewhere around
 250e6, when it became necessary to test the reboot feature (which worked
 remarkably well). As there are quite a lot of primes to be found before reaching

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -120,7 +120,7 @@ solution wherein the disks end up on peg 2; for an even
 number of disks, they will end on peg 3.  This should
 provide some hint as to what sort of algorithm is used.
 
-We have included a [spoiler](%%REPO_URL%%/1995/vanschnitz/spoiler.c) version of the program, with
+We have included a [spoiler](%%REPO_URL%%/1995/vanschnitz/vanschnitz.alt.c) version of the program, with
 meaningful symbol names and comments, but we encourage you
 to try to decipher the program without it...
 
@@ -203,7 +203,6 @@ to try to decipher the program without it...
     `
     end
 ```
-
 
 <!--
 

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -470,7 +470,7 @@ the resulting program (on a Unix system) is to do the command</p>
 solution wherein the disks end up on peg 2; for an even
 number of disks, they will end on peg 3. This should
 provide some hint as to what sort of algorithm is used.</p>
-<p>We have included a <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/spoiler.c">spoiler</a> version of the program, with
+<p>We have included a <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.alt.c">spoiler</a> version of the program, with
 meaningful symbol names and comments, but we encourage you
 to try to decipher the program without it…</p>
 <pre><code>    begin 444 spoiler.c

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -114,6 +114,9 @@ OBJ= ${PROG}.o
 DATA= luna.jpg old_default.jpg otherroom.jpg otherroom.scene \
 	doc/camera.png doc/cosine.png doc/draft.png doc/example.md
 TARGET= ${PROG}
+OTHER_PROG= a
+OTHER_SRC= a.c
+OTHER_OBJ= a.o
 #
 ALT_OBJ=
 ALT_TARGET=
@@ -134,6 +137,13 @@ all: data ${TARGET}
 ${PROG}: ${PROG}.c
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 	./${PROG} | ${CC} ${CFLAGS} -x c - -o $@ ${LDFLAGS}
+
+${OTHER_PROG}: ${PROG}.c
+	${CC} ${CFLAGS} $< -o $@ ${LIBS}
+
+${OTHER_SRC}: ${OTHER_PROG}
+	${RM} -f $@
+	./${OTHER_PROG} > $@
 
 
 # alternative executable
@@ -207,7 +217,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM luna.ppm old_default.ppm otherroom.ppm
+	${RM} -rf *.dSYM luna.ppm old_default.ppm otherroom.ppm a a.c
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/2013/hou/README.md
+++ b/2013/hou/README.md
@@ -65,16 +65,18 @@ program.
 This program will loop infinitely while progressively refining a
 [raytraced](https://en.wikipedia.org/wiki/Ray_tracing_&#x28;graphics&#x29;) image.
 
-NOTE: the author refers to [a.c](%%REPO_URL%%/2013/hou/a.c), placed in a gzipped file `a.c.gz`. We do not
+NOTE: the author refers to `a.c`, placed in a gzipped file `a.c.gz`. We do not
 include it but it can be generated like:
 
 ``` <!---sh-->
-    cc -Wall hou.c -o hou -lm
-    ./hou > a.c
+    make a.c
 ```
 
-but there is no need to do this as the Makefile takes care of it without even
-needing to create a temporary file.
+There is no longer a need to do this as the Makefile takes care of it without
+even needing to create a temporary file but as the author refers to it and its
+uses it can still be generated to follow along.
+
+
 
 
 ## Author's remarks:
@@ -148,15 +150,15 @@ restrictions](#self-imposed-restrictions) section below for more details.
 * Neither [hou.c](%%REPO_URL%%/2013/hou/hou.c) nor [a.c](%%REPO_URL%%/2013/hou/a.c) (the *real* decompressed source) uses
 `#define` (or `cc -D`) at all.
 * The source code is not required at runtime.
-* [a.c](%%REPO_URL%%/2013/hou/a.c) does not drop optional features to reduce size. There are pure
+* `a.c` does not drop optional features to reduce size. There are pure
 optimization code that can be dropped without affecting the converged output
 (only affecting the ray tracing speed / convergence rate). All files are
 properly `fopen()`ed with `"rb"` / `"wb"` for Windows compatibility. The PPM
 header has a comment line for non-standard-compliant viewers (specifically, my
 old HDRShop 1.0). And there is a nice text message saying "please wait...".
-Despite the messy look, [a.c](%%REPO_URL%%/2013/hou/a.c) and [hou.c](%%REPO_URL%%/2013/hou/hou.c) compile warning-free
+Despite the messy look, `a.c` and [hou.c](%%REPO_URL%%/2013/hou/hou.c) compile warning-free
 ([hou.c](%%REPO_URL%%/2013/hou/hou.c) even wastes 18 bytes on `#include<stdio.h>` just for `putchar(3)`).
-[a.c](%%REPO_URL%%/2013/hou/a.c) compiles mostly clean in the C99/ANSI modes of clang and gcc (with:
+`a.c` compiles mostly clean in the C99/ANSI modes of clang and gcc (with:
 
 ```
 -Wall --pedantic
@@ -178,15 +180,15 @@ internal states.
 the code, but they leave the text clear in the *result*. This entry takes it
 further and obfuscates the output image as well. Can you find the text in the
 image? Hint: look up.
-* [a.c](%%REPO_URL%%/2013/hou/a.c) leaves all shaders in plain text, but the plain text shader code can't
+* `a.c` leaves all shaders in plain text, but the plain text shader code can't
 be taken for its face value; the arithmetic rules subtly diverge from our common
 sense.
-* [a.c](%%REPO_URL%%/2013/hou/a.c) is less portable than [hou.c](%%REPO_URL%%/2013/hou/hou.c) itself. [hou.c](%%REPO_URL%%/2013/hou/hou.c) only depends
+* `a.c` is less portable than [hou.c](%%REPO_URL%%/2013/hou/hou.c) itself. [hou.c](%%REPO_URL%%/2013/hou/hou.c) only depends
 on ASCII and should run just fine on 16-bit, small memory, or
-floating-point-incapable machines. [a.c](%%REPO_URL%%/2013/hou/a.c), while still reasonably portable, is
+floating-point-incapable machines. `a.c`, while still reasonably portable, is
 quite memory consuming, requires IEEE754-compliant `double`, and assumes `int` to be
 32-bits.
-* Though technically endian-dependent, [a.c](%%REPO_URL%%/2013/hou/a.c) remains portable providing that one
+* Though technically endian-dependent, `a.c` remains portable providing that one
 doesn't copy saved sessions across different endianness.
 
 

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -431,12 +431,12 @@ really just a decompressor to generate the real source code of the
 program.</p>
 <p>This program will loop infinitely while progressively refining a
 <a href="https://en.wikipedia.org/wiki/Ray_tracing_(graphics)">raytraced</a> image.</p>
-<p>NOTE: the author refers to <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a>, placed in a gzipped file <code>a.c.gz</code>. We do not
+<p>NOTE: the author refers to <code>a.c</code>, placed in a gzipped file <code>a.c.gz</code>. We do not
 include it but it can be generated like:</p>
-<pre><code>    cc -Wall hou.c -o hou -lm
-    ./hou &gt; a.c</code></pre>
-<p>but there is no need to do this as the Makefile takes care of it without even
-needing to create a temporary file.</p>
+<pre><code>    make a.c</code></pre>
+<p>There is no longer a need to do this as the Makefile takes care of it without
+even needing to create a temporary file but as the author refers to it and its
+uses it can still be generated to follow along.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <h3 id="using-hou">Using hou</h3>
 <p>This program is a programmable rendering engine with a built-in default scene.
@@ -497,15 +497,15 @@ restrictions</a> section below for more details.</li>
 <li>Neither <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> nor <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> (the <em>real</em> decompressed source) uses
 <code>#define</code> (or <code>cc -D</code>) at all.</li>
 <li>The source code is not required at runtime.</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> does not drop optional features to reduce size. There are pure
+<li><code>a.c</code> does not drop optional features to reduce size. There are pure
 optimization code that can be dropped without affecting the converged output
 (only affecting the ray tracing speed / convergence rate). All files are
 properly <code>fopen()</code>ed with <code>"rb"</code> / <code>"wb"</code> for Windows compatibility. The PPM
 header has a comment line for non-standard-compliant viewers (specifically, my
 old HDRShop 1.0). And there is a nice text message saying “please wait…”.
-Despite the messy look, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> compile warning-free
+Despite the messy look, <code>a.c</code> and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> compile warning-free
 (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> even wastes 18 bytes on <code>#include&lt;stdio.h&gt;</code> just for <code>putchar(3)</code>).
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> compiles mostly clean in the C99/ANSI modes of clang and gcc (with:</li>
+<code>a.c</code> compiles mostly clean in the C99/ANSI modes of clang and gcc (with:</li>
 </ul>
 <pre><code>-Wall --pedantic</code></pre>
 <p>The only warning generated is a pedantic one: <code>"string constant too long"</code>.</p>
@@ -521,15 +521,15 @@ internal states.</li>
 the code, but they leave the text clear in the <em>result</em>. This entry takes it
 further and obfuscates the output image as well. Can you find the text in the
 image? Hint: look up.</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> leaves all shaders in plain text, but the plain text shader code can’t
+<li><code>a.c</code> leaves all shaders in plain text, but the plain text shader code can’t
 be taken for its face value; the arithmetic rules subtly diverge from our common
 sense.</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> is less portable than <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> itself. <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> only depends
+<li><code>a.c</code> is less portable than <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> itself. <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">hou.c</a> only depends
 on ASCII and should run just fine on 16-bit, small memory, or
-floating-point-incapable machines. <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a>, while still reasonably portable, is
+floating-point-incapable machines. <code>a.c</code>, while still reasonably portable, is
 quite memory consuming, requires IEEE754-compliant <code>double</code>, and assumes <code>int</code> to be
 32-bits.</li>
-<li>Though technically endian-dependent, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/a.c">a.c</a> remains portable providing that one
+<li>Though technically endian-dependent, <code>a.c</code> remains portable providing that one
 doesn’t copy saved sessions across different endianness.</li>
 </ul>
 <h3 id="spoiler">Spoiler</h3>


### PR DESCRIPTION

I noticed a problem with my improvement to the Makefile allowing one to
not use a temporary file so although the 'all' rule uses that method one
can still generate a.c so one can follow the author's remarks.

Links to this file were changed to code blocks, however, as the file
does not always exist. make clobber will remove a and a.c.