### PR TITLE
Fix make clobber in 1991/dds

### DIFF
--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -209,7 +209,7 @@ clean:
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
 	${RM} -rf *.dSYM
-	${RM} -f a.out
+	${RM} -f a.out a.c
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \


### PR DESCRIPTION
It has to remove a.c too, not just a.out.