### PR TITLE
Improve links to bugs.html in README.md files

### DIFF
--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1984 decot bugs](../../bugs.html#1984_decot).
+For more detailed information see [1984/decot in bugs.html](../../bugs.html#1984_decot).
 
 
 ## To use:

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -403,7 +403,7 @@ The original code was fixed in 2023 to not require this.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1984_decot">1984 decot bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1984_decot">1984/decot in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./decot</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -19,7 +19,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1984 mullender bugs](../../bugs.html#1984_mullender).
+For more detailed information see [1984/mullender in bugs.html](../../bugs.html#1984_mullender).
 
 
 ## To use:

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -410,7 +410,7 @@ the original version.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1984_mullender">1984 mullender bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1984_mullender">1984/mullender in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mullender.alt [microseconds]</code></pre>
 <p>Hit ctrl-c/intr to exit the program.</p>

--- a/1986/august/README.md
+++ b/1986/august/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1986 august bugs](../../bugs.html#1986_august).
+For more detailed information see [1986/august in bugs.html](../../bugs.html#1986_august).
 
 
 ## Try:

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#SE">SE</a> - <em>Kingdom of Sweden</em> (
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1986_august">1986 august bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1986_august">1986/august in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./august</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1988 dale bugs](../../bugs.html#1988_dale).
+For more detailed information see [1988/dale in bugs.html](../../bugs.html#1988_dale).
 
 
 ## Try:

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#AU">AU</a> - <em>Commonwealth of Australi
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1988_dale">1988 dale bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1988_dale">1988/dale in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <p>Observe that three of the commands in the script are:</p>

--- a/1989/fubar/README.md
+++ b/1989/fubar/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1989 fubar bugs](../../bugs.html#1989_fubar).
+For more detailed information see [1989/fubar in bugs.html](../../bugs.html#1989_fubar).
 
 
 ## To use:
@@ -36,7 +36,7 @@ For more detailed information see [1989 fubar bugs](../../bugs.html#1989_fubar).
 ## Judges' remarks:
 
 Run this with a single digit argument (or wait a long time and risk an infinite
-loop as described in the [1989 fubar bugs](../../bugs.html#1989_fubar) file).
+loop as described in the [1989/fubar in bugs.html](../../bugs.html#1989_fubar) file).
 
 The blank line at the beginning of the source is mandatory.
 Do you know why?

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1989_fubar">1989 fubar bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1989_fubar">1989/fubar in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./fubar &lt;number&gt;</code></pre>
 <h2 id="try">Try:</h2>
@@ -410,7 +410,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
     ./fubar 2 # run directly</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>Run this with a single digit argument (or wait a long time and risk an infinite
-loop as described in the <a href="../../bugs.html#1989_fubar">1989 fubar bugs</a> file).</p>
+loop as described in the <a href="../../bugs.html#1989_fubar">1989/fubar in bugs.html</a> file).</p>
 <p>The blank line at the beginning of the source is mandatory.
 Do you know why?</p>
 <p>NOTE: the file <code>ouroboros.c</code> is created by the program itself so this is why it

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1989 robison bugs](../../bugs.html#1989_robison).
+For more detailed information see [1989/robison in bugs.html](../../bugs.html#1989_robison).
 
 
 ## To use:

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1989_robison">1989 robison bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1989_robison">1989/robison in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./robison
     # enter valid expressions</code></pre>

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1989 westley bugs](../../bugs.html#1989_westley).
+For more detailed information see [1989/westley in bugs.html](../../bugs.html#1989_westley).
 
 
 ## Try:

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1989_westley">1989 westley bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1989_westley">1989/westley in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <p>Try compiling and running the 4 resulting programs like:</p>
 <pre><code>    ./compile.sh</code></pre>

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1990 baruch bugs](../../bugs.html#1990_baruch).
+For more detailed information see [1990/baruch in bugs.html](../../bugs.html#1990_baruch).
 
 
 ## To use:

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -407,7 +407,7 @@ code</a> below for details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1990_baruch">1990 baruch bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1990_baruch">1990/baruch in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo 4 | ./baruch
     echo 7 | ./baruch</code></pre>

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1990 tbr bugs](../../bugs.html#1990_tbr).
+For more detailed information see [1990/tbr in bugs.html](../../bugs.html#1990_tbr).
 
 
 ### A note about the fixes of this entry in 2023:

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -407,7 +407,7 @@ version</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1990_tbr">1990 tbr bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1990_tbr">1990/tbr in bugs.html</a>.</p>
 <h3 id="a-note-about-the-fixes-of-this-entry-in-2023">A note about the fixes of this entry in 2023:</h3>
 <p>In 2023 it was noticed that in some systems like macOS there was confusing
 output due to a warning at runtime that was interspersed with the output of the

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1990 theorem bugs](../../bugs.html#1990_theorem).
+For more detailed information see [1990/theorem in bugs.html](../../bugs.html#1990_theorem).
 
 
 ## To use:

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1990_theorem">1990 theorem bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1990_theorem">1990/theorem in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./theorem expression x1 x2 h y1</code></pre>
 <p>where:</p>

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1991 buzzard bugs](../../bugs.html#1991_buzzard).
+For more detailed information see [1991/buzzard in bugs.html](../../bugs.html#1991_buzzard).
 
 
 ## To use:

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -402,7 +402,7 @@ for vi(m) users in navigation.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1991_buzzard">1991 buzzard bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1991_buzzard">1991/buzzard in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./buzzard</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1991 westley bugs](../../bugs.html#1991_westley).
+For more detailed information see [1991/westley in bugs.html](../../bugs.html#1991_westley).
 
 
 ## To use:

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -402,7 +402,7 @@ time.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1991_westley">1991 westley bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1991_westley">1991/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>NOTE: we have provided a script to perform the below procedure which we include
 for the interested. See the <a href="#try">try</a> section if you just want to play.</p>

--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -14,7 +14,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1992 adrian bugs](../../bugs.html#1992_adrian).
+For more detailed information see [1992/adrian in bugs.html](../../bugs.html#1992_adrian).
 
 
 ## Try:

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_adrian">1992 adrian bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_adrian">1992/adrian in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <p>For the slow minded, try:</p>

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1992 albert bugs](../../bugs.html#1992_albert).
+For more detailed information see [1992/albert in bugs.html](../../bugs.html#1992_albert).
 
 
 ## To use:

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#NL">NL</a> - <em>Kingdom of the Netherlan
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_albert">1992 albert bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_albert">1992/albert in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./albert number</code></pre>
 <h2 id="try">Try:</h2>

--- a/1992/gson/README.md
+++ b/1992/gson/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: uses gets() - change to fgets() if possible
 ```
 
-For more detailed information see [1992 gson bugs](../../bugs.html#1992_gson).
+For more detailed information see [1992/gson in bugs.html](../../bugs.html#1992_gson).
 
 
 ## To use:

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -402,7 +402,7 @@ to crash in some systems.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_gson">1992 gson bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_gson">1992/gson in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ag word word2 word3 &lt; /path/to/dictionary</code></pre>
 <h2 id="try">Try:</h2>

--- a/1992/kivinen/README.md
+++ b/1992/kivinen/README.md
@@ -19,7 +19,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1992 kivinen bugs](../../bugs.html#1992_kivinen).
+For more detailed information see [1992/kivinen in bugs.html](../../bugs.html#1992_kivinen).
 
 
 ## To use:

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -404,7 +404,7 @@ original should you wish to see what we mean.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_kivinen">1992 kivinen bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_kivinen">1992/kivinen in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./kivinen.alt
 

--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers
 ```
 
-For more detailed information see [1992 lush bugs](../../bugs.html#1992_lush).
+For more detailed information see [1992/lush in bugs.html](../../bugs.html#1992_lush).
 
 
 ## To use:

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: doesn&#39;t work with some compilers - please provide alternative code or fix for more compilers</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_lush">1992 lush bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_lush">1992/lush in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./lush.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>

--- a/1992/vern/README.md
+++ b/1992/vern/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1992 vern bugs](../../bugs.html#1992_vern).
+For more detailed information see [1992/vern in bugs.html](../../bugs.html#1992_vern).
 
 
 ## To use:

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_vern">1992 vern bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_vern">1992/vern in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vern 3    # &lt;-- default is 2</code></pre>
 <h2 id="try">Try:</h2>

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -14,7 +14,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1992 westley bugs](../../bugs.html#1992_westley).
+For more detailed information see [1992/westley in bugs.html](../../bugs.html#1992_westley).
 
 
 ## To use:

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix
     STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1992_westley">1992 westley bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1992_westley">1992/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>If lost:</p>
 <pre><code>    ./whereami.sh lat long</code></pre>

--- a/1993/ant/README.md
+++ b/1993/ant/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: missing file - please provide it
 ```
 
-For more detailed information see [1993 ant bugs](../../bugs.html#1993_ant).
+For more detailed information see [1993/ant in bugs.html](../../bugs.html#1993_ant).
 
 
 ## To use:

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing file - please provide it</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1993_ant">1993 ant bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1993_ant">1993/ant in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ant &#39;ERE&#39; [file ...]</code></pre>
 <h2 id="try">Try:</h2>

--- a/1993/cmills/README.md
+++ b/1993/cmills/README.md
@@ -29,7 +29,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1993 cmills bugs](../../bugs.html#1993_cmills).
+For more detailed information see [1993/cmills in bugs.html](../../bugs.html#1993_cmills).
 
 
 ## To use:

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -409,7 +409,7 @@ requires X11?</a>.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1993_cmills">1993 cmills bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1993_cmills">1993/cmills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    DISPLAY=&quot;your_X_server_display&quot;
     export DISPLAY

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -41,7 +41,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1993 lmfjyh bugs](../../bugs.html#1993_lmfjyh).
+For more detailed information see [1993/lmfjyh in bugs.html](../../bugs.html#1993_lmfjyh).
 
 
 ## To use:

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -418,7 +418,7 @@ section below for more details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1993_lmfjyh">1993 lmfjyh bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1993_lmfjyh">1993/lmfjyh in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>If you have gcc &lt; 2.3.3 (i.e. the entry can compile):</p>
 <pre><code>    ./lmfjyh</code></pre>

--- a/1993/schnitzi/README.md
+++ b/1993/schnitzi/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1993 schnitzi bugs](../../bugs.html#1993_schnitzi).
+For more detailed information see [1993/schnitzi in bugs.html](../../bugs.html#1993_schnitzi).
 
 
 ## To use:
@@ -28,7 +28,7 @@ where
 `file` is a file containing some text.
 
 Certain input will cause the program to fail as described
-in [1993 schnitzi bugs](../../bugs.html#1993_schnitzi).
+in [1993/schnitzi in bugs.html](../../bugs.html#1993_schnitzi).
 
 
 ## Try:

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -400,13 +400,13 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1993_schnitzi">1993 schnitzi bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1993_schnitzi">1993/schnitzi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schnitzi file</code></pre>
 <p>where</p>
 <p><code>file</code> is a file containing some text.</p>
 <p>Certain input will cause the program to fail as described
-in <a href="../../bugs.html#1993_schnitzi">1993 schnitzi bugs</a>.</p>
+in <a href="../../bugs.html#1993_schnitzi">1993/schnitzi in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./schnitzi schnitzi.info
     # ask some questions suggested by the author, noted below</code></pre>

--- a/1993/vanb/README.md
+++ b/1993/vanb/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1993 vanb bugs](../../bugs.html#1993_vanb).
+For more detailed information see [1993/vanb in bugs.html](../../bugs.html#1993_vanb).
 
 
 ## To use:

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1993_vanb">1993 vanb bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1993_vanb">1993/vanb in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vanb &#39;exp&#39;</code></pre>
 <p>where <code>exp</code> is an octal expression. See below for how it can also have

--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -18,7 +18,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1994 dodsond2 bugs](../../bugs.html#1994_dodsond2).
+For more detailed information see [1994/dodsond2 in bugs.html](../../bugs.html#1994_dodsond2).
 
 
 ## To use:

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -403,7 +403,7 @@ code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1994_dodsond2">1994 dodsond2 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1994_dodsond2">1994/dodsond2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dodsond2</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1994 ldb bugs](../../bugs.html#1994_ldb).
+For more detailed information see [1994/ldb in bugs.html](../../bugs.html#1994_ldb).
 
 
 ## To use:

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1994_ldb">1994 ldb bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1994_ldb">1994/ldb in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ldb &lt; file
 

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -18,7 +18,7 @@ The current status of this entry is:
     STATUS: uses gets() - change to fgets() if possible
 ```
 
-For more detailed information see [1994 schnitzi bugs](../../bugs.html#1994_schnitzi).
+For more detailed information see [1994/schnitzi in bugs.html](../../bugs.html#1994_schnitzi).
 
 
 ## To use:

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -404,7 +404,7 @@ code</a> section for how to use.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1994_schnitzi">1994 schnitzi bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1994_schnitzi">1994/schnitzi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schnitzi &lt; textfile</code></pre>
 <h2 id="try">Try:</h2>

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -14,7 +14,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1994 shapiro bugs](../../bugs.html#1994_shapiro).
+For more detailed information see [1994/shapiro in bugs.html](../../bugs.html#1994_shapiro).
 
 
 ## To use:
@@ -53,7 +53,7 @@ From time to time, run `ps(1)` and look at the new processes.
 See [shapiro.html](shapiro.html) for more information in the internals of this program.
 The file `shapiro.alt.c` contains a non-obfuscated version of
 this program. Note that this alt file is currently missing. See
-[1994 shapiro bugs](../../bugs.html#1994_shapiro) for details.
+[1994/shapiro in bugs.html](../../bugs.html#1994_shapiro) for details.
 
 
 ## Author's remarks:

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing file - please provide it
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1994_shapiro">1994 shapiro bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1994_shapiro">1994/shapiro in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./shapiro &amp;</code></pre>
 <p>Now find the clock in the same terminal window (or console if at the console).</p>
@@ -423,7 +423,7 @@ source file is self documenting. :-)</p>
 <p>See <a href="shapiro.html">shapiro.html</a> for more information in the internals of this program.
 The file <code>shapiro.alt.c</code> contains a non-obfuscated version of
 this program. Note that this alt file is currently missing. See
-<a href="../../bugs.html#1994_shapiro">1994 shapiro bugs</a> for details.</p>
+<a href="../../bugs.html#1994_shapiro">1994/shapiro in bugs.html</a> for details.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>The basic theme (pun) of this program is:</p>
 <pre><code>    &quot;This time (everything) is not where it should be.&quot;

--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1994 tvr bugs](../../bugs.html#1994_tvr).
+For more detailed information see [1994/tvr in bugs.html](../../bugs.html#1994_tvr).
 
 
 ## To use:

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -402,7 +402,7 @@ code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1994_tvr">1994 tvr bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1994_tvr">1994/tvr in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./tvr mode screensize/2 &lt; colormapfile</code></pre>
 <p>Mode may be a value from 0 to 12.</p>

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -23,7 +23,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1995 cdua bugs](../../bugs.html#1995_cdua).
+For more detailed information see [1995/cdua in bugs.html](../../bugs.html#1995_cdua).
 
 
 ## To use:

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -408,7 +408,7 @@ making it 100000 (which is actually fun :-) ).</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1995_cdua">1995 cdua bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1995_cdua">1995/cdua in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./cdua.alt</code></pre>
 <h2 id="try">Try:</h2>

--- a/1995/leo/README.md
+++ b/1995/leo/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [1995 leo bugs](../../bugs.html#1995_leo).
+For more detailed information see [1995/leo in bugs.html](../../bugs.html#1995_leo).
 
 
 ## To use:

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1995_leo">1995 leo bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1995_leo">1995/leo in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./leo [ deep ] [ right ] [ Variable ] [ cycle [ freq ] ]</code></pre>
 <p>See the author’s information below on these details.</p>

--- a/1995/savastio/README.md
+++ b/1995/savastio/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1995 savastio bugs](../../bugs.html#1995_savastio).
+For more detailed information see [1995/savastio in bugs.html](../../bugs.html#1995_savastio).
 
 
 ## To use:

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1995_savastio">1995 savastio bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1995_savastio">1995/savastio in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./savastio
     # enter a POSITIVE number such as 100</code></pre>

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: missing file - please provide it
 ```
 
-For more detailed information see [1995 vanschnitz bugs](../../bugs.html#1995_vanschnitz).
+For more detailed information see [1995/vanschnitz in bugs.html](../../bugs.html#1995_vanschnitz).
 
 
 ## To use:

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -407,7 +407,7 @@ in 2023. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing file - please provide it</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1995_vanschnitz">1995 vanschnitz bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1995_vanschnitz">1995/vanschnitz in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vanschnitz</code></pre>
 <h2 id="try">Try:</h2>

--- a/1996/august/README.md
+++ b/1996/august/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers
 ```
 
-For more detailed information see [1996 august bugs](../../bugs.html#1996_august).
+For more detailed information see [1996/august in bugs.html](../../bugs.html#1996_august).
 
 
 ## To use:

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#SE">SE</a> - <em>Kingdom of Sweden</em> (
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: doesn&#39;t work with some compilers - please provide alternative code or fix for more compilers</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1996_august">1996 august bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1996_august">1996/august in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    cat august.c test.oc | ./august &gt; test.oo
     ./august &lt; test.oo</code></pre>

--- a/1996/gandalf/README.md
+++ b/1996/gandalf/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: missing or dead link - please provide them
 ```
 
-For more detailed information see [1996 gandalf bugs](../../bugs.html#1996_gandalf).
+For more detailed information see [1996/gandalf in bugs.html](../../bugs.html#1996_gandalf).
 
 
 ## To use:

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing or dead link - please provide them</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1996_gandalf">1996 gandalf bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1996_gandalf">1996/gandalf in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./gandalf</code></pre>
 <h2 id="try">Try:</h2>

--- a/1996/huffman/README.md
+++ b/1996/huffman/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: uses gets() - change to fgets() if possible
 ```
 
-For more detailed information see [1996 huffman bugs](../../bugs.html#1996_huffman).
+For more detailed information see [1996/huffman in bugs.html](../../bugs.html#1996_huffman).
 
 
 ## To use:

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1996_huffman">1996 huffman bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1996_huffman">1996/huffman in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo &#39;Huffman Decoding&#39; | ./huffman</code></pre>
 <h2 id="try">Try:</h2>

--- a/1996/jonth/README.md
+++ b/1996/jonth/README.md
@@ -19,7 +19,7 @@ The current status of this entry is:
     STATUS: missing or dead link - please provide them
 ```
 
-For more detailed information see [1996 jonth bugs](../../bugs.html#1996_jonth).
+For more detailed information see [1996/jonth in bugs.html](../../bugs.html#1996_jonth).
 
 
 ## To use:

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -405,7 +405,7 @@ entry.</p>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix
     STATUS: missing or dead link - please provide them</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1996_jonth">1996 jonth bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1996_jonth">1996/jonth in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./jonth :0 :0</code></pre>
 <p>NOTE: the two boards will be on top of each other so you will have to drag one

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -25,7 +25,7 @@ The current status of this entry is:
     STATUS: missing or dead link - please provide them
 ```
 
-For more detailed information see [1998 dlowe bugs](../../bugs.html#1998_dlowe).
+For more detailed information see [1998/dlowe in bugs.html](../../bugs.html#1998_dlowe).
 
 
 ## Try:

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -406,7 +406,7 @@ below for more details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing or dead link - please provide them</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1998_dlowe">1998 dlowe bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1998_dlowe">1998/dlowe in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./dlowe &lt; README.md
     ./dlowe &lt; README.md &gt; README.poot.md</code></pre>

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: missing or dead link - please provide them
 ```
 
-For more detailed information see [1998 dloweneil bugs](../../bugs.html#1998_dloweneil).
+For more detailed information see [1998/dloweneil in bugs.html](../../bugs.html#1998_dloweneil).
 
 
 ## To use:

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -408,7 +408,7 @@ code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing or dead link - please provide them</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1998_dloweneil">1998 dloweneil bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1998_dloweneil">1998/dloweneil in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./pootris [X size of board] [Y size of board]</code></pre>
 <p>Pressing <code>a</code> moves the current letter position counterclockwise/anticlockwise

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [1998 schnitzi bugs](../../bugs.html#1998_schnitzi).
+For more detailed information see [1998/schnitzi in bugs.html](../../bugs.html#1998_schnitzi).
 
 
 ## To use:

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1998_schnitzi">1998 schnitzi bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#1998_schnitzi">1998/schnitzi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schnitzi n &gt; sort.c
     make sort

--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -22,7 +22,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2000 dlowe bugs](../../bugs.html#2000_dlowe).
+For more detailed information see [2000/dlowe in bugs.html](../../bugs.html#2000_dlowe).
 
 
 ## To use:

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -404,7 +404,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2000_dlowe">2000 dlowe bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2000_dlowe">2000/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe [file ...]</code></pre>
 <h2 id="try">Try:</h2>

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2000 primenum bugs](../../bugs.html#2000_primenum).
+For more detailed information see [2000/primenum in bugs.html](../../bugs.html#2000_primenum).
 
 
 ## To use:

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2000_primenum">2000 primenum bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2000_primenum">2000/primenum in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo n | ./primenum n</code></pre>
 <p>NOTE: <code>n</code> is an integer.</p>

--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2000 rince bugs](../../bugs.html#2000_rince).
+For more detailed information see [2000/rince in bugs.html](../../bugs.html#2000_rince).
 
 
 ## To use:

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2000_rince">2000 rince bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2000_rince">2000/rince in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./rince number number2</code></pre>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash or do something

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -22,7 +22,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2001 anonymous bugs](../../bugs.html#2001_anonymous).
+For more detailed information see [2001/anonymous in bugs.html](../../bugs.html#2001_anonymous).
 
 
 ## To use:

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -408,7 +408,7 @@ whatever your system will compile them as).</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_anonymous">2001 anonymous bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_anonymous">2001/anonymous in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./anonymous x86_program</code></pre>
 <h2 id="try">Try:</h2>

--- a/2001/bellard/README.md
+++ b/2001/bellard/README.md
@@ -14,7 +14,7 @@ The current status of this entry is:
     STATUS: doesn't work with some platforms - please help us fix
 ```
 
-For more detailed information see [2001 bellard bugs](../../bugs.html#2001_bellard).
+For more detailed information see [2001/bellard in bugs.html](../../bugs.html#2001_bellard).
 
 
 ## To use:

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#FR">FR</a> - <em>French Republic</em> (<e
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix
     STATUS: doesn&#39;t work with some platforms - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_bellard">2001 bellard bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_bellard">2001/bellard in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./bellard file</code></pre>
 <h2 id="try">Try:</h2>

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2001 dgbeards bugs](../../bugs.html#2001_dgbeards).
+For more detailed information see [2001/dgbeards in bugs.html](../../bugs.html#2001_dgbeards).
 
 
 ## To use:

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -402,7 +402,7 @@ code</a> below for more details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_dgbeards">2001 dgbeards bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_dgbeards">2001/dgbeards in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dgbeards</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>

--- a/2001/herrmann1/README.md
+++ b/2001/herrmann1/README.md
@@ -14,7 +14,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [2001 herrmann1 bugs](../../bugs.html#2001_herrmann1).
+For more detailed information see [2001/herrmann1 in bugs.html](../../bugs.html#2001_herrmann1).
 
 
 ## To use:

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing files - please provide them
     STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_herrmann1">2001 herrmann1 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_herrmann1">2001/herrmann1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./herrmann1.sh &#39;prg=file&#39;</code></pre>
 <p>NOTE: this entry seems to rely on older versions of gcc for the compilation

--- a/2001/kev/README.md
+++ b/2001/kev/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2001 kev bugs](../../bugs.html#2001_kev).
+For more detailed information see [2001/kev in bugs.html](../../bugs.html#2001_kev).
 
 
 ## To use:

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -402,7 +402,7 @@ awkward <code>,</code> and <code>.</code> keys. See <a href="#alternate-code">al
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_kev">2001 kev bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_kev">2001/kev in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./kev # in one terminal
 

--- a/2001/rosten/README.md
+++ b/2001/rosten/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: missing files - please provide them
 ```
 
-For more detailed information see [2001 rosten bugs](../../bugs.html#2001_rosten).
+For more detailed information see [2001/rosten in bugs.html](../../bugs.html#2001_rosten).
 
 
 ## To use:

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing files - please provide them</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_rosten">2001 rosten bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_rosten">2001/rosten in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./rosten [number]</code></pre>
 <p>WARNING: this will mess with your mouse and can make it hard to quit the

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2001 schweikh bugs](../../bugs.html#2001_schweikh).
+For more detailed information see [2001/schweikh in bugs.html](../../bugs.html#2001_schweikh).
 
 
 ## To use:

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_schweikh">2001 schweikh bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_schweikh">2001/schweikh in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schweikh string string2</code></pre>
 <p>This program will very likely crash or do something else if you do not give it

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -20,7 +20,7 @@ The current status of this entry is:
     STATUS: main() has only one arg - try and make it have 2 or 3
 ```
 
-For more detailed information see [2001 westley bugs](../../bugs.html#2001_westley).
+For more detailed information see [2001/westley in bugs.html](../../bugs.html#2001_westley).
 
 
 ## To use:

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -406,7 +406,7 @@ code</a> below.</p>
 <pre><code>    STATUS: uses gets() - change to fgets() if possible
     STATUS: missing files - please provide them
     STATUS: main() has only one arg - try and make it have 2 or 3</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_westley">2001 westley bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_westley">2001/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./westley 2&gt;/dev/null
     # enter some input, terminate with EOF

--- a/2001/williams/README.md
+++ b/2001/williams/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [2001 williams bugs](../../bugs.html#2001_williams).
+For more detailed information see [2001/williams in bugs.html](../../bugs.html#2001_williams).
 
 
 ## To use:

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2001_williams">2001 williams bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2001_williams">2001/williams in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./williams</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -20,7 +20,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2004 gavin bugs](../../bugs.html#2004_gavin).
+For more detailed information see [2004/gavin in bugs.html](../../bugs.html#2004_gavin).
 
 
 ## To use:

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -405,7 +405,7 @@ to reboot and rely on having a floppy drive (if you even remember what those are
 <pre><code>    STATUS: compiled executable crashes - please help us fix
     STATUS: doesn&#39;t work with some platforms - please help us fix
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2004_gavin">2004 gavin bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2004_gavin">2004/gavin in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./gavin</code></pre>
 <h2 id="try">Try:</h2>

--- a/2004/jdalbec/README.md
+++ b/2004/jdalbec/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2004 jdalbec bugs](../../bugs.html#2004_jdalbec).
+For more detailed information see [2004/jdalbec in bugs.html](../../bugs.html#2004_jdalbec).
 
 
 ## To use:

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -402,7 +402,7 @@ to print on a line. See <a href="#alternate-code">alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2004_jdalbec">2004 jdalbec bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2004_jdalbec">2004/jdalbec in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./jdalbec number ...</code></pre>
 <h2 id="try">Try:</h2>

--- a/2004/sds/README.md
+++ b/2004/sds/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2004 sds bugs](../../bugs.html#2004_sds).
+For more detailed information see [2004/sds in bugs.html](../../bugs.html#2004_sds).
 
 
 ## To use:

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2004_sds">2004 sds bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2004_sds">2004/sds in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sds</code></pre>
 <h2 id="try">Try:</h2>

--- a/2005/anon/README.md
+++ b/2005/anon/README.md
@@ -23,7 +23,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2005 anon bugs](../../bugs.html#2005_anon).
+For more detailed information see [2005/anon in bugs.html](../../bugs.html#2005_anon).
 
 
 ## To use:

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -405,7 +405,7 @@ version</a> below. If your terminal has problems with the
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2005_anon">2005 anon bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2005_anon">2005/anon in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./anon x y [z]</code></pre>
 <h2 id="try">Try:</h2>

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2005 giljade bugs](../../bugs.html#2005_giljade).
+For more detailed information see [2005/giljade in bugs.html](../../bugs.html#2005_giljade).
 
 
 ## To use:

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -402,7 +402,7 @@ will not work with it enabled.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2005_giljade">2005 giljade bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2005_giljade">2005/giljade in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./giljade</code></pre>
 <h2 id="try">Try:</h2>

--- a/2005/mikeash/README.md
+++ b/2005/mikeash/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2005 mikeash bugs](../../bugs.html#2005_mikeash).
+For more detailed information see [2005/mikeash in bugs.html](../../bugs.html#2005_mikeash).
 
 
 ## To use:

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2005_mikeash">2005 mikeash bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2005_mikeash">2005/mikeash in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mikeash</code></pre>
 <p>NOTE: the author stated that they tested this under i386 machines but this works

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2005 mynx bugs](../../bugs.html#2005_mynx).
+For more detailed information see [2005/mynx in bugs.html](../../bugs.html#2005_mynx).
 
 
 ## To use:

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -402,7 +402,7 @@ as a starting point. See <a href="#alternate-code">alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2005_mynx">2005 mynx bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2005_mynx">2005/mynx in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mynx http://&lt;domain&gt;</code></pre>
 <p>You can specify a port by appending to the domain <code>:port</code>. See notes below on

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2005 sykes bugs](../../bugs.html#2005_sykes).
+For more detailed information see [2005/sykes in bugs.html](../../bugs.html#2005_sykes).
 
 
 ## To use:

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2005_sykes">2005 sykes bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2005_sykes">2005/sykes in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sykes binary_file</code></pre>
 <h2 id="try">Try:</h2>

--- a/2006/birken/README.md
+++ b/2006/birken/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: uses gets() - change to fgets() if possible
 ```
 
-For more detailed information see [2006 birken bugs](../../bugs.html#2006_birken).
+For more detailed information see [2006/birken in bugs.html](../../bugs.html#2006_birken).
 
 
 ## To use:

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2006_birken">2006 birken bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2006_birken">2006/birken in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./birken &lt; file.tofu</code></pre>
 <h2 id="try">Try:</h2>

--- a/2006/borsanyi/README.md
+++ b/2006/borsanyi/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2006 borsanyi bugs](../../bugs.html#2006_borsanyi).
+For more detailed information see [2006/borsanyi in bugs.html](../../bugs.html#2006_borsanyi).
 
 
 ## To use:

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2006_borsanyi">2006 borsanyi bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2006_borsanyi">2006/borsanyi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./borsanyi string &gt; file.gif</code></pre>
 <h2 id="try">Try:</h2>

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -19,7 +19,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2006 monge bugs](../../bugs.html#2006_monge).
+For more detailed information see [2006/monge in bugs.html](../../bugs.html#2006_monge).
 
 
 ## To use:

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -404,7 +404,7 @@ of iterations to use. See <a href="#alternate-code">Alternate code</a> below.</p
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: doesn&#39;t work with some platforms - please help us fix
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2006_monge">2006 monge bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2006_monge">2006/monge in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./monge expression ...</code></pre>
 <p>Incorrect formulas will ungracefully crash the program.</p>

--- a/2006/sykes1/README.md
+++ b/2006/sykes1/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2006 sykes1 bugs](../../bugs.html#2006_sykes1).
+For more detailed information see [2006/sykes1 in bugs.html](../../bugs.html#2006_sykes1).
 
 
 ## To use:

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -403,7 +403,7 @@ specifically see the <a href="#alternate-code">Alternate code</a> section below.
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2006_sykes1">2006 sykes1 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2006_sykes1">2006/sykes1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sykes1</code></pre>
 <p>Next point your browser to the file: <code>sykes1.html</code>.</p>

--- a/2006/toledo2/README.md
+++ b/2006/toledo2/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2006 toledo2 bugs](../../bugs.html#2006_toledo2).
+For more detailed information see [2006/toledo2 in bugs.html](../../bugs.html#2006_toledo2).
 
 
 ## To use:

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -403,7 +403,7 @@ that it should be fine, after the proper header files were added.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2006_toledo2">2006 toledo2 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2006_toledo2">2006/toledo2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./toledo2</code></pre>
 <p>To end execution press <code>ctrl-z</code>. As mentioned in the author’s remarks and in the

--- a/2011/borsanyi/README.md
+++ b/2011/borsanyi/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2011 borsanyi bugs](../../bugs.html#2011_borsanyi).
+For more detailed information see [2011/borsanyi in bugs.html](../../bugs.html#2011_borsanyi).
 
 
 ## To use:

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2011_borsanyi">2011 borsanyi bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2011_borsanyi">2011/borsanyi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./borsanyi &lt; some_data_file</code></pre>
 <h2 id="try">Try:</h2>

--- a/2011/dlowe/README.md
+++ b/2011/dlowe/README.md
@@ -14,7 +14,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2011 dlowe bugs](../../bugs.html#2011_dlowe).
+For more detailed information see [2011/dlowe in bugs.html](../../bugs.html#2011_dlowe).
 
 
 ## To use:

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -401,7 +401,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: missing or dead link - please provide them
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2011_dlowe">2011 dlowe bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2011_dlowe">2011/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe -&lt;n_iterations&gt; corpus1/ [...] corpus0/ &lt; start.net &gt; trained.net</code></pre>
 <p>NOTE: In the above command, the directory args MUST end in a <code>/</code>.</p>

--- a/2011/fredriksson/README.md
+++ b/2011/fredriksson/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2011 fredriksson bugs](../../bugs.html#2011_fredriksson).
+For more detailed information see [2011/fredriksson in bugs.html](../../bugs.html#2011_fredriksson).
 
 
 ## To use:

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2011_fredriksson">2011 fredriksson bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2011_fredriksson">2011/fredriksson in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./fredriksson [-icvtnk#] regexp &lt; file</code></pre>
 <h2 id="try">Try:</h2>

--- a/2011/richards/README.md
+++ b/2011/richards/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: doesn't work with some platforms - please help us fix
 ```
 
-For more detailed information see [2011 richards bugs](../../bugs.html#2011_richards).
+For more detailed information see [2011/richards in bugs.html](../../bugs.html#2011_richards).
 
 
 ## To use:

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: doesn&#39;t work with some platforms - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2011_richards">2011 richards bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2011_richards">2011/richards in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo expression | ./richards</code></pre>
 <h2 id="try">Try:</h2>

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2011 vik bugs](../../bugs.html#2011_vik).
+For more detailed information see [2011/vik in bugs.html](../../bugs.html#2011_vik).
 
 
 ## To use:

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -402,7 +402,7 @@ code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2011_vik">2011 vik bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2011_vik">2011/vik in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vik file.mod &gt; audio_file.raw</code></pre>
 <p>If you have <code>mplayer(1)</code>:</p>

--- a/2012/blakely/README.md
+++ b/2012/blakely/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2012 blakely bugs](../../bugs.html#2012_blakely).
+For more detailed information see [2012/blakely in bugs.html](../../bugs.html#2012_blakely).
 
 
 ## To use:

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2012_blakely">2012 blakely bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2012_blakely">2012/blakely in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./blakely &quot;RPN formula&quot; resolution &gt; output.gif</code></pre>
 <h2 id="try">Try:</h2>

--- a/2012/deckmyn/README.md
+++ b/2012/deckmyn/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2012 deckmyn bugs](../../bugs.html#2012_deckmyn).
+For more detailed information see [2012/deckmyn in bugs.html](../../bugs.html#2012_deckmyn).
 
 
 ## To use:

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#BE">BE</a> - <em>Kingdom of Belgium</em> 
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2012_deckmyn">2012 deckmyn bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2012_deckmyn">2012/deckmyn in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./deckmyn &quot;$(cat deckmyn.c)&quot; &quot;$(cat musicfile.txt)&quot; &gt; sheetmusic.pbm</code></pre>
 <h2 id="try">Try:</h2>

--- a/2012/dlowe/README.md
+++ b/2012/dlowe/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2012 dlowe bugs](../../bugs.html#2012_dlowe).
+For more detailed information see [2012/dlowe in bugs.html](../../bugs.html#2012_dlowe).
 
 
 ## To use:

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2012_dlowe">2012 dlowe bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2012_dlowe">2012/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe</code></pre>
 <h2 id="try">Try:</h2>

--- a/2012/tromp/README.md
+++ b/2012/tromp/README.md
@@ -15,7 +15,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2012 tromp bugs](../../bugs.html#2012_tromp).
+For more detailed information see [2012/tromp in bugs.html](../../bugs.html#2012_tromp).
 
 
 ## To use:

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -402,7 +402,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2012_tromp">2012 tromp bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2012_tromp">2012/tromp in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./tromp [-b]</code></pre>
 <p>Use <code>./tromp32</code> as you would <code>./tromp</code> if on a 32-bit machine.</p>

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -18,7 +18,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2012 vik bugs](../../bugs.html#2012_vik).
+For more detailed information see [2012/vik in bugs.html](../../bugs.html#2012_vik).
 
 
 ## To use:

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -403,7 +403,7 @@ code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2012_vik">2012 vik bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2012_vik">2012/vik in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>To embed text (from file or command line):</p>
 <pre><code>    ./vik e base.png filename &gt; encodedimg.png</code></pre>

--- a/2013/cable2/README.md
+++ b/2013/cable2/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 cable2 bugs](../../bugs.html#2013_cable2).
+For more detailed information see [2013/cable2 in bugs.html](../../bugs.html#2013_cable2).
 
 
 ## To use:

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_cable2">2013 cable2 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_cable2">2013/cable2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./cable2 file.bmp [color]</code></pre>
 <h2 id="try">Try:</h2>

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 dlowe bugs](../../bugs.html#2013_dlowe).
+For more detailed information see [2013/dlowe in bugs.html](../../bugs.html#2013_dlowe).
 
 
 ## To use:

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_dlowe">2013 dlowe bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_dlowe">2013/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe [number...]</code></pre>
 <p>where <code>[number...]</code> is one or more number, space separated.</p>

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 endoh1 bugs](../../bugs.html#2013_endoh1).
+For more detailed information see [2013/endoh1 in bugs.html](../../bugs.html#2013_endoh1).
 
 
 ## To use:

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_endoh1">2013 endoh1 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_endoh1">2013/endoh1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./endoh1 [file.lazy]</code></pre>
 <h2 id="try">Try:</h2>

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 endoh3 bugs](../../bugs.html#2013_endoh3).
+For more detailed information see [2013/endoh3 in bugs.html](../../bugs.html#2013_endoh3).
 
 
 ## To use:

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_endoh3">2013 endoh3 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_endoh3">2013/endoh3 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./endoh3</code></pre>
 <p>This program plays sound. See <a href="../../faq.html#sox">FAQ 3.10 - How do I compile and use an IOCCC

--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -24,7 +24,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 endoh4 bugs](../../bugs.html#2013_endoh4).
+For more detailed information see [2013/endoh4 in bugs.html](../../bugs.html#2013_endoh4).
 
 
 ## To use:

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -405,7 +405,7 @@ described below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_endoh4">2013 endoh4 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_endoh4">2013/endoh4 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./endoh4 &lt; file
     ./endoh4.sh file</code></pre>

--- a/2013/hou/README.md
+++ b/2013/hou/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 hou bugs](../../bugs.html#2013_hou).
+For more detailed information see [2013/hou in bugs.html](../../bugs.html#2013_hou).
 
 
 ## To use:

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#CN">CN</a> - <em>People’s Republic of C
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_hou">2013 hou bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_hou">2013/hou in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./hou [scene-file-name] [options]</code></pre>
 <p>Follow the instructions in <code>stdout</code>, preferably with an auto-refreshing PPM

--- a/2013/mills/README.md
+++ b/2013/mills/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2013 mills bugs](../../bugs.html#2013_mills).
+For more detailed information see [2013/mills in bugs.html](../../bugs.html#2013_mills).
 
 
 ## To use:

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2013_mills">2013 mills bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2013_mills">2013/mills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mills</code></pre>
 <h2 id="try">Try:</h2>

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2014 maffiodo1 bugs](../../bugs.html#2014_maffiodo1).
+For more detailed information see [2014/maffiodo1 in bugs.html](../../bugs.html#2014_maffiodo1).
 
 
 ## To use:

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -402,7 +402,7 @@ don’t know how to do this for your system.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2014_maffiodo1">2014 maffiodo1 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2014_maffiodo1">2014/maffiodo1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    cat game.level | ./prog 320 200 800 300 128 144 game.rgba game.wav 10343679</code></pre>
 <p>The parameters to the program are:</p>

--- a/2014/maffiodo2/README.md
+++ b/2014/maffiodo2/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2014 maffiodo2 bugs](../../bugs.html#2014_maffiodo2).
+For more detailed information see [2014/maffiodo2 in bugs.html](../../bugs.html#2014_maffiodo2).
 
 
 ## To use:

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -402,7 +402,7 @@ code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2014_maffiodo2">2014 maffiodo2 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2014_maffiodo2">2014/maffiodo2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog arg</code></pre>
 <h2 id="try">Try:</h2>

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: known bug - please help us fix
 ```
 
-For more detailed information see [2014 vik bugs](../../bugs.html#2014_vik).
+For more detailed information see [2014/vik in bugs.html](../../bugs.html#2014_vik).
 
 
 ## To use:

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -403,7 +403,7 @@ code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2014_vik">2014 vik bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2014_vik">2014/vik in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo foo | ./prog &gt; audio_file.raw
 

--- a/2015/hou/README.md
+++ b/2015/hou/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2015 hou bugs](../../bugs.html#2015_hou).
+For more detailed information see [2015/hou in bugs.html](../../bugs.html#2015_hou).
 
 
 ## To use:

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#CN">CN</a> - <em>People’s Republic of C
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2015_hou">2015 hou bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2015_hou">2015/hou in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo something | ./prog
     ./prog &lt; file</code></pre>

--- a/2015/mills2/README.md
+++ b/2015/mills2/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2015 mills2 bugs](../../bugs.html#2015_mills2).
+For more detailed information see [2015/mills2 in bugs.html](../../bugs.html#2015_mills2).
 
 
 ## To use:

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2015_mills2">2015 mills2 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2015_mills2">2015/mills2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog compressed_file.Z</code></pre>
 <h2 id="try">Try:</h2>

--- a/2015/schweikhardt/README.md
+++ b/2015/schweikhardt/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2015 schweikhardt bugs](../../bugs.html#2015_schweikhardt).
+For more detailed information see [2015/schweikhardt in bugs.html](../../bugs.html#2015_schweikhardt).
 
 
 ## To use:

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2015_schweikhardt">2015 schweikhardt bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2015_schweikhardt">2015/schweikhardt in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog n</code></pre>
 <p>where n is a base 16 number of any size.</p>

--- a/2018/algmyr/README.md
+++ b/2018/algmyr/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2018 algmyr bugs](../../bugs.html#2018_algmyr).
+For more detailed information see [2018/algmyr in bugs.html](../../bugs.html#2018_algmyr).
 
 
 ## To use:

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -403,7 +403,7 @@ compile and use an IOCCC entry that requires sound?</a>.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2018_algmyr">2018 algmyr bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2018_algmyr">2018/algmyr in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; prog.c                     # Print garbage: might mess up your terminal
     ./prog &lt;file1&gt; &lt;file2&gt; &gt; out.raw

--- a/2018/hou/README.md
+++ b/2018/hou/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2018 hou bugs](../../bugs.html#2018_hou).
+For more detailed information see [2018/hou in bugs.html](../../bugs.html#2018_hou).
 
 
 ## To use:

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#CN">CN</a> - <em>People’s Republic of C
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2018_hou">2018 hou bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2018_hou">2018/hou in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; input.json &gt; output.html</code></pre>
 <p>View <code>output.html</code> in a browser.</p>

--- a/2018/mills/README.md
+++ b/2018/mills/README.md
@@ -26,7 +26,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2018 mills bugs](../../bugs.html#2018_mills).
+For more detailed information see [2018/mills in bugs.html](../../bugs.html#2018_mills).
 
 
 ## To use:

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -408,7 +408,7 @@ will be corrupt if it does.</p>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: known bug - please help us fix
     STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2018_mills">2018 mills bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2018_mills">2018/mills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
 <h2 id="try">Try:</h2>

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2018 vokes bugs](../../bugs.html#2018_vokes).
+For more detailed information see [2018/vokes in bugs.html](../../bugs.html#2018_vokes).
 
 
 ## To use:

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2018_vokes">2018 vokes bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2018_vokes">2018/vokes in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; file.txt</code></pre>
 <h2 id="try">Try:</h2>

--- a/2019/adamovsky/README.md
+++ b/2019/adamovsky/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 adamovsky bugs](../../bugs.html#2019_adamovsky).
+For more detailed information see [2019/adamovsky in bugs.html](../../bugs.html#2019_adamovsky).
 
 
 ## To use:

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#CZ">CZ</a> - <em>Czech Republic</em> (<em
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_adamovsky">2019 adamovsky bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_adamovsky">2019/adamovsky in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog file.unl</code></pre>
 <h2 id="try">Try:</h2>

--- a/2019/burton/README.md
+++ b/2019/burton/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 burton bugs](../../bugs.html#2019_burton).
+For more detailed information see [2019/burton in bugs.html](../../bugs.html#2019_burton).
 
 
 ## To use:

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_burton">2019 burton bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_burton">2019/burton in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; file
 

--- a/2019/ciura/README.md
+++ b/2019/ciura/README.md
@@ -17,7 +17,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 ciura bugs](../../bugs.html#2019_ciura).
+For more detailed information see [2019/ciura in bugs.html](../../bugs.html#2019_ciura).
 
 
 ## To use:

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -402,7 +402,7 @@ below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_ciura">2019 ciura bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_ciura">2019/ciura in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./getwords.sh en | grep .. | ./prog string</code></pre>
 <h2 id="try">Try:</h2>

--- a/2019/dogon/README.md
+++ b/2019/dogon/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: uses gets() - change to fgets() if possible
 ```
 
-For more detailed information see [2019 dogon bugs](../../bugs.html#2019_dogon).
+For more detailed information see [2019/dogon in bugs.html](../../bugs.html#2019_dogon).
 
 
 ## To use:

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#IL">IL</a> - <em>State of Israel</em> (<e
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_dogon">2019 dogon bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_dogon">2019/dogon in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; pattern.mc</code></pre>
 <h2 id="try">Try:</h2>

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 duble bugs](../../bugs.html#2019_duble).
+For more detailed information see [2019/duble in bugs.html](../../bugs.html#2019_duble).
 
 
 ## To use:
@@ -82,11 +82,11 @@ WARNING: if the file is deleted it might lock any session still in use. These
 will have to be killed from another shell session or by closing the terminal tab
 (in other words don't do this from the console!). If the file cannot be opened
 in the beginning this will also happen. This is discussed in
-[2019 duble bugs](../../bugs.html#2019_duble).
+[2019/duble in bugs.html](../../bugs.html#2019_duble).
 
 NOTE: this entry might leave sockets lying about in the current working
 directory which you'll have to delete manually. This is also discussed in
-[2019 duble bugs](../../bugs.html#2019_duble).
+[2019/duble in bugs.html](../../bugs.html#2019_duble).
 
 
 ## Alternate code:

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -402,7 +402,7 @@ See <a href="#alternate-code">Alternate code</a> below if you are curious.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_duble">2019 duble bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_duble">2019/duble in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog file</code></pre>
 <h2 id="try">Try:</h2>
@@ -435,10 +435,10 @@ the editor.</p>
 will have to be killed from another shell session or by closing the terminal tab
 (in other words don’t do this from the console!). If the file cannot be opened
 in the beginning this will also happen. This is discussed in
-<a href="../../bugs.html#2019_duble">2019 duble bugs</a>.</p>
+<a href="../../bugs.html#2019_duble">2019/duble in bugs.html</a>.</p>
 <p>NOTE: this entry might leave sockets lying about in the current working
 directory which you’ll have to delete manually. This is also discussed in
-<a href="../../bugs.html#2019_duble">2019 duble bugs</a>.</p>
+<a href="../../bugs.html#2019_duble">2019/duble in bugs.html</a>.</p>
 <h2 id="alternate-code">Alternate code:</h2>
 <p>An alternate version of this entry, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.alt.c">prog.alt.c</a>, is provided. This
 alternate code might not work as well in macOS.</p>

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 endoh bugs](../../bugs.html#2019_endoh).
+For more detailed information see [2019/endoh in bugs.html](../../bugs.html#2019_endoh).
 
 
 ## To use:

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -402,7 +402,7 @@ this entry because it is SUPPOSED to crash and it needs debugging symbols.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_endoh">2019 endoh bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_endoh">2019/endoh in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
 <h2 id="try">Try:</h2>

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -16,7 +16,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 karns bugs](../../bugs.html#2019_karns).
+For more detailed information see [2019/karns in bugs.html](../../bugs.html#2019_karns).
 
 
 ## To use:

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -402,7 +402,7 @@ enabled.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_karns">2019 karns bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_karns">2019/karns in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; textfile_that_fits_on_the_screen</code></pre>
 <p>You might want to type:</p>

--- a/2019/lynn/README.md
+++ b/2019/lynn/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 lynn bugs](../../bugs.html#2019_lynn).
+For more detailed information see [2019/lynn in bugs.html](../../bugs.html#2019_lynn).
 
 
 ## To use:

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_lynn">2019 lynn bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_lynn">2019/lynn in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
 <h2 id="try">Try:</h2>

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 mills bugs](../../bugs.html#2019_mills).
+For more detailed information see [2019/mills in bugs.html](../../bugs.html#2019_mills).
 
 
 ## To use:

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_mills">2019 mills bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_mills">2019/mills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    make cpclean
     # Let this run for about about an hour and then kill it:

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -21,7 +21,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 poikola bugs](../../bugs.html#2019_poikola).
+For more detailed information see [2019/poikola in bugs.html](../../bugs.html#2019_poikola).
 
 
 ## To use:
@@ -53,7 +53,7 @@ If you don't have a few days, try:
     ./try.sh
 ```
 
-As the [2019 poikola bugs](../../bugs.html#2019_poikola) says, this program will not validate
+As the [2019/poikola in bugs.html](../../bugs.html#2019_poikola) says, this program will not validate
 input so it might get stuck or fail if invoked erroneously.
 
 

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -406,7 +406,7 @@ forcing <code>-std=gnu11</code>.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_poikola">2019 poikola bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_poikola">2019/poikola in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog 512 ./prog
 
@@ -421,7 +421,7 @@ forcing <code>-std=gnu11</code>.</p>
 <h2 id="try">Try:</h2>
 <p>If you don’t have a few days, try:</p>
 <pre><code>    ./try.sh</code></pre>
-<p>As the <a href="../../bugs.html#2019_poikola">2019 poikola bugs</a> says, this program will not validate
+<p>As the <a href="../../bugs.html#2019_poikola">2019/poikola in bugs.html</a> says, this program will not validate
 input so it might get stuck or fail if invoked erroneously.</p>
 <h2 id="alternate-code">Alternate code:</h2>
 <p>This version prints a newline after each number for parsing in other ways than

--- a/2019/yang/README.md
+++ b/2019/yang/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2019 yang bugs](../../bugs.html#2019_yang).
+For more detailed information see [2019/yang in bugs.html](../../bugs.html#2019_yang).
 
 
 ## To use:

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2019_yang">2019 yang bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2019_yang">2019/yang in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog sample_input.txt a b c d
 

--- a/2020/burton/README.md
+++ b/2020/burton/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2020 burton bugs](../../bugs.html#2020_burton).
+For more detailed information see [2020/burton in bugs.html](../../bugs.html#2020_burton).
 
 
 ## To use:

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2020_burton">2020 burton bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2020_burton">2020/burton in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog arg ...</code></pre>
 <h2 id="try">Try:</h2>

--- a/2020/carlini/README.md
+++ b/2020/carlini/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2020 carlini bugs](../../bugs.html#2020_carlini).
+For more detailed information see [2020/carlini in bugs.html](../../bugs.html#2020_carlini).
 
 
 ## To use:

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2020_carlini">2020 carlini bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2020_carlini">2020/carlini in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
 <h2 id="try">Try:</h2>

--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2020 ferguson1 bugs](../../bugs.html#2020_ferguson1).
+For more detailed information see [2020/ferguson1 in bugs.html](../../bugs.html#2020_ferguson1).
 
 
 ## To use:

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2020_ferguson1">2020 ferguson1 bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2020_ferguson1">2020/ferguson1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    WAIT=N WALLS=[01] EVADE=N SIZE=N MAXSIZE=N GROW=N SHEDS=N SHED=N CANNIBAL=[01] ./prog
     # start pressing some arrow keys</code></pre>

--- a/2020/giles/README.md
+++ b/2020/giles/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2020 giles bugs](../../bugs.html#2020_giles).
+For more detailed information see [2020/giles in bugs.html](../../bugs.html#2020_giles).
 
 
 ## To use:

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#AU">AU</a> - <em>Commonwealth of Australi
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2020_giles">2020 giles bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2020_giles">2020/giles in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; dtmf.wav
 

--- a/2020/otterness/README.md
+++ b/2020/otterness/README.md
@@ -13,7 +13,7 @@ The current status of this entry is:
     STATUS: INABIAF - please **DO NOT** fix
 ```
 
-For more detailed information see [2020 otterness bugs](../../bugs.html#2020_otterness).
+For more detailed information see [2020/otterness in bugs.html](../../bugs.html#2020_otterness).
 
 
 ## To use:

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -400,7 +400,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#2020_otterness">2020 otterness bugs</a>.</p>
+<p>For more detailed information see <a href="../../bugs.html#2020_otterness">2020/otterness in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
 <h2 id="try">Try:</h2>

--- a/bugs.html
+++ b/bugs.html
@@ -376,7 +376,7 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: bugs.md -->
-<h1 id="bugs-and-misfeatures">Bugs and (Mis)features</h1>
+<h1 id="bugs-and-misfeatures">Bugs and (mis)features</h1>
 <p>There are a number of known problems with IOCCC entries: many of
 which have to do with differences between today’s compiler environments
 and those of today. In some cases the original code has a bug, some
@@ -717,7 +717,7 @@ emulator to test it) but running the code on the binary itself produces a
 <h1 id="section-1">1985</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
-<p>There are no known bugs and (Mis)features for entries in 1985.</p>
+<p>There are no known bugs or (mis)features for entries in 1985.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1986">
 <h1 id="section-2">1986</h1>
@@ -736,7 +736,7 @@ the judges and shouldn’t be fixed.</p>
 <h1 id="section-3">1987</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
-<p>There are no known bugs and (Mis)features for entries in 1987.</p>
+<p>There are no known bugs or (mis)features for entries in 1987.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1988">
 <h1 id="section-4">1988</h1>
@@ -791,7 +791,7 @@ be compiled with clang. An example invocation is:</p>
 <p>It should be noted that in additional to rot13 names there is code that is the
 reverse of other code (also wrt names). See the source file and the index.html
 (in the author’s remarks) for more details.</p>
-<p>Fixing the (Mis)feature is likely to be a very difficult challenge especially
+<p>Fixing the (mis)feature is likely to be a very difficult challenge especially
 without breaking something else which is far more likely (see below in tips from
 Cody). You are welcome to try and fix it if you can!</p>
 <h3 id="tips-from-cody">Tips from Cody:</h3>
@@ -830,7 +830,7 @@ ROT13 of each other as well which is the reverse of the original (this is not
 because it goes backwards (it doesn’t in this version) but because they are
 ROT13 pairs!). <code>main</code> spelt backwards is <code>niam</code> and <code>pain</code> spelt backwards is
 <code>niap</code>. Furthermore see the Makefile for other defines that had to be specified
-and for ver2 and ver3 (that both work with gcc) one had to be undefined (search
+and for <code>ver2</code> and <code>ver3</code> (that both work with gcc) one had to be undefined (search
 for <code>CDEFINE</code> and <code>-U</code>). These details will be important momentarily.</p>
 <p>As far as <code>NOON</code> and <code>ABBA</code> being ROT13 pairs, notice how <code>NOON</code> is not in the
 original code but <code>ABBA</code> is; but in other versions it becomes <code>NOON</code> and they

--- a/bugs.md
+++ b/bugs.md
@@ -1,4 +1,4 @@
-# Bugs and (Mis)features
+# Bugs and (mis)features
 
 There are a number of known problems with IOCCC entries: many of
 which have to do with differences between today's compiler environments
@@ -493,7 +493,7 @@ emulator to test it) but running the code on the binary itself produces a
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
-There are no known bugs and (Mis)features for entries in 1985.
+There are no known bugs or (mis)features for entries in 1985.
 
 
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -522,7 +522,7 @@ the judges and shouldn't be fixed.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
-There are no known bugs and (Mis)features for entries in 1987.
+There are no known bugs or (mis)features for entries in 1987.
 
 
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -605,7 +605,7 @@ It should be noted that in additional to rot13 names there is code that is the
 reverse of other code (also wrt names). See the source file and the index.html
 (in the author's remarks) for more details.
 
-Fixing the (Mis)feature is likely to be a very difficult challenge especially
+Fixing the (mis)feature is likely to be a very difficult challenge especially
 without breaking something else which is far more likely (see below in tips from
 Cody). You are welcome to try and fix it if you can!
 
@@ -667,7 +667,7 @@ ROT13 of each other as well which is the reverse of the original (this is not
 because it goes backwards (it doesn't in this version) but because they are
 ROT13 pairs!). `main` spelt backwards is `niam` and `pain` spelt backwards is
 `niap`. Furthermore see the Makefile for other defines that had to be specified
-and for ver2 and ver3 (that both work with gcc) one had to be undefined (search
+and for `ver2` and `ver3` (that both work with gcc) one had to be undefined (search
 for `CDEFINE` and `-U`). These details will be important momentarily.
 
 As far as `NOON` and `ABBA` being ROT13 pairs, notice how `NOON` is not in the

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -383,7 +383,7 @@ we centralize them below.</p>
 <p>The <a href="judges.html">IOCCC judges</a> wish to recognize the many
 important contributions to the IOCCC presentation of past IOCCC entries.
 We are pleased to note the many contributions, <strong>made since 2021 Jan 01</strong>,
-on a IOCCC entry by entry basis.</p>
+on an IOCCC entry by entry basis.</p>
 <h2 id="ioccc-thank-you-table-of-contents">IOCCC thank you table of contents</h2>
 <ul>
 <li><a href="#1984">1984 entries</a> | <a href="#1985">1985 entries</a> | <a href="#1986">1986 entries</a> | <a href="#1987">1987 entries</a></li>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -9,7 +9,7 @@ we centralize them below.
 The [IOCCC judges](judges.html) wish to recognize the many
 important contributions to the IOCCC presentation of past IOCCC entries.
 We are pleased to note the many contributions, **made since 2021 Jan 01**,
-on a IOCCC entry by entry basis.
+on an IOCCC entry by entry basis.
 
 
 ## IOCCC thank you table of contents


### PR DESCRIPTION

In other words rather than have the link name in the form of:

    1984 decot bugs
 
it is now:

    1984/decot in bugs.html

so that it matches how the entry itself looks (as in how it's 
identified) and to say where (what file) it is (in). The reason it says 
'in bugs.html' rather than 'bugs' (saying that the entry has bugs) is 
because not all are bugs and it's saying where to see it anyway. But 
some are features, others are missing links or files or other things 
like that and to keep the same form it now says 'in bugs.html'.

This was done with my sgit(1) tool like:
    
    sgit -e 's,\([0-9][0-9][0-9][0-9]\) \([-a-z\.0-9]*\) bugs,\1/\2 in bugs.html,g' '*/*md'

The link to bugs.html itself has the path '../../bugs.html'. This is 
important as it's meant to be rendered in the browser. At first this was
not remembered and I did something like:
    
    sgit -e 's,\[\([0-9][0-9][0-9][0-9]\) \([-a-z\.0-9]*\) bugs\](../../bugs.html,\[\1/\2 in bugs.html\](%%REPO_URL%%/bugs.html,g' '*/*md'

but this was changed to the simpler one due to the problem described 
above. It's worth putting this note here as a reminder, though, so I
have included it here.
