### PR TITLE
Fix 2012/zeitak/Makefile

### DIFF
--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-constant-conversion -Wno-format-security \
 	  -Wno-incompatible-function-pointer-types -Wno-int-conversion \
 	  -Wno-missing-braces -Wno-non-literal-null-conversion \
-	  -Wno-pointer-sign \Wno-pointer-to-int-cast -Wno-self-assign \
+	  -Wno-pointer-sign -Wno-pointer-to-int-cast -Wno-self-assign \
 	  -Wno-unused-parameter -Wno-incompatible-pointer-types -Wno-overflow \
 	  -Wno-pointer-to-int-cast -Wno-strict-aliasing
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -3703,13 +3703,15 @@ does this for the few who might use Windows.</p>
 <h2 id="zeitak"><a href="2012/zeitak/index.html">2012/zeitak</a></h2>
 <h3 id="source-code-zeitak.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak//zeitak.c">zeitak.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak/test.sh">test.sh</a> script and the <code>make test</code> rule
+<p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak/test.sh">test.sh</a> script and the <code>make test</code> rule
 that uses the script along with a number of files that will correctly be flagged
 as incorrect (including a text file and a java file, with a joke, to show that
 it’s not that it parses C but rather just matching pairs though that’s probably
 obvious) and some correctly nested files were also added including
 <a href="1984/anonymous/index.html">1984/anonymous</a> (as the author explicitly mentioned
 it) and a java file as well with another joke.</p>
+<p>A problem was later fixed in the Makefile by Cody, a typo in the <code>CSILENCE</code>
+variable that prevented compilation.</p>
 <p>A minor point is that the author noted that one should
 look at the program source with tab space of 4 characters so Cody added the
 command to do this in vim for those who use it, in the judges’ remarks, to make

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -4711,13 +4711,16 @@ does this for the few who might use Windows.
 ### Source code: [zeitak.c](%%REPO_URL%%/2012/zeitak//zeitak.c)
 </div>
 
-[Cody](#cody) [test.sh](%%REPO_URL%%/2012/zeitak/test.sh) script and the `make test` rule
+[Cody](#cody) added the [test.sh](%%REPO_URL%%/2012/zeitak/test.sh) script and the `make test` rule
 that uses the script along with a number of files that will correctly be flagged
 as incorrect (including a text file and a java file, with a joke, to show that
 it's not that it parses C but rather just matching pairs though that's probably
 obvious) and some correctly nested files were also added including
 [1984/anonymous](1984/anonymous/index.html) (as the author explicitly mentioned
 it) and a java file as well with another joke.
+
+A problem was later fixed in the Makefile by Cody, a typo in the `CSILENCE`
+variable that prevented compilation.
 
 A minor point is that the author noted that one should
 look at the program source with tab space of 4 characters so Cody added the


### PR DESCRIPTION
An error (a typo) in the CSILENCE prevented the code from compiling.