### PR TITLE
Clarify FAQ 5.5 wrt anonymous authors

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -2146,7 +2146,7 @@ and ask for help. See <a href="#fix_an_entry">FAQ 5.3</a> for information on ope
 <h2 id="faq-5.5-how-may-i-correct-or-update-ioccc-author-information">FAQ 5.5: How may I correct or update IOCCC author information?</h2>
 </div>
 </div>
-<h4 id="please-help-us-identify-proper-locations-for-ioccc-authors">PLEASE HELP us identify proper locations for IOCCC authors</h4>
+<h4 id="please-help-us-identify-proper-locations-for-ioccc-authors-non-anonymous-only">PLEASE HELP us identify proper locations for IOCCC authors (NON-ANONYMOUS ONLY)</h4>
 <p>If you know the location of an author listed under:</p>
 <p>      <strong><a href="location.html#ZZ">ZZ - Unknown location</a></strong></p>
 <p>or if you find IOCCC author location that is incorrect,
@@ -2159,10 +2159,13 @@ information about author handles.</p>
 <p>The contents of these JSON files contain the best known information
 about authors of IOCCC entries. See <a href="#author_json">FAQ 6.6</a> for information
 about the contents of these JSON file and how they are used.</p>
-<p>You may update IOCCC author information in a <code>author_handle.json</code> file
-by <a href="faq.html#pull_request">submitting a pull request</a>
-against the master <a href="https://github.com/ioccc-src/winner/branches">branch</a>
-of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>.</p>
+<p>Assuming that it’s not an anonymous author, you may update IOCCC author
+information in an <code>author_handle.json</code> file by <a href="faq.html#pull_request">submitting a pull
+request</a> against the master
+<a href="https://github.com/ioccc-src/winner/branches">branch</a> of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner
+repo</a>. If it’s an anonymous author it’s
+best that you leave it to the judges as only the judges know what the authors
+want.</p>
 <p>Please see <a href="#fix_an_entry">FAQ 5.2 How may I submit a fix to an IOCCC entry</a>.</p>
 <p>See also the <a href="#ull_request">FAQ 6.10 How does someone
 make a change to a file and submit that change as a GitHub pull

--- a/faq.md
+++ b/faq.md
@@ -2570,7 +2570,7 @@ and ask for help.  See [FAQ 5.3](#fix_an_entry) for information on opening up an
 </div>
 </div>
 
-#### PLEASE HELP us identify proper locations for IOCCC authors
+#### PLEASE HELP us identify proper locations for IOCCC authors (NON-ANONYMOUS ONLY)
 
 If you know the location of an author listed under:
 
@@ -2593,10 +2593,13 @@ The contents of these JSON files contain the best known information
 about authors of IOCCC entries.  See [FAQ 6.6](#author_json) for information
 about the contents of these JSON file and how they are used.
 
-You may update IOCCC author information in a `author_handle.json` file
-by [submitting  a pull request](faq.html#pull_request)
-against the master [branch](https://github.com/ioccc-src/winner/branches)
-of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner).
+Assuming that it's not an anonymous author, you may update IOCCC author
+information in an `author_handle.json` file by [submitting  a pull
+request](faq.html#pull_request) against the master
+[branch](https://github.com/ioccc-src/winner/branches) of the [ioccc-src/winner
+repo](https://github.com/ioccc-src/winner). If it's an anonymous author it's
+best that you leave it to the judges as only the judges know what the authors
+want.
 
 Please see [FAQ 5.2 How may I submit a fix to an IOCCC entry](#fix_an_entry).
 


### PR DESCRIPTION
The FAQ asks to fix or fill in missing author locations but I have changed it to say only for non-anonymous authors as only the judges know exactly what each anonymous author wants. This is added because against better judgement and making an assumption (and we all know what that does) I had thought that since location is identifying it must have been a mistake that location codes were in some of the anonymous author details (in one case it appeared to not be an error so that one was not touched).

But the only mistake is that anonymous authors were touched in the first place so to try and prevent that I have updated the FAQ about not updating anonymous author details. There might be other places that have to be updated with this thought and it might be a good idea to have an FAQ about both past and future handling of anonymous entries but that is something I will leave to the judges.