### PR TITLE
Typo fix in FAQ 3.9 title

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -415,7 +415,7 @@
 <li><a href="#faq3_6">3.6 - An IOCCC entry messed up my terminal application, how do I fix this?</a></li>
 <li><a href="#faq3_7">3.7 - How do I run an IOCCC entry that requires X11?</a></li>
 <li><a href="#faq3_8">3.8 - How do I compile an IOCCC entry that requires SDL1 or SDL2?</a></li>
-<li><a href="#faq3_9">3.9 - How do I compile an IOCCC entry that requires (n)?</a></li>
+<li><a href="#faq3_9">3.9 - How do I compile an IOCCC entry that requires (n)curses?</a></li>
 <li><a href="#faq3_10">3.10 - How do I compile and use an IOCCC entry that requires sound?</a></li>
 <li><a href="#faq3_11">3.11 - Why do Makefiles use -Weverything with clang?</a></li>
 <li><a href="#faq3_12">3.12 - How do I find out how to send interrupt/EOF etc. for entries that require it?</a></li>
@@ -1456,7 +1456,7 @@ fix it and make a new pull request.</p>
 as a GitHub pull request</a> for more information about pull requests.</p>
 <div id="faq3_9">
 <div id="curses">
-<h3 id="faq-3.9-how-do-i-compile-an-ioccc-entry-that-requires-n">FAQ 3.9: How do I compile an IOCCC entry that requires (n)?</h3>
+<h3 id="faq-3.9-how-do-i-compile-an-ioccc-entry-that-requires-ncurses">FAQ 3.9: How do I compile an IOCCC entry that requires (n)curses?</h3>
 </div>
 </div>
 <p>This depends on your operating system but below are instructions for Linux and

--- a/faq.md
+++ b/faq.md
@@ -38,7 +38,7 @@
 - [3.6  - An IOCCC entry messed up my terminal application, how do I fix this?](#faq3_6)
 - [3.7  - How do I run an IOCCC entry that requires X11?](#faq3_7)
 - [3.8  - How do I compile an IOCCC entry that requires SDL1 or SDL2?](#faq3_8)
-- [3.9  - How do I compile an IOCCC entry that requires &#x28;n&#x29;?](#faq3_9)
+- [3.9  - How do I compile an IOCCC entry that requires &#x28;n&#x29;curses?](#faq3_9)
 - [3.10 - How do I compile and use an IOCCC entry that requires sound?](#faq3_10)
 - [3.11 - Why do Makefiles use -Weverything with clang?](#faq3_11)
 - [3.12 - How do I find out how to send interrupt/EOF etc. for entries that require it?](#faq3_12)
@@ -1466,7 +1466,7 @@ as a GitHub pull request](#ull_request) for more information about pull requests
 
 <div id="faq3_9">
 <div id="curses">
-### FAQ 3.9: How do I compile an IOCCC entry that requires &#x28;n&#x29;?
+### FAQ 3.9: How do I compile an IOCCC entry that requires &#x28;n&#x29;curses?
 </div>
 </div>
 


### PR DESCRIPTION
It ended up being just:

    3.9 - How do I compile an IOCCC entry that requires (n)?

instead of:

    3.9 - How do I compile an IOCCC entry that requires (n)curses?

and this has been corrected.