### PR TITLE
Typo fix in FAQ 4.1

### DIFF
--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -136,13 +136,15 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c ${PROG}.alt.c
-	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS} || \
-	    ${CC} ${CFLAGS} ${PROG}.alt.c -o $@ ${LDFLAGS}
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # alternative executable
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} ${PROG}.alt.c -o $@ ${LDFLAGS}
 
 # data files
 #

--- a/1985/sicherman/README.md
+++ b/1985/sicherman/README.md
@@ -4,9 +4,8 @@
     make all
 ```
 
-There is another version that will be compiled in case the first fails. This
-should happen automatically. See [Alternate code](#alternate-code) below for
-more details on it.
+There is another version that can be compiled in case the first fails.
+See [Alternate code](#alternate-code) below for more details on it.
 
 
 ## To use:
@@ -40,14 +39,10 @@ audience.
 
 ### Alternate build:
 
-Although this will be built if the original fails to compile you can do it
-manually like:
 
 ``` <!---sh-->
     make alt
 ```
-
-In this case it will be built as `sicherman.alt`.
 
 
 ### Alternate use:

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -397,9 +397,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 1985/sicherman/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
-<p>There is another version that will be compiled in case the first fails. This
-should happen automatically. See <a href="#alternate-code">Alternate code</a> below for
-more details on it.</p>
+<p>There is another version that can be compiled in case the first fails.
+See <a href="#alternate-code">Alternate code</a> below for more details on it.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sicherman &lt; file
 
@@ -417,10 +416,7 @@ will be built in the case of the <a href="https://github.com/ioccc-src/temp-test
 In this case it’ll be compiled to <code>sicherman</code> to simplify it for the larger
 audience.</p>
 <h3 id="alternate-build">Alternate build:</h3>
-<p>Although this will be built if the original fails to compile you can do it
-manually like:</p>
 <pre><code>    make alt</code></pre>
-<p>In this case it will be built as <code>sicherman.alt</code>.</p>
 <h3 id="alternate-use">Alternate use:</h3>
 <pre><code>    ./sicherman.alt &lt; file</code></pre>
 <h3 id="alternate-try">Alternate try:</h3>

--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -25,7 +25,8 @@ if nothing else.
 
 ## Alternate code:
 
-Due to the different [conflicting problems](compilers.html) with gcc and clang, we
+Due to the different [conflicting problems](compilers.html) with `gcc` and
+`clang`, we
 instead offer the problematic code as an alternate version whereas
 [marshall.c](%%REPO_URL%%/1986/marshall/marshall.c) has both the infinite loop and the complicated arg to
 `_exit()` commented out, changing the value passed into `_exit()` to `1`.

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -378,7 +378,7 @@
 
 <!-- BEFORE: 1st line of markdown file: 1986/marshall/compilers.md -->
 <h1 id="conflicting-compilers-and-optimisers-that-broke-this-entry-in-2023">Conflicting compilers and optimisers that broke this entry in 2023</h1>
-<p>As briefly noted in the <a href="index.html">index.html</a> gcc and clang caused different
+<p>As briefly noted in the <a href="index.html">index.html</a> <code>gcc</code> and <code>clang</code> caused different
 problems with this entry depending on the optimiser being enabled or not, where
 if the optimiser was enabled it would work with one compiler and not the other.
 But if you then disabled the optimiser the opposite problem would occur: the
@@ -386,7 +386,7 @@ working compiler would no longer work and the non-functional one would start to
 work! And then there’s the problem of linux versus macOS causing problems.</p>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.alt.c">alternate code</a> (source code) demonstrates the problem so
 you can see if your compiler has the problem as described below.</p>
-<p>In some versions of gcc and clang (this was first discovered in fedora linux 38)
+<p>In some versions of <code>gcc</code> and <code>clang</code> (this was first discovered in fedora linux 38)
 if the compiler was enabled one compiler would generate code that segfaulted but
 the other one would not. However, when then disabling the optimiser the compiler
 that had no problem suddenly did and the one that did suddenly did not. But
@@ -396,25 +396,26 @@ entered. But then removing it would cause other problems as well, including a
 segfault.</p>
 <p>It was not only one compiler that dumped core. Both dumped core with other
 behaviour, depending on what changes in code were made and the optimiser being
-on or off. Clang in macOS also dumped core!</p>
-<p>The <a href="index.html">index.html</a> has the original fix
-for clang which works with some compilers depending on the optimiser. When we
-refer to the code below we refer to the alternate code.</p>
+on or off. <code>Clang</code> in macOS also dumped core!</p>
+<p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a> has the original fix
+for <code>clang</code> which works with some compilers depending on the optimiser. When we
+refer to the code below we refer to the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.alt.c">alternate code,
+marshall.alt.c</a>.</p>
 <h2 id="the-conflicting-compiler-problems">The conflicting compiler problems:</h2>
 <p>Below we describe the conflicting options that resulted in the need to modify
 the original code.</p>
 <h3 id="linux">Linux</h3>
-<p>With the optimiser disabled GCC compiled the code to enter an infinite loop.
-Enabling the optimiser and it worked fine. But if the optimiser is enabled clang
-generates code that first prints the text twice (it should print it once) and
+<p>With the optimiser disabled <code>GCC</code> compiled the code to enter an infinite loop.
+If the optimiser was enabled it worked fine. But if the optimiser is enabled
+<code>clang</code> generates code that first prints the text twice (it should print it once) and
 then immediately dumps core!</p>
 <p>But then there’s that infinite loop. What happens if we remove it?</p>
-<p>Once the loop is removed if we compile with clang and the optimiser is disabled
-all is okay. If however we compile with gcc and the optimiser is disabled the
+<p>Once the loop is removed if we compile with <code>clang</code> and the optimiser is disabled
+all is okay. If however we compile with <code>gcc</code> and the optimiser is disabled the
 string is printed once and then the program dumps core! Why is this? It is
 because of the call to <code>_exit()</code> (see below).</p>
-<p>Clang works fine with the loop removed and the optimiser disabled. If however we
-enable the optimiser clang will generate code that prints the string twice and
+<p><code>Clang</code> works fine with the loop removed and the optimiser disabled. If however we
+enable the optimiser <code>clang</code> will generate code that prints the string twice and
 dumps core just like before! What about the call to <code>_exit()</code>?</p>
 <p>The call was:</p>
 <pre><code>    _exit(argv[(int)*argc-2/cc[1*(int)*argc]|-1&lt;&lt;4]);</code></pre>
@@ -438,7 +439,7 @@ change to <code>_exit()</code>.</p>
 <p>And that is the tale of a little <del>engine</del> train that
 could…eventually! Or perhaps it’s the compilers, optimisers and OSes that
 eventually could?</p>
-<p>Whichever you wish it to be, it now works with both clang and gcc! Choo choo!</p>
+<p>Whichever you wish it to be, it now works with both <code>clang</code> and <code>cc</code> Choo choo!</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a></p>
 <!--

--- a/1986/marshall/compilers.md
+++ b/1986/marshall/compilers.md
@@ -1,6 +1,6 @@
 # Conflicting compilers and optimisers that broke this entry in 2023
 
-As briefly noted in the [index.html](index.html) gcc and clang caused different
+As briefly noted in the [index.html](index.html) `gcc` and `clang` caused different
 problems with this entry depending on the optimiser being enabled or not, where
 if the optimiser was enabled it would work with one compiler and not the other.
 But if you then disabled the optimiser the opposite problem would occur: the
@@ -10,7 +10,7 @@ work! And then there's the problem of linux versus macOS causing problems.
 The [alternate code](%%REPO_URL%%/1986/marshall/marshall.alt.c) (source code) demonstrates the problem so
 you can see if your compiler has the problem as described below.
 
-In some versions of gcc and clang (this was first discovered in fedora linux 38)
+In some versions of `gcc` and `clang` (this was first discovered in fedora linux 38)
 if the compiler was enabled one compiler would generate code that segfaulted but
 the other one would not. However, when then disabling the optimiser the compiler
 that had no problem suddenly did and the one that did suddenly did not. But
@@ -22,11 +22,12 @@ segfault.
 
 It was not only one compiler that dumped core. Both dumped core with other
 behaviour, depending on what changes in code were made and the optimiser being
-on or off. Clang in macOS also dumped core!
+on or off. `Clang` in macOS also dumped core!
 
-The [index.html](index.html) has the original fix
-for clang which works with some compilers depending on the optimiser. When we
-refer to the code below we refer to the alternate code.
+The [marshall.c](%%REPO_URL%%/1986/marshall/marshall.c) has the original fix
+for `clang` which works with some compilers depending on the optimiser. When we
+refer to the code below we refer to the [alternate code,
+marshall.alt.c](%%REPO_URL%%/1986/marshall/marshall.alt.c).
 
 ## The conflicting compiler problems:
 
@@ -35,20 +36,20 @@ the original code.
 
 ### Linux
 
-With the optimiser disabled GCC compiled the code to enter an infinite loop.
-Enabling the optimiser and it worked fine. But if the optimiser is enabled clang
-generates code that first prints the text twice (it should print it once) and
+With the optimiser disabled `GCC` compiled the code to enter an infinite loop.
+If the optimiser was enabled it worked fine. But if the optimiser is enabled
+`clang` generates code that first prints the text twice (it should print it once) and
 then immediately dumps core!
 
 But then there's that infinite loop. What happens if we remove it?
 
-Once the loop is removed if we compile with clang and the optimiser is disabled
-all is okay. If however we compile with gcc and the optimiser is disabled the
+Once the loop is removed if we compile with `clang` and the optimiser is disabled
+all is okay. If however we compile with `gcc` and the optimiser is disabled the
 string is printed once and then the program dumps core! Why is this? It is
 because of the call to `_exit()` (see below).
 
-Clang works fine with the loop removed and the optimiser disabled. If however we
-enable the optimiser clang will generate code that prints the string twice and
+`Clang` works fine with the loop removed and the optimiser disabled. If however we
+enable the optimiser `clang` will generate code that prints the string twice and
 dumps core just like before!  What about the call to `_exit()`?
 
 The call was:
@@ -90,7 +91,7 @@ And that is the tale of a little <del>engine</del> train that
 could...eventually! Or perhaps it's the compilers, optimisers and OSes that
 eventually could?
 
-Whichever you wish it to be, it now works with both clang and gcc! Choo choo!
+Whichever you wish it to be, it now works with both `clang` and `cc` Choo choo!
 
 
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -409,7 +409,8 @@ if nothing else.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./marshall</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
-<p>Due to the different <a href="compilers.html">conflicting problems</a> with gcc and clang, we
+<p>Due to the different <a href="compilers.html">conflicting problems</a> with <code>gcc</code> and
+<code>clang</code>, we
 instead offer the problematic code as an alternate version whereas
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a> has both the infinite loop and the complicated arg to
 <code>_exit()</code> commented out, changing the value passed into <code>_exit()</code> to <code>1</code>.</p>

--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ gen_top_html: ${GEN_TOP_HTML}
 # Just kidding .. So Long, and Thanks for All the Fish :-)
 thanks: ${GEN_TOP_HTML} thanks-for-help.md
 	@echo "Thanks for all the help ..."
-	@${GEN_TOP_HTML}
+	@${GEN_TOP_HTML} thanks-for-help
 	@echo "... and thanks for all the fish :-)"
 
 # build entry HTML files from markdown other than README.md to index.html

--- a/bin/gen-top-html.sh
+++ b/bin/gen-top-html.sh
@@ -93,7 +93,7 @@ shopt -s globstar	# enable ** to match all files and zero or more directories an
 
 # set variables referenced in the usage message
 #
-export VERSION="1.4.5 2024-04-23"
+export VERSION="1.4.6 2024-05-05"
 NAME=$(basename "$0")
 export NAME
 export V_FLAG=0
@@ -150,7 +150,7 @@ declare -ag TOOL_OPTION
 # usage
 #
 export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
-			[-t tagline] [-T md2html.sh] [-p tool] [-u repo_url]
+			[-t tagline] [-T md2html.sh] [-p tool] [-u repo_url] [file...]
 
 	-h		print help message and exit
 	-v level	set verbosity level (def level: 0)

--- a/bin/gen-top-html.sh
+++ b/bin/gen-top-html.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 #
-# gen-top-html.sh - generate select top level HTML files from markdown files
+# gen-top-html.sh - generate all or select top level HTML files from markdown files
 #
 # We also generate the bin/index.html file from the bin/README.md file.
 # We also generate the inc/index.html file from the inc/README.md file.
 # We also generate the archive/historic/index.html file from the archive/historic/README.md file.
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
+#
+# Cody Boone Ferguson made an improvement where one can specify the select top
+# html files to generate to save time. Works just like the script without args
+# but if any args are specified and the markdown file exists it will just
+# generate that or those html files. This is to save time for some Makefile
+# rules that only need update one file.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
@@ -130,6 +136,7 @@ TOP_MD_SET+=("next/guidelines")
 TOP_MD_SET+=("next/rules")
 TOP_MD_SET+=("nojs-menu")
 TOP_MD_SET+=("thanks-for-help")
+declare -ag TOP_MD_SELECT_SET
 #
 export NOOP=
 export DO_NOT_PROCESS=
@@ -283,7 +290,22 @@ shift $(( OPTIND - 1 ));
 if [[ $V_FLAG -ge 5 ]]; then
     echo "$0: debug[5]: file argument count: $#" 1>&2
 fi
-#
+
+# allow specifying specific files to generate
+FILE_COUNT="$#"
+while [[ $# -ne 0 ]]; do
+    for (( index=0; index < ${#TOP_MD_SET[@]}; index++ )); do
+	if [[ "${TOP_MD_SET[$index]}" = "$1" ]]; then
+	    TOP_MD_SELECT_SET+=("$1")
+	fi
+    done
+    shift 1
+done
+if [[ "$FILE_COUNT" != 0 && ${#TOP_MD_SELECT_SET[@]} = 0 ]]; then
+    echo "$0: ERROR: no select files specified are in allowed set" 1>&2
+    exit 3
+fi
+
 if [[ $# -ne 0 ]]; then
     echo "$0: ERROR: expected 0 args, found: $#" 1>&2
     exit 3
@@ -414,6 +436,11 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: PANDOC_WRAPPER=$PANDOC_WRAPPER" 1>&2
     echo "$0: debug[3]: REPO_URL=$REPO_URL" 1>&2
     echo "$0: debug[3]: SITE_URL=$SITE_URL" 1>&2
+    if (( ${#TOP_MD_SELECT_SET[@]} )); then
+	for index in "${!TOP_MD_SELECT_SET[@]}"; do
+	    echo "$0: debug[3]: TOP_MD_SELECT_SET[$index]=${TOP_MD_SELECT_SET[$index]}" 1>&2
+	done
+    fi
     for index in "${!TOP_MD_SET[@]}"; do
 	echo "$0: debug[3]: TOP_MD_SET[$index]=${TOP_MD_SET[$index]}" 1>&2
     done
@@ -442,80 +469,157 @@ fi
 
 # process the entire markdown set
 #
-for name in "${TOP_MD_SET[@]}"; do
+if (( ${#TOP_MD_SELECT_SET[@]} )); then
+    for name in "${TOP_MD_SELECT_SET[@]}"; do
 
-    # verify that the markdown file exists at the topdir
-    #
-    export MD_FILE="$name.md"
-    if [[ ! -e $MD_FILE ]]; then
-	echo  "$0: Warning: markdown file does not exist: $MD_FILE" 1>&2
-	EXIT_CODE=8 # exit 8
-	echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
-	continue
-    fi
-    if [[ ! -f $MD_FILE ]]; then
-	echo  "$0: Warning: markdown file is not a regular file: $MD_FILE" 1>&2
-	EXIT_CODE=8 # exit 8
-	echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
-	continue
-    fi
-    if [[ ! -r $MD_FILE ]]; then
-	echo  "$0: Warning: markdown file is not a readable file: $MD_FILE" 1>&2
-	EXIT_CODE=8 # exit 8
-	echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
-	continue
-    fi
-    if [[ ! -s $MD_FILE ]]; then
-	echo  "$0: Warning: markdown file is not a non-empty readable file: $MD_FILE" 1>&2
-	EXIT_CODE=8 # exit 8
-	echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
-	continue
-    fi
-    export HTML_FILE="$name.html"
-    # bin/README is a special case
-    if [[ $name == bin/README ]]; then
-	HTML_FILE="bin/index.html"
-    fi
-    # inc/README is a special case
-    if [[ $name == inc/README ]]; then
-	HTML_FILE="inc/index.html"
-    fi
-    # next/README is a special case
-    if [[ $name == next/README ]]; then
-	HTML_FILE="next/index.html"
-    fi
-    # archive/historic/README is a special case
-    if [[ $name == archive/historic/README ]]; then
-	HTML_FILE="archive/historic/index.html"
-    fi
-
-    # use the md2html.sh tool to form the HTML file, unless -n
-    #
-    if [[ -z $NOOP ]]; then
-	if [[ $V_FLAG -ge 1 ]]; then
-	    echo "$0: debug[1]: about to run: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
-	         "-m $MD_FILE -- $MD_FILE $HTML_FILE" 1>&2
-	fi
-	"$MD2HTML_SH" -U "$SITE_URL/$HTML_FILE" "${TOOL_OPTION[@]}" \
-	    -m "$MD_FILE" -- "$MD_FILE" "$HTML_FILE"
-	status="$?"
-	if [[ $status -ne 0 ]]; then
-	    echo "$0: Warning: md2html.sh: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
-		 "-m $MD_FILE -- $MD_FILE $HTML_FILE" \
-		 "failed, error: $status" 1>&2
-	    EXIT_CODE="1"  # exit 1
+	# verify that the markdown file exists at the topdir
+	#
+	export MD_FILE="$name.md"
+	if [[ ! -e $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file does not exist: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
 	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
-	elif [[ $V_FLAG -ge 3 ]]; then
-	    echo "$0: debug[3]: now up to date: $HTML_FILE" 1>&2
+	    continue
+	fi
+	if [[ ! -f $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file is not a regular file: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	if [[ ! -r $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file is not a readable file: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	if [[ ! -s $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file is not a non-empty readable file: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	export HTML_FILE="$name.html"
+	# bin/README is a special case
+	if [[ $name == bin/README ]]; then
+	    HTML_FILE="bin/index.html"
+	fi
+	# inc/README is a special case
+	if [[ $name == inc/README ]]; then
+	    HTML_FILE="inc/index.html"
+	fi
+	# next/README is a special case
+	if [[ $name == next/README ]]; then
+	    HTML_FILE="next/index.html"
+	fi
+	# archive/historic/README is a special case
+	if [[ $name == archive/historic/README ]]; then
+	    HTML_FILE="archive/historic/index.html"
 	fi
 
-    # report disabled by -n
-    #
-    elif [[ $V_FLAG -ge 5 ]]; then
-	echo "$0: debug[5]: because of -n, did not run: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
-	     "-m $MD_FILE -- $MD_FILE $HTML_FILE" 1>&2
-    fi
-done
+	# use the md2html.sh tool to form the HTML file, unless -n
+	#
+	if [[ -z $NOOP ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: debug[1]: about to run: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
+		     "-m $MD_FILE -- $MD_FILE $HTML_FILE" 1>&2
+	    fi
+	    "$MD2HTML_SH" -U "$SITE_URL/$HTML_FILE" "${TOOL_OPTION[@]}" \
+		-m "$MD_FILE" -- "$MD_FILE" "$HTML_FILE"
+	    status="$?"
+	    if [[ $status -ne 0 ]]; then
+		echo "$0: Warning: md2html.sh: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
+		     "-m $MD_FILE -- $MD_FILE $HTML_FILE" \
+		     "failed, error: $status" 1>&2
+		EXIT_CODE="1"  # exit 1
+		echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    elif [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: now up to date: $HTML_FILE" 1>&2
+	    fi
+
+	# report disabled by -n
+	#
+	elif [[ $V_FLAG -ge 5 ]]; then
+	    echo "$0: debug[5]: because of -n, did not run: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
+		 "-m $MD_FILE -- $MD_FILE $HTML_FILE" 1>&2
+	fi
+    done
+else
+    for name in "${TOP_MD_SET[@]}"; do
+
+	# verify that the markdown file exists at the topdir
+	#
+	export MD_FILE="$name.md"
+	if [[ ! -e $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file does not exist: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	if [[ ! -f $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file is not a regular file: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	if [[ ! -r $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file is not a readable file: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	if [[ ! -s $MD_FILE ]]; then
+	    echo  "$0: Warning: markdown file is not a non-empty readable file: $MD_FILE" 1>&2
+	    EXIT_CODE=8 # exit 8
+	    echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    continue
+	fi
+	export HTML_FILE="$name.html"
+	# bin/README is a special case
+	if [[ $name == bin/README ]]; then
+	    HTML_FILE="bin/index.html"
+	fi
+	# inc/README is a special case
+	if [[ $name == inc/README ]]; then
+	    HTML_FILE="inc/index.html"
+	fi
+	# next/README is a special case
+	if [[ $name == next/README ]]; then
+	    HTML_FILE="next/index.html"
+	fi
+	# archive/historic/README is a special case
+	if [[ $name == archive/historic/README ]]; then
+	    HTML_FILE="archive/historic/index.html"
+	fi
+
+	# use the md2html.sh tool to form the HTML file, unless -n
+	#
+	if [[ -z $NOOP ]]; then
+	    if [[ $V_FLAG -ge 1 ]]; then
+		echo "$0: debug[1]: about to run: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
+		     "-m $MD_FILE -- $MD_FILE $HTML_FILE" 1>&2
+	    fi
+	    "$MD2HTML_SH" -U "$SITE_URL/$HTML_FILE" "${TOOL_OPTION[@]}" \
+		-m "$MD_FILE" -- "$MD_FILE" "$HTML_FILE"
+	    status="$?"
+	    if [[ $status -ne 0 ]]; then
+		echo "$0: Warning: md2html.sh: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
+		     "-m $MD_FILE -- $MD_FILE $HTML_FILE" \
+		     "failed, error: $status" 1>&2
+		EXIT_CODE="1"  # exit 1
+		echo "$0: Warning: EXIT_CODE set to: $EXIT_CODE" 1>&2
+	    elif [[ $V_FLAG -ge 3 ]]; then
+		echo "$0: debug[3]: now up to date: $HTML_FILE" 1>&2
+	    fi
+
+	# report disabled by -n
+	#
+	elif [[ $V_FLAG -ge 5 ]]; then
+	    echo "$0: debug[5]: because of -n, did not run: $MD2HTML_SH -U $SITE_URL/$HTML_FILE ${TOOL_OPTION[*]}" \
+		 "-m $MD_FILE -- $MD_FILE $HTML_FILE" 1>&2
+	fi
+    done
+fi
 
 # All Done!!! -- Jessica Noll, Age 2
 #

--- a/faq.html
+++ b/faq.html
@@ -430,7 +430,7 @@
 <h2 id="section-4---changes-made-to-ioccc-entries">Section 4 - <a href="#faq4">Changes made to IOCCC entries</a></h2>
 <ul>
 <li><a href="#faq4_0">4.0 - Why are some winning author remarks incongruent with the winning IOCCC code?</a></li>
-<li><a href="#faq4_1">4.1 - Why were some calls to the libc function gets(3( changed to use fgets(3)?</a></li>
+<li><a href="#faq4_1">4.1 - Why were some calls to the libc function gets(3) changed to use fgets(3)?</a></li>
 <li><a href="#faq4_2">4.2 - What was changed in an IOCCC entry source code?</a></li>
 <li><a href="#faq4_3">4.3 - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?</a></li>

--- a/faq.md
+++ b/faq.md
@@ -53,7 +53,7 @@
 
 ## Section  4 - [Changes made to IOCCC entries](#faq4)
 - [4.0  - Why are some winning author remarks incongruent with the winning IOCCC code?](#faq4_0)
-- [4.1  - Why were some calls to the libc function gets&#x28;3&#x28; changed to use fgets&#x28;3&#x29;?](#faq4_1)
+- [4.1  - Why were some calls to the libc function gets&#x28;3&#x29; changed to use fgets&#x28;3&#x29;?](#faq4_1)
 - [4.2  - What was changed in an IOCCC entry source code?](#faq4_2)
 - [4.3  - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?](#faq4_3)


### PR DESCRIPTION
 

The text in markdown was gets&#x28;3&#x28; which resulted in gets(( 
rather than gets().