### PR TITLE
Fix make clobber in 1991/brnstnd

### DIFF
--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -209,7 +209,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM
+	${RM} -rf *.dSYM sorta
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \


### PR DESCRIPTION
It left 'sorta' in the directory even after the target file was deleted.