### PR TITLE
Update template issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Suggest a feature
 title: "[Feature] <title>"
+labels: ["Feature"]
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,24 +1,37 @@
 name: Feature request
 description: Suggest a feature
-title: "[Feature] <feature>"
+title: "[Feature] <title>"
 body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the problem you're reporting.
+    description: Please search to see if an issue already exists for the feature you're suggesting.
     options:
     - label: I have searched for existing issues and did not find anything like it
       required: true
+
 - type: textarea
   attributes:
     label: Describe the feature
-    description: Please describe what you would like to have.
+    description: |
+        Please describe the feature you would like to have and why, as best you can (the more details you provide the better).
   validations:
     required: true
+
+- type: textarea
+  attributes:
+    label: Relevant images, screenshots or other files
+    description: |
+       If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
 - type: textarea
   attributes:
     label: Relevant links
-    description: Please provide us with a list of relevant links if applicable.
+    description: Please provide us with a list of relevant links, if applicable.
   validations:
     required: false
 
@@ -26,9 +39,8 @@ body:
   attributes:
     label: Anything else?
     description: |
-      Do you have any additional context or information?
+      Do you have any additional context or information? Please let us know!
 
-      Tip: you can attach images or log files by clicking this area to highlight it and then dragging files in.
   validations:
     required: false
 

--- a/.github/ISSUE_TEMPLATE/other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yml
@@ -1,6 +1,6 @@
 name: Other issue
 description: Some problem not listed
-title: "[Other] <subject>"
+title: "[Other] <title>"
 body:
 - type: checkboxes
   attributes:
@@ -12,19 +12,52 @@ body:
 - type: textarea
   attributes:
     label: Describe the problem
-    description: Please describe the issue that you are having.
+    description: Please describe the issue that you are having, as best you can (the more details you provide the better).
   validations:
     required: true
+
+- type: textarea
+  attributes:
+    label: Relevant images, screenshots or other files
+    description: |
+       Do you have any **relevant** screenshots or other files? This can be **EXTREMELY** helpful, if you do.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
 - type: textarea
   attributes:
     label: What you expect
-    description: Please describe what you think it should be instead and why.
+    description: |
+        Please describe what you think it should be instead and why, as best you can (the more details you provide the better). If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+        Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
   validations:
     required: true
+
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      Example:
+        - **OS**: macOS Sonoma 14.5
+        - **Device**: MacBook Pro M1
+        - **Browser**: Safari 17.5 (19618.2.12.11.6)
+
+        **PLEASE** provide **AT** **LEAST** the above items. If you have the **SAME** problem with more than one device please list the above for **ALL** **RELEVANT** **devices** with **any** **relevant** **context**.
+    value: |
+        - OS:
+        - Device:
+        - Browser:
+    render: markdown
+  validations:
+    required: true
+
 - type: textarea
   attributes:
     label: Relevant links
-    description: Please provide us with a list of relevant links if applicable.
+    description: Please provide us with a list of relevant links, if applicable.
   validations:
     required: false
 
@@ -34,7 +67,7 @@ body:
     description: |
       Do you have any additional context or information?
 
-      Tip: you can attach images or log files by clicking this area to highlight it and then dragging files in.
+      Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
   validations:
     required: false
 

--- a/.github/ISSUE_TEMPLATE/website_issue.yml
+++ b/.github/ISSUE_TEMPLATE/website_issue.yml
@@ -1,6 +1,6 @@
 name: Website issue
-description: File a problem with the website
-title: "[Website] <subject>"
+description: Report a problem with the website
+title: "[Website] <title>"
 labels: ["Website"]
 body:
 - type: checkboxes
@@ -13,31 +13,45 @@ body:
 - type: textarea
   attributes:
     label: Describe the problem
-    description: Please describe the issue that you have with the website.
+    description: Please describe the issue that you have with the website, as best you can (the more details you provide the better).
   validations:
     required: true
+
+- type: textarea
+  attributes:
+    label: Screenshots
+    description: |
+       Do you have any **relevant** screenshots? This can be **EXTREMELY** helpful, if you do.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
 - type: textarea
   attributes:
     label: What you expect
-    description: Please describe what you think it should be instead and why.
+    description: |
+        Please describe what you think it should be instead and why (the more details you provide the better). If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+        Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
   validations:
     required: true
 - type: textarea
   attributes:
     label: Relevant links
-    description: Please provide us with a list of relevant links.
+    description: Please provide a list of **relevant** links.
   validations:
     required: true
 - type: textarea
   attributes:
     label: Environment
     description: |
-      Examples:
+      Example:
         - **OS**: macOS Sonoma 14.5
         - **Device**: MacBook Pro M1
         - **Browser**: Safari 17.5 (19618.2.12.11.6)
 
-        If you have the problem with more than one device please list the above for all devices.
+        **PLEASE** provide **AT** **LEAST** the above items. If you have the **SAME** problem with more than one device please list the above for **ALL** **RELEVANT** **devices** with **any** **relevant** **context**.
     value: |
         - OS:
         - Device:
@@ -48,7 +62,7 @@ body:
 - type: checkboxes
   attributes:
     label: Do you have JavaScript enabled?
-    description: Please let us know if you have JavaScript enabled or not.
+    description: Please let us know if you have JavaScript enabled or not, as this might be relevant in some cases.
     options:
     - label: JavaScript enabled?
       required: true
@@ -57,9 +71,9 @@ body:
   attributes:
     label: Anything else?
     description: |
-      Do you have any additional context? Do you have any browser plug-ins that might be causing a problem? Please let us know!
+      Do you have any additional context or information? Do you have any browser plug-ins that might be causing a problem? Please let us know!
 
-      Tip: you can attach images or log files by clicking this area to highlight it and then dragging files in.
+      Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
   validations:
     required: false
 


### PR DESCRIPTION
I believe that with this commit issue #858 can be marked complete but this can only be determined once this has been merged. From a test repo I made it does look pretty nice.

Things are more consistent, there is a place for attaching images explicitly (though not required as it's not always relevant though very helpful), typo fixes and rewording at the least.