### PR TITLE
Many fixes in thanks file through 1995

### DIFF
--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -209,7 +209,7 @@ clean:
 
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
-	${RM} -rf *.dSYM
+	${RM} -rf *.dSYM sorta
 	@-if [ -e sandwich ]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \

--- a/faq.html
+++ b/faq.html
@@ -435,6 +435,7 @@
 <li><a href="#faq4_3">4.3 - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?</a></li>
 <li><a href="#faq4_4">4.4 - What is the meaning of the file ending in .orig.c in IOCCC entries?</a></li>
+<li><a href="#faq4_5">4.5 - Why were alternate versions added to some entries when the original entry worked fine and well?</a></li>
 </ul>
 <h2 id="section-5---helping-the-ioccc">Section 5 - <a href="#faq5">Helping the IOCCC</a></h2>
 <ul>
@@ -1990,6 +1991,18 @@ VAX-11/PDP-11, however).</p>
 <p>Due to the fact that the original code has sometimes had to change these files
 are the original winning entry or as close to as possible to the original that
 we can find.</p>
+<div id="faq4_5">
+<h3 id="faq-4.5-why-were-alternate-versions-added-to-some-entries-when-the-original-entry-worked-fine-and-well">FAQ 4.5: Why were alternate versions added to some entries when the original entry worked fine and well?</h3>
+</div>
+<p>This was a judgement call and the reasons vary. In many cases it was simply to
+make the entry more presentable to more people but without modifying the entry
+itself, which would be tampering with the entry, and in some cases it would be
+changing it so much that it would no longer be what was submitted.</p>
+<p>In one case an alternate version was created to help locate and fix a bug that
+prevented the entry from working properly and it seemed like it should be added
+as well, for fun.</p>
+<p>In some cases it might be better to not have them but as noted this is a
+judgement call.</p>
 <div id="faq5">
 <h2 id="section-5-updating-or-correcting-ioccc-web-site-content">Section 5: Updating or correcting IOCCC web site content</h2>
 </div>

--- a/faq.md
+++ b/faq.md
@@ -58,6 +58,7 @@
 - [4.3  - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?](#faq4_3)
 - [4.4  - What is the meaning of the file ending in .orig.c in IOCCC entries?](#faq4_4)
+- [4.5  - Why were alternate versions added to some entries when the original entry worked fine and well?](#faq4_5)
 
 
 ## Section  5 - [Helping the IOCCC](#faq5)
@@ -2358,6 +2359,22 @@ See also [FAQ 4.2: What was changed in an IOCCC entry source code?](#what_change
 Due to the fact that the original code has sometimes had to change these files
 are the original winning entry or as close to as possible to the original that
 we can find.
+
+<div id="faq4_5">
+### FAQ 4.5: Why were alternate versions added to some entries when the original entry worked fine and well?
+</div>
+
+This was a judgement call and the reasons vary. In many cases it was simply to
+make the entry more presentable to more people but without modifying the entry
+itself, which would be tampering with the entry, and in some cases it would be
+changing it so much that it would no longer be what was submitted.
+
+In one case an alternate version was created to help locate and fix a bug that
+prevented the entry from working properly and it seemed like it should be added
+as well, for fun.
+
+In some cases it might be better to not have them but as noted this is a
+judgement call.
 
 
 <div id="faq5">

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -404,8 +404,8 @@ on an IOCCC entry by entry basis.</p>
 <h1 id="section"><a href="1984/index.html">1984</a></h1>
 </div>
 <div id="1984_anonymous">
-<h2 id="anonymous"><a href="1984/anonymous/index.html">1984/anonymous</a></h2>
-<h3 id="source-code-anonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/anonymous/anonymous.c">anonymous.c</a></h3>
+<h2 id="winning-entry-1984anonymous">Winning entry: <a href="1984/anonymous/index.html">1984/anonymous</a></h2>
+<h3 id="winning-entry-source-code-anonymous.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/anonymous/anonymous.c">anonymous.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work for macOS.</p>
 <p>The problem was to do with the way that the <code>read(2)</code> function was redefined.
@@ -426,8 +426,8 @@ source code and the tattoo together as an image):</p>
 <p>The tattoo was done in 2005 by <a href="https://web.archive.org/web/20070120220721/https://thomasscovell.com/tattoo.php">Thomas
 Scovell</a>.</p>
 <div id="1984_decot">
-<h2 id="decot"><a href="1984/decot/index.html">1984/decot</a></h2>
-<h3 id="source-code-decot.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.c">decot.c</a></h3>
+<h2 id="winning-entry-1984decot">Winning entry: <a href="1984/decot/index.html">1984/decot</a></h2>
+<h3 id="winning-entry-source-code-decot.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.c">decot.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to not require <code>-traditional-cpp</code> which some compilers like
 <code>clang</code> do not support. Fixing <code>-traditional-cpp</code> is, as noted later on, very
@@ -477,8 +477,8 @@ but not <code>clang</code> - or at least some versions.</p>
 <p>To see the difference from start to fixed:</p>
 <pre><code>    cd 1984/decot ; make diff_orig_prog</code></pre>
 <div id="1984_laman">
-<h2 id="laman"><a href="1984/laman/index.html">1984/laman</a></h2>
-<h3 id="source-code-laman.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">laman.c</a></h3>
+<h2 id="winning-entry-1984laman">Winning entry: <a href="1984/laman/index.html">1984/laman</a></h2>
+<h3 id="winning-entry-source-code-laman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">laman.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/try.sh">try.sh</a> script.</p>
 <p>Cody also fixed this to not crash when no arg is specified. Note that if the arg
@@ -486,8 +486,8 @@ is not a positive number it will not do anything useful or anything at all.
 This was fixed on 30 October 2023 after the bug status was changed from INABIAF
 (it’s not a bug it’s a feature) to bug.</p>
 <div id="1984_mullender">
-<h2 id="mullender"><a href="1984/mullender/index.html">1984/mullender</a></h2>
-<h3 id="source-code-mullender.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">mullender.c</a></h3>
+<h2 id="winning-entry-1984mullender">Winning entry: <a href="1984/mullender/index.html">1984/mullender</a></h2>
+<h3 id="winning-entry-source-code-mullender.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">mullender.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.alt.c">alternate version</a>,
 an improved version of the judges, so that everyone can enjoy it with systems
@@ -510,8 +510,8 @@ Repo</a>.</p>
 <h1 id="section-1"><a href="1985/index.html">1985</a></h1>
 </div>
 <div id="1985_applin">
-<h2 id="applin"><a href="1985/applin/index.html">1984/applin</a></h2>
-<h3 id="source-code-applin.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/applin/applin.c">applin.c</a></h3>
+<h2 id="winning-entry-1984applin">Winning entry: <a href="1985/applin/index.html">1984/applin</a></h2>
+<h3 id="winning-entry-source-code-applin.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/applin/applin.c">applin.c</a></h3>
 </div>
 <p>Both <a href="#cody">Cody</a> and <a href="#yusuke">Yusuke</a> fixed this; Yusuke got this to not crash and Cody fixed it
 to work with macOS.</p>
@@ -530,8 +530,8 @@ shell, after the output (despite having <code>\n</code> in the string - can you 
 why?) but to make it more friendly to users Cody made it print a <code>\n</code> prior to
 returning to the shell. The original code does not have this change.</p>
 <div id="1985_august">
-<h2 id="august"><a href="1985/august/index.html">1985/august</a></h2>
-<h3 id="source-code-august.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/august/august.c">august.c</a></h3>
+<h2 id="winning-entry-1985august">Winning entry: <a href="1985/august/index.html">1985/august</a></h2>
+<h3 id="winning-entry-source-code-august.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/august/august.c">august.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, out of abundance of caution, added a second arg to <code>main()</code> because some
 versions of <code>clang</code> object to the number of args of <code>main()</code>, saying that it must
@@ -547,8 +547,8 @@ way.</p>
 whether <code>primes(6)</code> is installed or not, but it only does it once with the
 default value).</p>
 <div id="1985_lycklama">
-<h2 id="lycklama"><a href="1985/lycklama/index.html">1985/lycklama</a></h2>
-<h3 id="source-code-lycklama.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/lycklama/lycklama.c">lycklama.c</a></h3>
+<h2 id="winning-entry-1985lycklama">Winning entry: <a href="1985/lycklama/index.html">1985/lycklama</a></h2>
+<h3 id="winning-entry-source-code-lycklama.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/lycklama/lycklama.c">lycklama.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with modern compilers. In the past one could get away
 with defining some macro to <code>#define</code> and then use <code>#foo</code> to have the same
@@ -558,8 +558,8 @@ changed the <code>#o</code> lines to <code>#define</code>. Also <code>unistd.h</
 that Cody added. See the <a href="1985/lycklama/index.html">index.html</a> for details.</p>
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/lycklama/try.alt.sh">try.alt.sh</a> script.</p>
 <div id="1985_shapiro">
-<h2 id="shapiro"><a href="1985/shapiro/index.html">1985/shapiro</a></h2>
-<h3 id="source-code-shapiro.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/shapiro/shapiro.c">shapiro.c</a></h3>
+<h2 id="winning-entry-1985shapiro">Winning entry: <a href="1985/shapiro/index.html">1985/shapiro</a></h2>
+<h3 id="winning-entry-source-code-shapiro.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/shapiro/shapiro.c">shapiro.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/shapiro/shapiro.alt.c">alt code</a>
 which allows one to resize the maze and he also added the
@@ -569,8 +569,8 @@ you to enter a number, in an infinite loop, exiting if any non-digits are in
 input (this includes negative numbers which in the code actually sets it back to
 39, the default).</p>
 <div id="1985_sicherman">
-<h2 id="sicherman"><a href="1985/sicherman/index.html">1985/sicherman</a></h2>
-<h3 id="source-code-1985sicherman">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/sicherman.c">1985/sicherman</a></h3>
+<h2 id="winning-entry-1985sicherman">Winning entry: <a href="1985/sicherman/index.html">1985/sicherman</a></h2>
+<h3 id="winning-entry-source-code-1985sicherman">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/sicherman.c">1985/sicherman</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this <em>very twisted entry</em> to not require <code>-traditional-cpp</code>. Fixing
 <code>-traditional-cpp</code> is, as noted later on, very complicated, but Cody would like
@@ -655,18 +655,18 @@ should they object to <code>main()</code> having only one arg.</p>
 <h1 id="section-2"><a href="1986/index.html">1986</a></h1>
 </div>
 <div id="1986_applin">
-<h2 id="applin-1"><a href="1986/applin/index.html">1986/applin</a></h2>
-<h3 id="source-code-applin.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/applin/applin.c">applin.c</a></h3>
+<h2 id="winning-entry-1986applin">Winning entry: <a href="1986/applin/index.html">1986/applin</a></h2>
+<h3 id="winning-entry-source-code-applin.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/applin/applin.c">applin.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made the C file executable so one does not have to do <code>sh ./applin.c</code> or <code>./applin</code>; they can do either <code>./applin.c</code> or <code>./applin</code>.</p>
 <div id="1986_bright">
-<h2 id="bright"><a href="1986/bright/index.html">1986/bright</a></h2>
-<h3 id="source-code-bright.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/bright/bright.c">bright.c</a></h3>
+<h2 id="winning-entry-1986bright">Winning entry: <a href="1986/bright/index.html">1986/bright</a></h2>
+<h3 id="winning-entry-source-code-bright.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/bright/bright.c">bright.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/bright/try.sh">try.sh</a> script.</p>
 <div id="1986_hague">
-<h2 id="hague"><a href="1986/hague/index.html">1986/hague</a></h2>
-<h3 id="source-code-hague.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/hague/hague.c">hague.c</a></h3>
+<h2 id="winning-entry-1986hague">Winning entry: <a href="1986/hague/index.html">1986/hague</a></h2>
+<h3 id="winning-entry-source-code-hague.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/hague/hague.c">hague.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this use <code>fgets()</code>. See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
 the libc function gets(3) changed to use
@@ -674,8 +674,8 @@ fgets(3)?</a> for why this was done.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/hague/try.sh">try.sh</a> script which also feeds to the
 program the <code>input.txt</code> text file that Cody added.</p>
 <div id="1986_holloway">
-<h2 id="holloway"><a href="1986/holloway/index.html">1986/holloway</a></h2>
-<h3 id="source-code-holloway.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/holloway/holloway.c">holloway.c</a></h3>
+<h2 id="winning-entry-1986holloway">Winning entry: <a href="1986/holloway/index.html">1986/holloway</a></h2>
+<h3 id="winning-entry-source-code-holloway.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/holloway/holloway.c">holloway.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile and work with <code>clang</code> (it already worked with <code>gcc</code>).
 The problem was that <code>clang</code> is more strict about the types of args to
@@ -685,8 +685,8 @@ caused a segfault. By adding a new variable, <code>char *t</code>, initialising 
 and then using <code>t</code> instead of <code>s</code> it compiles and runs successfully under
 <code>clang</code> and <code>gcc</code>.</p>
 <div id="1986_marshall">
-<h2 id="marshall"><a href="1986/marshall/index.html">1986/marshall</a></h2>
-<h3 id="source-code-marshall.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a></h3>
+<h2 id="winning-entry-1986marshall">Winning entry: <a href="1986/marshall/index.html">1986/marshall</a></h2>
+<h3 id="winning-entry-source-code-marshall.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> got this to compile and work with <code>clang</code> and <code>gcc</code>. He noted that he tried to
 keep the ASCII art as close to the original as possible. The line lengths are
@@ -728,15 +728,15 @@ the directory) slightly so that it was possible to silence it. In particular:</p
 <p>which can be disabled. It results in the same behaviour but this way no warnings
 are produced.</p>
 <div id="1986_pawka">
-<h2 id="pawka"><a href="1986/pawka/index.html">1986/pawka</a></h2>
-<h3 id="source-code-pawka.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/pawka/pawka.c">pawka.c</a></h3>
+<h2 id="winning-entry-1986pawka">Winning entry: <a href="1986/pawka/index.html">1986/pawka</a></h2>
+<h3 id="winning-entry-source-code-pawka.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/pawka/pawka.c">pawka.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> noticed and fixed a funny mistake in the Makefile where a
 <code>-Wno-strict-prototypes</code> was in the wrong location, suggesting that there is a
-<code>-D</code> needed to compile the entry.</p>
+<code>-D</code> needed to compile the entry but this is not actually so.</p>
 <div id="1986_stein">
-<h2 id="stein"><a href="1986/stein/index.html">1986/stein</a></h2>
-<h3 id="source-code-stein.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/stein/stein.c">stein.c</a></h3>
+<h2 id="winning-entry-1986stein">Winning entry: <a href="1986/stein/index.html">1986/stein</a></h2>
+<h3 id="winning-entry-source-code-stein.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/stein/stein.c">stein.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> restored the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/stein/stein.orig.c">original
 entry</a> which was a single line. The code
@@ -746,8 +746,8 @@ code is now one line.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/stein/stein.sh">stein.sh</a> script which runs the two
 commands that we suggest in order to get it to show clean output.</p>
 <div id="1986_wall">
-<h2 id="wall"><a href="1986/wall/index.html">1986/wall</a></h2>
-<h3 id="source-code-wall.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/wall/wall.c">wall.c</a></h3>
+<h2 id="winning-entry-1986wall">Winning entry: <a href="1986/wall/index.html">1986/wall</a></h2>
+<h3 id="winning-entry-source-code-wall.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/wall/wall.c">wall.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that it does not require <code>-traditional-cpp</code>. This took a fair
 bit of tinkering as this entry <em>very twisted</em>; fixing <code>-traditional-cpp</code> is, as
@@ -814,13 +814,13 @@ work with <code>gcc</code> - but it still required <code>-traditional-cpp</code>
 <h1 id="section-3"><a href="1987/index.html">1987</a></h1>
 </div>
 <div id="1987_biggar">
-<h2 id="biggar"><a href="1987/biggar/index.html">1987/biggar</a></h2>
-<h3 id="source-code-biggar.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/biggar/biggar.c">biggar.c</a></h3>
+<h2 id="winning-entry-1987biggar">Winning entry: <a href="1987/biggar/index.html">1987/biggar</a></h2>
+<h3 id="winning-entry-source-code-biggar.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/biggar/biggar.c">biggar.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/biggar/try.sh">try.sh</a> script.</p>
 <div id="1987_heckbert">
-<h2 id="heckbert"><a href="1987/heckbert/index.html">1987/heckbert</a></h2>
-<h3 id="source-code-heckbert.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/heckbert/heckbert.c">heckbert.c</a></h3>
+<h2 id="winning-entry-1987heckbert">Winning entry: <a href="1987/heckbert/index.html">1987/heckbert</a></h2>
+<h3 id="winning-entry-source-code-heckbert.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/heckbert/heckbert.c">heckbert.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this look more like the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/heckbert/heckbert.orig.c">original
 entry</a> by restoring the <code>#define _ define</code>. It’s not used but it now looks closer to the original.</p>
@@ -831,16 +831,16 @@ of <code>strings.h</code> and because it’s identical in use to <code>strchr(3)
 that for System V we had to do this) Cody added to the Makefile
 <code>-Dindex=strchr</code>.</p>
 <div id="1987_hines">
-<h2 id="hines"><a href="1987/hines/index.html">1987/hines</a></h2>
-<h3 id="source-code-hines.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/hines/hines.c">hines.c</a></h3>
+<h2 id="winning-entry-1987hines">Winning entry: <a href="1987/hines/index.html">1987/hines</a></h2>
+<h3 id="winning-entry-source-code-hines.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/hines/hines.c">hines.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/hines/try.sh">try.sh</a> script, the C file
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/hines/goto.c">goto.c</a> and the text file <a href="1987/hines/goto.txt">goto.txt</a>
 for demonstration purposes. Notice that the program is case sensitive which
 running the program on the text file demonstrates.</p>
 <div id="1987_lievaart">
-<h2 id="lievaart"><a href="1987/lievaart/index.html">1987/lievaart</a></h2>
-<h3 id="source-code-lievaart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/lievaart/lievaart.c">lievaart.c</a></h3>
+<h2 id="winning-entry-1987lievaart">Winning entry: <a href="1987/lievaart/index.html">1987/lievaart</a></h2>
+<h3 id="winning-entry-source-code-lievaart.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/lievaart/lievaart.c">lievaart.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added back the documented checks for invalid input which no longer worked
 and instead resulted in accepting the level, whether or not it was a
@@ -877,16 +877,16 @@ immediately goes back to the prompting of the level.</p>
 well (the one with the board and the one without, the entry itself with the
 size constraints of the contest).</p>
 <div id="1987_wall">
-<h2 id="wall-1"><a href="1987/wall/index.html">1987/wall</a></h2>
-<h3 id="source-code-wall.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/wall/wall.c">wall.c</a></h3>
+<h2 id="winning-entry-1987wall">Winning entry: <a href="1987/wall/index.html">1987/wall</a></h2>
+<h3 id="winning-entry-source-code-wall.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/wall/wall.c">wall.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
 the libc function gets(3) changed to use
 fgets(3)?</a> for why this was done.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/wall/try.sh">try.sh</a> script.</p>
 <div id="1987_westley">
-<h2 id="westley"><a href="1987/westley/index.html">1987/westley</a></h2>
-<h3 id="source-code-westley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1987westley">Winning entry: <a href="1987/westley/index.html">1987/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/westley/westley.c">westley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for modern systems. The problem was <code>'assignment to cast is illegal, lvalue casts are not supported'</code>. For details on the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/westley/westley.orig.c">original
 code</a> see the
@@ -902,8 +902,8 @@ unlikely(?) but nevertheless suggested case that <code>putchar(3)</code> is not 
 <h1 id="section-4"><a href="1988/index.html">1988</a></h1>
 </div>
 <div id="1988_dale">
-<h2 id="dale"><a href="1988/dale/index.html">1988/dale</a></h2>
-<h3 id="source-code-dale.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/dale.c">dale.c</a></h3>
+<h2 id="winning-entry-1988dale">Winning entry: <a href="1988/dale/index.html">1988/dale</a></h2>
+<h3 id="winning-entry-source-code-dale.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/dale.c">dale.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this twisted entry (as we called it :-) ) for modern compilers,
 including making it no longer require <code>-traditional-cpp</code>. Fixing
@@ -956,8 +956,8 @@ modern compilers do not allow directives like:</p>
 macro in place but it’s no longer used.</p>
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/try.sh">try.sh</a> script.</p>
 <div id="1988_isaak">
-<h2 id="isaak"><a href="1988/isaak/index.html">1988/isaak</a></h2>
-<h3 id="source-code-isaak.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/isaak/isaak.c">isaak.c</a></h3>
+<h2 id="winning-entry-1988isaak">Winning entry: <a href="1988/isaak/index.html">1988/isaak</a></h2>
+<h3 id="winning-entry-source-code-isaak.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/isaak/isaak.c">isaak.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work for modern systems. The problem was that the important
 function, a redefinition of <code>exit(3)</code>, was not being called in <code>main()</code>. Earlier
@@ -968,15 +968,15 @@ index.html file for more details.</p>
 <code>isaak.output.txt</code>. This was done strictly for historical remarks that can be
 found in the index.html file.</p>
 <div id="1988_litmaath">
-<h2 id="litmaath"><a href="1988/litmaath/index.html">1988/litmaath</a></h2>
-<h3 id="source-code-litmaath.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/litmaath/litmaath.c">litmaath.c</a></h3>
+<h2 id="winning-entry-1988litmaath">Winning entry: <a href="1988/litmaath/index.html">1988/litmaath</a></h2>
+<h3 id="winning-entry-source-code-litmaath.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/litmaath/litmaath.c">litmaath.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/litmaath/litmaath.alt.c">alt code</a>
 which is code that we suggested at the time of publication, in the remarks, to
 help understand the entry, and for fun.</p>
 <div id="1988_phillipps">
-<h2 id="phillipps"><a href="1988/phillipps/index.html">1988/phillipps</a></h2>
-<h3 id="source-code-phillipps.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/phillipps/phillipps.c">phillipps.c</a></h3>
+<h2 id="winning-entry-1988phillipps">Winning entry: <a href="1988/phillipps/index.html">1988/phillipps</a></h2>
+<h3 id="winning-entry-source-code-phillipps.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/phillipps/phillipps.c">phillipps.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for modern systems. It did not compile with <code>clang</code> because it
 requires the second and third args of <code>main()</code> to be <code>char **</code> but even before
@@ -992,15 +992,15 @@ once did; instead, the format of <code>pain()</code> is exactly like how <code>m
 same code, just a <code>p</code> instead of an <code>m</code> in the name. Additionally, <code>main()</code> returns
 <code>!pain(...)</code> like <code>main()</code> used to do to itself (<code>pain()</code> does as well).</p>
 <div id="1988_reddy">
-<h2 id="reddy"><a href="1988/reddy/index.html">1988/reddy</a></h2>
-<h3 id="source-code-reddy.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/reddy/reddy.c">reddy.c</a></h3>
+<h2 id="winning-entry-1988reddy">Winning entry: <a href="1988/reddy/index.html">1988/reddy</a></h2>
+<h3 id="winning-entry-source-code-reddy.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/reddy/reddy.c">reddy.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
 the libc function gets(3) changed to use
 fgets(3)?</a> for why this was done.</p>
 <div id="1988_spinellis">
-<h2 id="spinellis"><a href="1988/spinellis/index.html">1988/spinellis</a></h2>
-<h3 id="source-code-spinellis.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/spinellis/spinellis.c">spinellis.c</a></h3>
+<h2 id="winning-entry-1988spinellis">Winning entry: <a href="1988/spinellis/index.html">1988/spinellis</a></h2>
+<h3 id="winning-entry-source-code-spinellis.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/spinellis/spinellis.c">spinellis.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/spinellis/spinellis.alt.c">alternate version</a> so that
 this will work with compilers like <code>clang</code>. An alternate version had to be
@@ -1013,8 +1013,8 @@ original. See the index.html file for details on the alternate code.</p>
 doing this) that with a slight modification this entry can be C++ instead. We don’t
 thank him for this ghastly point! :-)</p>
 <div id="1988_westley">
-<h2 id="westley-1"><a href="1988/westley/index.html">1988/westley</a></h2>
-<h3 id="source-code-westley.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1988westley">Winning entry: <a href="1988/westley/index.html">1988/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/westley/westley.c">westley.c</a></h3>
 </div>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/westley/westley.alt.c">original version</a>, provided as alternate code,
 was fixed by Misha Dynin, based on the judges’ remarks, so that this would work
@@ -1028,8 +1028,8 @@ not strictly necessary but nonetheless more correct, even if not warned against.
 <h1 id="section-5"><a href="1989/index.html">1989</a></h1>
 </div>
 <div id="1989_fubar">
-<h2 id="fubar"><a href="1989/fubar/index.html">1989/fubar</a></h2>
-<h3 id="source-code-fubar.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/fubar/fubar.c">fubar.c</a></h3>
+<h2 id="winning-entry-1989fubar">Winning entry: <a href="1989/fubar/index.html">1989/fubar</a></h2>
+<h3 id="winning-entry-source-code-fubar.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/fubar/fubar.c">fubar.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> got this to work with modern systems. The main issues were that an
 <code>#include</code> had to be added along with fixing the path (due to <code>.</code> not being in
@@ -1056,8 +1056,8 @@ might end up failing to work even after changing it back. This was resolved by:<
 <code>if [ .. ]</code> was changed in the C code as well as the script.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/fubar/try.sh">try.sh</a> script.</p>
 <div id="1989_jar.1">
-<h2 id="jar.1"><a href="1989/jar.1/index.html">1989/jar.1</a></h2>
-<h3 id="source-code-jar.1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.1/jar.1.c">jar.1.c</a></h3>
+<h2 id="winning-entry-1989jar.1">Winning entry: <a href="1989/jar.1/index.html">1989/jar.1</a></h2>
+<h3 id="winning-entry-source-code-jar.1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.1/jar.1.c">jar.1.c</a></h3>
 </div>
 <p>To prevent annoying output to <code>/dev/tty</code> we changed the code to simulate the
 output via <code>strings(1)</code> but <a href="#cody">Cody</a> removed the ill-famed <code>useless use of cat</code> to
@@ -1072,8 +1072,8 @@ code directly, to match that of the main entry. As we simulate the functionality
 anyway, and since one may still run the code or the script (for the original
 entry and the alt code) anyway, it works out well.</p>
 <div id="1989_jar.2">
-<h2 id="jar.2"><a href="1989/jar.2/index.html">1989/jar.2</a></h2>
-<h3 id="source-code-jar.2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/jar.2.c">jar.2.c</a></h3>
+<h2 id="winning-entry-1989jar.2">Winning entry: <a href="1989/jar.2/index.html">1989/jar.2</a></h2>
+<h3 id="winning-entry-source-code-jar.2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/jar.2.c">jar.2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with modern compilers. Modern compilers do not allow
 code like:</p>
@@ -1087,7 +1087,7 @@ you know how?</p>
 <p>The old <code>#define</code>s are left in to make it look like the original as much as
 possible but they are not used.</p>
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/try.sh">try.sh</a> script and the
-supplementary files <a href="1989/jar.2/try.lisp">try.lisp</a>,
+supplementary files <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/try.lisp">try.lisp</a>,
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/fib.lisp">fib.lisp</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/chocolate_cake.lisp">chocolate_cake.lisp</a>. The
 <code>try.lisp</code> comes from the author and the <code>fib.lisp</code> comes from
@@ -1102,8 +1102,8 @@ result in:</p>
     shell returned 2</code></pre>
 <p>because the <code>alt</code> rule had what normally is in the <code>${PROG}.alt</code> rule.</p>
 <div id="1989_ovdluhe">
-<h2 id="ovdluhe"><a href="1989/ovdluhe/index.html">1989/ovdluhe</a></h2>
-<h3 id="source-code-ovdluhe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/ovdluhe/ovdluhe.c">ovdluhe.c</a></h3>
+<h2 id="winning-entry-1989ovdluhe">Winning entry: <a href="1989/ovdluhe/index.html">1989/ovdluhe</a></h2>
+<h3 id="winning-entry-source-code-ovdluhe.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/ovdluhe/ovdluhe.c">ovdluhe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an infinite loop where the program would print the same thing over
 and over again, flooding the screen. The problem is that there was a <code>for</code> loop
@@ -1120,8 +1120,8 @@ uses the alt code, allowing one to configure the alt build. See the index.html
 for details. The fix described above was fixed in this version too, after it was
 discovered and fixed.</p>
 <div id="1989_paul">
-<h2 id="paul"><a href="1989/paul/index.html">1989/paul</a></h2>
-<h3 id="source-code-paul.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/paul/paul.c">paul.c</a></h3>
+<h2 id="winning-entry-1989paul">Winning entry: <a href="1989/paul/index.html">1989/paul</a></h2>
+<h3 id="winning-entry-source-code-paul.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/paul/paul.c">paul.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault under macOS that prevented it from working. The problem
 was that the int (from <code>#define f</code>) should be a <code>long</code>. This became apparent when
@@ -1130,8 +1130,8 @@ he was using lldb and saw that the type of a pointer was too <code>long</code> :
 which has the trace function that the author included but commented out. See the
 index.html for details.</p>
 <div id="1989_robison">
-<h2 id="robison"><a href="1989/robison/index.html">1989/robison</a></h2>
-<h3 id="source-code-robison.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/robison.c">robison.c</a></h3>
+<h2 id="winning-entry-1989robison">Winning entry: <a href="1989/robison/index.html">1989/robison</a></h2>
+<h3 id="winning-entry-source-code-robison.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/robison.c">robison.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke Endoh</a> fixed this to compile under modern systems. To see the changes
 made, try:</p>
@@ -1139,8 +1139,8 @@ made, try:</p>
 <p>(It adds the C token pasting operator <code>##</code> instead of <code>/**/</code>.)</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/try.sh">try.sh</a> script.</p>
 <div id="1989_tromp">
-<h2 id="tromp"><a href="1989/tromp/index.html">1989/tromp</a></h2>
-<h3 id="source-code-tromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/tromp/tromp.c">tromp.c</a></h3>
+<h2 id="winning-entry-1989tromp">Winning entry: <a href="1989/tromp/index.html">1989/tromp</a></h2>
+<h3 id="winning-entry-source-code-tromp.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/tromp/tromp.c">tromp.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> and <a href="#yusuke">Yusuke</a> fixed this entry: Yusuke fixed this to compile with <code>gcc</code> and Cody
 fixed it for <code>clang</code> and made some other fixes as well.</p>
@@ -1163,20 +1163,23 @@ various other things, so that now the alt version, which is better, can be used.
 IOCCC <a href="https://en.wikipedia.org/wiki/Tetris">Tetris</a> working (this of course was
 not his only reason :-) )</p>
 <div id="1989_vanb">
-<h2 id="vanb"><a href="1989/vanb/index.html">1989/vanb</a></h2>
-<h3 id="source-code-vanb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/vanb/vanb.c">vanb.c</a></h3>
+<h2 id="winning-entry-1989vanb">Winning entry: <a href="1989/vanb/index.html">1989/vanb</a></h2>
+<h3 id="winning-entry-source-code-vanb.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/vanb/vanb.c">vanb.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/vanb/try.sh">try.sh</a> script.</p>
 <div id="1989_westley">
-<h2 id="westley-2"><a href="1989/westley/index.html">1989/westley</a></h2>
-<h3 id="source-code-westley.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1989westley">Winning entry: <a href="1989/westley/index.html">1989/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/westley/westley.c">westley.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> fixed this for <code>clang</code>, except that two versions generated by the program
-cannot be compiled by <code>clang</code> due to inherent defects in the compiler and how the
-entry works. This is an <strong>incredibly hard</strong> one to fix for <code>clang</code> whilst still
-being compilable with <code>gcc</code> (and <code>gcc</code> can compile every generated version with the
-fix) and even if one fixes it to compile with <code>clang</code> it does not mean that any
-other version will compile! It is, however, possible to get <code>clang</code> to work with
+<p><a href="#cody">Cody</a> fixed this for <code>clang</code>, except that two versions generated by the
+program cannot be compiled by <code>clang</code> due to inherent defects in the compiler
+and how the entry works. This is an <strong>incredibly hard</strong> one to fix for <code>clang</code>
+whilst still being compilable with <code>gcc</code> (<code>gcc</code> can compile every generated
+version with the fix but if one fixes all to compile with <code>clang</code>, which was
+attempted, it introduced compile errors for <code>gcc</code>) and even if one fixes it to
+compile with <code>clang</code> it does not, depending on how it’s done, mean that any
+other version will compile!</p>
+<p>It is, however, possible to get <code>clang</code> to work with
 two versions generated, <code>ver0</code> and <code>ver1</code>, though <code>ver0</code> is actually just the
 main entry (but still generated by the program itself).</p>
 <p>Unfortunately due to the way this entry works if it is even possible to get all
@@ -1232,8 +1235,8 @@ environmental variable; see the index.html for details.</p>
 <h1 id="section-6"><a href="1990/index.html">1990</a></h1>
 </div>
 <div id="1990_baruch">
-<h2 id="baruch"><a href="1990/baruch/index.html">1990/baruch</a></h2>
-<h3 id="source-code-baruch.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/baruch.c">baruch.c</a></h3>
+<h2 id="winning-entry-1990baruch">Winning entry: <a href="1990/baruch/index.html">1990/baruch</a></h2>
+<h3 id="winning-entry-source-code-baruch.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/baruch.c">baruch.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/try.sh">try.sh</a> script.</p>
 <p>Cody also added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/baruch.alt.c">alternate version</a>, which allows Turbo-C
@@ -1241,16 +1244,12 @@ and MSC to compile this code, based on the authors’ remarks, except that Cody
 did not change the <code>" #Q"</code> string as that appeared to show worse looking output
 instead of improved output though he has no way to test the compilers in
 question (i.e. it was only tested in the original entry). YMMV.</p>
-<p>Although this is appreciated we agree with him that <del>no one</del>
-<a href="https://en.wikipedia.org/wiki/0">very few</a>
-<a href="https://en.wikipedia.org/wiki/Microsoft_Windows">users</a>
-<a href="https://www.ioccc.org">here</a> will need it! :-)</p>
-<p>Cody made the code look more like the original, removing the <code>int</code> from
+<p>Cody also made the code look more like the original, removing the <code>int</code> from
 the variables, adding instead <code>-Wno-implicit-int</code>. The newline added by the
 judges was retained.</p>
 <div id="1990_cmills">
-<h2 id="cmills"><a href="1990/cmills/index.html">1990/cmills</a></h2>
-<h3 id="source-code-cmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/cmills/cmills.c">cmills.c</a></h3>
+<h2 id="winning-entry-1990cmills">Winning entry: <a href="1990/cmills/index.html">1990/cmills</a></h2>
+<h3 id="winning-entry-source-code-cmills.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/cmills/cmills.c">cmills.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> got this to work in modern systems (it previously resulted in a bus
 error).</p>
@@ -1258,13 +1257,13 @@ error).</p>
 the libc function gets(3) changed to use
 fgets(3)?</a> for why this was done.</p>
 <div id="1990_dds">
-<h2 id="dds"><a href="1990/dds/index.html">1990/dds</a></h2>
-<h3 id="source-code-dds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dds/dds.c">dds.c</a></h3>
+<h2 id="winning-entry-1990dds">Winning entry: <a href="1990/dds/index.html">1990/dds</a></h2>
+<h3 id="winning-entry-source-code-dds.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dds/dds.c">dds.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> and <a href="#cody">Cody</a> in conjunction fixed this for modern systems (both fixed a
 different compiler error but more fixes were also made).</p>
 <p>Yusuke added the comma operator for a binary expression with <code>free(3)</code> which is
-a compiler error because <code>free()</code> returns <code>void</code>. Cody then made it slightly
+a compiler error because <code>free(3)</code> returns <code>void</code>. Cody then made it slightly
 more like the original in this way by redefining <code>free</code> to have the comma
 operator itself.</p>
 <p>Cody fixed another compiler error by removing the erroneous prototype to
@@ -1273,8 +1272,8 @@ operator itself.</p>
 the libc function gets(3) changed to use
 fgets(3)?</a> for why this was done.</p>
 <div id="1990_dg">
-<h2 id="dg"><a href="1990/dg/index.html">1990/dg</a></h2>
-<h3 id="source-code-dg.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dg/dg.c">dg.c</a></h3>
+<h2 id="winning-entry-1990dg">Winning entry: <a href="1990/dg/index.html">1990/dg</a></h2>
+<h3 id="winning-entry-source-code-dg.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dg/dg.c">dg.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for modern systems. There were two problems to be resolved.</p>
 <p>One can no longer do:</p>
@@ -1286,11 +1285,11 @@ fgets(3)?</a> for why this was done.</p>
 <p>so the use of <code>#d</code> is now instead <code>#define</code> (the macro was originally deleted
 but later Cody added it back to make it more like the original).</p>
 <p>The second problem was suggested by the judges at the time of judging, to do
-with if the C preprocessor botches single quotes in cpp expansion.</p>
+with if the C preprocessor botches single quotes in <code>cpp</code> expansion.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dg/try.sh">try.sh</a> script.</p>
 <div id="1990_jaw">
-<h2 id="jaw"><a href="1990/jaw/index.html">1990/jaw</a></h2>
-<h3 id="source-code-jaw.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/jaw/jaw.c">jaw.c</a></h3>
+<h2 id="winning-entry-1990jaw">Winning entry: <a href="1990/jaw/index.html">1990/jaw</a></h2>
+<h3 id="winning-entry-source-code-jaw.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/jaw/jaw.c">jaw.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the script to work properly in modern environments including writing
 to and extracting from <code>stdout</code> and relying on the exit code in the commands to
@@ -1302,25 +1301,26 @@ bugs.html</a>.</p>
 the time of releasing the winning entries of 1990.</p>
 <p>NOTE: as <code>btoa</code> is not common we used a ruby script from <a href="#yusuke">Yusuke</a> but with a minor
 fix applied by Cody that made the program just show <code>oops</code> twice (twice is not
-an error here) from invalid input but which now works.</p>
+a typo here) from invalid input but which now works.</p>
 <div id="1990_pjr">
-<h2 id="pjr"><a href="1990/pjr/index.html">1990/pjr</a></h2>
-<h3 id="source-code-pjr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/pjr/pjr.c">pjr.c</a></h3>
+<h2 id="winning-entry-1990pjr">Winning entry: <a href="1990/pjr/index.html">1990/pjr</a></h2>
+<h3 id="winning-entry-source-code-pjr.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/pjr/pjr.c">pjr.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/pjr/pjr.alt.c">alt code</a> which was suggested by the judges
 in the case that your compiler cannot compile <code>X=g()...</code> but it actually does
 something else and is recommended by the author as well.</p>
 <div id="1990_scjones">
-<h2 id="scjones"><a href="1990/scjones/index.html">1990/scjones</a></h2>
-<h3 id="source-code-scjones.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/scjones/scjones.c">scjones.c</a></h3>
+<h2 id="winning-entry-1990scjones">Winning entry: <a href="1990/scjones/index.html">1990/scjones</a></h2>
+<h3 id="winning-entry-source-code-scjones.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/scjones/scjones.c">scjones.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> suggested <code>-ansi</code> to get the entry to compile due to trigraphs and <a href="#cody">Cody</a>
-suggested <code>-trigraphs</code>. Both work but we used Yusuke’s idea.</p>
+suggested <code>-trigraphs</code>. Both work but we used Yusuke’s idea as this was seen
+first.</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/scjones/try.sh">try.sh</a> script to show exactly what the
 entry does.</p>
 <div id="1990_tbr">
-<h2 id="tbr"><a href="1990/tbr/index.html">1990/tbr</a></h2>
-<h3 id="source-code-tbr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/tbr/tbr.c">tbr.c</a></h3>
+<h2 id="winning-entry-1990tbr">Winning entry: <a href="1990/tbr/index.html">1990/tbr</a></h2>
+<h3 id="winning-entry-source-code-tbr.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/tbr/tbr.c">tbr.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with modern compilers; <code>exit(3)</code> returns <code>void</code> but the
 function was used in a binary expression so this wouldn’t even compile.</p>
@@ -1335,8 +1335,8 @@ warning being interspersed with the program’s interactive output. See <a href=
 fgets(3)?</a> for more details on why this change was
 done more generally.</p>
 <div id="1990_theorem">
-<h2 id="theorem"><a href="1990/theorem/index.html">1990/theorem</a></h2>
-<h3 id="source-code-theorem.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/theorem/theorem.c">theorem.c</a></h3>
+<h2 id="winning-entry-1990theorem">Winning entry: <a href="1990/theorem/index.html">1990/theorem</a></h2>
+<h3 id="winning-entry-source-code-theorem.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/theorem/theorem.c">theorem.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with modern systems.</p>
 <p>He also fixed some bugs that impacted the usability of this program including some
@@ -1368,20 +1368,22 @@ original program and some of the programs it generates.</p>
 used in order to get this to work initially (prior to this output was there but
 incomplete).</p>
 <div id="1990_stig">
-<h2 id="stig"><a href="1990/stig/index.html">1990/stig</a></h2>
-<h3 id="source-code-stig.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/stig/stig.c">stig.c</a></h3>
+<h2 id="winning-entry-1990stig">Winning entry: <a href="1990/stig/index.html">1990/stig</a></h2>
+<h3 id="winning-entry-source-code-stig.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/stig/stig.c">stig.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the paths in the <code>Makefile</code> so that this would build in Linux (it
 worked fine in macOS).</p>
 <p>He also changed the <code>Makefile</code> to use <code>bash</code> not <code>zsh</code> as not all systems have
 <code>zsh</code> and the <code>Makefile</code> actually sets <code>SHELL</code> to <code>bash</code>.</p>
 <div id="1990_westley">
-<h2 id="westley-3"><a href="1990/westley/index.html">1990/westley</a></h2>
-<h3 id="source-code-westley.c-3">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1990westley">Winning entry: <a href="1990/westley/index.html">1990/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.c">westley.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> fixed this for modern systems. It had <code>1s</code> in places for a <code>short int</code> which was changed to just <code>1</code>. Since it’s instructional to see the
-differences he has provided an alternate version,
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.alt.c">westley.alt.c</a>, which is the original code.</p>
+<p><a href="#cody">Cody</a> fixed this for modern systems. It had <code>1s</code> (digit one, letter s)
+in places for a <code>short int</code> which was changed to just <code>1</code>. Since it’s
+instructional to see the differences he has provided an alternate version,
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.alt.c">westley.alt.c</a>, which is the original
+code.</p>
 <p>He also changed the <code>argc</code> to be an <code>int</code>, not a <code>char</code>, even though it might
 often be the same (this in particular was done for <code>clang</code>).</p>
 <p>He also fixed the code to not enter an infinite loop if arg is a number not &gt; 0
@@ -1394,8 +1396,8 @@ original code.</p>
 <h1 id="section-7"><a href="1991/index.html">1991</a></h1>
 </div>
 <div id="1991_ant">
-<h2 id="ant"><a href="1991/ant/index.html">1991/ant</a></h2>
-<h3 id="source-code-ant.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/ant/ant.c">ant.c</a></h3>
+<h2 id="winning-entry-1991ant">Winning entry: <a href="1991/ant/index.html">1991/ant</a></h2>
+<h3 id="winning-entry-source-code-ant.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/ant/ant.c">ant.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/ant/ant.alt.c">alt code</a> that will be a bit easier to use for
 those familiar with vim in the following ways (we don’t want vi users to also
@@ -1410,8 +1412,8 @@ not be able to use it or exit it, now do we ? :-) ):</p>
 </ul>
 <p>The other keys were left unchanged.</p>
 <div id="1991_brnstnd">
-<h2 id="brnstnd"><a href="1991/brnstnd/index.html">1991/brnstnd</a></h2>
-<h3 id="source-code-brnstnd.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/brnstnd/brnstnd.c">brnstnd.c</a></h3>
+<h2 id="winning-entry-1991brnstnd">Winning entry: <a href="1991/brnstnd/index.html">1991/brnstnd</a></h2>
+<h3 id="winning-entry-source-code-brnstnd.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/brnstnd/brnstnd.c">brnstnd.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for modern systems. There were two invalid operands to binary
 expression (<code>char *</code>, <code>void</code> and <code>int</code>, <code>void</code>) to resolve and
@@ -1423,9 +1425,11 @@ invalid operands to binary expressions were resolved with the comma operator.</p
 slightly more like the original, even though it’s unused.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/brnstnd/try.sh">try.sh</a> script and
 <a href="1991/brnstnd/try.txt">try.txt</a> which the script uses.</p>
+<p>Cody also fixed the make clobber rule which left a symbolic link in the
+directory even after the target file was deleted (from make clobber).</p>
 <div id="1991_buzzard">
-<h2 id="buzzard"><a href="1991/buzzard/index.html">1991/buzzard</a></h2>
-<h3 id="source-code-buzzard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">buzzard.c</a></h3>
+<h2 id="winning-entry-1991buzzard">Winning entry: <a href="1991/buzzard/index.html">1991/buzzard</a></h2>
+<h3 id="winning-entry-source-code-buzzard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">buzzard.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that the coordinates being specified, a documented
 feature, would not crash the program. This happened because the function that
@@ -1440,16 +1444,16 @@ for right. This version also has a more useful way to exit, just entering <code>
 followed by enter, rather than completing (and it’s a maze) or killing the
 program. We still recommend you try the original version first, of course.</p>
 <div id="1991_davidguy">
-<h2 id="davidguy"><a href="1991/davidguy/index.html">1991/davidguy</a></h2>
-<h3 id="source-code-davidguy.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/davidguy/davidguy.c">davidguy.c</a></h3>
+<h2 id="winning-entry-1991davidguy">Winning entry: <a href="1991/davidguy/index.html">1991/davidguy</a></h2>
+<h3 id="winning-entry-source-code-davidguy.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/davidguy/davidguy.c">davidguy.c</a></h3>
 </div>
 <p>As some systems like macOS can be particular about not declaring functions
 <a href="#cody">Cody</a> added to the <code>Makefile</code> some <code>-include</code> options. These appear to
 not be strictly necessary (currently) but it was done due to other syscalls
 being a problem not being declared first, to hopefully future-proof it.</p>
 <div id="1991_dds">
-<h2 id="dds-1"><a href="1991/dds/index.html">1991/dds</a></h2>
-<h3 id="source-code-dds.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/dds/dds.c">dds.c</a></h3>
+<h2 id="winning-entry-1991dds">Winning entry: <a href="1991/dds/index.html">1991/dds</a></h2>
+<h3 id="winning-entry-source-code-dds.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/dds/dds.c">dds.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault that prevented this entry from working in any
 condition (the <code>char *s</code> had to be changed to <code>char s[]</code>) and he also made it
@@ -1459,12 +1463,13 @@ and the generated code work for <code>clang</code>.</p>
 the libc function gets(3) changed to use
 fgets(3)?</a> for why this was done.</p>
 <p>For the magic of <code>clang</code> (which was done manually except the returning a value
-in <code>main()</code>) and <code>fgets(3)</code>, see below. The problem with <code>clang</code> can be
-described simply as: <code>clang</code> (at least in some systems?) defaults to having
-<code>-Werror</code> and the code that the entry generates had some warnings that were
-causing compilation to fail if <code>cc</code> is <code>clang</code> (the entry runs <code>cc a.c</code>). An
-example problem that had to be fixed is that the generated code returned from
-<code>main()</code> no value but rather just had <code>return;</code>.</p>
+in <code>main()</code> in the generated code and possibly <code>fgets(3)</code>) and <code>fgets(3)</code>, see
+below. The problem with <code>clang</code> can be described simply as: <code>clang</code> (at least in
+some systems?) defaults to having <code>-Werror</code> and the code that the entry
+generates had some warnings that were causing compilation to fail if <code>cc</code> is
+<code>clang</code> (the entry runs <code>cc a.c</code>). An example problem that had to be fixed is
+that the generated code returned from <code>main()</code> no value but rather just had
+<code>return;</code>.</p>
 <p>The code used to run <code>cc a.c</code> by what was once <code>system(q-6);</code> but if <code>cc</code> is <code>clang</code>
 like in macOS this is not enough.</p>
 <p>If you have the time and interest and you wish to follow the below a bit better,
@@ -1531,12 +1536,13 @@ The definition of whether that should be a bug to fix or a feature to not fix
 was pondered and changed numerous times and ultimately that problem with this
 entry was fixed. It has not been done in all.</p>
 <div id="1991_fine">
-<h2 id="fine"><a href="1991/fine/index.html">1991/fine</a></h2>
-<h3 id="source-code-fine.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/fine/fine.c">fine.c</a></h3>
+<h2 id="winning-entry-1991fine">Winning entry: <a href="1991/fine/index.html">1991/fine</a></h2>
+<h3 id="winning-entry-source-code-fine.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/fine/fine.c">fine.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made it look much more like the original entry even after the fix
-for <code>clang</code> (by the judges) that increased the count in characters from 80 to
-106, getting it back down to just 85 (and later back down to 80, see below).</p>
+for <code>clang</code> (made by the judges) that increased the count in characters from 80 to
+106, getting it back down to just 85 (and later back down to the original 80,
+see below).</p>
 <p>This was done by redefining <code>main</code> at the compiler line so that it looks like
 the original where one didn’t have to worry about the type of args of <code>main()</code>
 (when there were fewer restrictions), and also by removing a cast that was
@@ -1551,8 +1557,8 @@ some fun input for fun but mostly different output. He added a great string from
 Brian Westley and Cody also added several of his own (can you figure out exactly
 which ones? :-) )</p>
 <div id="1991_rince">
-<h2 id="rince"><a href="1991/rince/index.html">1991/rince</a></h2>
-<h3 id="source-code-rince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/rince/rince.c">rince.c</a></h3>
+<h2 id="winning-entry-1991rince">Winning entry: <a href="1991/rince/index.html">1991/rince</a></h2>
+<h3 id="winning-entry-source-code-rince.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/rince/rince.c">rince.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed it so that the messages that show if you won or lost will be seen
 after the end of the game. The reason it did not work before is curses was ended
@@ -1565,8 +1571,8 @@ remove the maximum number of moves you may make and another to let you configure
 the maximum number of moves, even if that is making it harder to win. Naturally
 the above fix was applied to these versions too.</p>
 <div id="1991_westley">
-<h2 id="westley-4"><a href="1991/westley/index.html">1991/westley</a></h2>
-<h3 id="source-code-westley.c-4">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1991westley">Winning entry: <a href="1991/westley/index.html">1991/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-4">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">westley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault in this program which prevented it from working. The
 problem was that the read-only <code>char</code> array <code>char *z[]</code> was being written to. The
@@ -1578,7 +1584,7 @@ value that works without having to find the correct value.</p>
 also improved it so that warnings/errors/about to compile messages are not shown
 unless the <code>-e</code> option is used. This is because the errors being shown kind of
 ruins the experience. Finally he made it pass
-<a href="https://github.com/koalaman/shellcheck">ShellCheck</a>.</p>
+<a href="https://www.shellcheck.net">ShellCheck</a>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.alt.c">alt version</a> which
 is based on the author’s remarks, a version that supposedly (:-) ) always wins.</p>
 <p>Cody also fixed the make clobber rule where a file was left lying about when it
@@ -1587,8 +1593,8 @@ should have been removed.</p>
 <h1 id="section-8"><a href="1992/index.html">1992</a></h1>
 </div>
 <div id="1992_adrian">
-<h2 id="adrian"><a href="1992/adrian/index.html">1992/adrian</a></h2>
-<h3 id="source-code-adrian.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">adrian.c</a></h3>
+<h2 id="winning-entry-1992adrian">Winning entry: <a href="1992/adrian/index.html">1992/adrian</a></h2>
+<h3 id="winning-entry-source-code-adrian.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">adrian.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the code so that it will try opening the file the code was compiled
 from (<code>__FILE__</code>), not <code>adgrep.c</code>, as the latter does not exist: <code>adgrep</code> is
@@ -1641,8 +1647,8 @@ and some of the tools this entry generates. Unlike other scripts, it does not
 clear the screen after compilation so that one can see how the other files are
 generated.</p>
 <div id="1992_albert">
-<h2 id="albert"><a href="1992/albert/index.html">1992/albert</a></h2>
-<h3 id="source-code-albert.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/albert.c">albert.c</a></h3>
+<h2 id="winning-entry-1992albert">Winning entry: <a href="1992/albert/index.html">1992/albert</a></h2>
+<h3 id="winning-entry-source-code-albert.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/albert.c">albert.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with modern systems. Note that in 1996 a bug fix was
 applied to the code, provided as the alt code as that version is not obfuscated.
@@ -1654,8 +1660,8 @@ return <code>void</code>.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/try.alt.sh">try.alt.sh</a> scripts that correspond to the entry and
 the alt code.</p>
 <div id="1992_ant">
-<h2 id="ant-1"><a href="1992/ant/index.html">1992/ant</a></h2>
-<h3 id="source-code-ant.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/ant/ant.c">ant.c</a></h3>
+<h2 id="winning-entry-1992ant">Winning entry: <a href="1992/ant/index.html">1992/ant</a></h2>
+<h3 id="winning-entry-source-code-ant.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/ant/ant.c">ant.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the Makefile so that the program will actually work with it (or at
 least the rule to clobber files and link <code>am</code> to <code>ant</code>). The issue was that the
@@ -1673,8 +1679,8 @@ necessary to include <code>time.h</code> so Cody did this as well as this exists
 systems too.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/ant/try.sh">try.sh</a> script.</p>
 <div id="1992_buzzard.1">
-<h2 id="buzzard.1"><a href="1992/buzzard.1/index.html">1992/buzzard.1</a></h2>
-<h3 id="source-code-buzzard.1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.1/buzzard.1.c">buzzard.1.c</a></h3>
+<h2 id="winning-entry-1992buzzard.1">Winning entry: <a href="1992/buzzard.1/index.html">1992/buzzard.1</a></h2>
+<h3 id="winning-entry-source-code-buzzard.1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.1/buzzard.1.c">buzzard.1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added a check for the right number of args, exiting 1 if not enough (2)
 used. This was not originally done but at a time it was changed to be considered
@@ -1683,8 +1689,8 @@ verified that it was consistent with the <a href="bugs.html">bugs.html</a> file.
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.1/try.sh">try.sh</a> script to try out some
 commands that we suggested and some additional ones that he provide for some fun.</p>
 <div id="1992_buzzard.2">
-<h2 id="buzzard.2"><a href="1992/buzzard.2/index.html">1992/buzzard.2</a></h2>
-<h3 id="source-code-buzzard.2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.2/buzzard.2.c">buzzard.2.c</a></h3>
+<h2 id="winning-entry-1992buzzard.2">Winning entry: <a href="1992/buzzard.2/index.html">1992/buzzard.2</a></h2>
+<h3 id="winning-entry-source-code-buzzard.2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.2/buzzard.2.c">buzzard.2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the alt code to compile. The problem was it assumed that
 <code>exit(3)</code> returns a value, not <code>void</code>. This was fixed with a <code>,0</code>.</p>
@@ -1692,25 +1698,25 @@ commands that we suggested and some additional ones that he provide for some fun
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.2/try.alt.sh">try.alt.sh</a> scripts that correspond to the entry
 and its alt code.</p>
 <div id="1992_gson">
-<h2 id="gson"><a href="1992/gson/index.html">1992/gson</a></h2>
-<h3 id="source-code-gson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/gson/gson.c">gson.c</a></h3>
+<h2 id="winning-entry-1992gson">Winning entry: <a href="1992/gson/index.html">1992/gson</a></h2>
+<h3 id="winning-entry-source-code-gson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/gson/gson.c">gson.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a crash that prevented this entry from working in some cases in some
 systems (like macOS) by disabling the optimiser in the Makefile.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/gson/try.sh">try.sh</a> script.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/gson/mkdict.sh">mkdict.sh</a> script that the author
 included in their remarks. See the index.html for its purpose. It was NOT fixed
-for <a href="https://github.com/koalaman/shellcheck">ShellCheck</a>
+for <a href="https://www.shellcheck.net">ShellCheck</a>
 because the author deliberately obfuscated it so <strong>PLEASE <em>DO NOT</em> FIX THIS OR
 MODERNISE IT</strong>.</p>
 <p>Cody also changed the buffer size in such a way that <code>gets(3)</code> should be safe
 (well, theoretically) as it comes from the command line (though it can also read input
 from <code>stdin</code> after starting the program). Ideally <code>fgets(3)</code> would be used but this
-is a more problematic. See <a href="bugs.html#1992-gson">1992/gson in bugs.html</a> for more
+is a more problematic. See <a href="bugs.html#1992_gson">1992/gson in bugs.html</a> for more
 details if you’re interested in trying to understand it (or fix?).</p>
 <div id="1992_imc">
-<h2 id="imc"><a href="1992/imc/index.html">1992/imc</a></h2>
-<h3 id="source-code-imc.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/imc/imc.c">imc.c</a></h3>
+<h2 id="winning-entry-1992imc">Winning entry: <a href="1992/imc/index.html">1992/imc</a></h2>
+<h3 id="winning-entry-source-code-imc.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/imc/imc.c">imc.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/imc/try.sh">try.sh</a> script.</p>
 <p>The original code, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/imc/imc.orig.c">imc.orig.c</a>, assumed that <code>exit(3)</code>
@@ -1719,8 +1725,8 @@ source code was modified to avoid this problem but like Cody did with other fixe
 he made this more like the original by redefining <code>exit</code> to use the comma
 operator so that it could be used in binary expressions.</p>
 <div id="1992_kivinen">
-<h2 id="kivinen"><a href="1992/kivinen/index.html">1992/kivinen</a></h2>
-<h3 id="source-code-kivinen.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/kivinen/kivinen.c">kivinen.c</a></h3>
+<h2 id="winning-entry-1992kivinen">Winning entry: <a href="1992/kivinen/index.html">1992/kivinen</a></h2>
+<h3 id="winning-entry-source-code-kivinen.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/kivinen/kivinen.c">kivinen.c</a></h3>
 </div>
 <p>It was observed that on modern systems this goes much too quick. <a href="#yusuke">Yusuke</a> created
 a patch that calls <code>usleep(3)</code> but <a href="#cody">Cody</a> thought the value was too slow so he
@@ -1741,26 +1747,28 @@ changing this.</p>
 <p>Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back.</p>
 <div id="1992_lush">
-<h2 id="lush"><a href="1992/lush/index.html">1992/lush</a></h2>
-<h3 id="source-code-lush.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/lush/lush.c">lush.c</a></h3>
+<h2 id="winning-entry-1992lush">Winning entry: <a href="1992/lush/index.html">1992/lush</a></h2>
+<h3 id="winning-entry-source-code-lush.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/lush/lush.c">lush.c</a></h3>
 </div>
-<p><a href="#yusuke">Yusuke</a> supplied a patch which makes this work with <code>gcc</code>. Due to how it works (see
-Judges’ remarks in the index.html file) this will not work with <code>clang</code>.</p>
+<p><a href="#yusuke">Yusuke</a> supplied a patch which makes this work with <code>gcc</code>. Due to how
+it works (see <a href="1992/lush/index.html#judges-remarks">Judges’ remarks in the index.html
+file</a>) this will not work with <code>clang</code>.</p>
 <p><a href="#cody">Cody</a> also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/lush/lush.sh">lush.sh</a> script to
 demonstrate it as using make was problematic.</p>
 <p>Cody made it use <code>fgets()</code> instead of <code>gets()</code>. See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
 the libc function gets)3( changed to use
 fgets(3)?</a> for why this was done.</p>
 <p>NOTE: this entry cannot work with <code>clang</code> due to different compiler messages (it
-will compile fine but it won’t work). See <a href="bugs.html">bugs.html</a> for details.</p>
+will compile fine but it won’t work). See <a href="bugs.html#1992_lush">1992/lush in
+bugs.html</a> for details.</p>
 <div id="1992_marangon">
-<h2 id="marangon"><a href="1992/marangon/index.html">1992/marangon</a></h2>
-<h3 id="source-code-marangon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/marangon/marangon.c">marangon.c</a></h3>
+<h2 id="winning-entry-1992marangon">Winning entry: <a href="1992/marangon/index.html">1992/marangon</a></h2>
+<h3 id="winning-entry-source-code-marangon.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/marangon/marangon.c">marangon.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this more portable by changing the <code>void main()</code> to be <code>int main()</code>.</p>
 <div id="1992_nathan">
-<h2 id="nathan"><a href="1992/nathan/index.html">1992/nathan</a></h2>
-<h3 id="source-code-nathan.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a></h3>
+<h2 id="winning-entry-1992nathan">Winning entry: <a href="1992/nathan/index.html">1992/nathan</a></h2>
+<h3 id="winning-entry-source-code-nathan.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the original file back as it was deemed that the export restrictions
 should no longer be a cause of concern for this entry. Doing this did require a
@@ -1771,8 +1779,8 @@ participates in the IOCCC, that it must be our fault! :-)</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/try.sh">try.sh</a> script that runs a few commands
 that we suggested as well as one he provided.</p>
 <div id="1992_vern">
-<h2 id="vern"><a href="1992/vern/index.html">1992/vern</a></h2>
-<h3 id="source-code-vern.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">vern.c</a></h3>
+<h2 id="winning-entry-1992vern">Winning entry: <a href="1992/vern/index.html">1992/vern</a></h2>
+<h3 id="winning-entry-source-code-vern.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">vern.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an infinite loop if one were to input numbers &lt; <code>0</code> or &gt; <code>077</code>. The
 problem was that it tried to use <code>scanf(3)</code> with the format specifier <code>"%o %o"</code> in a
@@ -1786,8 +1794,8 @@ both numbers (using <code>"%o %o"</code> does not solve the problem).</p>
 <p>This was deemed a problem to fix as the Judges’ remarks hinted that this was how
 it used to be.</p>
 <div id="1992_westley">
-<h2 id="westley-5"><a href="1992/westley/index.html">1992/westley</a></h2>
-<h3 id="source-code-westley.c-5">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1992westley">Winning entry: <a href="1992/westley/index.html">1992/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-5">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">westley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work for <code>clang</code> by changing the third and fourth arg of
 <code>main()</code> to be <code>char ** inside</code>main()<code>;</code>clang<code>requires args 2 - 4 to be</code>char
@@ -1828,38 +1836,40 @@ encourage you to try the original without two args :-)</p>
 <h1 id="section-9"><a href="1993/index.html">1993</a></h1>
 </div>
 <div id="1993_ant">
-<h2 id="ant-2"><a href="1993/ant/index.html">1993/ant</a></h2>
-<h3 id="source-code-ant.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">ant.c</a></h3>
+<h2 id="winning-entry-1993ant">Winning entry: <a href="1993/ant/index.html">1993/ant</a></h2>
+<h3 id="winning-entry-source-code-ant.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">ant.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/try.sh">try.sh</a> script and a data file,
 <a href="1993/ant/ants.txt">ants.txt</a>, full of ants for the script.</p>
 <div id="1993_cmills">
-<h2 id="cmills-1"><a href="1993/cmills/index.html">1993/cmills</a></h2>
-<h3 id="source-code-cmills.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/cmills/cmills.c">cmills.c</a></h3>
+<h2 id="winning-entry-1993cmills">Winning entry: <a href="1993/cmills/index.html">1993/cmills</a></h2>
+<h3 id="winning-entry-source-code-cmills.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/cmills/cmills.c">cmills.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> suggested that with modern systems this goes too fast so he added a call
 to <code>usleep(3)</code> in a patch he made. <a href="#cody">Cody</a> made it configurable at compilation by
-using a macro. This is in the alt version which is the recommended one to try
+using a macro. This is in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/cmills/cmills.alt.c">alt
+version</a> which is the recommended one to try
 first.</p>
 <div id="1993_dgibson">
-<h2 id="dgibson"><a href="1993/dgibson/index.html">1993/dgibson</a></h2>
-<h3 id="source-code-dgibson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/dgibson/dgibson.c">dgibson.c</a></h3>
+<h2 id="winning-entry-1993dgibson">Winning entry: <a href="1993/dgibson/index.html">1993/dgibson</a></h2>
+<h3 id="winning-entry-source-code-dgibson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/dgibson/dgibson.c">dgibson.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/dgibson/dgibson.sh">dgibson.sh</a> script to work
 which assumed that <code>.</code> is in the path.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/dgibson/try.sh">try.sh</a> script which runs the above
 mentioned script on all the data files.</p>
 <div id="1993_ejb">
-<h2 id="ejb"><a href="1993/ejb/index.html">1993/ejb</a></h2>
-<h3 id="source-code-ejb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ejb/ejb.c">ejb.c</a></h3>
+<h2 id="winning-entry-1993ejb">Winning entry: <a href="1993/ejb/index.html">1993/ejb</a></h2>
+<h3 id="winning-entry-source-code-ejb.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ejb/ejb.c">ejb.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ejb/try.sh">try.sh</a> script.</p>
 <div id="1993_jonth">
-<h2 id="jonth"><a href="1993/jonth/index.html">1993/jonth</a></h2>
-<h3 id="source-code-jonth.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/jonth/jonth.c">jonth.c</a></h3>
+<h2 id="winning-entry-1993jonth">Winning entry: <a href="1993/jonth/index.html">1993/jonth</a></h2>
+<h3 id="winning-entry-source-code-jonth.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/jonth/jonth.c">jonth.c</a></h3>
 </div>
 <p>Both <a href="#cody">Cody</a> and <a href="#yusuke">Yusuke</a> fixed this so that it will work with modern systems. Yusuke
-provided some fixes of the X code and Cody fixed the C pre-processor directives
+provided some fixes of the X code (it is not known at the time of writing this
+what changed) and Cody fixed the C pre-processor directives
 so that it would compile. It used to be that you could get away with code like:</p>
 <pre><code>    G        int i,j
     K        case</code></pre>
@@ -1867,16 +1877,16 @@ so that it would compile. It used to be that you could get away with code like:<
 <code>case</code> but that’s no longer the case so the offending lines had <code>#define</code>
 prepended to them.</p>
 <div id="1993_leo">
-<h2 id="leo"><a href="1993/leo/index.html">1993/leo</a></h2>
-<h3 id="source-code-leo.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/leo/leo.c">leo.c</a></h3>
+<h2 id="winning-entry-1993leo">Winning entry: <a href="1993/leo/index.html">1993/leo</a></h2>
+<h3 id="winning-entry-source-code-leo.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/leo/leo.c">leo.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with modern compilers. This involved different header
 files for functions.</p>
 <div id="1993_lmfjyh">
-<h2 id="lmfjyh"><a href="1993/lmfjyh/index.html">1993/lmfjyh</a></h2>
-<h3 id="source-code-lmfjyh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">lmfjyh.c</a></h3>
+<h2 id="winning-entry-1993lmfjyh">Winning entry: <a href="1993/lmfjyh/index.html">1993/lmfjyh</a></h2>
+<h3 id="winning-entry-source-code-lmfjyh.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">lmfjyh.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added an <a href="1993/lmfjyh/index.html#alternate-code">alternate
+<p><a href="#cody">Cody</a> added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.alt.c">alternate
 version</a> which does what the program did
 with <code>gcc</code> &lt; 2.3.3. See the index.html file for details and for why this was made
 the alternate version, not the actual entry.</p>
@@ -1884,22 +1894,22 @@ the alternate version, not the actual entry.</p>
 would be compiled if <code>gcc</code> &lt; 2.3.3) whether or not compilation succeeds (which is
 highly unlikely).</p>
 <div id="1993_plummer">
-<h2 id="plummer"><a href="1993/plummer/index.html">1993/plummer</a></h2>
-<h3 id="source-code-plummer.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/plummer.c">plummer.c</a></h3>
+<h2 id="winning-entry-1993plummer">Winning entry: <a href="1993/plummer/index.html">1993/plummer</a></h2>
+<h3 id="winning-entry-source-code-plummer.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/plummer.c">plummer.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added check for two args during a time that this was considered a
 bug to fix.</p>
-<p>Cody also added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/plummer.alt.c">alternate version</a> which uses
-<code>usleep(3)</code> so you can see what is happening with faster systems. This version
-also checks for two args and it is the one we recommend one try first. See the
-index.html files for details.</p>
+<p>Cody also added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/plummer.alt.c">alternate version</a>
+which uses <code>usleep(3)</code> so you can see how this entry used to look, if you’re
+using a more modern system. This version also checks for two args and it is the
+one we recommend one try first. See the index.html files for details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/try.alt.sh">try.alt.sh</a> scripts that correspond to the original
 entry and the alt version, both allowing one to change the args (and in the case
 of the alt one allowing one to change the amount to sleep).</p>
 <div id="1993_rince">
-<h2 id="rince-1"><a href="1993/rince/index.html">1993/rince</a></h2>
-<h3 id="source-code-rince.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">rince.c</a></h3>
+<h2 id="winning-entry-1993rince">Winning entry: <a href="1993/rince/index.html">1993/rince</a></h2>
+<h3 id="winning-entry-source-code-rince.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">rince.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> supplied a patch to get this to work in modern systems. This fix also
 applies the compatibility issue of <code>select(2)</code> described in the index.html file.</p>
@@ -1911,15 +1921,15 @@ users. The slowing down was based on our suggestion that it might be desired to
 slow down but Cody did it in such a way that makes it easy to configure at
 compile time. See the index.html for details.</p>
 <div id="1993_schnitzi">
-<h2 id="schnitzi"><a href="1993/schnitzi/index.html">1993/schnitzi</a></h2>
-<h3 id="source-code-schnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">schnitzi.c</a></h3>
+<h2 id="winning-entry-1993schnitzi">Winning entry: <a href="1993/schnitzi/index.html">1993/schnitzi</a></h2>
+<h3 id="winning-entry-source-code-schnitzi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">schnitzi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this use <code>fgets(3)</code> not <code>gets(3)</code>. See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
 the libc function gets(3) changed to use
 fgets(3)?</a> for why this was done.</p>
 <div id="1993_vanb">
-<h2 id="vanb-1"><a href="1993/vanb/index.html">1993/vanb</a></h2>
-<h3 id="source-code-vanb.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">vanb.c</a></h3>
+<h2 id="winning-entry-1993vanb">Winning entry: <a href="1993/vanb/index.html">1993/vanb</a></h2>
+<h3 id="winning-entry-source-code-vanb.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">vanb.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with <code>clang</code>. The problem was that the third arg to main()
 was not a <code>char **. Instead</code>O5()<code>(which was</code>main()<code>via</code>-DO5=main`) is now
@@ -1943,8 +1953,8 @@ this code. Other code is also described there.</p>
 <h1 id="section-10"><a href="1994/index.html">1994</a></h1>
 </div>
 <div id="1994_dodsond2">
-<h2 id="dodsond2"><a href="1994/dodsond2/index.html">1994/dodsond2</a></h2>
-<h3 id="source-code-1994dodsond2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2</a></h3>
+<h2 id="winning-entry-1994dodsond2">Winning entry: <a href="1994/dodsond2/index.html">1994/dodsond2</a></h2>
+<h3 id="winning-entry-source-code-1994dodsond2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an infinite loop that could happen when you shoot an arrow
 and end up having no arrows, thus making one force quit the game. The problem
@@ -1955,8 +1965,8 @@ started over, doing nothing. This fix also seems to have fixed a problem where
 if you shoot your last arrow it would not move you to the room you shoot into
 (whereas if you had more arrows it would).</p>
 <p>Cody added an alt version that allows one to cheat by specifying how many arrows
-to start with (this was for fun but it turned out a good way to debug the above
-infinite loop too which hanged the program).</p>
+to start with (this does make for fun but it allowed to easily debug the above
+mentioned infinite loop which hanged the program).</p>
 <p>As in some places it would properly say that you have ‘1 arrow’ or else, if you
 have any other number of arrows (including 0), it would say ‘arrows’, Cody fixed
 a place where it always said ‘arrows’. A minor fix and not that important.</p>
@@ -1971,8 +1981,8 @@ Now the counters are reset. The way this bug was fixed is that there is now a
 counter for how many you have found and how many you shot in addition to the two
 that already existed, how many you had and how many were stolen.</p>
 <div id="1994_horton">
-<h2 id="horton"><a href="1994/horton/index.html">1994/horton</a></h2>
-<h3 id="source-code-1994horton">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.c">1994/horton</a></h3>
+<h2 id="winning-entry-1994horton">Winning entry: <a href="1994/horton/index.html">1994/horton</a></h2>
+<h3 id="winning-entry-source-code-1994horton">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.c">1994/horton</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to check that four args were specified (at a time it
 was considered a bug to fix). With the use of the C pre-processor macro and
@@ -1986,8 +1996,8 @@ shouldn’t be.</p>
 <p>Finally he added the article (written by the entry’s author) cited in
 <a href="1994/horton/login_sept92-pp28-31.pdf">login_sept92-pp28-31.pdf</a>.</p>
 <div id="1994_imc">
-<h2 id="imc-1"><a href="1994/imc/index.html">1994/imc</a></h2>
-<h3 id="source-code-imc.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/imc/imc.c">imc.c</a></h3>
+<h2 id="winning-entry-1994imc">Winning entry: <a href="1994/imc/index.html">1994/imc</a></h2>
+<h3 id="winning-entry-source-code-imc.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/imc/imc.c">imc.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/imc/try.sh">try.sh</a> script.</p>
 <p>Cody also added inclusion of <code>unistd.h</code> for <code>getpid(2)</code>. While strictly speaking
@@ -1995,8 +2005,8 @@ this was not necessary (in multiple systems) it can sometimes be a problem and
 as it was noticed it was changed (the only case this was done except in the
 entries that actually did not work because of missing or incorrect prototypes).</p>
 <div id="1994_ldb">
-<h2 id="ldb"><a href="1994/ldb/index.html">1994/ldb</a></h2>
-<h3 id="source-code-ldb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">ldb.c</a></h3>
+<h2 id="winning-entry-1994ldb">Winning entry: <a href="1994/ldb/index.html">1994/ldb</a></h2>
+<h3 id="winning-entry-source-code-ldb.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">ldb.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so it would compile and work with modern compilers. The problem
 was that <code>srand()</code> returns <code>void</code> but it was used in a <code>||</code> expression. Thus the
@@ -2020,28 +2030,28 @@ than 231 in length if the program chooses that line it might print the first 231
 characters or it might print (up to) the next 231 characters and so on.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/try.sh">try.sh</a> script.</p>
 <div id="1994_schnitzi">
-<h2 id="schnitzi-1"><a href="1994/schnitzi/index.html">1994/schnitzi</a></h2>
-<h3 id="source-code-schnitzi.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/schnitzi.c">schnitzi.c</a></h3>
+<h2 id="winning-entry-1994schnitzi">Winning entry: <a href="1994/schnitzi/index.html">1994/schnitzi</a></h2>
+<h3 id="winning-entry-source-code-schnitzi.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/schnitzi.c">schnitzi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added two alt versions, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/schnitzi.alt.c">one which uses
 fgets_()</a> but when fed its own source code cannot
 generate code that compile and another <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/schnitzi.alt2.c">one with a bigger buffer
 size</a> which, when fed its own source code, will
 generate compilable code but not with the same buffer size but rather the
-original buffer size. Cody explains this in the at <a href="bugs.html#1994-schnitzi">1994/schnitzi in
+original buffer size. Cody explains this at <a href="bugs.html#1994-schnitzi">1994/schnitzi in
 bugs.html</a>.</p>
 <p>The purpose for these versions it both demonstrate how the magic works behind it
 and to help others, should they wish, get the code to work with <code>fgets(3)</code>, with
 or without an increase in buffer size. Note that without this feeding longer
-files, say the index.html file, will crash the program. See <a href="bugs.html#1994-schnitzi">1994/schnitzi in
+files, say the index.html file, will crash the program. See <a href="bugs.html#1994_schnitzi">1994/schnitzi in
 bugs.html</a> where Cody also explains the magic for more
 details. Later on, if nobody takes up the task, Cody might resume it, but for
 now there is more important work to do so that the next contest can run.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/try.alt.sh">try.alt.sh</a> scripts.</p>
 <div id="1994_shapiro">
-<h2 id="shapiro-1"><a href="1994/shapiro/index.html">1994/shapiro</a></h2>
-<h3 id="source-code-shapiro.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">shapiro.c</a></h3>
+<h2 id="winning-entry-1994shapiro">Winning entry: <a href="1994/shapiro/index.html">1994/shapiro</a></h2>
+<h3 id="winning-entry-source-code-shapiro.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">shapiro.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a bug on systems where <code>EOF != -1</code>. The problem is that <code>getc()</code> and
 the related functions do not return <code>-1</code> on EOF or error but rather <code>EOF</code>.
@@ -2049,19 +2059,20 @@ However <code>EOF</code> is not required to be <code>-1</code> but merely an int
 assumed that <code>getc()</code> will return <code>-1</code> on EOF or error, not <code>EOF</code>. On systems
 where <code>EOF != -1</code> it could result in an infinite loop.</p>
 <p>For an interesting problem that occurred here and what was done to solve it,
-check the <a href="bugs.html">bugs.html</a> file.</p>
+check <a href="bugs.html#1994_shapiro">1994/shapiro in bugs.html</a>.</p>
 <div id="1994_smr">
-<h2 id="smr"><a href="1994/smr/index.html">1994/smr</a></h2>
-<h3 id="source-code-smr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/smr/smr.c">smr.c</a></h3>
+<h2 id="winning-entry-1994smr">Winning entry: <a href="1994/smr/index.html">1994/smr</a></h2>
+<h3 id="winning-entry-source-code-smr.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/smr/smr.c">smr.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/smr/try.sh">try.sh</a> script.</p>
 <div id="1994_tvr">
-<h2 id="tvr"><a href="1994/tvr/index.html">1994/tvr</a></h2>
-<h3 id="source-code-1994tvr">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.c">1994/tvr</a></h3>
+<h2 id="winning-entry-1994tvr">Winning entry: <a href="1994/tvr/index.html">1994/tvr</a></h2>
+<h3 id="winning-entry-source-code-1994tvr">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.c">1994/tvr</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the try scripts, four total, colour and black and white
 pairs for the original entry and the alt code. These scripts are
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.color.sh">try.color.sh</a>, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.bw.sh">try.bw.sh</a>,
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.color.sh">try.color.sh</a> (color to match the author’s
+remarks), <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.bw.sh">try.bw.sh</a>,
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.alt.color.sh">try.alt.color.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.alt.bw.sh">try.alt.bw.sh</a>, respectively. The scripts go through
 each mode allowed with two sizes, 128 and 256, allowing one to quit or skip each
@@ -2076,8 +2087,8 @@ to use <code>fgets()</code> and the inclusion of <code>stdio.h</code> had to be 
 more like the original entry this was done in the Makefile. The alt code was
 also changed to use <code>fgets(3)</code>.</p>
 <div id="1994_weisberg">
-<h2 id="weisberg"><a href="1994/weisberg/index.html">1994/weisberg</a></h2>
-<h3 id="source-code-weisberg.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.c">weisberg.c</a></h3>
+<h2 id="winning-entry-1994weisberg">Winning entry: <a href="1994/weisberg/index.html">1994/weisberg</a></h2>
+<h3 id="winning-entry-source-code-weisberg.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.c">weisberg.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> changed the Makefile to make this program more user friendly and easier to
 use with other tools as well by making the program output not a space after each
@@ -2089,26 +2100,27 @@ lines of the <code>weisberg</code>, feeding it to <code>primes(1)</code>, showin
 primes. It only does the reversed output because the program actually prints
 primes.</p>
 <div id="1994_westley">
-<h2 id="westley-6"><a href="1994/westley/index.html">1994/westley</a></h2>
-<h3 id="source-code-westley.c-6">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1994westley">Winning entry: <a href="1994/westley/index.html">1994/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-6">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/westley.c">westley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> converted the spoiler compiler options (provided by the author) to be
 compiler commands and added a script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.sh">try.sh</a> to
 automate the spoiler commands to make it easier to see the game in action from
 start to finish.</p>
-<p>Cody also added the alternate version that will look fine on terminals not set
-to 80 columns and the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.alt.sh">try.alt.sh</a> script to automate
-the play along the lines of the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.sh">try.sh</a> script.</p>
+<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/westley.alt.c">alternate version</a>
+that will look fine on terminals not set to 80 columns and the
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.alt.sh">try.alt.sh</a> script to automate the play
+along the lines of the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.sh">try.sh</a> script.</p>
 <div id="1995">
-<h1 id="section-11">1995</h1>
+<h1 id="section-11"><a href="1995/index.html">1995</a></h1>
 </div>
 <div id="1995_cdua">
-<h2 id="cdua"><a href="1995/cdua/index.html">1995/cdua</a></h2>
-<h3 id="source-code-cdua.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">cdua.c</a></h3>
+<h2 id="winning-entry-1995cdua">Winning entry: <a href="1995/cdua/index.html">1995/cdua</a></h2>
+<h3 id="winning-entry-source-code-cdua.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">cdua.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that it would work with macOS. Once it could compile it
 additionally segfaulted under macOS which he also fixed.</p>
-<p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.alt.c">Alternate code</a> for fun :-) ) (in
+<p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.alt.c">alternate code</a> for fun :-) ) (in
 particular to make it easier to see the program do what it does in systems that
 are too fast … if there is such a thing anyway :-) ). See the index.html for
 details on this.</p>
@@ -2119,19 +2131,19 @@ It actually appears to allow 1 but if you specify 4 it says 0, 2 or 3 and it is
 an error but it’s entirely possible that they will eventually make the defect
 function as the error message claims.</p>
 <div id="1995_dodsond1">
-<h2 id="dodsond1"><a href="1995/dodsond1/index.html">1995/dodsond1</a></h2>
-<h3 id="source-code-dodsond1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/dodsond1/dodsond1.c">dodsond1.c</a></h3>
+<h2 id="winning-entry-1995dodsond1">Winning entry: <a href="1995/dodsond1/index.html">1995/dodsond1</a></h2>
+<h3 id="winning-entry-source-code-dodsond1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/dodsond1/dodsond1.c">dodsond1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/dodsond1/try.sh">try.sh</a> script that uses the text file he
 provided which is input we suggested one try with the entry.</p>
 <div id="1995_esde">
-<h2 id="esde"><a href="1995/esde/index.html">1995/esde</a></h2>
-<h3 id="source-code-esde.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/esde/esde.c">esde.c</a></h3>
+<h2 id="winning-entry-1995esde">Winning entry: <a href="1995/esde/index.html">1995/esde</a></h2>
+<h3 id="winning-entry-source-code-esde.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/esde/esde.c">esde.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/esde/try.sh">try.sh</a> script.</p>
 <div id="1995_garry">
-<h2 id="garry"><a href="1995/garry/index.html">1995/garry</a></h2>
-<h3 id="source-code-garry.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/garry.c">garry.c</a></h3>
+<h2 id="winning-entry-1995garry">Winning entry: <a href="1995/garry/index.html">1995/garry</a></h2>
+<h3 id="winning-entry-source-code-garry.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/garry.c">garry.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the alt code so that it will compile with modern compilers. The
 problem was a missing <code>int</code> for the <code>f</code> variable. He felt it was even more
@@ -2145,38 +2157,38 @@ alt version is not as important as alt code in other entries. In order to get
 the paging to work right for the <code>garry.data</code> file leading blank lines had to be
 added.</p>
 <div id="1995_heathbar">
-<h2 id="heathbar"><a href="1995/heathbar/index.html">1995/heathbar</a></h2>
-<h3 id="source-code-1995heathbar">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/heathbar/heathbar.c">1995/heathbar</a></h3>
+<h2 id="winning-entry-1995heathbar">Winning entry: <a href="1995/heathbar/index.html">1995/heathbar</a></h2>
+<h3 id="winning-entry-source-code-1995heathbar">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/heathbar/heathbar.c">1995/heathbar</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/heathbar/try.sh">try.sh</a> script.</p>
 <div id="1995_leo">
-<h2 id="leo-1"><a href="1995/leo/index.html">1995/leo</a></h2>
-<h3 id="source-code-leo.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/leo/leo.c">leo.c</a></h3>
+<h2 id="winning-entry-1995leo">Winning entry: <a href="1995/leo/index.html">1995/leo</a></h2>
+<h3 id="winning-entry-source-code-leo.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/leo/leo.c">leo.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/leo/try.sh">try.sh</a> script.</p>
 <p>At our change in how to deal with spoilers, Cody also uudecoded the spoiler provided
 by the author, putting it in <a href="1995/leo/spoiler1.html">spoiler1.html</a>.</p>
 <div id="1995_makarios">
-<h2 id="makarios"><a href="1995/makarios/index.html">1995/makarios</a></h2>
-<h3 id="source-code-makarios.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/makarios/makarios.c">makarios.c</a></h3>
+<h2 id="winning-entry-1995makarios">Winning entry: <a href="1995/makarios/index.html">1995/makarios</a></h2>
+<h3 id="winning-entry-source-code-makarios.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/makarios/makarios.c">makarios.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that it will compile with versions of <code>clang</code> that has a defect
 which only allows <code>main()</code> to have 0, 2 or 3 args. This is done by a new
 function (<code>pain()</code> as it’s annoying that <code>clang</code> is this way :-) ) that <code>main()</code>
 calls which has the four args.</p>
 <div id="1995_savastio">
-<h2 id="savastio"><a href="1995/savastio/index.html">1995/savastio</a></h2>
-<h3 id="source-code-savastio.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">savastio.c</a></h3>
+<h2 id="winning-entry-1995savastio">Winning entry: <a href="1995/savastio/index.html">1995/savastio</a></h2>
+<h3 id="winning-entry-source-code-savastio.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">savastio.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/try.sh">try.sh</a> script.</p>
 <div id="1995_schnitzi">
-<h2 id="schnitzi-2"><a href="1995/schnitzi/index.html">1995/schnitzi</a></h2>
-<h3 id="source-code-schnitzi.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/schnitzi/schnitzi.c">schnitzi.c</a></h3>
+<h2 id="winning-entry-1995schnitzi">Winning entry: <a href="1995/schnitzi/index.html">1995/schnitzi</a></h2>
+<h3 id="winning-entry-source-code-schnitzi.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/schnitzi/schnitzi.c">schnitzi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/schnitzi/try.sh">try.sh</a> script.</p>
 <div id="1995_vanschnitz">
-<h2 id="vanschnitz"><a href="1995/vanschnitz/index.html">1995/vanschnitz</a></h2>
-<h3 id="source-code-vanschnitz.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.c">vanschnitz.c</a></h3>
+<h2 id="winning-entry-1995vanschnitz">Winning entry: <a href="1995/vanschnitz/index.html">1995/vanschnitz</a></h2>
+<h3 id="winning-entry-source-code-vanschnitz.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.c">vanschnitz.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the authors’ <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.alt.c">spoiler as a C
 file</a> as in 2023 we have decided that in most
@@ -2185,11 +2197,11 @@ extract it. The exception is when the files are created by the entry or the
 entry decrypts the text or something like that.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/try.sh">try.sh</a> script.</p>
 <div id="1996">
-<h1 id="section-12">1996</h1>
+<h1 id="section-12"><a href="1996/index.html">1996</a></h1>
 </div>
 <div id="1996_august">
-<h2 id="august-1"><a href="1996/august/index.html">1996/august</a></h2>
-<h3 id="source-code-august.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/august/august.c">august.c</a></h3>
+<h2 id="winning-entry-1996august">Winning entry: <a href="1996/august/index.html">1996/august</a></h2>
+<h3 id="winning-entry-source-code-august.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/august/august.c">august.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault in this program that prevented it from working right and
 also fixed an infinite loop in the try commands.</p>
@@ -2202,8 +2214,8 @@ problem existed in macOS.</p>
 commands that were given by the judges in the try section, with the fix above
 applied.</p>
 <div id="1996_dalbec">
-<h2 id="dalbec"><a href="1996/dalbec/index.html">1996/dalbec</a></h2>
-<h3 id="source-code-dalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/dalbec/dalbec.c">dalbec.c</a></h3>
+<h2 id="winning-entry-1996dalbec">Winning entry: <a href="1996/dalbec/index.html">1996/dalbec</a></h2>
+<h3 id="winning-entry-source-code-dalbec.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/dalbec/dalbec.c">dalbec.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> proposed a fix for this to compile with <code>clang</code> and Landon implemented it
 after some discussion (though Cody changed the function name). The reason Cody
@@ -2219,8 +2231,8 @@ numbers on the same line. This was not put in an alternate version but perhaps
 it should be.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/dalbec/try.sh">try.sh</a> script.</p>
 <div id="1996_eldby">
-<h2 id="eldby"><a href="1996/eldby/index.html">1996/eldby</a></h2>
-<h3 id="source-code-eldby.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/eldby/eldby.c">eldby.c</a></h3>
+<h2 id="winning-entry-1996eldby">Winning entry: <a href="1996/eldby/index.html">1996/eldby</a></h2>
+<h3 id="winning-entry-source-code-eldby.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/eldby/eldby.c">eldby.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/eldby/eldby.alt.c">alternate version</a> which uses
 <code>usleep()</code> in between writing the output to make it easier to see what is going
@@ -2229,8 +2241,8 @@ flashing by rapidly (it affects him too but he also thinks it moves too fast
 nowadays anyway). We recommend that you try the alternate version first due to
 these reasons.</p>
 <div id="1996_gandalf">
-<h2 id="gandalf"><a href="1996/gandalf/index.html">1996/gandalf</a></h2>
-<h3 id="source-code-gandalf.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/gandalf/gandalf.c">gandalf.c</a></h3>
+<h2 id="winning-entry-1996gandalf">Winning entry: <a href="1996/gandalf/index.html">1996/gandalf</a></h2>
+<h3 id="winning-entry-source-code-gandalf.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/gandalf/gandalf.c">gandalf.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile and work with modern systems. As he loved the
 references in the code that could not compile he just commented out as little as
@@ -2241,26 +2253,26 @@ either different output or the same output that we briefly pointed out.</p>
 <p>BTW: it is perilous to try the patience of
 <a href="https://www.glyphweb.com/arda/g/gandalf.html">Gandalf</a>. Go ahead, try it! :-)</p>
 <div id="1996_huffman">
-<h2 id="huffman"><a href="1996/huffman/index.html">1996/huffman</a></h2>
-<h3 id="source-code-huffman.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/huffman/huffman.c">huffman.c</a></h3>
+<h2 id="winning-entry-1996huffman">Winning entry: <a href="1996/huffman/index.html">1996/huffman</a></h2>
+<h3 id="winning-entry-source-code-huffman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/huffman/huffman.c">huffman.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/huffman/try.sh">try.sh</a> script.</p>
 <div id="1996_jonth">
-<h2 id="jonth-1"><a href="1996/jonth/index.html">1996/jonth</a></h2>
-<h3 id="source-code-jonth.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">jonth.c</a></h3>
+<h2 id="winning-entry-1996jonth">Winning entry: <a href="1996/jonth/index.html">1996/jonth</a></h2>
+<h3 id="winning-entry-source-code-jonth.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">jonth.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to not segfault under macOS. The problem was that the function
 pointer <code>w</code>, which points to <code>XCreateWindow()</code>, did not specify the parameters of
 the function in the pointer assignment.</p>
 <p>NOTE: if there is no X server running this program will still crash.</p>
 <div id="1996_rcm">
-<h2 id="rcm"><a href="1996/rcm/index.html">1996/rcm</a></h2>
-<h3 id="source-code-rcm.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/rcm/rcm.c">rcm.c</a></h3>
+<h2 id="winning-entry-1996rcm">Winning entry: <a href="1996/rcm/index.html">1996/rcm</a></h2>
+<h3 id="winning-entry-source-code-rcm.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/rcm/rcm.c">rcm.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/rcm/try.sh">try.sh</a> script.</p>
 <div id="1996_schweikh1">
-<h2 id="schweikh1"><a href="1996/schweikh1/index.html">1996/schweikh1</a></h2>
-<h3 id="source-code-schweikh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh1/schweikh1.c">schweikh1.c</a></h3>
+<h2 id="winning-entry-1996schweikh1">Winning entry: <a href="1996/schweikh1/index.html">1996/schweikh1</a></h2>
+<h3 id="winning-entry-source-code-schweikh1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh1/schweikh1.c">schweikh1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh1/try.sh">try.sh</a> script.</p>
 <p>The author stated that <code>-I/usr/include</code> is needed by <code>gcc</code> in Solaris because
@@ -2271,23 +2283,23 @@ on other systems (the other file is
 <code>gcc-lib/sparc-sun-solaris2.5/2.7.2/include/errno.h</code>). Thus Cody also added this to
 the Makefile despite the fact that very few probably use Solaris nowadays.</p>
 <div id="1996_schweikh2">
-<h2 id="schweikh2"><a href="1996/schweikh2/index.html">1996/schweikh2</a></h2>
-<h3 id="source-code-schweikh2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh2/schweikh2.c">schweikh2.c</a></h3>
+<h2 id="winning-entry-1996schweikh2">Winning entry: <a href="1996/schweikh2/index.html">1996/schweikh2</a></h2>
+<h3 id="winning-entry-source-code-schweikh2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh2/schweikh2.c">schweikh2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh2/try.sh">try.sh</a> script with a few commands to try
 along with a shorter version of something the author suggested one try (it is
 suggested that one try the longer version too but it will run in an infinite
 loop so having it in a script is less desired).</p>
 <div id="1996_schweikh3">
-<h2 id="schweikh3"><a href="1996/schweikh3/index.html">1996/schweikh3</a></h2>
+<h2 id="winning-entry-1996schweikh3">Winning entry: <a href="1996/schweikh3/index.html">1996/schweikh3</a></h2>
 <h2 id="source-code-schweikh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh3/schweikh3.c">schweikh3.c</a></h2>
 </div>
 <p><a href="#cody">Cody</a> updated the Makefile so that if it fails to compile it will try he
 method suggested for SunOS rather than having to update the Makefile manually or
 running a more complicated command: now one can just run <code>make</code>.</p>
 <div id="1996_westley">
-<h2 id="westley-7"><a href="1996/westley/index.html">1996/westley</a></h2>
-<h3 id="source-code-westley.c-7">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/westley/westley.c">westley.c</a></h3>
+<h2 id="winning-entry-1996westley">Winning entry: <a href="1996/westley/index.html">1996/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-7">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/westley/westley.c">westley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault in this entry as well as it displaying environmental
 variables. Although the scripts showed correct output, it somewhat lessened the
@@ -2305,11 +2317,11 @@ clocks, both with the fixed version and the original (alt) version.</p>
 <p>Also, to fix any potential problem with displaying in GitHub the scripts
 provided by the author, Cody added ‘.sh’ to the <code>clock[1-3].sh</code> scripts.</p>
 <div id="1998">
-<h1 id="section-13">1998</h1>
+<h1 id="section-13"><a href="1998/index.html">1998</a></h1>
 </div>
 <div id="1998_banks">
-<h2 id="banks"><a href="1998/banks/index.html">1998/banks</a></h2>
-<h3 id="source-code-banks.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/banks/banks.c">/banks.c</a></h3>
+<h2 id="winning-entry-1998banks">Winning entry: <a href="1998/banks/index.html">1998/banks</a></h2>
+<h3 id="winning-entry-source-code-banks.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/banks/banks.c">/banks.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> improved the Makefile to allow for easier redefining the control
 keys and time step that the author set up.</p>
@@ -2322,8 +2334,8 @@ have them like with Macs. The alt build hard codes the page up and page down
 alternatives because not doing so would overly complicate both builds and since
 you can configure them all in both builds it shouldn’t matter.</p>
 <div id="1998_bas1">
-<h2 id="bas1"><a href="1998/bas1/index.html">1998/bas1</a></h2>
-<h3 id="source-code-bas1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas1/bas1.c">bas1.c</a></h3>
+<h2 id="winning-entry-1998bas1">Winning entry: <a href="1998/bas1/index.html">1998/bas1</a></h2>
+<h3 id="winning-entry-source-code-bas1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas1/bas1.c">bas1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution, added a second arg to <code>main()</code> as some
 versions of <code>clang</code> whine about the number of args on top of what type they are
@@ -2334,14 +2346,14 @@ be a problem at such a time.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas1/bas1.sh">bas1.sh</a> script to simplify running the
 program.</p>
 <div id="1998_bas2">
-<h2 id="bas2"><a href="1998/bas2/index.html">1998/bas2</a></h2>
-<h3 id="source-code-bas2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas2/bas2.c">bas2.c</a></h3>
+<h2 id="winning-entry-1998bas2">Winning entry: <a href="1998/bas2/index.html">1998/bas2</a></h2>
+<h3 id="winning-entry-source-code-bas2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas2/bas2.c">bas2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas2/try.sh">try.sh</a> script which runs some default actions
 as well as allowing one to pass in different file names or strings.</p>
 <div id="1998_chaos">
-<h2 id="chaos"><a href="1998/chaos/index.html">1998/chaos</a></h2>
-<h3 id="source-code-chaos.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/chaos/chaos.c">chaos.c</a></h3>
+<h2 id="winning-entry-1998chaos">Winning entry: <a href="1998/chaos/index.html">1998/chaos</a></h2>
+<h3 id="winning-entry-source-code-chaos.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/chaos/chaos.c">chaos.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added a call to <code>endwin()</code> to restore terminal sanity (echo etc.) when
 exiting the program (in both versions).</p>
@@ -2349,8 +2361,8 @@ exiting the program (in both versions).</p>
 all the data files, giving instructions on how to rotate and zoom in and out,
 prior to each run.</p>
 <div id="1998_df">
-<h2 id="df"><a href="1998/df/index.html">1998/df</a></h2>
-<h3 id="source-code-df.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/df/df.c">df.c</a></h3>
+<h2 id="winning-entry-1998df">Winning entry: <a href="1998/df/index.html">1998/df</a></h2>
+<h3 id="winning-entry-source-code-df.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/df/df.c">df.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> changed a <code>int *</code> used for <code>fopen(3)</code> to be a <code>FILE *</code> to be more correct
 and prevent any possible problems in some systems (which has happened).</p>
@@ -2362,8 +2374,8 @@ for why this has to be done this way.</p>
 loop until one hits <code>q</code> (or <code>Q</code>) or sends intr/ctrl-c. He also proposed there’s
 a way to cheat very easily. Can you figure out how?</p>
 <div id="1998_dlowe">
-<h2 id="dlowe"><a href="1998/dlowe/index.html">1998/dlowe</a></h2>
-<h3 id="source-code-dlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dlowe/dlowe.c">dlowe.c</a></h3>
+<h2 id="winning-entry-1998dlowe">Winning entry: <a href="1998/dlowe/index.html">1998/dlowe</a></h2>
+<h3 id="winning-entry-source-code-dlowe.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dlowe/dlowe.c">dlowe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made the program more portable by changing the void return type of <code>main()</code>
 to be <code>int</code> (in both versions).</p>
@@ -2374,20 +2386,20 @@ program, a local pootifier of web pages and a CGI pootifier. See <a href="1998/d
 remarks</a> for more details on the
 pootify scripts.</p>
 <div id="1998_dloweneil">
-<h2 id="c1998dloweneil"><a href="1998/dloweneil/index.html">c1998/dloweneil</a></h2>
-<h3 id="source-code-dloweneil.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.c">dloweneil.c</a></h3>
+<h2 id="winning-entry-c1998dloweneil">Winning entry: <a href="1998/dloweneil/index.html">c1998/dloweneil</a></h2>
+<h3 id="winning-entry-source-code-dloweneil.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.c">dloweneil.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.alt.c">alt code</a> which has vi(m) movement
 (in addition to the other keys except for dropping it’s not <code>d</code> but <code>j</code> or
 space) keys as well as allowing one to quit the game.</p>
 <div id="1998_dorssel">
-<h2 id="dorssel"><a href="1998/dorssel/index.html">1998/dorssel</a></h2>
-<h3 id="source-code-dorssel.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c">dorssel.c</a></h3>
+<h2 id="winning-entry-1998dorssel">Winning entry: <a href="1998/dorssel/index.html">1998/dorssel</a></h2>
+<h3 id="winning-entry-source-code-dorssel.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c">dorssel.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/try.sh">try.sh</a> script.</p>
 <div id="1998_fanf">
-<h2 id="fanf.html"><a href="1998/fanf/index.html">1998/fanf.html</a></h2>
-<h3 id="source-code-fanf.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/fanf/fanf.c">fanf.c</a></h3>
+<h2 id="winning-entry-1998fanf.html">Winning entry: <a href="1998/fanf/index.html">1998/fanf.html</a></h2>
+<h3 id="winning-entry-source-code-fanf.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/fanf/fanf.c">fanf.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile. The problem was the intermediate steps to get to the
 final code that is compiled. The code is now what it essentially becomes when
@@ -2404,8 +2416,8 @@ code look like the original with just an extra arg.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/fanf/try.sh">try.sh</a> script to show the output of some
 of the expressions that we selected.</p>
 <div id="1998_schnitzi">
-<h2 id="schnitzi-3"><a href="1998/schnitzi/index.html">1998/schnitzi</a></h2>
-<h3 id="source-code-schnitzi.c-3">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">schnitzi.c</a></h3>
+<h2 id="winning-entry-1998schnitzi">Winning entry: <a href="1998/schnitzi/index.html">1998/schnitzi</a></h2>
+<h3 id="winning-entry-source-code-schnitzi.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">schnitzi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed invalid data types which prevented this entry from working, causing a
 segfault. This showed itself in two parts which required two fixes, one for
@@ -2423,8 +2435,8 @@ doing:</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/try.sh">try.sh</a> script to help users try the
 commands that we recommended as well as some added by him.</p>
 <div id="1998_schweikh1">
-<h2 id="index.html"><a href="1998/schweikh1/index.html">index.html</a></h2>
-<h3 id="source-code-1998schweikh1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c">1998/schweikh1</a></h3>
+<h2 id="winning-entry-index.html">Winning entry: <a href="1998/schweikh1/index.html">index.html</a></h2>
+<h3 id="winning-entry-source-code-1998schweikh1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c">1998/schweikh1</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for modern systems (it did not work at all) and added an
 alternate version that works with macOS. Cody also made it ever so slightly more
@@ -2468,8 +2480,8 @@ the macros in the form of <code>gcc -dM</code> i.e., the lines are in the form <
 compute the character count in the code according to the contest rules of 1998
 in the file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/charcount.pl">charcount.pl</a>.</p>
 <div id="1998_schweikh2">
-<h2 id="schweikh2-1"><a href="1998/schweikh2/index.html">1998/schweikh2</a></h2>
-<h3 id="source-code-schweikh2.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh2/schweikh2.c">schweikh2.c</a></h3>
+<h2 id="winning-entry-1998schweikh2">Winning entry: <a href="1998/schweikh2/index.html">1998/schweikh2</a></h2>
+<h3 id="winning-entry-source-code-schweikh2.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh2/schweikh2.c">schweikh2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the code to not trigger an internal compiler error in <code>gcc</code>:</p>
 <pre><code>    :10:16: warning: type defaults to &#39;int&#39; in declaration of &#39;zero&#39; [-Wimplicit-int]
@@ -2485,8 +2497,8 @@ have a problem with that in the future which is not entirely out of the
 question.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh2/try.sh">try.sh</a> script.</p>
 <div id="1998_schweikh3">
-<h2 id="schweikh3-1"><a href="1998/schweikh3/index.html">1998/schweikh3</a></h2>
-<h3 id="source-code-schweikh3.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/schweikh3.c">schweikh3.c</a></h3>
+<h2 id="winning-entry-1998schweikh3">Winning entry: <a href="1998/schweikh3/index.html">1998/schweikh3</a></h2>
+<h3 id="winning-entry-source-code-schweikh3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/schweikh3.c">schweikh3.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="1998/schweikh3/index.html#alternate-code">alternate code</a> which allows one
 to reconfigure the size constant in the rare case that the author wrote about
@@ -2511,8 +2523,8 @@ for more details.</p>
 <p>There actually is a web page for the tool and this was added to the author
 information for the entry. It has not been added to any JSON file.</p>
 <div id="1998_tomtorfs">
-<h2 id="tomtorfs"><a href="1998/tomtorfs/index.html">1998/tomtorfs</a></h2>
-<h3 id="source-code-tomtorfs.chttpsgithub.comioccc-srctemp-test-iocccblobmaster1998tomtorfstomtorfs.c">Source code: /tomtorfs.c](https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/tomtorfs/tomtorfs.c)</h3>
+<h2 id="winning-entry-1998tomtorfs">Winning entry: <a href="1998/tomtorfs/index.html">1998/tomtorfs</a></h2>
+<h3 id="winning-entry-source-code-tomtorfs.chttpsgithub.comioccc-srctemp-test-iocccblobmaster1998tomtorfstomtorfs.c">Winning entry source code: /tomtorfs.c](https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/tomtorfs/tomtorfs.c)</h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the assumption that <code>EOF</code> is <code>-1</code> (the author noted that it assumes
 it is <code>-1</code> and it’s indeed a valid concern as the standard only guarantees that
@@ -2524,11 +2536,11 @@ program had <code>return 1</code>).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/tomtorfs/try.sh">try.sh</a> script to try out a few
 commands that we recommended.</p>
 <div id="2000">
-<h1 id="section-14">2000</h1>
+<h1 id="section-14"><a href="2000/index.html">2000</a></h1>
 </div>
 <div id="2000_anderson">
-<h2 id="anderson"><a href="2000/anderson/index.html">2000/anderson</a></h2>
-<h3 id="source-code-anderson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/anderson//anderson.c">anderson.c</a></h3>
+<h2 id="winning-entry-2000anderson">Winning entry: <a href="2000/anderson/index.html">2000/anderson</a></h2>
+<h3 id="winning-entry-source-code-anderson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/anderson//anderson.c">anderson.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> changed this entry to use <code>fgets(3)</code> instead of <code>gets(3)</code>.
 See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
@@ -2537,43 +2549,43 @@ fgets(3)?</a> for why this was done.
 This involved changing the <code>K</code> arg to <code>gets(3)</code> to <code>&amp;K</code> in <code>fgets(3)</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/anderson/try.sh">try.sh</a> script.</p>
 <div id="2000_bmeyer">
-<h2 id="bmeyer"><a href="2000/bmeyer/index.html">2000/bmeyer</a></h2>
-<h3 id="source-code-bmeyer.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/bmeyer//bmeyer.c">bmeyer.c</a></h3>
+<h2 id="winning-entry-2000bmeyer">Winning entry: <a href="2000/bmeyer/index.html">2000/bmeyer</a></h2>
+<h3 id="winning-entry-source-code-bmeyer.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/bmeyer//bmeyer.c">bmeyer.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/bmeyer/try.sh">try.sh</a> script with some improvements to the
 commands we recommended like not assuming the number of columns one has in their
 terminal.</p>
 <div id="2000_briddlebane">
-<h2 id="briddlebane"><a href="2000/briddlebane/index.html">2000/briddlebane</a></h2>
-<h3 id="source-code-briddlebane.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/briddlebane//briddlebane.c">briddlebane.c</a></h3>
+<h2 id="winning-entry-2000briddlebane">Winning entry: <a href="2000/briddlebane/index.html">2000/briddlebane</a></h2>
+<h3 id="winning-entry-source-code-briddlebane.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/briddlebane//briddlebane.c">briddlebane.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile in systems that require one to explicitly link in
 <code>libm</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/briddlebane/try.sh">try.sh</a> script for those who are
 feeling a bit too confident, cocky or even happy :-)</p>
 <div id="2000_dhyang">
-<h2 id="dhyang"><a href="2000/dhyang/index.html">2000/dhyang</a></h2>
-<h3 id="source-code-dhyang.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dhyang//dhyang.c">dhyang.c</a></h3>
+<h2 id="winning-entry-2000dhyang">Winning entry: <a href="2000/dhyang/index.html">2000/dhyang</a></h2>
+<h3 id="winning-entry-source-code-dhyang.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dhyang//dhyang.c">dhyang.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this more portable by changing the <code>void main</code> to <code>int main</code>.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dhyang/try.sh">try.sh</a> script.</p>
 <div id="2000_dlowe">
-<h2 id="dlowe-1"><a href="2000/dlowe/index.html">2000/dlowe</a></h2>
-<h3 id="source-code-dlowe.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe//dlowe.c">dlowe.c</a></h3>
+<h2 id="winning-entry-2000dlowe">Winning entry: <a href="2000/dlowe/index.html">2000/dlowe</a></h2>
+<h3 id="winning-entry-source-code-dlowe.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe//dlowe.c">dlowe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with more recent perl versions; the symbol that’s now
 <code>PL_na</code> was once <code>na</code>. He notes that this entry crashes under macOS but it works
 under Linux after this change.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe/try.sh">try.sh</a> script.</p>
 <div id="2000_jarijyrki">
-<h2 id="jarijyrki"><a href="2000/jarijyrki/index.html">2000/jarijyrki</a></h2>
-<h3 id="source-code-jarijyrki.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/jarijyrki//jarijyrki.c">jarijyrki.c</a></h3>
+<h2 id="winning-entry-2000jarijyrki">Winning entry: <a href="2000/jarijyrki/index.html">2000/jarijyrki</a></h2>
+<h3 id="winning-entry-source-code-jarijyrki.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/jarijyrki//jarijyrki.c">jarijyrki.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made it easier to compile this in some cases by adding <code>X11/</code> to the
 includes of <code>Xlib.h</code> and <code>keysym.h</code>.</p>
 <div id="2000_natori">
-<h2 id="natori"><a href="2000/natori/index.html">2000/natori</a></h2>
-<h3 id="source-code-natori.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/natori//natori.c">natori.c</a></h3>
+<h2 id="winning-entry-2000natori">Winning entry: <a href="2000/natori/index.html">2000/natori</a></h2>
+<h3 id="winning-entry-source-code-natori.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/natori//natori.c">natori.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for modern compilers. Depending on the compiler it would either
 segfault when run or not compile at all (<code>gcc</code> and <code>clang</code> respectively).</p>
@@ -2593,19 +2605,19 @@ like the original entry but with the two fixes.</p>
 variable which although works it is incongruent with the other Makefiles and is
 more confusing (even if not confusing).</p>
 <div id="2000_primenum">
-<h2 id="primenum"><a href="2000/primenum/index.html">2000/primenum</a></h2>
-<h3 id="source-code-primenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum//primenum.c">primenum.c</a></h3>
+<h2 id="winning-entry-2000primenum">Winning entry: <a href="2000/primenum/index.html">2000/primenum</a></h2>
+<h3 id="winning-entry-source-code-primenum.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum//primenum.c">primenum.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this more portable by changing the <code>void main</code> to <code>int main</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/try.sh">try.sh</a> script.</p>
 <div id="2000_rince">
-<h2 id="rince-2"><a href="2000/rince/index.html">2000/rince</a></h2>
-<h3 id="source-code-rince.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince//rince.c">rince.c</a></h3>
+<h2 id="winning-entry-2000rince">Winning entry: <a href="2000/rince/index.html">2000/rince</a></h2>
+<h3 id="winning-entry-source-code-rince.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince//rince.c">rince.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/try.sh">try.sh</a> script.</p>
 <div id="2000_robison">
-<h2 id="robison-1"><a href="2000/robison/index.html">2000/robison</a></h2>
-<h3 id="source-code-robison.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/robison//robison.c">robison.c</a></h3>
+<h2 id="winning-entry-2000robison">Winning entry: <a href="2000/robison/index.html">2000/robison</a></h2>
+<h3 id="winning-entry-source-code-robison.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/robison//robison.c">robison.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an infinite loop that occurred if invalid input was entered, flooding
 the screen with:</p>
@@ -2614,13 +2626,13 @@ the screen with:</p>
 on it to assign to the <code>int</code>s, much like with <code>1987/lievaart</code>. The strings are
 <code>char[5]</code> and the <code>%</code> specifier is <code>%4s</code> which is enough for the game.</p>
 <div id="2000_schneiderwent">
-<h2 id="schneiderwent"><a href="2000/schneiderwent/index.html">2000/schneiderwent</a></h2>
-<h3 id="source-code-schneiderwent.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/schneiderwent//schneiderwent.c">schneiderwent.c</a></h3>
+<h2 id="winning-entry-2000schneiderwent">Winning entry: <a href="2000/schneiderwent/index.html">2000/schneiderwent</a></h2>
+<h3 id="winning-entry-source-code-schneiderwent.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/schneiderwent//schneiderwent.c">schneiderwent.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/schneiderwent/try.sh">try.sh</a> script.</p>
 <div id="2000_thadgavin">
-<h2 id="thadgavin"><a href="2000/thadgavin/index.html">2000/thadgavin</a></h2>
-<h3 id="source-code-thadgavin.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/thadgavin//thadgavin.c">thadgavin.c</a></h3>
+<h2 id="winning-entry-2000thadgavin">Winning entry: <a href="2000/thadgavin/index.html">2000/thadgavin</a></h2>
+<h3 id="winning-entry-source-code-thadgavin.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/thadgavin//thadgavin.c">thadgavin.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the code and added an appropriate make rule so that the
 <a href="https://www.libsdl.org">SDL</a> version works independent from the curses version
@@ -2656,8 +2668,8 @@ index.html for details on that. Note that this alternate version only will impac
 the curses and the SDL versions as Cody does not have a DOS system to test the
 other version in.</p>
 <div id="2000_tomx">
-<h2 id="tomx"><a href="2000/tomx/index.html">2000/tomx</a></h2>
-<h3 id="source-code-tomx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/tomx//tomx.c">tomx.c</a></h3>
+<h2 id="winning-entry-2000tomx">Winning entry: <a href="2000/tomx/index.html">2000/tomx</a></h2>
+<h3 id="winning-entry-source-code-tomx.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/tomx//tomx.c">tomx.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="2000/tomx/index.html#alternate-code">alt code</a> based on the
 author’s remarks with a fix for modern systems and he also added the two
@@ -2666,11 +2678,11 @@ the main code and the alt code respectively.</p>
 <p>And although the scripts do <code>chmod +x</code> on the source code (see the index.html for
 details) the source code is now executable by default.</p>
 <div id="2001">
-<h1 id="section-15">2001</h1>
+<h1 id="section-15"><a href="2001/index.html">2001</a></h1>
 </div>
 <div id="2001_anonymous">
-<h2 id="anonymous-1"><a href="2001/anonymous/index.html">2001/anonymous</a></h2>
-<h3 id="source-code-anonymous.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous//anonymous.c">anonymous.c</a></h3>
+<h2 id="winning-entry-2001anonymous">Winning entry: <a href="2001/anonymous/index.html">2001/anonymous</a></h2>
+<h3 id="winning-entry-source-code-anonymous.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous//anonymous.c">anonymous.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed both the supplementary program and the program itself (both of which
 segfaulted and once that was fixed only the binary was modified; it was not run
@@ -2729,8 +2741,8 @@ sings <a href="https://allnurseryrhymes.com/ten-in-the-bed/">Ten in the Bed</a> 
 attempt to use the program as it was designed but if compiling as 32-bit fails
 it will at least run the supplementary program as a 64-bit program directly.</p>
 <div id="2001_bellard">
-<h2 id="bellard"><a href="2001/bellard/index.html">2001/bellard</a></h2>
-<h3 id="source-code-bellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard//bellard.c">bellard.c</a></h3>
+<h2 id="winning-entry-2001bellard">Winning entry: <a href="2001/bellard/index.html">2001/bellard</a></h2>
+<h3 id="winning-entry-source-code-bellard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard//bellard.c">bellard.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with <code>clang</code> but according to the author this will not
 work without i386 Linux. It generates i386 32-bit code (not bytecode) but
@@ -2766,8 +2778,8 @@ versions of <code>clang</code> it is. With <code>gcc</code> we can get away with
 compiler that does not support this would not work. Thus we use the modification
 by Yusuke.</p>
 <div id="2001_cheong">
-<h2 id="cheong"><a href="2001/cheong/index.html">2001/cheong</a></h2>
-<h3 id="source-code-cheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong//cheong.c">cheong.c</a></h3>
+<h2 id="winning-entry-2001cheong">Winning entry: <a href="2001/cheong/index.html">2001/cheong</a></h2>
+<h3 id="winning-entry-source-code-cheong.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong//cheong.c">cheong.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with <code>clang</code> by adding another function that is allowed to
 have a third arg as an int, not a <code>char **. He chose</code>pain()<code>because it's a four letter word that would match the format and because it's pain that</code>clang` forces
@@ -2776,8 +2788,8 @@ valid, BTW.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/try.sh">try.sh</a> script.</p>
 <p>He also fixed it to check the number of args.</p>
 <div id="2001_coupard">
-<h2 id="coupard"><a href="2001/coupard/index.html">2001/coupard</a></h2>
-<h3 id="source-code-coupard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard//coupard.c">coupard.c</a></h3>
+<h2 id="winning-entry-2001coupard">Winning entry: <a href="2001/coupard/index.html">2001/coupard</a></h2>
+<h3 id="winning-entry-source-code-coupard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard//coupard.c">coupard.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added a value to <code>return</code> in <code>main()</code> to make it more portable.</p>
 <p>Cody fixed this to compile with <code>clang</code> in Linux. The problem was C99 does not
@@ -2799,8 +2811,8 @@ those with macOS) (to do with sound; see his
 sound devices in macOS).</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard/try.sh">try.sh</a>.</p>
 <div id="2001_ctk">
-<h2 id="ctk"><a href="2001/ctk/index.html">2001/ctk</a></h2>
-<h3 id="source-code-ctk.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ctk//ctk.c">ctk.c</a></h3>
+<h2 id="winning-entry-2001ctk">Winning entry: <a href="2001/ctk/index.html">2001/ctk</a></h2>
+<h3 id="winning-entry-source-code-ctk.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ctk//ctk.c">ctk.c</a></h3>
 </div>
 <p>The ANSI escape codes were no longer valid but <a href="#yusuke">Yusuke</a> provided a patch to fix
 the ANSI escape codes. This works with both Linux and macOS.</p>
@@ -2811,8 +2823,8 @@ end of <code>main()</code>.</p>
 <p>Cody also added the <a href="2001/ctk/index.html#alternate-code">alt code</a> that adds
 vi(m) movement keys.</p>
 <div id="2001_dgbeards">
-<h2 id="dgbeards"><a href="2001/dgbeards/index.html">2001/dgbeards</a></h2>
-<h3 id="source-code-dgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards//dgbeards.c">dgbeards.c</a></h3>
+<h2 id="winning-entry-2001dgbeards">Winning entry: <a href="2001/dgbeards/index.html">2001/dgbeards</a></h2>
+<h3 id="winning-entry-source-code-dgbeards.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards//dgbeards.c">dgbeards.c</a></h3>
 </div>
 <p>The author provided two changes: one to speed it up and one to make it not crash
 on losing. <a href="#cody">Cody</a> provided an alternate version which does the former but he felt
@@ -2821,8 +2833,8 @@ might be) too good to get rid of so he kept that in.</p>
 <p>He also points out that there is a way to get the computer to automatically lose
 very quickly. Do you know what it is?</p>
 <div id="2001_herrmann1">
-<h2 id="herrmann1"><a href="2001/herrmann1/index.html">2001/herrmann1</a></h2>
-<h3 id="source-code-herrmann1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1//herrmann1.c">herrmann1.c</a></h3>
+<h2 id="winning-entry-2001herrmann1">Winning entry: <a href="2001/herrmann1/index.html">2001/herrmann1</a></h2>
+<h3 id="winning-entry-source-code-herrmann1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1//herrmann1.c">herrmann1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that the when compiling the code the program is not executed
 itself by itself which just showed the usage string and exited. The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.sh">script
@@ -2837,8 +2849,8 @@ shellcheck. In particular there were quite a few:</p>
 <p>errors/warnings.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/try.sh">try.sh</a> script.</p>
 <div id="2001_herrmann2">
-<h2 id="herrmann2"><a href="2001/herrmann2/index.html">2001/herrmann2</a></h2>
-<h3 id="source-code-herrmann2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann2//herrmann2.c">herrmann2.c</a></h3>
+<h2 id="winning-entry-2001herrmann2">Winning entry: <a href="2001/herrmann2/index.html">2001/herrmann2</a></h2>
+<h3 id="winning-entry-source-code-herrmann2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann2//herrmann2.c">herrmann2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with both 64-bit and 32-bit compilers by changing most
 of the <code>int</code>s (all but that in <code>main(int ...)</code>) to <code>long</code>s. He also fixed it to
@@ -2848,8 +2860,8 @@ useful than any other place as the command to try is quite long with C code.</p>
 <p>For some reason the original code was missing (presumingly because it had been
 added to <code>.gitignore</code> by accident) but Cody restored it from the archive.</p>
 <div id="2001_kev">
-<h2 id="kev"><a href="2001/kev/index.html">2001/kev</a></h2>
-<h3 id="source-code-kev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev//kev.c">kev.c</a></h3>
+<h2 id="winning-entry-2001kev">Winning entry: <a href="2001/kev/index.html">2001/kev</a></h2>
+<h3 id="winning-entry-source-code-kev.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev//kev.c">kev.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> improved the Makefile to allow one to more easily set up the port,
 speed and <code>socket(2)</code> call that the author had set up.</p>
@@ -2865,40 +2877,40 @@ done). The speed, <code>SPEED</code>, will be set to 50 if it’s not defined at
 line as 50 is what it used to be set to. This way it’s more to the original but
 without having to sacrifice playability by running <code>make</code>.</p>
 <div id="2001_ollinger">
-<h2 id="ollinger"><a href="2001/ollinger/index.html">2001/ollinger</a></h2>
-<h3 id="source-code-ollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger//ollinger.c">ollinger.c</a></h3>
+<h2 id="winning-entry-2001ollinger">Winning entry: <a href="2001/ollinger/index.html">2001/ollinger</a></h2>
+<h3 id="winning-entry-source-code-ollinger.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger//ollinger.c">ollinger.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/try.sh">try.sh</a> script.</p>
 <p>Cody also fixed it to not crash if not enough args, exiting 1 instead. This was
 done at a time where it was said to be a bug that should be fixed, for better or
 worse.</p>
 <div id="2001_schweikh">
-<h2 id="schweikh"><a href="2001/schweikh/index.html">2001/schweikh</a></h2>
-<h3 id="source-code-schweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh//schweikh.c">schweikh.c</a></h3>
+<h2 id="winning-entry-2001schweikh">Winning entry: <a href="2001/schweikh/index.html">2001/schweikh</a></h2>
+<h3 id="winning-entry-source-code-schweikh.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh//schweikh.c">schweikh.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to not crash if not enough args as this was not documented by
 the author. The other problems are documented so were not fixed. See
 index.html for details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/try.sh">try.sh</a> script.</p>
 <div id="2001_westley">
-<h2 id="westley-8"><a href="2001/westley/index.html">2001/westley</a></h2>
-<h3 id="source-code-westley.c-8">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley//westley.c">westley.c</a></h3>
+<h2 id="winning-entry-2001westley">Winning entry: <a href="2001/westley/index.html">2001/westley</a></h2>
+<h3 id="winning-entry-source-code-westley.c-8">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley//westley.c">westley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley/try.sh">try.sh</a> to automate a heap of commands
 that we, the IOCCC judges, suggested, as well as some additional ones that he
 thought would be fun. He also provided the sort and punch card versions,
 described in the index.html, based on the author’s remarks.</p>
 <div id="2004">
-<h1 id="section-16">2004</h1>
+<h1 id="section-16"><a href="2004/index.html">2004</a></h1>
 </div>
 <div id="2004_anonymous">
-<h2 id="anonymous-2"><a href="2004/anonymous/index.html">2004/anonymous</a></h2>
-<h3 id="source-code-anonymous.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/anonymous//anonymous.c">anonymous.c</a></h3>
+<h2 id="winning-entry-2004anonymous">Winning entry: <a href="2004/anonymous/index.html">2004/anonymous</a></h2>
+<h3 id="winning-entry-source-code-anonymous.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/anonymous//anonymous.c">anonymous.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/anonymous/try.sh">try.sh</a> script.</p>
 <div id="2004_arachnid">
-<h2 id="arachnid"><a href="2004/arachnid/index.html">2004/arachnid</a></h2>
-<h3 id="source-code-arachnid.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/arachnid//arachnid.c">arachnid.c</a></h3>
+<h2 id="winning-entry-2004arachnid">Winning entry: <a href="2004/arachnid/index.html">2004/arachnid</a></h2>
+<h3 id="winning-entry-source-code-arachnid.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/arachnid//arachnid.c">arachnid.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added an <a href="2004/arachnid/index.html#alternate-code">alternate version</a> which
 allows those like himself used to <code>h</code>, <code>j</code>, <code>k</code> and <code>l</code> movement keys to not get
@@ -2909,8 +2921,8 @@ use the original version)! :-)</p>
 file but a maze file. The extension <code>.maz</code> was not chosen to help with (some?)
 browsers knowing what to do with it.</p>
 <div id="2004_burley">
-<h2 id="burley"><a href="2004/burley/index.html">2004/burley</a></h2>
-<h3 id="source-code-burley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/burley//burley.c">burley.c</a></h3>
+<h2 id="winning-entry-2004burley">Winning entry: <a href="2004/burley/index.html">2004/burley</a></h2>
+<h3 id="winning-entry-source-code-burley.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/burley//burley.c">burley.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with <code>clang</code> and to work with both <code>gcc</code> and
 <code>clang</code> (even after fixing it to compile with <code>clang</code> it did not work properly).</p>
@@ -2938,8 +2950,8 @@ nowadays and other entries had to have this same kind of change,
 <p>Finally the optimiser cannot be enabled so the compiler flags were changed for
 this, forcing <code>-O0</code>.</p>
 <div id="2004_gavare">
-<h2 id="gavare"><a href="2004/gavare/index.html">2004/gavare</a></h2>
-<h3 id="source-code-gavare.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavare//gavare.c">gavare.c</a></h3>
+<h2 id="winning-entry-2004gavare">Winning entry: <a href="2004/gavare/index.html">2004/gavare</a></h2>
+<h3 id="winning-entry-source-code-gavare.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavare//gavare.c">gavare.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added three different <a href="2004/gavare/index.html#alternate-code">alternate
 versions</a>:</p>
@@ -2954,8 +2966,8 @@ that was used during development, found on their <a href="https://gavare.se/iocc
 entry</a>.</li>
 </ul>
 <div id="2004_gavin">
-<h2 id="gavin"><a href="2004/gavin/index.html">2004/gavin</a></h2>
-<h3 id="source-code-gavin.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin//gavin.c">gavin.c</a></h3>
+<h2 id="winning-entry-2004gavin">Winning entry: <a href="2004/gavin/index.html">2004/gavin</a></h2>
+<h3 id="winning-entry-source-code-gavin.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin//gavin.c">gavin.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided the <a href="2004/gavin/index.html#alternate-code">alt code</a> for
 those who want to use QEMU. The most important part of this is the macro <code>K</code> has
@@ -2967,8 +2979,8 @@ the <code>img/fs.tar</code> extracts into <code>fs/</code> so you will have to f
 is done this way to prevent extraction from the entry directory overwriting the
 files and causing <code>make clobber</code> to wipe some of them out.</p>
 <div id="2004_hibachi">
-<h2 id="hibachi"><a href="2004/hibachi/index.html">2004/hibachi</a></h2>
-<h3 id="source-code-hibachi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi//hibachi.c">hibachi.c</a></h3>
+<h2 id="winning-entry-2004hibachi">Winning entry: <a href="2004/hibachi/index.html">2004/hibachi</a></h2>
+<h3 id="winning-entry-source-code-hibachi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi//hibachi.c">hibachi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a bunch of links in the index.html provided with the entry
 (web server) that no longer exist or have changed in some other way (<code>https</code>
@@ -2976,13 +2988,13 @@ instead of <code>http</code> for instance). In most cases a new link or change t
 all that was necessary but at least one or two URLs required the Internet
 Wayback Machine.</p>
 <div id="2004_hoyle">
-<h2 id="hoyle"><a href="2004/hoyle/index.html">2004/hoyle</a></h2>
-<h3 id="source-code-hoyle.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hoyle//hoyle.c">hoyle.c</a></h3>
+<h2 id="winning-entry-2004hoyle">Winning entry: <a href="2004/hoyle/index.html">2004/hoyle</a></h2>
+<h3 id="winning-entry-source-code-hoyle.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hoyle//hoyle.c">hoyle.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hoyle/try.sh">try.sh</a> script.</p>
 <div id="2004_jdalbec">
-<h2 id="jdalbec"><a href="2004/jdalbec/index.html">2004/jdalbec</a></h2>
-<h3 id="source-code-jdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec//jdalbec.c">jdalbec.c</a></h3>
+<h2 id="winning-entry-2004jdalbec">Winning entry: <a href="2004/jdalbec/index.html">2004/jdalbec</a></h2>
+<h3 id="winning-entry-source-code-jdalbec.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec//jdalbec.c">jdalbec.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with <code>gcc</code> (it worked with <code>clang</code>). The problem was the
 cpp being unable to parse the generated code (see the index.html for details) and
@@ -3009,8 +3021,8 @@ a lot of numbers this will be harder to see).</p>
 <p>Finally Cody added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/try.alt.sh">try.alt.sh</a> to demonstrate both versions.</p>
 <div id="2004_kopczynski">
-<h2 id="kopczynski"><a href="2004/kopczynski/index.html">2004/kopczynski</a></h2>
-<h3 id="source-code-kopczynski.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski//kopczynski.c">kopczynski.c</a></h3>
+<h2 id="winning-entry-2004kopczynski">Winning entry: <a href="2004/kopczynski/index.html">2004/kopczynski</a></h2>
+<h3 id="winning-entry-source-code-kopczynski.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski//kopczynski.c">kopczynski.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> reported that this entry cannot be optimised by the compiler as otherwise
 it will not work.</p>
@@ -3023,21 +3035,21 @@ like a letter is fed to the program and the <code>kopczynski*-rev</code> files w
 the data files reversed with <code>rev(1)</code>. One had to be modified additionally to
 get it to work, that being <code>kopczynski-10-rev</code>.</p>
 <div id="2004_newbern">
-<h2 id="newbern"><a href="2004/newbern/index.html">2004/newbern</a></h2>
-<h3 id="source-code-newbern.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/newbern//newbern.c">newbern.c</a></h3>
+<h2 id="winning-entry-2004newbern">Winning entry: <a href="2004/newbern/index.html">2004/newbern</a></h2>
+<h3 id="winning-entry-source-code-newbern.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/newbern//newbern.c">newbern.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> and Landon individually fixed this to work with <code>clang</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/newbern/try.sh">try.sh</a> script (with a hidden feature
 that the author referred to and was documented by <a href="#yusuke">Yusuke</a> though Cody
 chose the word <code>IOCCC</code> instead of <code>AAA</code>).</p>
 <div id="2004_omoikane">
-<h2 id="omoikane"><a href="2004/omoikane/index.html">2004/omoikane</a></h2>
-<h3 id="source-code-omoikane.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/omoikane//omoikane.c">omoikane.c</a></h3>
+<h2 id="winning-entry-2004omoikane">Winning entry: <a href="2004/omoikane/index.html">2004/omoikane</a></h2>
+<h3 id="winning-entry-source-code-omoikane.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/omoikane//omoikane.c">omoikane.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/omoikane/try.sh">try.sh</a> script.</p>
 <div id="2004_schnitzi">
-<h2 id="schnitzi-4"><a href="2004/schnitzi/index.html">2004/schnitzi</a></h2>
-<h3 id="source-code-schnitzi.c-4">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi//schnitzi.c">schnitzi.c</a></h3>
+<h2 id="winning-entry-2004schnitzi">Winning entry: <a href="2004/schnitzi/index.html">2004/schnitzi</a></h2>
+<h3 id="winning-entry-source-code-schnitzi.c-4">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi//schnitzi.c">schnitzi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See <a href="faq.html#faq4_1">FAQ 4.1 - Why were some calls to
 the libc function gets(3) changed to use
@@ -3047,16 +3059,16 @@ fast in modern systems, especially the scrolling text of
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi/schnitzi.inp1">schnitzi.inp1</a>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi/try.sh">try.sh</a> script.</p>
 <div id="2004_sds">
-<h2 id="sds"><a href="2004/sds/index.html">2004/sds</a></h2>
-<h3 id="source-code-sds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds//sds.c">sds.c</a></h3>
+<h2 id="winning-entry-2004sds">Winning entry: <a href="2004/sds/index.html">2004/sds</a></h2>
+<h3 id="winning-entry-source-code-sds.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds//sds.c">sds.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/try.sh">try.sh</a> script.</p>
 <p>Also, after the README.md file had copyright changes, it broke the script so
 Cody made a copy of the older README.md file into <code>README_sds.txt</code> and added that
 to the repo for the script instead.</p>
 <div id="2004_vik2">
-<h2 id="vik2"><a href="2004/vik2/index.html">2004/vik2</a></h2>
-<h3 id="source-code-vik2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/vik2//vik2.c">vik2.c</a></h3>
+<h2 id="winning-entry-2004vik2">Winning entry: <a href="2004/vik2/index.html">2004/vik2</a></h2>
+<h3 id="winning-entry-source-code-vik2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/vik2//vik2.c">vik2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile in Linux. Although it compiled cleanly in macOS (and
 BSD?) the code failed to compile at all in Linux due to:</p>
@@ -3109,11 +3121,11 @@ which used to be generated by the Makefile via <code>cc -E</code>.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/vik2/vik2.possible.cat.death.c">vik2.possible.cat.death.c</a>!) <code>__FILE__</code>
 just to make it a bit easier to compile.</p>
 <div id="2005">
-<h1 id="section-17">2005</h1>
+<h1 id="section-17"><a href="2005/index.html">2005</a></h1>
 </div>
 <div id="2005_aidan">
-<h2 id="aidan"><a href="2005/aidan/index.html">2005/aidan</a></h2>
-<h3 id="source-code-aidan.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/aidan//aidan.c">aidan.c</a></h3>
+<h2 id="winning-entry-2005aidan">Winning entry: <a href="2005/aidan/index.html">2005/aidan</a></h2>
+<h3 id="winning-entry-source-code-aidan.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/aidan//aidan.c">aidan.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the test script, described by the author in their remarks, to refer
 to the proper compiled program (it’s hardcoded). This had never been done and so
@@ -3128,8 +3140,8 @@ alt code respectively.</p>
 <p>Cody added the <code>make test</code> and <code>make test-n0</code> rules for easier use of the test
 suite.</p>
 <div id="2005_anon">
-<h2 id="anon"><a href="2005/anon/index.html">2005/anon</a></h2>
-<h3 id="source-code-anon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon//anon.c">anon.c</a></h3>
+<h2 id="winning-entry-2005anon">Winning entry: <a href="2005/anon/index.html">2005/anon</a></h2>
+<h3 id="winning-entry-source-code-anon.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon//anon.c">anon.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a problem where in some systems (like macOS) the <code>stty sane</code> would
 not work and end up causing a bus error. Instead of <code>stty sane</code> it uses <code>stty echo</code> which is what it was trying to accomplish.</p>
@@ -3139,15 +3151,15 @@ explained in the index.html.</p>
 <p>Cody added the <a href="2005/anon/index.html#alternate-code">alt code</a> with vi(m) like
 movements.</p>
 <div id="2005_boutines">
-<h2 id="boutines"><a href="2005/boutines/index.html">2005/boutines</a></h2>
-<h3 id="source-code-boutines.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/boutines//boutines.c">boutines.c</a></h3>
+<h2 id="winning-entry-2005boutines">Winning entry: <a href="2005/boutines/index.html">2005/boutines</a></h2>
+<h3 id="winning-entry-source-code-boutines.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/boutines//boutines.c">boutines.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="2005/boutines/input.txt">input.txt</a> data file based on suggested
 input from the author, adapting it to a command to try out.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/boutines/try.sh">try.sh</a> script.</p>
 <div id="2005_giljade">
-<h2 id="giljade"><a href="2005/giljade/index.html">2005/giljade</a></h2>
-<h3 id="source-code-giljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade//giljade.c">giljade.c</a></h3>
+<h2 id="winning-entry-2005giljade">Winning entry: <a href="2005/giljade/index.html">2005/giljade</a></h2>
+<h3 id="winning-entry-source-code-giljade.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade//giljade.c">giljade.c</a></h3>
 </div>
 <p>After Landon fixed the entry to compile with <code>clang</code> <a href="#cody">Cody</a> noticed this
 does not work at all in modern systems (see below). He fixed this to work and
@@ -3193,19 +3205,19 @@ uses <code>grep -c</code> on the file to show that there are indeed as many vers
 program generates as the author states, 180. If it does not find 180 it is an
 error; otherwise it is success. It uses <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/test.sh">test.sh</a>.</p>
 <div id="2005_jetro">
-<h2 id="jetro"><a href="2005/jetro/index.html">2005/jetro</a></h2>
-<h3 id="source-code-jetro.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/jetro//jetro.c">jetro.c</a></h3>
+<h2 id="winning-entry-2005jetro">Winning entry: <a href="2005/jetro/index.html">2005/jetro</a></h2>
+<h3 id="winning-entry-source-code-jetro.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/jetro//jetro.c">jetro.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) for systems like Linux that seem to
 not do it implicitly (like macOS does).</p>
 <div id="2005_klausler">
-<h2 id="klausler"><a href="2005/klausler/index.html">2005/klausler</a></h2>
-<h3 id="source-code-klausler.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/klausler//klausler.c">klausler.c</a></h3>
+<h2 id="winning-entry-2005klausler">Winning entry: <a href="2005/klausler/index.html">2005/klausler</a></h2>
+<h3 id="winning-entry-source-code-klausler.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/klausler//klausler.c">klausler.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/klausler/try.sh">try.sh</a> script.</p>
 <div id="2005_mikeash">
-<h2 id="mikeash"><a href="2005/mikeash/index.html">2005/mikeash</a></h2>
-<h3 id="source-code-mikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash//mikeash.c">mikeash.c</a></h3>
+<h2 id="winning-entry-2005mikeash">Winning entry: <a href="2005/mikeash/index.html">2005/mikeash</a></h2>
+<h3 id="winning-entry-source-code-mikeash.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash//mikeash.c">mikeash.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work in Linux. The problem was an unknown escape sequence,
 <code>\N</code>, which caused a funny compiler error:</p>
@@ -3229,8 +3241,8 @@ what is supposed to happen. It is not known, however, if having to change the
 also show correct output though.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/try.sh">try.sh</a> script.</p>
 <div id="2005_mynx">
-<h2 id="mynx"><a href="2005/mynx/index.html">2005/mynx</a></h2>
-<h3 id="source-code-mynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx//mynx.c">mynx.c</a></h3>
+<h2 id="winning-entry-2005mynx">Winning entry: <a href="2005/mynx/index.html">2005/mynx</a></h2>
+<h3 id="winning-entry-source-code-mynx.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx//mynx.c">mynx.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/source/configure">configure</a> script (which is not
 needed but part of the entry) would work with compilers that have by default
@@ -3240,8 +3252,8 @@ how https is set up, in which case just enjoy it for what it was. But there
 might be some command line that will let it work that way or perhaps someone
 wants to add the necessary code.</p>
 <div id="2005_persano">
-<h2 id="persano"><a href="2005/persano/index.html">2005/persano</a></h2>
-<h3 id="source-code-persano.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/persano//persano.c">persano.c</a></h3>
+<h2 id="winning-entry-2005persano">Winning entry: <a href="2005/persano/index.html">2005/persano</a></h2>
+<h3 id="winning-entry-source-code-persano.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/persano//persano.c">persano.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the (untested) <a href="2005/persano/index.html#alternate-code">alternate
 code</a> which should work for Windows as it
@@ -3249,8 +3261,8 @@ sets binary mode on <code>stdout</code>. It is untested as Cody has no Windows s
 test it on.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/persano/try.sh">try.sh</a> script.</p>
 <div id="2005_sykes">
-<h2 id="sykes"><a href="2005/sykes/index.html">2005/sykes</a></h2>
-<h3 id="source-code-sykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes//sykes.c">sykes.c</a></h3>
+<h2 id="winning-entry-2005sykes">Winning entry: <a href="2005/sykes/index.html">2005/sykes</a></h2>
+<h3 id="winning-entry-source-code-sykes.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes//sykes.c">sykes.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the saved (with the <code>SAVE</code> command) BASIC program <code>PET</code> which was:</p>
 <pre><code>    10 PRINT &quot;2005&#39;S IOCCC BEST EMULATOR&quot;
@@ -3277,23 +3289,23 @@ have to hit ctrl-c to end it which the script tells you.</p>
 <p>The scripts note every time that one will have to send ctrl-c or whatever their
 interrupt is set to in order to exit the program.</p>
 <div id="2005_timwi">
-<h2 id="timwi"><a href="2005/timwi/index.html">2005/timwi</a></h2>
-<h3 id="source-code-timwi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/timwi//timwi.c">timwi.c</a></h3>
+<h2 id="winning-entry-2005timwi">Winning entry: <a href="2005/timwi/index.html">2005/timwi</a></h2>
+<h3 id="winning-entry-source-code-timwi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/timwi//timwi.c">timwi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/timwi/try.sh">try.sh</a>. It only has one command as he doesn’t
 want to knacker his brain any more than it might or might not already be :-) and
 he doesn’t want to damage anyone else’s brain either. :-)</p>
 <div id="2005_toledo">
-<h2 id="toledo"><a href="2005/toledo/index.html">2005/toledo</a></h2>
-<h3 id="source-code-toledo.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/toledo//toledo.c">toledo.c</a></h3>
+<h2 id="winning-entry-2005toledo">Winning entry: <a href="2005/toledo/index.html">2005/toledo</a></h2>
+<h3 id="winning-entry-source-code-toledo.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/toledo//toledo.c">toledo.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with some versions of <code>clang</code> which have an additional
 defect where <code>main()</code> can only have 0, 2 or 3 args (it was 4). It now calls
 another function that takes 4 args and which is what used to be <code>main()</code>.</p>
 <p>The alternate versions were also fixed.</p>
 <div id="2005_vince">
-<h2 id="vince"><a href="2005/vince/index.html">2005/vince</a></h2>
-<h3 id="source-code-vince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/vince//vince.c">vince.c</a></h3>
+<h2 id="winning-entry-2005vince">Winning entry: <a href="2005/vince/index.html">2005/vince</a></h2>
+<h3 id="winning-entry-source-code-vince.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/vince//vince.c">vince.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this in the case that the program is compiled or linked/copies to
 another file name: the code constructed the source code file name in a clever
@@ -3305,37 +3317,37 @@ find it’ but the source code file name is not always the same as the executabl
 with the appropriate extension so this might be called a bug fix as well though
 if one runs it from another directory, specifying the directory, it’ll not catch it.</p>
 <div id="2006">
-<h1 id="section-18">2006</h1>
+<h1 id="section-18"><a href="2006/index.html">2006</a></h1>
 </div>
 <div id="2006_birken">
-<h2 id="birken"><a href="2006/birken/index.html">2006/birken</a></h2>
-<h3 id="source-code-birken.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/birken//birken.c">birken.c</a></h3>
+<h2 id="winning-entry-2006birken">Winning entry: <a href="2006/birken/index.html">2006/birken</a></h2>
+<h3 id="winning-entry-source-code-birken.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/birken//birken.c">birken.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault in macOS with this entry. The problem was a missing <code>+1</code>
 for strlen() with malloc(). This prevented it from working.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/birken/try.sh">try.sh</a> script.</p>
 <div id="2006_borsanyi">
-<h2 id="borsanyi"><a href="2006/borsanyi/index.html">2006/borsanyi</a></h2>
-<h3 id="source-code-borsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi//borsanyi.c">borsanyi.c</a></h3>
+<h2 id="winning-entry-2006borsanyi">Winning entry: <a href="2006/borsanyi/index.html">2006/borsanyi</a></h2>
+<h3 id="winning-entry-source-code-borsanyi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi//borsanyi.c">borsanyi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the Makefile to work in systems where the <code>lpthread</code> is not
 implicitly linked in.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/try.sh">try.sh</a> script.</p>
 <div id="2006_grothe">
-<h2 id="grothe"><a href="2006/grothe/index.html">2006/grothe</a></h2>
-<h3 id="source-code-grothe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/grothe//grothe.c">grothe.c</a></h3>
+<h2 id="winning-entry-2006grothe">Winning entry: <a href="2006/grothe/index.html">2006/grothe</a></h2>
+<h3 id="winning-entry-source-code-grothe.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/grothe//grothe.c">grothe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/grothe/try.sh">try.sh</a> script.</p>
 <div id="2006_hamre">
-<h2 id="hamre"><a href="2006/hamre/index.html">2006/hamre</a></h2>
-<h3 id="source-code-hamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre//hamre.c">hamre.c</a></h3>
+<h2 id="winning-entry-2006hamre">Winning entry: <a href="2006/hamre/index.html">2006/hamre</a></h2>
+<h3 id="winning-entry-source-code-hamre.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre//hamre.c">hamre.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that it will not crash without an arg after it was suggested
 this should be fixed.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/try.sh">try.sh</a> script.</p>
 <div id="2006_monge">
-<h2 id="monge"><a href="2006/monge/index.html">2006/monge</a></h2>
-<h3 id="source-code-monge.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge//monge.c">monge.c</a></h3>
+<h2 id="winning-entry-2006monge">Winning entry: <a href="2006/monge/index.html">2006/monge</a></h2>
+<h3 id="winning-entry-source-code-monge.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge//monge.c">monge.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="2006/monge/index.html#alternate-code">alternate code</a> that lets
 one resize the image and redefine the number of iterations.</p>
@@ -3351,14 +3363,14 @@ the original it was simply made to link in SDL1.</p>
 feature but one which we will accept fixes to. See <a href="bugs.html#2006-monge">2006/monge in
 bugs.html</a>.</p>
 <div id="2006_night">
-<h2 id="night"><a href="2006/night/index.html">2006/night</a></h2>
-<h3 id="source-code-night.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/night//night.c">night.c</a></h3>
+<h2 id="winning-entry-2006night">Winning entry: <a href="2006/night/index.html">2006/night</a></h2>
+<h3 id="winning-entry-source-code-night.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/night//night.c">night.c</a></h3>
 </div>
 <p>As <a href="#cody">Cody</a> is a lost :-) <code>vim</code> user he took the author’s remarks to add support
 back for arrow keys in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/night/night.alt.c">alternate version</a>.</p>
 <div id="2006_sloane">
-<h2 id="sloane"><a href="2006/sloane/index.html">2006/sloane</a></h2>
-<h3 id="source-code-sloane.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sloane//sloane.c">sloane.c</a></h3>
+<h2 id="winning-entry-2006sloane">Winning entry: <a href="2006/sloane/index.html">2006/sloane</a></h2>
+<h3 id="winning-entry-source-code-sloane.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sloane//sloane.c">sloane.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this entry to work with <code>clang</code> which has a defect with the args to
 <code>main()</code>: it requires specific types: <code>int</code> and `char ** for the first and
@@ -3381,16 +3393,16 @@ by default.</p>
 <p>Since the author suggested that the lack of certain <code>#include</code>s might break the
 program in some systems he also added <code>-include ...</code> to the Makefile as well.</p>
 <div id="2006_stewart">
-<h2 id="stewart"><a href="2006/stewart/index.html">2006/stewart</a></h2>
-<h3 id="source-code-stewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart//stewart.c">stewart.c</a></h3>
+<h2 id="winning-entry-2006stewart">Winning entry: <a href="2006/stewart/index.html">2006/stewart</a></h2>
+<h3 id="winning-entry-source-code-stewart.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart//stewart.c">stewart.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/try.sh">try.sh</a> script.</p>
 <p>Cody also fixed it so that if the file cannot be opened it exits rather than trying
 to read from the file. This was done at a time when it was considered to be a
 bug to fix.</p>
 <div id="2006_sykes1">
-<h2 id="sykes1"><a href="2006/sykes1/index.html">2006/sykes1</a></h2>
-<h3 id="source-code-sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1//sykes1.c">sykes1.c</a></h3>
+<h2 id="winning-entry-2006sykes1">Winning entry: <a href="2006/sykes1/index.html">2006/sykes1</a></h2>
+<h3 id="winning-entry-source-code-sykes1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1//sykes1.c">sykes1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided the <a href="2006/sykes1/index.html#alternate-code">alt code</a> based on the
 author’s remarks.</p>
@@ -3400,8 +3412,8 @@ obtained from the Internet Wayback Machine, as the file was no longer available.
 The video was also no longer available but Cody found an alternative and added
 it to the repo as well.</p>
 <div id="2006_sykes2">
-<h2 id="sykes2"><a href="2006/sykes2/index.html">2006/sykes2</a></h2>
-<h3 id="source-code-sykes2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2//sykes2.c">sykes2.c</a></h3>
+<h2 id="winning-entry-2006sykes2">Winning entry: <a href="2006/sykes2/index.html">2006/sykes2</a></h2>
+<h3 id="winning-entry-source-code-sykes2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2//sykes2.c">sykes2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution for <code>clang</code>’s defects, made <code>main()</code> have
 to args instead of 1 as some versions report that <code>main()</code> must have 0, 2 or 3
@@ -3409,13 +3421,13 @@ args, even though at least one of those versions allows 1 arg only.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2/try.sh">try.sh</a> script for easier use of the
 entry to show the clock update in real time.</p>
 <div id="2006_toledo1">
-<h2 id="toledo1"><a href="2006/toledo1/index.html">2006/toledo1</a></h2>
-<h3 id="source-code-toledo1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo1//toledo1.c">toledo1.c</a></h3>
+<h2 id="winning-entry-2006toledo1">Winning entry: <a href="2006/toledo1/index.html">2006/toledo1</a></h2>
+<h3 id="winning-entry-source-code-toledo1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo1//toledo1.c">toledo1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo1/try.sh">try.sh</a> script.</p>
 <div id="2006_toledo2">
-<h2 id="toledo2"><a href="2006/toledo2/index.html">2006/toledo2</a></h2>
-<h3 id="source-code-toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2//toledo2.c">toledo2.c</a></h3>
+<h2 id="winning-entry-2006toledo2">Winning entry: <a href="2006/toledo2/index.html">2006/toledo2</a></h2>
+<h3 id="winning-entry-source-code-toledo2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2//toledo2.c">toledo2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault in this program which was making it fail to work under
 macOS - it did not seem to be a problem under Linux, at least not fedora. The
@@ -3430,8 +3442,8 @@ the program and modified the <code>fread(3)</code>/<code>fwrite(3)</code> sectio
 (perhaps Cody’s fix was for arm64 only?). Also, he added a note to clarify from
 where appears the <code>IMPORT.COM</code> and <code>HALT.COM</code> files.</p>
 <div id="2006_toledo3">
-<h2 id="toledo3"><a href="2006/toledo3/index.html">2006/toledo3</a></h2>
-<h3 id="source-code-toledo3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3//toledo3.c">toledo3.c</a></h3>
+<h2 id="winning-entry-2006toledo3">Winning entry: <a href="2006/toledo3/index.html">2006/toledo3</a></h2>
+<h3 id="winning-entry-source-code-toledo3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3//toledo3.c">toledo3.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a crash and a display problem in this entry so that it now works in
 modern (64-bit) systems. The crash appears to only occur in macOS but the fix
@@ -3442,45 +3454,45 @@ have been a problem in Linux with the old <code>int</code>s but this is no longe
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>, based on the author’s remarks.
 We’re not able to test this.</p>
 <div id="2011">
-<h1 id="section-19">2011</h1>
+<h1 id="section-19"><a href="2011/index.html">2011</a></h1>
 </div>
 <div id="2011_akari">
-<h2 id="akari"><a href="2011/akari/index.html">2011/akari</a></h2>
-<h3 id="source-code-akari.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/akari//akari.c">akari.c</a></h3>
+<h2 id="winning-entry-2011akari">Winning entry: <a href="2011/akari/index.html">2011/akari</a></h2>
+<h3 id="winning-entry-source-code-akari.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/akari//akari.c">akari.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/akari/try.sh">try.sh</a> script.</p>
 <div id="2011_blakely">
-<h2 id="blakely"><a href="2011/blakely/index.html">2011/blakely</a></h2>
-<h3 id="source-code-blakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/blakely//blakely.c">blakely.c</a></h3>
+<h2 id="winning-entry-2011blakely">Winning entry: <a href="2011/blakely/index.html">2011/blakely</a></h2>
+<h3 id="winning-entry-source-code-blakely.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/blakely//blakely.c">blakely.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/blakely/try.sh">try.sh</a> script.</p>
 <div id="2011_borsanyi">
-<h2 id="borsanyi-1"><a href="2011/borsanyi/index.html">2011/borsanyi</a></h2>
-<h3 id="source-code-borsanyi.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi//borsanyi.c">borsanyi.c</a></h3>
+<h2 id="winning-entry-2011borsanyi">Winning entry: <a href="2011/borsanyi/index.html">2011/borsanyi</a></h2>
+<h3 id="winning-entry-source-code-borsanyi.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi//borsanyi.c">borsanyi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution, added a second arg to <code>main()</code> as some
 versions of <code>clang</code> complain about not only the type of each arg to <code>main()</code> but
 the number of args as well.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/try.sh">try.sh</a> script.</p>
 <div id="2011_dlowe">
-<h2 id="dlowe-2"><a href="2011/dlowe/index.html">2011/dlowe</a></h2>
-<h3 id="source-code-dlowe.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/dlowe//dlowe.c">dlowe.c</a></h3>
+<h2 id="winning-entry-2011dlowe">Winning entry: <a href="2011/dlowe/index.html">2011/dlowe</a></h2>
+<h3 id="winning-entry-source-code-dlowe.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/dlowe//dlowe.c">dlowe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/dlowe/try.sh">try.sh</a> script.</p>
 <div id="2011_eastman">
-<h2 id="eastman"><a href="2011/eastman/index.html">2011/eastman</a></h2>
-<h3 id="source-code-eastman.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/eastman//eastman.c">eastman.c</a></h3>
+<h2 id="winning-entry-2011eastman">Winning entry: <a href="2011/eastman/index.html">2011/eastman</a></h2>
+<h3 id="winning-entry-source-code-eastman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/eastman//eastman.c">eastman.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the video file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/eastman">boing-ball.mp4</a> which is the demo the
 author referred to.</p>
 <div id="2011_fredriksson">
-<h2 id="fredriksson"><a href="2011/fredriksson/index.html">2011/fredriksson</a></h2>
-<h3 id="source-code-fredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson//fredriksson.c">fredriksson.c</a></h3>
+<h2 id="winning-entry-2011fredriksson">Winning entry: <a href="2011/fredriksson/index.html">2011/fredriksson</a></h2>
+<h3 id="winning-entry-source-code-fredriksson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson//fredriksson.c">fredriksson.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/try.sh">try.sh</a> script.</p>
 <div id="2011_goren">
-<h2 id="goren"><a href="2011/goren/index.html">2011/goren</a></h2>
-<h3 id="source-code-goren.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/goren//goren.c">goren.c</a></h3>
+<h2 id="winning-entry-2011goren">Winning entry: <a href="2011/goren/index.html">2011/goren</a></h2>
+<h3 id="winning-entry-source-code-goren.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/goren//goren.c">goren.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this for macOS. Before the fix it segfaulted. It worked fine under
 Linux. After fixing it it was noticed that the author stated it does not work
@@ -3490,8 +3502,8 @@ and now it does work with 64-bit systems as well as 32-bit systems.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/goren/try.sh">try.sh</a> script.</p>
 <p>Cody added the following words of wisdom: <code>'"this" is not a pipe but "!" is'</code>.</p>
 <div id="2011_hamaji">
-<h2 id="hamaji"><a href="2011/hamaji/index.html">2011/hamaji</a></h2>
-<h3 id="source-code-hamaji.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hamaji//hamaji.c">hamaji.c</a></h3>
+<h2 id="winning-entry-2011hamaji">Winning entry: <a href="2011/hamaji/index.html">2011/hamaji</a></h2>
+<h3 id="winning-entry-source-code-hamaji.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hamaji//hamaji.c">hamaji.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hamaji/try.sh">try.sh</a> script and the <code>.nono</code> files
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hamaji/conway-game-of-life.nono">conway-game-of-life.nono</a>,
@@ -3502,20 +3514,20 @@ The latter two <code>.nono</code> files were taken from
 <a href="https://web.archive.org/web/20130218055139/http://codegolf.com/paint-by-numbers" class="uri">https://web.archive.org/web/20130218055139/http://codegolf.com/paint-by-numbers</a>
 and the others were from the authors’ remarks.</p>
 <div id="2011_hou">
-<h2 id="hou"><a href="2011/hou/index.html">2011/hou</a></h2>
-<h3 id="source-code-hou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hou//hou.c">hou.c</a></h3>
+<h2 id="winning-entry-2011hou">Winning entry: <a href="2011/hou/index.html">2011/hou</a></h2>
+<h3 id="winning-entry-source-code-hou.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hou//hou.c">hou.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hou/try.sh">try.sh</a> script.</p>
 <div id="2011_konno">
-<h2 id="konno"><a href="2011/konno/index.html">2011/konno</a></h2>
-<h3 id="source-code-konno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno//konno.c">konno.c</a></h3>
+<h2 id="winning-entry-2011konno">Winning entry: <a href="2011/konno/index.html">2011/konno</a></h2>
+<h3 id="winning-entry-source-code-konno.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno//konno.c">konno.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the program to not crash if no arg was specified as this was not a
 documented feature.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/try.sh">try.sh</a> script.</p>
 <div id="2011_richards">
-<h2 id="richards"><a href="2011/richards/index.html">2011/richards</a></h2>
-<h3 id="source-code-richards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards//richards.c">richards.c</a></h3>
+<h2 id="winning-entry-2011richards">Winning entry: <a href="2011/richards/index.html">2011/richards</a></h2>
+<h3 id="winning-entry-source-code-richards.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards//richards.c">richards.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a minor problem that showed up in both Linux and macOS. He notes
 however that as of this time this entry does not work properly with macOS at
@@ -3532,8 +3544,8 @@ not be worth, as it is a possible starting point that Cody added.</p>
 helpful to test any fixes for Apple silicon chips (see <a href="bugs.html#2011-richards">2011/richards in
 bugs.html</a> for more details).</p>
 <div id="2011_toledo">
-<h2 id="toledo-1"><a href="2011/toledo/index.html">2011/toledo</a></h2>
-<h3 id="source-code-toledo.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/toledo//toledo.c">toledo.c</a></h3>
+<h2 id="winning-entry-2011toledo">Winning entry: <a href="2011/toledo/index.html">2011/toledo</a></h2>
+<h3 id="winning-entry-source-code-toledo.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/toledo//toledo.c">toledo.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added two <a href="2011/toledo/index.html#alternate-code">alternate versions</a>: one that
 lets one reconfigure the controls and also the size of the game and another
@@ -3542,16 +3554,16 @@ file, <code>layer.c</code>.</p>
 <p>The Makefile was also modified by Cody to make it simpler to redefine the
 controls, width and height.</p>
 <div id="2011_vik">
-<h2 id="vik"><a href="2011/vik/index.html">2011/vik</a></h2>
-<h3 id="source-code-vik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik//vik.c">vik.c</a></h3>
+<h2 id="winning-entry-2011vik">Winning entry: <a href="2011/vik/index.html">2011/vik</a></h2>
+<h3 id="winning-entry-source-code-vik.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik//vik.c">vik.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/try.sh">try.sh</a> script.</p>
 <p>Cody also added an <a href="2011/vik/index.html#alternate-code">alternate version</a> for Windows
 based on the author’s comments (along with looking up the function for the right
 header files). To build try the alt rule of the Makefile.</p>
 <div id="2011_zucker">
-<h2 id="zucker"><a href="2011/zucker/index.html">2011/zucker</a></h2>
-<h3 id="source-code-zucker.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/zucker//zucker.c">zucker.c</a></h3>
+<h2 id="winning-entry-2011zucker">Winning entry: <a href="2011/zucker/index.html">2011/zucker</a></h2>
+<h3 id="winning-entry-source-code-zucker.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/zucker//zucker.c">zucker.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/zucker/try.sh">try.sh</a> script.</p>
 <p>Cody also added <a href="2011/zucker/index.html#alternate-code">alt code</a> that should work on
@@ -3561,23 +3573,23 @@ and text then <code>stdout</code> needs to be set to binary mode.</p>
 <a href="2011/zucker/sphere-tracing.pdf">sphere-tracing.pdf</a> in case the link
 eventually dies.</p>
 <div id="2012">
-<h1 id="section-20">2012</h1>
+<h1 id="section-20"><a href="2012/index.html">2012</a></h1>
 </div>
 <div id="2012_blakely">
-<h2 id="blakely-1"><a href="2012/blakely/index.html">2012/blakely</a></h2>
-<h3 id="source-code-blakely.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely//blakely.c">blakely.c</a></h3>
+<h2 id="winning-entry-2012blakely">Winning entry: <a href="2012/blakely/index.html">2012/blakely</a></h2>
+<h3 id="winning-entry-source-code-blakely.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely//blakely.c">blakely.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) as not all systems do this
 implicitly (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/try.sh">try.sh</a> script.</p>
 <div id="2012_deckmyn">
-<h2 id="deckmyn"><a href="2012/deckmyn/index.html">2012/deckmyn</a></h2>
-<h3 id="source-code-deckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn//deckmyn.c">deckmyn.c</a></h3>
+<h2 id="winning-entry-2012deckmyn">Winning entry: <a href="2012/deckmyn/index.html">2012/deckmyn</a></h2>
+<h3 id="winning-entry-source-code-deckmyn.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn//deckmyn.c">deckmyn.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/try.sh">try.sh</a> script.</p>
 <div id="2012_endoh1">
-<h2 id="endoh1"><a href="2012/endoh1/index.html">2012/endoh1</a></h2>
-<h3 id="source-code-endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1//endoh1.c">endoh1.c</a></h3>
+<h2 id="winning-entry-2012endoh1">Winning entry: <a href="2012/endoh1/index.html">2012/endoh1</a></h2>
+<h3 id="winning-entry-source-code-endoh1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1//endoh1.c">endoh1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) as not all systems do this
 implicitly (Linux doesn’t seem to but macOS does).</p>
@@ -3604,16 +3616,16 @@ version without colour, <a href="https://github.com/ioccc-src/temp-test-ioccc/bl
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1/endoh1.alt2.c">endoh1.alt2.c</a> was provided by the author,
 <a href="#yusuke">Yusuke</a>, at the time of the contest as a de-obfuscated version.</p>
 <div id="2012_endoh2">
-<h2 id="endoh2"><a href="2012/endoh2/index.html">2012/endoh2</a></h2>
-<h3 id="source-code-endoh2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh2//endoh2.c">endoh2.c</a></h3>
+<h2 id="winning-entry-2012endoh2">Winning entry: <a href="2012/endoh2/index.html">2012/endoh2</a></h2>
+<h3 id="winning-entry-source-code-endoh2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh2//endoh2.c">endoh2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh2/try.sh">try.sh</a> script that runs
 everything, filtered through less.</p>
 <p>Cody also fixed a typo in the ruby script
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh2/find-font-table.rb">find-font-table.rb</a>.</p>
 <div id="2012_grothe">
-<h2 id="grothe-1"><a href="2012/grothe/index.html">2012/grothe</a></h2>
-<h3 id="source-code-grothe.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/grothe//grothe.c">grothe.c</a></h3>
+<h2 id="winning-entry-2012grothe">Winning entry: <a href="2012/grothe/index.html">2012/grothe</a></h2>
+<h3 id="winning-entry-source-code-grothe.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/grothe//grothe.c">grothe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/grothe/try.sh">try.sh</a> script.</p>
 <p>Cody also changed <code>argv</code> to be not <code>const char ** but</code>char <strong>, mostly out of an
@@ -3628,15 +3640,15 @@ recent domain. For historical purposes the old link was
 <code>http://recipes.stevex.net/</code> but it redirects to <code>https://www.mealsteps.com</code>
 which the recipe file now links to.</p>
 <div id="2012_hamano">
-<h2 id="hamano"><a href="2012/hamano/index.html">2012/hamano</a></h2>
-<h3 id="source-code-hamano.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hamano//hamano.c">hamano.c</a></h3>
+<h2 id="winning-entry-2012hamano">Winning entry: <a href="2012/hamano/index.html">2012/hamano</a></h2>
+<h3 id="winning-entry-source-code-hamano.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hamano//hamano.c">hamano.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hamano/try.sh">try.sh</a> script and the helper
 Makefile rules <code>hint.pdf</code>, <code>hint</code>, <code>hello.pdf</code> and <code>hello</code> to simplify the
 procedure for both <code>hint.pdf</code> and <code>hello.pdf</code> as well as compiling them as C.</p>
 <div id="2012_hou">
-<h2 id="hou-1"><a href="2012/hou/index.html">2012/hou</a></h2>
-<h3 id="source-code-hou.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hou//hou.c">hou.c</a></h3>
+<h2 id="winning-entry-2012hou">Winning entry: <a href="2012/hou/index.html">2012/hou</a></h2>
+<h3 id="winning-entry-source-code-hou.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hou//hou.c">hou.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hou/try.sh">try.sh</a> script and restored the original <a href="2012/hou/hint.html">hint
 markdown file</a> as the changes made when converting to a GitHub
@@ -3644,8 +3656,8 @@ index.html made the generated html not look correct; it did not have a title, a
 stylesheet etc. due to the fact that there is no <code>#</code> header (which specified
 title and stylesheet) and other formatting changes.</p>
 <div id="2012_kang">
-<h2 id="kang"><a href="2012/kang/index.html">2012/kang</a></h2>
-<h3 id="source-code-kang.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/kang//kang.c">kang.c</a></h3>
+<h2 id="winning-entry-2012kang">Winning entry: <a href="2012/kang/index.html">2012/kang</a></h2>
+<h3 id="winning-entry-source-code-kang.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/kang//kang.c">kang.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added alt code that fixes a problem where in German ‘v’ sounds like ‘f’
 which the program has as ‘f’: with the original version it would translate
@@ -3670,13 +3682,13 @@ the other defaults to the submitted entry. See the index.html for details.</p>
 show different languages and numbers with the submitted and alternate version
 respectively. Notice how a single letter changes so much!</p>
 <div id="2012_konno">
-<h2 id="konno-1"><a href="2012/konno/index.html">2012/konno</a></h2>
-<h3 id="source-code-konno.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/konno//konno.c">konno.c</a></h3>
+<h2 id="winning-entry-2012konno">Winning entry: <a href="2012/konno/index.html">2012/konno</a></h2>
+<h3 id="winning-entry-source-code-konno.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/konno//konno.c">konno.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/konno/try.sh">try.sh</a> script.</p>
 <div id="2012_omoikane">
-<h2 id="omoikane-1"><a href="2012/omoikane/index.html">2012/omoikane</a></h2>
-<h3 id="source-code-omoikane.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane//omoikane.c">omoikane.c</a></h3>
+<h2 id="winning-entry-2012omoikane">Winning entry: <a href="2012/omoikane/index.html">2012/omoikane</a></h2>
+<h3 id="winning-entry-source-code-omoikane.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane//omoikane.c">omoikane.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="2012/omoikane/index.html#alternate-code">alternate versions</a>
 which will, if no arg is specified, read in the program itself, rather than
@@ -3687,21 +3699,21 @@ theoretically make it work in Windows.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane/try.alt.sh">try.alt.sh</a> scripts.</p>
 <div id="2012_tromp">
-<h2 id="tromp-1"><a href="2012/tromp/index.html">2012/tromp</a></h2>
-<h3 id="source-code-tromp.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp//tromp.c">tromp.c</a></h3>
+<h2 id="winning-entry-2012tromp">Winning entry: <a href="2012/tromp/index.html">2012/tromp</a></h2>
+<h3 id="winning-entry-source-code-tromp.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp//tromp.c">tromp.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/try.sh">try.sh</a> script.</p>
 <div id="2012_vik">
-<h2 id="vik-1"><a href="2012/vik/index.html">2012/vik</a></h2>
-<h3 id="source-code-vik.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik//vik.c">vik.c</a></h3>
+<h2 id="winning-entry-2012vik">Winning entry: <a href="2012/vik/index.html">2012/vik</a></h2>
+<h3 id="winning-entry-source-code-vik.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik//vik.c">vik.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/try.sh">try.sh</a> script.</p>
 <p>Based on the author’s description it should be able to get this entry to work
 for Windows. With his instructions Cody also added the alternate version that
 does this for the few who might use Windows.</p>
 <div id="2012_zeitak">
-<h2 id="zeitak"><a href="2012/zeitak/index.html">2012/zeitak</a></h2>
-<h3 id="source-code-zeitak.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak//zeitak.c">zeitak.c</a></h3>
+<h2 id="winning-entry-2012zeitak">Winning entry: <a href="2012/zeitak/index.html">2012/zeitak</a></h2>
+<h3 id="winning-entry-source-code-zeitak.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak//zeitak.c">zeitak.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak/test.sh">test.sh</a> script and the <code>make test</code> rule
 that uses the script along with a number of files that will correctly be flagged
@@ -3717,11 +3729,11 @@ look at the program source with tab space of 4 characters so Cody added the
 command to do this in vim for those who use it, in the judges’ remarks, to make
 it easier for those who do not know how, and to make it more obvious to try it.</p>
 <div id="2013">
-<h1 id="section-21">2013</h1>
+<h1 id="section-21"><a href="2013/index.html">2013</a></h1>
 </div>
 <div id="2013_birken">
-<h2 id="birken-1"><a href="2013/birken/index.html">2013/birken</a></h2>
-<h3 id="source-code-birken.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/birken//birken.c">birken.c</a></h3>
+<h2 id="winning-entry-2013birken">Winning entry: <a href="2013/birken/index.html">2013/birken</a></h2>
+<h3 id="winning-entry-source-code-birken.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/birken//birken.c">birken.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> changed the <code>return 0;</code> at the end of the program to be <code>return system("reset");</code> (via redefining <code>exit(3)</code> so that the column ending would be
 the same) so that as long as it runs to completion the terminal will be sane and
@@ -3735,19 +3747,19 @@ it very easy to redefine it at compile time.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/birken/try.sh">try.sh</a> script for the entry and the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/birken/try.alt.sh">try.alt.sh</a> script for the alt code.</p>
 <div id="2013_cable1">
-<h2 id="cable1"><a href="2013/cable1/index.html">2013/cable1</a></h2>
-<h3 id="source-code-cable1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable1//cable1.c">cable1.c</a></h3>
+<h2 id="winning-entry-2013cable1">Winning entry: <a href="2013/cable1/index.html">2013/cable1</a></h2>
+<h3 id="winning-entry-source-code-cable1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable1//cable1.c">cable1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable1/try.sh">try.sh</a> script which also has an
 joke Easter egg in it based on the judges’ remarks.</p>
 <div id="2013_cable2">
-<h2 id="cable2"><a href="2013/cable2/index.html">2013/cable2</a></h2>
-<h3 id="source-code-cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2//cable2.c">cable2.c</a></h3>
+<h2 id="winning-entry-2013cable2">Winning entry: <a href="2013/cable2/index.html">2013/cable2</a></h2>
+<h3 id="winning-entry-source-code-cable2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2//cable2.c">cable2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/try.sh">try.sh</a> script.</p>
 <div id="2013_cable3">
-<h2 id="cable3"><a href="2013/cable3/index.html">2013/cable3</a></h2>
-<h3 id="source-code-cable3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable3//cable3.c">cable3.c</a></h3>
+<h2 id="winning-entry-2013cable3">Winning entry: <a href="2013/cable3/index.html">2013/cable3</a></h2>
+<h3 id="winning-entry-source-code-cable3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable3//cable3.c">cable3.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with modern systems. The problems were that
 <code>localtime()</code> is used differently and <code>time.h</code> being included (with
@@ -3778,8 +3790,8 @@ entry</a>, and the ‘ready-made
 40MB hard disk image containing a whole bunch of software’ in <code>hd.img</code> that the
 author linked to at <code>https://bitly.com/1bU8URK</code>.</p>
 <div id="2013_dlowe">
-<h2 id="dlowe-3"><a href="2013/dlowe/index.html">2013/dlowe</a></h2>
-<h3 id="source-code-dlowe.c-3">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe//dlowe.c">dlowe.c</a></h3>
+<h2 id="winning-entry-2013dlowe">Winning entry: <a href="2013/dlowe/index.html">2013/dlowe</a></h2>
+<h3 id="winning-entry-source-code-dlowe.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe//dlowe.c">dlowe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the source code that we suggested one should compile and run with
 different compilers as <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/fun.c">fun.c</a>. He modified the Makefile so
@@ -3798,13 +3810,13 @@ program.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/diff.sh">diff.sh</a> script which is based on some
 commands to try that he suggested to see how different lengths look.</p>
 <div id="2013_endoh1">
-<h2 id="endoh1-1"><a href="2013/endoh1/index.html">2013/endoh1</a></h2>
-<h3 id="source-code-endoh1.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1//endoh1.c">endoh1.c</a></h3>
+<h2 id="winning-entry-2013endoh1">Winning entry: <a href="2013/endoh1/index.html">2013/endoh1</a></h2>
+<h3 id="winning-entry-source-code-endoh1.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1//endoh1.c">endoh1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/try.sh">try.sh</a> script.</p>
 <div id="2013_endoh2">
-<h2 id="endoh2-1"><a href="2013/endoh2/index.html">2013/endoh2</a></h2>
-<h3 id="source-code-endoh2.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh2//endoh2.c">endoh2.c</a></h3>
+<h2 id="winning-entry-2013endoh2">Winning entry: <a href="2013/endoh2/index.html">2013/endoh2</a></h2>
+<h3 id="winning-entry-source-code-endoh2.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh2//endoh2.c">endoh2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the Makefile <code>check</code> rule so that it <code>checks</code> :-) that both
 <a href="https://www.ruby-lang.org">Ruby</a> and <a href="https://imagemagick.org">ImageMagick</a> are
@@ -3822,15 +3834,15 @@ not installed, and after checking these requirements it will exit if either is
 not found.</p>
 <p>The entry can still be enjoyed if you do not have these tools, however.</p>
 <div id="2013_endoh3">
-<h2 id="endoh3"><a href="2013/endoh3/index.html">2013/endoh3</a></h2>
-<h3 id="source-code-endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3//endoh3.c">endoh3.c</a></h3>
+<h2 id="winning-entry-2013endoh3">Winning entry: <a href="2013/endoh3/index.html">2013/endoh3</a></h2>
+<h3 id="winning-entry-source-code-endoh3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3//endoh3.c">endoh3.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/try.sh">try.sh</a> script.</p>
 <p>Cody also (out of an abundance of caution for <code>clang(1)</code> which is strict with
 arg type and count to <code>main()</code>) added a second (unused) arg to <code>main()</code>.</p>
 <div id="2013_endoh4">
-<h2 id="endoh4"><a href="2013/endoh4/index.html">2013/endoh4</a></h2>
-<h3 id="source-code-endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4//endoh4.c">endoh4.c</a></h3>
+<h2 id="winning-entry-2013endoh4">Winning entry: <a href="2013/endoh4/index.html">2013/endoh4</a></h2>
+<h3 id="winning-entry-source-code-endoh4.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4//endoh4.c">endoh4.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.sh">endoh4.sh</a> script which temporarily
 turns off the cursor as suggested by the author, with the addition that if no
@@ -3842,8 +3854,8 @@ pass more than one file to the script.</p>
 author’s remarks for more details on what this means). The <code>endoh4.sh</code> script
 allows one to redefine it as well.</p>
 <div id="2013_hou">
-<h2 id="hou-2"><a href="2013/hou/index.html">2013/hou</a></h2>
-<h3 id="source-code-hou.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou//hou.c">hou.c</a></h3>
+<h2 id="winning-entry-2013hou">Winning entry: <a href="2013/hou/index.html">2013/hou</a></h2>
+<h3 id="winning-entry-source-code-hou.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou//hou.c">hou.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the Makefile so that this would work properly. Before this
 the use of the program just did what the judges’ remarks said as far as how it
@@ -3868,7 +3880,7 @@ restored so that one can see what the author is talking about.</p>
 this broke <code>make</code> which Cody also fixed.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/try.sh">try.sh</a> script.</p>
 <div id="2013_mills">
-<h2 id="mills"><a href="2013/mills/index.html">2013/mills</a></h2>
+<h2 id="winning-entry-2013mills">Winning entry: <a href="2013/mills/index.html">2013/mills</a></h2>
 <h2 id="source-code-mills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">mills.c</a></h2>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that the server would not refuse the connection
@@ -3878,28 +3890,28 @@ The backlog was changed to 10 and this solves the problem. It is not known if
 this was specific to macOS but it was not specific to a browser as Safari and
 Firefox both had the problem.</p>
 <div id="2013_misaka">
-<h2 id="misaka"><a href="2013/misaka/index.html">2013/misaka</a></h2>
-<h3 id="source-code-misaka.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/misaka//misaka.c">misaka.c</a></h3>
+<h2 id="winning-entry-2013misaka">Winning entry: <a href="2013/misaka/index.html">2013/misaka</a></h2>
+<h3 id="winning-entry-source-code-misaka.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/misaka//misaka.c">misaka.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/misaka/try.sh">try.sh</a> script.</p>
 <div id="2013_morgan1">
-<h2 id="morgan1"><a href="2013/morgan1/index.html">2013/morgan1</a></h2>
-<h3 id="source-code-morgan1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/morgan1//morgan1.c">morgan1.c</a></h3>
+<h2 id="winning-entry-2013morgan1">Winning entry: <a href="2013/morgan1/index.html">2013/morgan1</a></h2>
+<h3 id="winning-entry-source-code-morgan1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/morgan1//morgan1.c">morgan1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) as not all systems do this
 implicitly (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/morgan1/try.sh">try.sh</a> script.</p>
 <div id="2013_robison">
-<h2 id="robison-2"><a href="2013/robison/index.html">2013/robison</a></h2>
-<h3 id="source-code-robison.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/robison//robison.c">robison.c</a></h3>
+<h2 id="winning-entry-2013robison">Winning entry: <a href="2013/robison/index.html">2013/robison</a></h2>
+<h3 id="winning-entry-source-code-robison.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/robison//robison.c">robison.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/robison/try.sh">try.sh</a> script.</p>
 <div id="2014">
-<h1 id="section-22">2014</h1>
+<h1 id="section-22"><a href="2014/index.html">2014</a></h1>
 </div>
 <div id="2014_birken">
-<h2 id="birken-2"><a href="2014/birken/index.html">2014/birken</a></h2>
-<h3 id="source-code-prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/birken//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014birken">Winning entry: <a href="2014/birken/index.html">2014/birken</a></h2>
+<h3 id="winning-entry-source-code-prog.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/birken//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided the <a href="2014/birken/index.html#alternate-code">alternate
 code</a> that lets one redefine the port to
@@ -3909,8 +3921,8 @@ you redefine the timing constant <code>STARDATE</code> (see the author’s remar
 details on this macro). The Makefile was made to use variables so it’s easier to
 redefine the port and timing constant.</p>
 <div id="2014_deak">
-<h2 id="deak"><a href="2014/deak/index.html">2014/deak</a></h2>
-<h3 id="source-code-prog.c-1">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/deak//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014deak">Winning entry: <a href="2014/deak/index.html">2014/deak</a></h2>
+<h3 id="winning-entry-source-code-prog.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/deak//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="2014/deak/index.html#alternate-code">alt code</a> that lets
 one (via the Makefile) reconfigure the coordinates but instead of being a
@@ -3927,8 +3939,8 @@ that was fixed and it also has <code>#include &lt;stdio.h&gt;</code> for <code>p
 <code>#ifndef..#define..#endif</code> was not part of the original alt code, of course.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/deak/try.alt.sh">try.alt.sh</a> script.</p>
 <div id="2014_endoh1">
-<h2 id="endoh1-2"><a href="2014/endoh1/index.html">2014/endoh1</a></h2>
-<h3 id="source-code-prog.c-2">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014endoh1">Winning entry: <a href="2014/endoh1/index.html">2014/endoh1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh1/rake.sh">rake.sh</a> script and <code>make rake</code>
 rule that runs the script. This script will check that <code>rake</code> is installed and
@@ -3949,13 +3961,13 @@ symbols from being built with <code>rake</code> Cody also updated the
 file to <a href="2014/endoh1/spoilers.html">spoilers.html</a> to be clearer in its purpose as
 it is a file with spoilers (and too close to index.html?).</p>
 <div id="2014_endoh2">
-<h2 id="endoh2-2"><a href="2014/endoh2/index.html">2014/endoh2</a></h2>
-<h3 id="source-code-prog.c-3">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014endoh2">Winning entry: <a href="2014/endoh2/index.html">2014/endoh2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh2/try.sh">try.sh</a> script.</p>
 <div id="2014_maffiodo1">
-<h2 id="maffiodo1"><a href="2014/maffiodo1/index.html">2014/maffiodo1</a></h2>
-<h3 id="source-code-prog.c-4">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014maffiodo1">Winning entry: <a href="2014/maffiodo1/index.html">2014/maffiodo1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-4">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the build for this entry: it does not require
 <a href="https://www.libsdl.org">SDL2</a> but SDL1 so there were linking errors.</p>
@@ -3965,20 +3977,20 @@ Mario Bros</a> and one of <a href="http://en.wikipedia.org/wiki/The_Great_Giana_
 Great Giana Sisters</a>, but
 which let one configure the width and height of the game.</p>
 <div id="2014_maffiodo2">
-<h2 id="maffiodo2"><a href="2014/maffiodo2/index.html">2014/maffiodo2</a></h2>
-<h3 id="source-code-prog.c-5">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014maffiodo2">Winning entry: <a href="2014/maffiodo2/index.html">2014/maffiodo2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-5">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/try.sh">try.sh</a> script.</p>
 <p>He also added the <a href="2014/maffiodo2/index.html#alternate-code">alternate code</a>
 provided by the author.</p>
 <div id="2014_morgan">
-<h2 id="morgan"><a href="2014/morgan/index.html">2014/morgan</a></h2>
-<h3 id="source-code-prog.c-6">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/morgan//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014morgan">Winning entry: <a href="2014/morgan/index.html">2014/morgan</a></h2>
+<h3 id="winning-entry-source-code-prog.c-6">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/morgan//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/morgan/try.sh">try.sh</a> script.</p>
 <div id="2014_sinon">
-<h2 id="sinon"><a href="2014/sinon/index.html">2014/sinon</a></h2>
-<h3 id="source-code-prog.c-7">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/sinon//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014sinon">Winning entry: <a href="2014/sinon/index.html">2014/sinon</a></h2>
+<h3 id="winning-entry-source-code-prog.c-7">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/sinon//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the code so that the game can play automatically like it
 once did. The problem is that it expects a certain file name which was
@@ -3992,8 +4004,8 @@ is installed) run the demo mode and then after that it will run the above noted
 scripts in a loop until the user says they do not want to try again (or they
 kill it). This is done this way in case it jams (see index.html for details).</p>
 <div id="2014_skeggs">
-<h2 id="skeggs"><a href="2014/skeggs/index.html">2014/skeggs</a></h2>
-<h3 id="source-code-prog.c-8">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/skeggs//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014skeggs">Winning entry: <a href="2014/skeggs/index.html">2014/skeggs</a></h2>
+<h3 id="winning-entry-source-code-prog.c-8">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/skeggs//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the Makefile to compile this entry in modern systems. The problem was
 that the <code>CDEFINE</code> variable in the Makefile was missing <code>'</code>s: the <code>#define CC</code>
@@ -4007,8 +4019,8 @@ added later to make it more portable.</p>
 <p>The program creates files in the working directory as part of how it works (see
 the index.html file for details) so Cody made sure that <code>make clobber</code> (via <code>make clean</code>) removes those files and so that they are ignored by <code>.gitignore</code>.</p>
 <div id="2014_vik">
-<h2 id="vik-2"><a href="2014/vik/index.html">2014/vik</a></h2>
-<h3 id="source-code-prog.c-9">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014vik">Winning entry: <a href="2014/vik/index.html">2014/vik</a></h2>
+<h3 id="winning-entry-source-code-prog.c-9">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/try.sh">try.sh</a> script. Cody notes that there
 is a bug that will show itself as one of the features does not work right. The
@@ -4018,8 +4030,8 @@ theoretically work for Microsoft Windows compilers (if anything works in Windows
 :-) ). We have no way of testing this and if anything has changed since 2014
 that would break it we do not know.</p>
 <div id="2014_wiedijk">
-<h2 id="wiedijk"><a href="2014/wiedijk/index.html">2014/wiedijk</a></h2>
-<h3 id="source-code-prog.c-10">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/wiedijk//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2014wiedijk">Winning entry: <a href="2014/wiedijk/index.html">2014/wiedijk</a></h2>
+<h3 id="winning-entry-source-code-prog.c-10">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/wiedijk//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/wiedijk/try.sh">try.sh</a> script which is based on
 the command to try in the ‘try’ section but improved so one can more easily
@@ -4028,11 +4040,11 @@ should they want to. It also checks that both of these two tools exist and are
 executable and it pipes it through less as it’s longer than a page worth of
 output.</p>
 <div id="2015">
-<h1 id="section-23">2015</h1>
+<h1 id="section-23"><a href="2015/index.html">2015</a></h1>
 </div>
 <div id="2015_burton">
-<h2 id="burton"><a href="2015/burton/index.html">2015/burton</a></h2>
-<h3 id="source-code-prog.c-11">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/burton//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015burton">Winning entry: <a href="2015/burton/index.html">2015/burton</a></h2>
+<h3 id="winning-entry-source-code-prog.c-11">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/burton//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the code so one can make use of the echo feature, where the
 first character of the filename starts with <code>e</code>. The only way it would work
@@ -4060,8 +4072,8 @@ to not have to maintain two copies of the same text.</p>
 called <code>calc</code> and is in documentation including the man page. Thus one only need
 add a <code>./</code> to the commands in the man page/index.html.</p>
 <div id="2015_dogon">
-<h2 id="dogon"><a href="2015/dogon/index.html">2015/dogon</a></h2>
-<h3 id="source-code-prog.c-12">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/dogon//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015dogon">Winning entry: <a href="2015/dogon/index.html">2015/dogon</a></h2>
+<h3 id="winning-entry-source-code-prog.c-12">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/dogon//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> improved the Makefile so that one can easily change the dimensions
 at compilation time via <code>make(1)</code>.</p>
@@ -4069,18 +4081,18 @@ at compilation time via <code>make(1)</code>.</p>
 one change the value of <code>q</code> to a different number, in order to see a bug that
 they avoided.</p>
 <div id="2015_duble">
-<h2 id="duble"><a href="2015/duble/index.html">2015/duble</a></h2>
-<h3 id="source-code-prog.c-13">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/duble//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015duble">Winning entry: <a href="2015/duble/index.html">2015/duble</a></h2>
+<h3 id="winning-entry-source-code-prog.c-13">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/duble//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/duble/try.sh">try.sh</a> script.</p>
 <div id="2015_endoh2">
-<h2 id="endoh2-3"><a href="2015/endoh2/index.html">2015/endoh2</a></h2>
-<h3 id="source-code-prog.c-14">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015endoh2">Winning entry: <a href="2015/endoh2/index.html">2015/endoh2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-14">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh2/try.sh">try.sh</a> script.</p>
 <div id="2015_endoh3">
-<h2 id="endoh3-1"><a href="2015/endoh3/index.html">2015/endoh3</a></h2>
-<h3 id="source-code-prog.c-15">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh3//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015endoh3">Winning entry: <a href="2015/endoh3/index.html">2015/endoh3</a></h2>
+<h3 id="winning-entry-source-code-prog.c-15">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh3//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with Linux which was having a problem with duplicate
 symbols of <code>main()</code>. The fix is through the compiler option <code>-fcommon</code> which
@@ -4091,13 +4103,13 @@ Future</a> using this entry by
 simply typing <code>make back_to</code> or <code>make mullender</code>) and then runs the famous
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">1984/mullender.c</a>.</p>
 <div id="2015_endoh4">
-<h2 id="endoh4-1"><a href="2015/endoh4/index.html">2015/endoh4</a></h2>
-<h3 id="source-code-prog.c-16">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh4//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015endoh4">Winning entry: <a href="2015/endoh4/index.html">2015/endoh4</a></h2>
+<h3 id="winning-entry-source-code-prog.c-16">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh4//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh4/try.sh">try.sh</a> script.</p>
 <div id="2015_hou">
-<h2 id="hou-3"><a href="2015/hou/index.html">2015/hou</a></h2>
-<h3 id="source-code-prog.c-17">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015hou">Winning entry: <a href="2015/hou/index.html">2015/hou</a></h2>
+<h3 id="winning-entry-source-code-prog.c-17">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux doesn’t seem to but macOS does).</p>
@@ -4107,8 +4119,8 @@ which the <code>try.sh</code> script uses.</p>
 the directory, to make it so one need not download it, and which the index.html
 file now links to.</p>
 <div id="2015_howe">
-<h2 id="howe"><a href="2015/howe/index.html">2015/howe</a></h2>
-<h3 id="source-code-prog.c-18">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015howe">Winning entry: <a href="2015/howe/index.html">2015/howe</a></h2>
+<h3 id="winning-entry-source-code-prog.c-18">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe/try.sh">try.sh</a> script, downloaded the War
 and Peace text file, fixed the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe/avgtime.sh">avgtime.sh</a> script (it
@@ -4116,8 +4128,8 @@ resulted in standard input errors in piping to <code>bc(1)</code>) and added the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe/cc.1">cc.1</a> man page as not all systems have it (in fact it’s
 <code>gcc(1)</code> from Rocky Linux).</p>
 <div id="2015_mills1">
-<h2 id="mills1"><a href="2015/mills1/index.html">2015/mills1</a></h2>
-<h3 id="source-code-prog.c-19">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015mills1">Winning entry: <a href="2015/mills1/index.html">2015/mills1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-19">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills1/try.sh">try.sh</a> script which changes the
 parameters to what we had in the judges’ remarks to make it easier (he only died
@@ -4126,18 +4138,18 @@ same time and he almost survived that, scoring at that point over 90 - but this
 also involves good eye-hand coordination and playing games like this in the
 past).</p>
 <div id="2015_mills2">
-<h2 id="mills2"><a href="2015/mills2/index.html">2015/mills2</a></h2>
-<h3 id="source-code-prog.c-20">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015mills2">Winning entry: <a href="2015/mills2/index.html">2015/mills2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-20">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/try.sh">try.sh</a> script.</p>
 <div id="2015_muth">
-<h2 id="muth"><a href="2015/muth/index.html">2015/muth</a></h2>
-<h3 id="source-code-prog.c-21">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/muth//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015muth">Winning entry: <a href="2015/muth/index.html">2015/muth</a></h2>
+<h3 id="winning-entry-source-code-prog.c-21">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/muth//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/muth/try.sh">try.sh</a> script.</p>
 <div id="2015_schweikhardt">
-<h2 id="schweikhardt"><a href="2015/schweikhardt/index.html">2015/schweikhardt</a></h2>
-<h3 id="source-code-prog.c-22">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015schweikhardt">Winning entry: <a href="2015/schweikhardt/index.html">2015/schweikhardt</a></h2>
+<h3 id="winning-entry-source-code-prog.c-22">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the build so that <code>EOF</code> will be <code>-1</code> as the program assumes
 this. It was decided by Cody to do <code>-UEOF -DEOF=-1</code> so as to not have to modify
@@ -4145,8 +4157,8 @@ the code any with C preprocessor directives (the preferred way) or changing
 <code>EOF</code> to <code>-1</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/try.sh">try.sh</a> script.</p>
 <div id="2015_yang">
-<h2 id="yang"><a href="2015/yang/index.html">2015/yang</a></h2>
-<h3 id="source-code-prog.c-23">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/yang//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2015yang">Winning entry: <a href="2015/yang/index.html">2015/yang</a></h2>
+<h3 id="winning-entry-source-code-prog.c-23">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/yang//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an unfortunate typo in the Makefile that was preventing some of the
 files from compiling properly, trying instead to compile already compiled code.</p>
@@ -4154,22 +4166,22 @@ files from compiling properly, trying instead to compile already compiled code.<
 (Linux seems to not but macOS does).</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/yang/try.sh">try.sh</a> script.</p>
 <div id="2018">
-<h1 id="section-24">2018</h1>
+<h1 id="section-24"><a href="2018/index.html">2018</a></h1>
 </div>
 <div id="2018_anderson">
-<h2 id="anderson-1"><a href="2018/anderson/index.html">2018/anderson</a></h2>
-<h3 id="source-code-prog.c-24">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018anderson">Winning entry: <a href="2018/anderson/index.html">2018/anderson</a></h2>
+<h3 id="winning-entry-source-code-prog.c-24">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson/try.alt.sh">try.alt.sh</a> scripts.</p>
 <div id="2018_algmyr">
-<h2 id="algmyr"><a href="2018/algmyr/index.html">2018/algmyr</a></h2>
-<h3 id="source-code-prog.c-25">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018algmyr">Winning entry: <a href="2018/algmyr/index.html">2018/algmyr</a></h2>
+<h3 id="winning-entry-source-code-prog.c-25">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/try.sh">try.sh</a> script.</p>
 <div id="2018_bellard">
-<h2 id="bellard-1"><a href="2018/bellard/index.html">2018/bellard</a></h2>
-<h3 id="source-code-prog.c-26">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/bellard//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018bellard">Winning entry: <a href="2018/bellard/index.html">2018/bellard</a></h2>
+<h3 id="winning-entry-source-code-prog.c-26">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/bellard//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/bellard/try.sh">try.sh</a> script.</p>
 <p>Cody also, out of abundance of caution, added a second arg to <code>main()</code> because
@@ -4184,8 +4196,8 @@ work for Windows, based on the author’s remarks. The same thing with the numbe
 of args to <code>main()</code> that was done in the original entry was done with this
 version as well.</p>
 <div id="2018_burton1">
-<h2 id="burton1"><a href="2018/burton1/index.html">2018/burton1</a></h2>
-<h3 id="source-code-prog.c-27">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018burton1">Winning entry: <a href="2018/burton1/index.html">2018/burton1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-27">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the <code>scripthd</code> script (referred to <code>prog</code> not <code>./prog</code>) and
 renamed it to <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1/scripthd.sh">scripthd.sh</a> to help browsers and
@@ -4193,8 +4205,8 @@ GitHub as far as downloading/displaying goes.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1/try.sh">try.sh</a> script which also uses
 <code>scripthd.sh</code> to show how it differs from <code>prog</code> itself.</p>
 <div id="2018_burton2">
-<h2 id="burton2"><a href="2018/burton2/index.html">2018/burton2</a></h2>
-<h3 id="source-code-prog.c-28">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018burton2">Winning entry: <a href="2018/burton2/index.html">2018/burton2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-28">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the <code>make test</code> rule: it tried to run <code>tac(1)</code> (in systems
 that have that command) rather than the entry itself which is called <code>tac</code> and
@@ -4212,16 +4224,16 @@ format.</p>
 included in the remarks of the author but not an included file.</p>
 <p>Finally Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2/try.sh">try.sh</a> script.</p>
 <div id="2018_ciura">
-<h2 id="ciura"><a href="2018/ciura/index.html">2018/ciura</a></h2>
-<h3 id="source-code-prog.c-29">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ciura//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018ciura">Winning entry: <a href="2018/ciura/index.html">2018/ciura</a></h2>
+<h3 id="winning-entry-source-code-prog.c-29">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ciura//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ciura/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ciura/try.alt.sh">try.alt.sh</a> scripts and the PDF file,
 <a href="2018/ciura/lexicon.pdf">lexicon.pdf</a>, that was a dead link, restored from the
 Internet Wayback Machine.</p>
 <div id="2018_endoh1">
-<h2 id="endoh1-3"><a href="2018/endoh1/index.html">2018/endoh1</a></h2>
-<h3 id="source-code-prog.c-30">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018endoh1">Winning entry: <a href="2018/endoh1/index.html">2018/endoh1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-30">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh1/try.sh">try.sh</a> script which shows the
 input files one at a time and after each one is shown, it feeds it to the
@@ -4231,8 +4243,8 @@ GIF files. It offers an example command for macOS like the judges did in their
 remarks. The input files offered includes the prog.c as the author,
 <a href="#yusuke">Yusuke</a>, suggested that it too has a secret.</p>
 <div id="2018_endoh2">
-<h2 id="endoh2-4"><a href="2018/endoh2/index.html">2018/endoh2</a></h2>
-<h3 id="source-code-prog.c-31">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018endoh2">Winning entry: <a href="2018/endoh2/index.html">2018/endoh2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-31">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh2/run.sh">run.sh</a> script (had commands that didn’t
 exist and also didn’t work even after that was addressed) and added the
@@ -4243,8 +4255,8 @@ and still continue to the next script (if one does it when not in a loop it will
 exit the script). The <code>make python</code> and <code>make python3</code> rules in the Makefile now
 run the respective scripts.</p>
 <div id="2018_ferguson">
-<h2 id="ferguson"><a href="2018/ferguson/index.html">2018/ferguson</a></h2>
-<h3 id="source-code-prog.c-32">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ferguson//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018ferguson">Winning entry: <a href="2018/ferguson/index.html">2018/ferguson</a></h2>
+<h3 id="winning-entry-source-code-prog.c-32">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ferguson//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, with irony well intended :-), fixed the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ferguson/test.sh">test.sh
 script</a> for portability, shellcheck, making it executable
@@ -4255,15 +4267,15 @@ and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/fergu
 that’s probably true: let’s just say that for the IOCCC I’m (Cody) a weasel! :-)
 (but isn’t that kind of the point ? :-) )</p>
 <div id="2018_hou">
-<h2 id="hou-4"><a href="2018/hou/index.html">2018/hou</a></h2>
-<h3 id="source-code-prog.c-33">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018hou">Winning entry: <a href="2018/hou/index.html">2018/hou</a></h2>
+<h3 id="winning-entry-source-code-prog.c-33">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/try.sh">try.sh</a> script.</p>
 <div id="2018_mills">
-<h2 id="mills-1"><a href="2018/mills/index.html">2018/mills</a></h2>
-<h3 id="source-code-prog.c-34">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/mills//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018mills">Winning entry: <a href="2018/mills/index.html">2018/mills</a></h2>
+<h3 id="winning-entry-source-code-prog.c-34">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/mills//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, based on the author’s remarks, made it possible to save state
 between runs of the program so that one can resume where they left off. It
@@ -4274,8 +4286,8 @@ file you should run <code>sync</code> prior to exiting or else the file might no
 it might be corrupt. See <a href="bugs.html#2018-mills">2018/mills in bugs.html</a> for more
 details on the bug.</p>
 <div id="2018_poikola">
-<h2 id="poikola"><a href="2018/poikola/index.html">2018/poikola</a></h2>
-<h3 id="source-code-prog.c-35">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/poikola//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018poikola">Winning entry: <a href="2018/poikola/index.html">2018/poikola</a></h2>
+<h3 id="winning-entry-source-code-prog.c-35">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/poikola//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the missing <code>docs</code> rule to the Makefile that forms a PDF
 file. The rule requires the tool <code>pdflatex</code>.</p>
@@ -4285,30 +4297,30 @@ problem where the macOS <code>Terminal.app</code> does not work properly for thi
 We added some additional notes on what might happen (it varies depending on
 configuration).</p>
 <div id="2018_vokes">
-<h2 id="vokes"><a href="2018/vokes/index.html">2018/vokes</a></h2>
-<h3 id="source-code-prog.c-36">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018vokes">Winning entry: <a href="2018/vokes/index.html">2018/vokes</a></h2>
+<h3 id="winning-entry-source-code-prog.c-36">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/try.sh">try.sh</a> script.</p>
 <div id="2018_yang">
-<h2 id="yang-1"><a href="2018/yang/index.html">2018/yang</a></h2>
-<h3 id="source-code-prog.c-37">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/yang//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2018yang">Winning entry: <a href="2018/yang/index.html">2018/yang</a></h2>
+<h3 id="winning-entry-source-code-prog.c-37">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/yang//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/yang/try.sh">try.sh</a> script. This script will ask
 if the user wants to see some of the spoilers and only show them if they type
 <code>y</code> or <code>Y</code>.</p>
 <div id="2019">
-<h1 id="section-25">2019</h1>
+<h1 id="section-25"><a href="2019/index.html">2019</a></h1>
 </div>
 <div id="2019_adamovsky">
-<h2 id="adamovsky"><a href="2019/adamovsky/index.html">2019/adamovsky</a></h2>
-<h3 id="source-code-prog.c-38">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019adamovsky">Winning entry: <a href="2019/adamovsky/index.html">2019/adamovsky</a></h2>
+<h3 id="winning-entry-source-code-prog.c-38">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/try.sh">try.sh</a> script and the Unlambda
 file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/crash.unl">crash.unl</a> which is in the judges’ remarks as
 to what can crash it - but it’s not a bug, it’s a feature.</p>
 <div id="2019_burton">
-<h2 id="burton-1"><a href="2019/burton/index.html">2019/burton</a></h2>
-<h3 id="source-code-prog.c-39">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019burton">Winning entry: <a href="2019/burton/index.html">2019/burton</a></h2>
+<h3 id="winning-entry-source-code-prog.c-39">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the Makefile which had a bad character, a ‘%’ instead of a ‘$’ which
 caused a rule to fail.</p>
@@ -4325,8 +4337,8 @@ wrong about) in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/maste
 <a href="2019/burton/on.one.liners.txt">on.one.liners.txt</a> to help with
 browsers/GitHub.</p>
 <div id="2019_ciura">
-<h2 id="ciura-1"><a href="2019/ciura/index.html">2019/ciura</a></h2>
-<h3 id="source-code-prog.c-40">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019ciura">Winning entry: <a href="2019/ciura/index.html">2019/ciura</a></h2>
+<h3 id="winning-entry-source-code-prog.c-40">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an invalid bytes error in <code>tr</code> in the scripts. This does not
 mean that they will produce any output, though, as they provide expect all
@@ -4343,8 +4355,8 @@ website.</p>
 version but with the caveat that only English appears to work. See the <a href="bugs.html#2019-ciura">entry in
 bugs.html</a> for more details.</p>
 <div id="2019_diels-grabsch1">
-<h2 id="diels-grabsch1"><a href="2019/diels-grabsch1/index.html">2019/diels-grabsch1</a></h2>
-<h3 id="source-code-prog.c-41">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019diels-grabsch1">Winning entry: <a href="2019/diels-grabsch1/index.html">2019/diels-grabsch1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-41">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch1/try.sh">try.sh</a> script.</p>
 <p>Cody also added the file <a href="2019/diels-grabsch1/Shakespeare.txt">Shakespeare.txt</a>
@@ -4353,8 +4365,8 @@ not worry about having the entire IOCCC winning entry tree (or at least the 2019
 entry in a subdirectory). This is more important as there is discussion of
 having tarballs for each individual entry as a convenience.</p>
 <div id="2019_diels-grabsch2">
-<h2 id="diels-grabsch2"><a href="2019/diels-grabsch2/index.html">2019/diels-grabsch2</a></h2>
-<h3 id="source-code-prog.c-42">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019diels-grabsch2">Winning entry: <a href="2019/diels-grabsch2/index.html">2019/diels-grabsch2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-42">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch2/try.sh">try.sh</a> script. This
 script will try and show the difference (i.e. the same output) between the
@@ -4362,8 +4374,8 @@ program and the result of <code>sha512sum</code> or <code>shasum -a 512</code> i
 tools can be found but otherwise it’ll just run the program itself, showing its
 own sha512sum value.</p>
 <div id="2019_dogon">
-<h2 id="dogon-1"><a href="2019/dogon/index.html">2019/dogon</a></h2>
-<h3 id="source-code-prog.c-43">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/dogon//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019dogon">Winning entry: <a href="2019/dogon/index.html">2019/dogon</a></h2>
+<h3 id="winning-entry-source-code-prog.c-43">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/dogon//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux does not seem to but macOS does).</p>
@@ -4376,8 +4388,8 @@ that this was done (some typos were fixed as well but only some - the purpose
 was to only correct spelling and only some, not to change wording or anything
 else).</p>
 <div id="2019_duble">
-<h2 id="duble-1"><a href="2019/duble/index.html">2019/duble</a></h2>
-<h3 id="source-code-prog.c-44">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019duble">Winning entry: <a href="2019/duble/index.html">2019/duble</a></h2>
+<h3 id="winning-entry-source-code-prog.c-44">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made the <code>make fullscreen</code> more portable by not relying on
 <code>stty(1)</code> and <code>sed(1)</code> but rather it just uses <code>tput(1)</code>. He also made it so
@@ -4389,8 +4401,8 @@ variables <code>LINES</code> and <code>COLUMNS</code> are set. But even if they�
 how to easily compile the program to a specific size. Note that <code>LINES</code> and
 <code>COLUMNS</code> is not available to scripts so it can’t make use of them that way.</p>
 <div id="2019_endoh">
-<h2 id="endoh"><a href="2019/endoh/index.html">2019/endoh</a></h2>
-<h3 id="source-code-prog.c-45">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019endoh">Winning entry: <a href="2019/endoh/index.html">2019/endoh</a></h2>
+<h3 id="winning-entry-source-code-prog.c-45">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh//prog.c">prog.c</a></h3>
 </div>
 <p>As this is a backtrace quine having the optimiser enabled is not a good idea so
 <a href="#cody">Cody</a> disabled it. For this same reason he also added the <code>-g</code> flag to the
@@ -4402,13 +4414,13 @@ combined with the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/mas
 to easily reconstruct the source code through GDB by the fact it’s a backtrace
 quine.</p>
 <div id="2019_giles">
-<h2 id="giles"><a href="2019/giles/index.html">2019/giles</a></h2>
-<h3 id="source-code-prog.c-46">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/giles//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019giles">Winning entry: <a href="2019/giles/index.html">2019/giles</a></h2>
+<h3 id="winning-entry-source-code-prog.c-46">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/giles//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/giles/try.sh">try.sh</a> script.</p>
 <div id="2019_karns">
-<h2 id="karns"><a href="2019/karns/index.html">2019/karns</a></h2>
-<h3 id="source-code-prog.c-47">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019karns">Winning entry: <a href="2019/karns/index.html">2019/karns</a></h2>
+<h3 id="winning-entry-source-code-prog.c-47">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> reported that with <code>-O</code> level &gt; 0 this program segfaults (sometimes?). He’s
 not sure why as it worked fine before on the same systems tested but <code>-O0</code>
@@ -4418,8 +4430,8 @@ debugging it since it works with <code>-O0</code>.</p>
 <p>He also added the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/try.sh">try.sh</a> to showcase the entry a
 bit more easily.</p>
 <div id="2019_lynn">
-<h2 id="lynn"><a href="2019/lynn/index.html">2019/lynn</a></h2>
-<h3 id="source-code-prog.c-48">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019lynn">Winning entry: <a href="2019/lynn/index.html">2019/lynn</a></h2>
+<h3 id="winning-entry-source-code-prog.c-48">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/try.sh">try.sh</a> script.</p>
 <p>Cody also added the <a href="2019/lynn/example-1.txt">example-1.txt</a> and
@@ -4427,13 +4439,13 @@ bit more easily.</p>
 <a href="2018/vokes/index.html">2018/vokes</a> so that the entry does not rely on any other
 entry existing.</p>
 <div id="2019_mills">
-<h2 id="mills-2"><a href="2019/mills/index.html">2019/mills</a></h2>
-<h3 id="source-code-prog.c-49">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019mills">Winning entry: <a href="2019/mills/index.html">2019/mills</a></h2>
+<h3 id="winning-entry-source-code-prog.c-49">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/try.sh">try.sh</a> script.</p>
 <div id="2019_poikola">
-<h2 id="poikola-1"><a href="2019/poikola/index.html">2019/poikola</a></h2>
-<h3 id="source-code-prog.c-50">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019poikola">Winning entry: <a href="2019/poikola/index.html">2019/poikola</a></h2>
+<h3 id="winning-entry-source-code-prog.c-50">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the missing <code>docs</code> rule to the Makefile that forms a PDF
 file. The rule requires the tool
@@ -4448,19 +4460,19 @@ suggesting that with some versions of <code>GCC</code> it might not be correct w
 tested: <code>gnu17</code> was not tested but <code>gnu11</code> was so the standard was set to
 <code>gnu11</code>.</p>
 <div id="2019_yang">
-<h2 id="yang-2"><a href="2019/yang/index.html">2019/yang</a></h2>
-<h3 id="source-code-prog.c-51">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2019yang">Winning entry: <a href="2019/yang/index.html">2019/yang</a></h2>
+<h3 id="winning-entry-source-code-prog.c-51">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/try.sh">try.sh</a> script which also involved
 slightly updating the <a href="2019/yang/sample_input.txt">sample_input.txt</a> file
 (removed trailing newlines as it resulted in <code>diff</code> showing differences when it
 shouldn’t) and adding the <a href="2019/yang/ioccc.txt">ioccc.txt</a> file.</p>
 <div id="2020">
-<h1 id="section-26">2020</h1>
+<h1 id="section-26"><a href="2020/index.html">2020</a></h1>
 </div>
 <div id="2020_burton">
-<h2 id="burton-2"><a href="2020/burton/index.html">2020/burton</a></h2>
-<h3 id="source-code-prog.c-52">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020burton">Winning entry: <a href="2020/burton/index.html">2020/burton</a></h2>
+<h3 id="winning-entry-source-code-prog.c-52">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/check_be.sh">check_be.sh</a>: it
 assumed that <code>prog_be</code> was in <code>PATH</code> which is unlikely so it was changed to
@@ -4470,24 +4482,24 @@ Endian counterpart) so that it shows that the files are identical rather than
 showing nothing at all.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/try.sh">try.sh</a> script.</p>
 <div id="2020_carlini">
-<h2 id="carlini"><a href="2020/carlini/index.html">2020/carlini</a></h2>
-<h3 id="source-code-prog.c-53">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020carlini">Winning entry: <a href="2020/carlini/index.html">2020/carlini</a></h2>
+<h3 id="winning-entry-source-code-prog.c-53">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/try.sh">try.sh</a> script which although at
 first glance might not appear to have a point, it actually does, namely showing
 how you can automate play and then reminding you to actually play for real, with
 a friend, whether that’s real or imagined.</p>
 <div id="2020_endoh2">
-<h2 id="endoh2-5"><a href="2020/endoh2/index.html">2020/endoh2</a></h2>
-<h3 id="source-code-prog.c-54">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020endoh2">Winning entry: <a href="2020/endoh2/index.html">2020/endoh2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-54">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> copied the files from the spoiler.zip file (from his copy during
 the preview period) that was password protected with a password that was no
 longer known.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/try.sh">try.sh</a> script.</p>
 <div id="2020_endoh3">
-<h2 id="endoh3-2"><a href="2020/endoh3/index.html">2020/endoh3</a></h2>
-<h3 id="source-code-prog.c-55">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020endoh3">Winning entry: <a href="2020/endoh3/index.html">2020/endoh3</a></h2>
+<h3 id="winning-entry-source-code-prog.c-55">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3/run_clock.sh">run_clock.sh</a> which gave a
 funny error when running it:</p>
@@ -4516,8 +4528,8 @@ knows it so he might be called unusual (and he argues, with pride, eccentric :-)
 which is analogous to the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3/run_clock.sh">run_clock.sh</a> but for the
 alt code provided by the author, Yusuke.</p>
 <div id="2020_ferguson1">
-<h2 id="ferguson1"><a href="2020/ferguson1/index.html">2020/ferguson1</a></h2>
-<h3 id="source-code-prog.c-56">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020ferguson1">Winning entry: <a href="2020/ferguson1/index.html">2020/ferguson1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-56">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, with intentional irony here :-), fixed formatting, links and typos in
 various files.</p>
@@ -4533,8 +4545,8 @@ how rich it is? If not and you like chocolate I (that is Cody :-) ) highly
 recommend you give it a go! :-) You’re welcome to ask me questions if you wish
 and I encourage you to do so as the cake is quite picky!</p>
 <div id="2020_ferguson2">
-<h2 id="ferguson2"><a href="2020/ferguson2/index.html">2020/ferguson2</a></h2>
-<h3 id="source-code-prog.c-57">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020ferguson2">Winning entry: <a href="2020/ferguson2/index.html">2020/ferguson2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-57">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, with intentional irony here :-), fixed formatting, links and typos in
 various files.</p>
@@ -4552,8 +4564,8 @@ how rich it is? If not and you like chocolate I (that is Cody :-) ) highly
 recommend you give it a go! :-) You’re welcome to ask me questions if you wish
 and I encourage you to do so as the cake is quite picky!</p>
 <div id="2020_giles">
-<h2 id="giles-1"><a href="2020/giles/index.html">2020/giles</a></h2>
-<h3 id="source-code-prog.c-58">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020giles">Winning entry: <a href="2020/giles/index.html">2020/giles</a></h2>
+<h3 id="winning-entry-source-code-prog.c-58">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/try.sh">try.sh</a> script. This script does
 the conversion of <code>pi.wav</code> (showing the digits) and also converts the number for
@@ -4565,13 +4577,13 @@ neither are installed it warns the user about this, linking to the FAQ about it,
 and tells them they will have to play the WAV files manually. Otherwise it’ll
 use the program to play the WAV files (and in one case <code>stdout</code>).</p>
 <div id="2020_kurdyukov1">
-<h2 id="kurdyukov1"><a href="2020/kurdyukov1/index.html">2020/kurdyukov1</a></h2>
-<h3 id="source-code-prog.c-59">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov1//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020kurdyukov1">Winning entry: <a href="2020/kurdyukov1/index.html">2020/kurdyukov1</a></h2>
+<h3 id="winning-entry-source-code-prog.c-59">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov1/try.sh">try.sh</a> script.</p>
 <div id="2020_kurdyukov2">
-<h2 id="kurdyukov2"><a href="2020/kurdyukov2/index.html">2020/kurdyukov2</a></h2>
-<h3 id="source-code-prog.c-60">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov2//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020kurdyukov2">Winning entry: <a href="2020/kurdyukov2/index.html">2020/kurdyukov2</a></h2>
+<h3 id="winning-entry-source-code-prog.c-60">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov2/try.sh">try.sh</a> script.</p>
 <p>Cody also added <code>-L</code>/<code>-I</code> paths to the Makefile to let this compile more easily if
@@ -4584,16 +4596,16 @@ specify which compiler to use with <code>CC=foo ./makegif.sh ...</code>), checki
 <code>convert(1)</code> is found and that it worked properly (linking to the proper FAQ
 entry if not installed or it fails).</p>
 <div id="2020_kurdyukov3">
-<h2 id="kurdyukov3"><a href="2020/kurdyukov3/index.html">2020/kurdyukov3</a></h2>
-<h3 id="source-code-prog.c-61">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov3//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020kurdyukov3">Winning entry: <a href="2020/kurdyukov3/index.html">2020/kurdyukov3</a></h2>
+<h3 id="winning-entry-source-code-prog.c-61">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov3//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov3/try.sh">try.sh</a> script.</p>
 <p>He also added a link that has much more details about this phenomenon to the
 index.html. Naturally he’s one of the ones who can read text even if it’s even
 more jumbled but we know of others too.</p>
 <div id="2020_kurdyukov4">
-<h2 id="kurdyukov4"><a href="2020/kurdyukov4/index.html">2020/kurdyukov4</a></h2>
-<h3 id="source-code-prog.c-62">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020kurdyukov4">Winning entry: <a href="2020/kurdyukov4/index.html">2020/kurdyukov4</a></h2>
+<h3 id="winning-entry-source-code-prog.c-62">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4/try.sh">try.sh</a> script.</p>
 <p>Cody also added from <a href="2019/mills/index.html">2019/mills</a> the text file
@@ -4605,8 +4617,8 @@ volume X, Morgoth’s Ring, which he also has (and which is part of the 12 volum
 set by the late Christopher Tolkien, son and literary executor and heir to
 J.R.R. Tolkien).</p>
 <div id="2020_otterness">
-<h2 id="otterness"><a href="2020/otterness/index.html">2020/otterness</a></h2>
-<h3 id="source-code-prog.c-63">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020otterness">Winning entry: <a href="2020/otterness/index.html">2020/otterness</a></h2>
+<h3 id="winning-entry-source-code-prog.c-63">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the MIDI files <a href="2020/otterness/cvikl.mid">cvikl.mid</a> and
 <a href="2020/otterness/entertainer.mid">entertainer.mid</a> from the URLs we suggested so
@@ -4614,15 +4626,15 @@ that one need not download them and to make sure they can always be obtained
 even if the domain or link goes dead.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/try.sh">try.sh</a> script.</p>
 <div id="2020_tsoj">
-<h2 id="tsoj"><a href="2020/tsoj/index.html">2020/tsoj</a></h2>
-<h3 id="source-code-prog.c-64">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/tsoj//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020tsoj">Winning entry: <a href="2020/tsoj/index.html">2020/tsoj</a></h2>
+<h3 id="winning-entry-source-code-prog.c-64">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/tsoj//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="2020/tsoj/index.html#alternate-code">alternate code</a> that will feel
 more at home for vi users. One might still end up cursing (see the index.html
 file) but probably a lot less :-)</p>
 <div id="2020_yang">
-<h2 id="yang-3"><a href="2020/yang/index.html">2020/yang</a></h2>
-<h3 id="source-code-prog.c-65">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/yang//prog.c">prog.c</a></h3>
+<h2 id="winning-entry-2020yang">Winning entry: <a href="2020/yang/index.html">2020/yang</a></h2>
+<h3 id="winning-entry-source-code-prog.c-65">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/yang//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/yang/try.sh">try.sh</a> script.</p>
 <p>Cody also added a make rule (<code>make cppp</code>) for the author’s provided C++ code

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -35,8 +35,8 @@ on an IOCCC entry by entry basis.
 
 
 <div id="1984_anonymous">
-## [1984/anonymous](1984/anonymous/index.html)
-### Source code: [anonymous.c](%%REPO_URL%%/1984/anonymous/anonymous.c)
+## Winning entry: [1984/anonymous](1984/anonymous/index.html)
+### Winning entry source code: [anonymous.c](%%REPO_URL%%/1984/anonymous/anonymous.c)
 </div>
 
 [Cody](#cody) fixed this to work for macOS.
@@ -65,8 +65,8 @@ Scovell](https://web.archive.org/web/20070120220721/https://thomasscovell.com/ta
 
 
 <div id="1984_decot">
-## [1984/decot](1984/decot/index.html)
-### Source code: [decot.c](%%REPO_URL%%/1984/decot/decot.c)
+## Winning entry: [1984/decot](1984/decot/index.html)
+### Winning entry source code: [decot.c](%%REPO_URL%%/1984/decot/decot.c)
 </div>
 
 [Cody](#cody) fixed this to not require `-traditional-cpp` which some compilers like
@@ -134,8 +134,8 @@ To see the difference from start to fixed:
 
 
 <div id="1984_laman">
-## [1984/laman](1984/laman/index.html)
-### Source code: [laman.c](%%REPO_URL%%/1984/laman/laman.c)
+## Winning entry: [1984/laman](1984/laman/index.html)
+### Winning entry source code: [laman.c](%%REPO_URL%%/1984/laman/laman.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1984/laman/try.sh) script.
@@ -147,8 +147,8 @@ This was fixed on 30 October 2023 after the bug status was changed from INABIAF
 
 
 <div id="1984_mullender">
-## [1984/mullender](1984/mullender/index.html)
-### Source code: [mullender.c](%%REPO_URL%%/1984/mullender/mullender.c)
+## Winning entry: [1984/mullender](1984/mullender/index.html)
+### Winning entry source code: [mullender.c](%%REPO_URL%%/1984/mullender/mullender.c)
 </div>
 
 [Cody](#cody) provided an [alternate version](%%REPO_URL%%/1984/mullender/mullender.alt.c),
@@ -178,8 +178,8 @@ Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
 
 <div id="1985_applin">
-## [1984/applin](1985/applin/index.html)
-### Source code: [applin.c](%%REPO_URL%%/1985/applin/applin.c)
+## Winning entry: [1984/applin](1985/applin/index.html)
+### Winning entry source code: [applin.c](%%REPO_URL%%/1985/applin/applin.c)
 </div>
 
 Both [Cody](#cody) and [Yusuke](#yusuke) fixed this; Yusuke got this to not crash and Cody fixed it
@@ -205,8 +205,8 @@ returning to the shell. The original code does not have this change.
 
 
 <div id="1985_august">
-## [1985/august](1985/august/index.html)
-### Source code: [august.c](%%REPO_URL%%/1985/august/august.c)
+## Winning entry: [1985/august](1985/august/index.html)
+### Winning entry source code: [august.c](%%REPO_URL%%/1985/august/august.c)
 </div>
 
 [Cody](#cody), out of abundance of caution, added a second arg to `main()` because some
@@ -227,8 +227,8 @@ default value).
 
 
 <div id="1985_lycklama">
-## [1985/lycklama](1985/lycklama/index.html)
-### Source code: [lycklama.c](%%REPO_URL%%/1985/lycklama/lycklama.c)
+## Winning entry: [1985/lycklama](1985/lycklama/index.html)
+### Winning entry source code: [lycklama.c](%%REPO_URL%%/1985/lycklama/lycklama.c)
 </div>
 
 [Cody](#cody) fixed this to compile with modern compilers. In the past one could get away
@@ -243,8 +243,8 @@ Cody also provided the [try.alt.sh](%%REPO_URL%%/1985/lycklama/try.alt.sh) scrip
 
 
 <div id="1985_shapiro">
-## [1985/shapiro](1985/shapiro/index.html)
-### Source code: [shapiro.c](%%REPO_URL%%/1985/shapiro/shapiro.c)
+## Winning entry: [1985/shapiro](1985/shapiro/index.html)
+### Winning entry source code: [shapiro.c](%%REPO_URL%%/1985/shapiro/shapiro.c)
 </div>
 
 [Cody](#cody) added the [alt code](%%REPO_URL%%/1985/shapiro/shapiro.alt.c)
@@ -257,8 +257,8 @@ input (this includes negative numbers which in the code actually sets it back to
 
 
 <div id="1985_sicherman">
-## [1985/sicherman](1985/sicherman/index.html)
-### Source code: [1985/sicherman](%%REPO_URL%%/1985/sicherman/sicherman.c)
+## Winning entry: [1985/sicherman](1985/sicherman/index.html)
+### Winning entry source code: [1985/sicherman](%%REPO_URL%%/1985/sicherman/sicherman.c)
 </div>
 
 [Cody](#cody) fixed this _very twisted entry_ to not require `-traditional-cpp`.  Fixing
@@ -376,8 +376,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 
 
 <div id="1986_applin">
-## [1986/applin](1986/applin/index.html)
-### Source code: [applin.c](%%REPO_URL%%/1986/applin/applin.c)
+## Winning entry: [1986/applin](1986/applin/index.html)
+### Winning entry source code: [applin.c](%%REPO_URL%%/1986/applin/applin.c)
 </div>
 
 [Cody](#cody) made the C file executable so one does not have to do `sh
@@ -385,16 +385,16 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 
 
 <div id="1986_bright">
-## [1986/bright](1986/bright/index.html)
-### Source code: [bright.c](%%REPO_URL%%/1986/bright/bright.c)
+## Winning entry: [1986/bright](1986/bright/index.html)
+### Winning entry source code: [bright.c](%%REPO_URL%%/1986/bright/bright.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1986/bright/try.sh) script.
 
 
 <div id="1986_hague">
-## [1986/hague](1986/hague/index.html)
-### Source code: [hague.c](%%REPO_URL%%/1986/hague/hague.c)
+## Winning entry: [1986/hague](1986/hague/index.html)
+### Winning entry source code: [hague.c](%%REPO_URL%%/1986/hague/hague.c)
 </div>
 
 [Cody](#cody) made this use `fgets()`. See [FAQ 4.1  - Why were some calls to
@@ -406,8 +406,8 @@ program the `input.txt` text file that Cody added.
 
 
 <div id="1986_holloway">
-## [1986/holloway](1986/holloway/index.html)
-### Source code: [holloway.c](%%REPO_URL%%/1986/holloway/holloway.c)
+## Winning entry: [1986/holloway](1986/holloway/index.html)
+### Winning entry source code: [holloway.c](%%REPO_URL%%/1986/holloway/holloway.c)
 </div>
 
 [Cody](#cody) fixed this to compile and work with `clang` (it already worked with `gcc`).
@@ -420,8 +420,8 @@ and then using `t` instead of `s` it compiles and runs successfully under
 
 
 <div id="1986_marshall">
-## [1986/marshall](1986/marshall/index.html)
-### Source code: [marshall.c](%%REPO_URL%%/1986/marshall/marshall.c)
+## Winning entry: [1986/marshall](1986/marshall/index.html)
+### Winning entry source code: [marshall.c](%%REPO_URL%%/1986/marshall/marshall.c)
 </div>
 
 [Cody](#cody) got this to compile and work with `clang` and `gcc`. He noted that he tried to
@@ -487,18 +487,18 @@ are produced.
 
 
 <div id="1986_pawka">
-## [1986/pawka](1986/pawka/index.html)
-### Source code: [pawka.c](%%REPO_URL%%/1986/pawka/pawka.c)
+## Winning entry: [1986/pawka](1986/pawka/index.html)
+### Winning entry source code: [pawka.c](%%REPO_URL%%/1986/pawka/pawka.c)
 </div>
 
 [Cody](#cody) noticed and fixed a funny mistake in the Makefile where a
 `-Wno-strict-prototypes` was in the wrong location, suggesting that there is a
-`-D` needed to compile the entry.
+`-D` needed to compile the entry but this is not actually so.
 
 
 <div id="1986_stein">
-## [1986/stein](1986/stein/index.html)
-### Source code: [stein.c](%%REPO_URL%%/1986/stein/stein.c)
+## Winning entry: [1986/stein](1986/stein/index.html)
+### Winning entry source code: [stein.c](%%REPO_URL%%/1986/stein/stein.c)
 </div>
 
 [Cody](#cody) restored the [original
@@ -512,8 +512,8 @@ commands that we suggest in order to get it to show clean output.
 
 
 <div id="1986_wall">
-## [1986/wall](1986/wall/index.html)
-### Source code: [wall.c](%%REPO_URL%%/1986/wall/wall.c)
+## Winning entry: [1986/wall](1986/wall/index.html)
+### Winning entry source code: [wall.c](%%REPO_URL%%/1986/wall/wall.c)
 </div>
 
 [Cody](#cody) fixed this so that it does not require `-traditional-cpp`. This took a fair
@@ -629,16 +629,16 @@ There might have been other changes as well.
 
 
 <div id="1987_biggar">
-## [1987/biggar](1987/biggar/index.html)
-### Source code: [biggar.c](%%REPO_URL%%/1987/biggar/biggar.c)
+## Winning entry: [1987/biggar](1987/biggar/index.html)
+### Winning entry source code: [biggar.c](%%REPO_URL%%/1987/biggar/biggar.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1987/biggar/try.sh) script.
 
 
 <div id="1987_heckbert">
-## [1987/heckbert](1987/heckbert/index.html)
-### Source code: [heckbert.c](%%REPO_URL%%/1987/heckbert/heckbert.c)
+## Winning entry: [1987/heckbert](1987/heckbert/index.html)
+### Winning entry source code: [heckbert.c](%%REPO_URL%%/1987/heckbert/heckbert.c)
 </div>
 
 [Cody](#cody) made this look more like the [original
@@ -655,8 +655,8 @@ that for System V we had to do this) Cody added to the Makefile
 
 
 <div id="1987_hines">
-## [1987/hines](1987/hines/index.html)
-### Source code: [hines.c](%%REPO_URL%%/1987/hines/hines.c)
+## Winning entry: [1987/hines](1987/hines/index.html)
+### Winning entry source code: [hines.c](%%REPO_URL%%/1987/hines/hines.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1987/hines/try.sh) script, the C file
@@ -666,8 +666,8 @@ running the program on the text file demonstrates.
 
 
 <div id="1987_lievaart">
-## [1987/lievaart](1987/lievaart/index.html)
-### Source code: [lievaart.c](%%REPO_URL%%/1987/lievaart/lievaart.c)
+## Winning entry: [1987/lievaart](1987/lievaart/index.html)
+### Winning entry source code: [lievaart.c](%%REPO_URL%%/1987/lievaart/lievaart.c)
 </div>
 
 [Cody](#cody) added back the documented checks for invalid input which no longer worked
@@ -714,8 +714,8 @@ size constraints of the contest).
 
 
 <div id="1987_wall">
-## [1987/wall](1987/wall/index.html)
-### Source code: [wall.c](%%REPO_URL%%/1987/wall/wall.c)
+## Winning entry: [1987/wall](1987/wall/index.html)
+### Winning entry source code: [wall.c](%%REPO_URL%%/1987/wall/wall.c)
 </div>
 
 [Cody](#cody) made this use `fgets(3)`. See [FAQ 4.1  - Why were some calls to
@@ -727,8 +727,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1987/wall/try.sh) script.
 
 
 <div id="1987_westley">
-## [1987/westley](1987/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1987/westley/westley.c)
+## Winning entry: [1987/westley](1987/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1987/westley/westley.c)
 </div>
 
 [Cody](#cody) fixed this for modern systems. The problem was `'assignment to cast is
@@ -752,8 +752,8 @@ unlikely(?) but nevertheless suggested case that `putchar(3)` is not available.
 
 
 <div id="1988_dale">
-## [1988/dale](1988/dale/index.html)
-### Source code: [dale.c](%%REPO_URL%%/1988/dale/dale.c)
+## Winning entry: [1988/dale](1988/dale/index.html)
+### Winning entry source code: [dale.c](%%REPO_URL%%/1988/dale/dale.c)
 </div>
 
 [Cody](#cody) fixed this twisted entry (as we called it :-) ) for modern compilers,
@@ -832,8 +832,8 @@ Cody also provided the [try.sh](%%REPO_URL%%/1988/dale/try.sh) script.
 
 
 <div id="1988_isaak">
-## [1988/isaak](1988/isaak/index.html)
-### Source code: [isaak.c](%%REPO_URL%%/1988/isaak/isaak.c)
+## Winning entry: [1988/isaak](1988/isaak/index.html)
+### Winning entry source code: [isaak.c](%%REPO_URL%%/1988/isaak/isaak.c)
 </div>
 
 [Cody](#cody) fixed this to work for modern systems. The problem was that the important
@@ -848,8 +848,8 @@ found in the index.html file.
 
 
 <div id="1988_litmaath">
-## [1988/litmaath](1988/litmaath/index.html)
-### Source code: [litmaath.c](%%REPO_URL%%/1988/litmaath/litmaath.c)
+## Winning entry: [1988/litmaath](1988/litmaath/index.html)
+### Winning entry source code: [litmaath.c](%%REPO_URL%%/1988/litmaath/litmaath.c)
 </div>
 
 [Cody](#cody) added the [alt code](%%REPO_URL%%/1988/litmaath/litmaath.alt.c)
@@ -858,8 +858,8 @@ help understand the entry, and for fun.
 
 
 <div id="1988_phillipps">
-## [1988/phillipps](1988/phillipps/index.html)
-### Source code: [phillipps.c](%%REPO_URL%%/1988/phillipps/phillipps.c)
+## Winning entry: [1988/phillipps](1988/phillipps/index.html)
+### Winning entry source code: [phillipps.c](%%REPO_URL%%/1988/phillipps/phillipps.c)
 </div>
 
 [Cody](#cody) fixed this for modern systems. It did not compile with `clang` because it
@@ -880,8 +880,8 @@ same code, just a `p` instead of an `m` in the name. Additionally, `main()` retu
 
 
 <div id="1988_reddy">
-## [1988/reddy](1988/reddy/index.html)
-### Source code: [reddy.c](%%REPO_URL%%/1988/reddy/reddy.c)
+## Winning entry: [1988/reddy](1988/reddy/index.html)
+### Winning entry source code: [reddy.c](%%REPO_URL%%/1988/reddy/reddy.c)
 </div>
 
 [Cody](#cody) made this use `fgets(3)`. See [FAQ 4.1  - Why were some calls to
@@ -891,8 +891,8 @@ fgets&#x28;3&#x29;?](faq.html#faq4_1) for why this was done.
 
 
 <div id="1988_spinellis">
-## [1988/spinellis](1988/spinellis/index.html)
-### Source code: [spinellis.c](%%REPO_URL%%/1988/spinellis/spinellis.c)
+## Winning entry: [1988/spinellis](1988/spinellis/index.html)
+### Winning entry source code: [spinellis.c](%%REPO_URL%%/1988/spinellis/spinellis.c)
 </div>
 
 [Cody](#cody) provided an [alternate version](%%REPO_URL%%/1988/spinellis/spinellis.alt.c) so that
@@ -910,8 +910,8 @@ thank him for this ghastly point! :-)
 
 
 <div id="1988_westley">
-## [1988/westley](1988/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1988/westley/westley.c)
+## Winning entry: [1988/westley](1988/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1988/westley/westley.c)
 </div>
 
 The [original version](%%REPO_URL%%/1988/westley/westley.alt.c), provided as alternate code,
@@ -934,8 +934,8 @@ not strictly necessary but nonetheless more correct, even if not warned against.
 
 
 <div id="1989_fubar">
-## [1989/fubar](1989/fubar/index.html)
-### Source code: [fubar.c](%%REPO_URL%%/1989/fubar/fubar.c)
+## Winning entry: [1989/fubar](1989/fubar/index.html)
+### Winning entry source code: [fubar.c](%%REPO_URL%%/1989/fubar/fubar.c)
 </div>
 
 [Cody](#cody) got this to work with modern systems. The main issues were that an
@@ -971,8 +971,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1989/fubar/try.sh) script.
 
 
 <div id="1989_jar.1">
-## [1989/jar.1](1989/jar.1/index.html)
-### Source code: [jar.1.c](%%REPO_URL%%/1989/jar.1/jar.1.c)
+## Winning entry: [1989/jar.1](1989/jar.1/index.html)
+### Winning entry source code: [jar.1.c](%%REPO_URL%%/1989/jar.1/jar.1.c)
 </div>
 
 To prevent annoying output to `/dev/tty` we changed the code to simulate the
@@ -991,8 +991,8 @@ entry and the alt code) anyway, it works out well.
 
 
 <div id="1989_jar.2">
-## [1989/jar.2](1989/jar.2/index.html)
-### Source code: [jar.2.c](%%REPO_URL%%/1989/jar.2/jar.2.c)
+## Winning entry: [1989/jar.2](1989/jar.2/index.html)
+### Winning entry source code: [jar.2.c](%%REPO_URL%%/1989/jar.2/jar.2.c)
 </div>
 
 [Cody](#cody) fixed this to work with modern compilers. Modern compilers do not allow
@@ -1013,7 +1013,7 @@ The old `#define`s are left in to make it look like the original as much as
 possible but they are not used.
 
 Cody also provided the [try.sh](%%REPO_URL%%/1989/jar.2/try.sh) script and the
-supplementary files [try.lisp](1989/jar.2/try.lisp),
+supplementary files [try.lisp](%%REPO_URL%%/1989/jar.2/try.lisp),
 [fib.lisp](%%REPO_URL%%/1989/jar.2/fib.lisp) and
 [chocolate_cake.lisp](%%REPO_URL%%/1989/jar.2/chocolate_cake.lisp). The
 `try.lisp` comes from the author and the `fib.lisp` comes from
@@ -1036,8 +1036,8 @@ because the `alt` rule had what normally is in the `${PROG}.alt` rule.
 
 
 <div id="1989_ovdluhe">
-## [1989/ovdluhe](1989/ovdluhe/index.html)
-### Source code: [ovdluhe.c](%%REPO_URL%%/1989/ovdluhe/ovdluhe.c)
+## Winning entry: [1989/ovdluhe](1989/ovdluhe/index.html)
+### Winning entry source code: [ovdluhe.c](%%REPO_URL%%/1989/ovdluhe/ovdluhe.c)
 </div>
 
 [Cody](#cody) fixed an infinite loop where the program would print the same thing over
@@ -1059,8 +1059,8 @@ discovered and fixed.
 
 
 <div id="1989_paul">
-## [1989/paul](1989/paul/index.html)
-### Source code: [paul.c](%%REPO_URL%%/1989/paul/paul.c)
+## Winning entry: [1989/paul](1989/paul/index.html)
+### Winning entry source code: [paul.c](%%REPO_URL%%/1989/paul/paul.c)
 </div>
 
 [Cody](#cody) fixed a segfault under macOS that prevented it from working. The problem
@@ -1073,8 +1073,8 @@ index.html for details.
 
 
 <div id="1989_robison">
-## [1989/robison](1989/robison/index.html)
-### Source code: [robison.c](%%REPO_URL%%/1989/robison/robison.c)
+## Winning entry: [1989/robison](1989/robison/index.html)
+### Winning entry source code: [robison.c](%%REPO_URL%%/1989/robison/robison.c)
 </div>
 
 [Yusuke Endoh](#yusuke) fixed this to compile under modern systems. To see the changes
@@ -1091,8 +1091,8 @@ Cody added the [try.sh](%%REPO_URL%%/1989/robison/try.sh) script.
 
 
 <div id="1989_tromp">
-## [1989/tromp](1989/tromp/index.html)
-### Source code: [tromp.c](%%REPO_URL%%/1989/tromp/tromp.c)
+## Winning entry: [1989/tromp](1989/tromp/index.html)
+### Winning entry source code: [tromp.c](%%REPO_URL%%/1989/tromp/tromp.c)
 </div>
 
 [Cody](#cody) and [Yusuke](#yusuke) fixed this entry: Yusuke fixed this to compile with `gcc` and Cody
@@ -1123,24 +1123,28 @@ not his only reason :-) )
 
 
 <div id="1989_vanb">
-## [1989/vanb](1989/vanb/index.html)
-### Source code: [vanb.c](%%REPO_URL%%/1989/vanb/vanb.c)
+## Winning entry: [1989/vanb](1989/vanb/index.html)
+### Winning entry source code: [vanb.c](%%REPO_URL%%/1989/vanb/vanb.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1989/vanb/try.sh) script.
 
 
 <div id="1989_westley">
-## [1989/westley](1989/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1989/westley/westley.c)
+## Winning entry: [1989/westley](1989/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1989/westley/westley.c)
 </div>
 
-[Cody](#cody) fixed this for `clang`, except that two versions generated by the program
-cannot be compiled by `clang` due to inherent defects in the compiler and how the
-entry works. This is an **incredibly hard** one to fix for `clang` whilst still
-being compilable with `gcc` (and `gcc` can compile every generated version with the
-fix) and even if one fixes it to compile with `clang` it does not mean that any
-other version will compile! It is, however, possible to get `clang` to work with
+[Cody](#cody) fixed this for `clang`, except that two versions generated by the
+program cannot be compiled by `clang` due to inherent defects in the compiler
+and how the entry works. This is an **incredibly hard** one to fix for `clang`
+whilst still being compilable with `gcc` (`gcc` can compile every generated
+version with the fix but if one fixes all to compile with `clang`, which was
+attempted, it introduced compile errors for `gcc`) and even if one fixes it to
+compile with `clang` it does not, depending on how it's done, mean that any
+other version will compile!
+
+It is, however, possible to get `clang` to work with
 two versions generated, `ver0` and `ver1`, though `ver0` is actually just the
 main entry (but still generated by the program itself).
 
@@ -1209,8 +1213,8 @@ environmental variable; see the index.html for details.
 
 
 <div id="1990_baruch">
-## [1990/baruch](1990/baruch/index.html)
-### Source code: [baruch.c](%%REPO_URL%%/1990/baruch/baruch.c)
+## Winning entry: [1990/baruch](1990/baruch/index.html)
+### Winning entry source code: [baruch.c](%%REPO_URL%%/1990/baruch/baruch.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1990/baruch/try.sh) script.
@@ -1221,19 +1225,14 @@ did not change the `" #Q"` string as that appeared to show worse looking output
 instead of improved output though he has no way to test the compilers in
 question (i.e. it was only tested in the original entry). YMMV.
 
-Although this is appreciated we agree with him that <del>no one</del>
-[very few](https://en.wikipedia.org/wiki/0)
-[users](https://en.wikipedia.org/wiki/Microsoft_Windows)
-[here](https://www.ioccc.org) will need it! :-)
-
-Cody made the code look more like the original, removing the `int` from
+Cody also made the code look more like the original, removing the `int` from
 the variables, adding instead `-Wno-implicit-int`. The newline added by the
 judges was retained.
 
 
 <div id="1990_cmills">
-## [1990/cmills](1990/cmills/index.html)
-### Source code: [cmills.c](%%REPO_URL%%/1990/cmills/cmills.c)
+## Winning entry: [1990/cmills](1990/cmills/index.html)
+### Winning entry source code: [cmills.c](%%REPO_URL%%/1990/cmills/cmills.c)
 </div>
 
 [Yusuke](#yusuke) got this to work in modern systems (it previously resulted in a bus
@@ -1246,15 +1245,15 @@ fgets&#x28;3&#x29;?](faq.html#faq4_1) for why this was done.
 
 
 <div id="1990_dds">
-## [1990/dds](1990/dds/index.html)
-### Source code: [dds.c](%%REPO_URL%%/1990/dds/dds.c)
+## Winning entry: [1990/dds](1990/dds/index.html)
+### Winning entry source code: [dds.c](%%REPO_URL%%/1990/dds/dds.c)
 </div>
 
 [Yusuke](#yusuke) and [Cody](#cody) in conjunction fixed this for modern systems (both fixed a
 different compiler error but more fixes were also made).
 
 Yusuke added the comma operator for a binary expression with `free(3)` which is
-a compiler error because `free()` returns `void`. Cody then made it slightly
+a compiler error because `free(3)` returns `void`. Cody then made it slightly
 more like the original in this way by redefining `free` to have the comma
 operator itself.
 
@@ -1269,8 +1268,8 @@ fgets&#x28;3&#x29;?](faq.html#faq4_1) for why this was done.
 
 
 <div id="1990_dg">
-## [1990/dg](1990/dg/index.html)
-### Source code: [dg.c](%%REPO_URL%%/1990/dg/dg.c)
+## Winning entry: [1990/dg](1990/dg/index.html)
+### Winning entry source code: [dg.c](%%REPO_URL%%/1990/dg/dg.c)
 </div>
 
 [Cody](#cody) fixed this for modern systems. There were two problems to be resolved.
@@ -1289,14 +1288,14 @@ so the use of `#d` is now instead `#define` (the macro was originally deleted
 but later Cody added it back to make it more like the original).
 
 The second problem was suggested by the judges at the time of judging, to do
-with if the C preprocessor botches single quotes in cpp expansion.
+with if the C preprocessor botches single quotes in `cpp` expansion.
 
 Cody also added the [try.sh](%%REPO_URL%%/1990/dg/try.sh) script.
 
 
 <div id="1990_jaw">
-## [1990/jaw](1990/jaw/index.html)
-### Source code: [jaw.c](%%REPO_URL%%/1990/jaw/jaw.c)
+## Winning entry: [1990/jaw](1990/jaw/index.html)
+### Winning entry source code: [jaw.c](%%REPO_URL%%/1990/jaw/jaw.c)
 </div>
 
 [Cody](#cody) fixed the script to work properly in modern environments including writing
@@ -1312,12 +1311,12 @@ the time of releasing the winning entries of 1990.
 
 NOTE: as `btoa` is not common we used a ruby script from [Yusuke](#yusuke) but with a minor
 fix applied by Cody that made the program just show `oops` twice (twice is not
-an error here) from invalid input but which now works.
+a typo here) from invalid input but which now works.
 
 
 <div id="1990_pjr">
-## [1990/pjr](1990/pjr/index.html)
-### Source code: [pjr.c](%%REPO_URL%%/1990/pjr/pjr.c)
+## Winning entry: [1990/pjr](1990/pjr/index.html)
+### Winning entry source code: [pjr.c](%%REPO_URL%%/1990/pjr/pjr.c)
 </div>
 
 [Cody](#cody) added the [alt code](%%REPO_URL%%/1990/pjr/pjr.alt.c) which was suggested by the judges
@@ -1326,20 +1325,21 @@ something else and is recommended by the author as well.
 
 
 <div id="1990_scjones">
-## [1990/scjones](1990/scjones/index.html)
-### Source code: [scjones.c](%%REPO_URL%%/1990/scjones/scjones.c)
+## Winning entry: [1990/scjones](1990/scjones/index.html)
+### Winning entry source code: [scjones.c](%%REPO_URL%%/1990/scjones/scjones.c)
 </div>
 
 [Yusuke](#yusuke) suggested `-ansi` to get the entry to compile due to trigraphs and [Cody](#cody)
-suggested `-trigraphs`. Both work but we used Yusuke's idea.
+suggested `-trigraphs`. Both work but we used Yusuke's idea as this was seen
+first.
 
 Cody added the [try.sh](%%REPO_URL%%/1990/scjones/try.sh) script to show exactly what the
 entry does.
 
 
 <div id="1990_tbr">
-## [1990/tbr](1990/tbr/index.html)
-### Source code: [tbr.c](%%REPO_URL%%/1990/tbr/tbr.c)
+## Winning entry: [1990/tbr](1990/tbr/index.html)
+### Winning entry source code: [tbr.c](%%REPO_URL%%/1990/tbr/tbr.c)
 </div>
 
 [Cody](#cody) fixed this to work with modern compilers; `exit(3)` returns `void` but the
@@ -1359,8 +1359,8 @@ done more generally.
 
 
 <div id="1990_theorem">
-## [1990/theorem](1990/theorem/index.html)
-### Source code: [theorem.c](%%REPO_URL%%/1990/theorem/theorem.c)
+## Winning entry: [1990/theorem](1990/theorem/index.html)
+### Winning entry source code: [theorem.c](%%REPO_URL%%/1990/theorem/theorem.c)
 </div>
 
 [Cody](#cody) fixed this to compile with modern systems.
@@ -1407,8 +1407,8 @@ incomplete).
 
 
 <div id="1990_stig">
-## [1990/stig](1990/stig/index.html)
-### Source code: [stig.c](%%REPO_URL%%/1990/stig/stig.c)
+## Winning entry: [1990/stig](1990/stig/index.html)
+### Winning entry source code: [stig.c](%%REPO_URL%%/1990/stig/stig.c)
 </div>
 
 [Cody](#cody) fixed the paths in the `Makefile` so that this would build in Linux (it
@@ -1419,14 +1419,15 @@ He also changed the `Makefile` to use `bash` not `zsh` as not all systems have
 
 
 <div id="1990_westley">
-## [1990/westley](1990/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1990/westley/westley.c)
+## Winning entry: [1990/westley](1990/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1990/westley/westley.c)
 </div>
 
-[Cody](#cody) fixed this for modern systems. It had `1s` in places for a `short
-int` which was changed to just `1`.  Since it's instructional to see the
-differences he has provided an alternate version,
-[westley.alt.c](%%REPO_URL%%/1990/westley/westley.alt.c), which is the original code.
+[Cody](#cody) fixed this for modern systems. It had `1s` (digit one, letter s)
+in places for a `short int` which was changed to just `1`.  Since it's
+instructional to see the differences he has provided an alternate version,
+[westley.alt.c](%%REPO_URL%%/1990/westley/westley.alt.c), which is the original
+code.
 
 He also changed the `argc` to be an `int`, not a `char`, even though it might
 often be the same (this in particular was done for `clang`).
@@ -1448,8 +1449,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1990/westley/try.sh) script.
 
 
 <div id="1991_ant">
-## [1991/ant](1991/ant/index.html)
-### Source code: [ant.c](%%REPO_URL%%/1991/ant/ant.c)
+## Winning entry: [1991/ant](1991/ant/index.html)
+### Winning entry source code: [ant.c](%%REPO_URL%%/1991/ant/ant.c)
 </div>
 
 [Cody](#cody) added [alt code](%%REPO_URL%%/1991/ant/ant.alt.c) that will be a bit easier to use for
@@ -1467,8 +1468,8 @@ The other keys were left unchanged.
 
 
 <div id="1991_brnstnd">
-## [1991/brnstnd](1991/brnstnd/index.html)
-### Source code: [brnstnd.c](%%REPO_URL%%/1991/brnstnd/brnstnd.c)
+## Winning entry: [1991/brnstnd](1991/brnstnd/index.html)
+### Winning entry source code: [brnstnd.c](%%REPO_URL%%/1991/brnstnd/brnstnd.c)
 </div>
 
 [Cody](#cody) fixed this for modern systems. There were two invalid operands to binary
@@ -1484,10 +1485,12 @@ slightly more like the original, even though it's unused.
 Cody also added the [try.sh](%%REPO_URL%%/1991/brnstnd/try.sh) script and
 [try.txt](1991/brnstnd/try.txt) which the script uses.
 
+Cody also fixed the make clobber rule which left a symbolic link in the
+directory even after the target file was deleted (from make clobber).
 
 <div id="1991_buzzard">
-## [1991/buzzard](1991/buzzard/index.html)
-### Source code: [buzzard.c](%%REPO_URL%%/1991/buzzard/buzzard.c)
+## Winning entry: [1991/buzzard](1991/buzzard/index.html)
+### Winning entry source code: [buzzard.c](%%REPO_URL%%/1991/buzzard/buzzard.c)
 </div>
 
 [Cody](#cody) fixed this so that the coordinates being specified, a documented
@@ -1507,8 +1510,8 @@ program. We still recommend you try the original version first, of course.
 
 
 <div id="1991_davidguy">
-## [1991/davidguy](1991/davidguy/index.html)
-### Source code: [davidguy.c](%%REPO_URL%%/1991/davidguy/davidguy.c)
+## Winning entry: [1991/davidguy](1991/davidguy/index.html)
+### Winning entry source code: [davidguy.c](%%REPO_URL%%/1991/davidguy/davidguy.c)
 </div>
 
 As some systems like macOS can be particular about not declaring functions
@@ -1518,8 +1521,8 @@ being a problem not being declared first, to hopefully future-proof it.
 
 
 <div id="1991_dds">
-## [1991/dds](1991/dds/index.html)
-### Source code: [dds.c](%%REPO_URL%%/1991/dds/dds.c)
+## Winning entry: [1991/dds](1991/dds/index.html)
+### Winning entry source code: [dds.c](%%REPO_URL%%/1991/dds/dds.c)
 </div>
 
 [Cody](#cody) fixed a segfault that prevented this entry from working in any
@@ -1532,12 +1535,13 @@ the libc function gets&#x28;3&#x29; changed to use
 fgets&#x28;3&#x29;?](faq.html#faq4_1) for why this was done.
 
 For the magic of `clang` (which was done manually except the returning a value
-in `main()`) and `fgets(3)`, see below. The problem with `clang` can be
-described simply as: `clang` (at least in some systems?) defaults to having
-`-Werror` and the code that the entry generates had some warnings that were
-causing compilation to fail if `cc` is `clang` (the entry runs `cc a.c`). An
-example problem that had to be fixed is that the generated code returned from
-`main()` no value but rather just had `return;`.
+in `main()` in the generated code and possibly `fgets(3)`) and `fgets(3)`, see
+below. The problem with `clang` can be described simply as: `clang` (at least in
+some systems?) defaults to having `-Werror` and the code that the entry
+generates had some warnings that were causing compilation to fail if `cc` is
+`clang` (the entry runs `cc a.c`).  An example problem that had to be fixed is
+that the generated code returned from `main()` no value but rather just had
+`return;`.
 
 The code used to run `cc a.c` by what was once `system(q-6);` but if `cc` is `clang`
 like in macOS this is not enough.
@@ -1659,13 +1663,14 @@ entry was fixed. It has not been done in all.
 
 
 <div id="1991_fine">
-## [1991/fine](1991/fine/index.html)
-### Source code: [fine.c](%%REPO_URL%%/1991/fine/fine.c)
+## Winning entry: [1991/fine](1991/fine/index.html)
+### Winning entry source code: [fine.c](%%REPO_URL%%/1991/fine/fine.c)
 </div>
 
 [Cody](#cody) made it look much more like the original entry even after the fix
-for `clang` (by the judges) that increased the count in characters from 80 to
-106, getting it back down to just 85 (and later back down to 80, see below).
+for `clang` (made by the judges) that increased the count in characters from 80 to
+106, getting it back down to just 85 (and later back down to the original 80,
+see below).
 
 This was done by redefining `main` at the compiler line so that it looks like
 the original where one didn't have to worry about the type of args of `main()`
@@ -1686,8 +1691,8 @@ which ones? :-) )
 
 
 <div id="1991_rince">
-## [1991/rince](1991/rince/index.html)
-### Source code: [rince.c](%%REPO_URL%%/1991/rince/rince.c)
+## Winning entry: [1991/rince](1991/rince/index.html)
+### Winning entry source code: [rince.c](%%REPO_URL%%/1991/rince/rince.c)
 </div>
 
 [Cody](#cody) fixed it so that the messages that show if you won or lost will be seen
@@ -1704,8 +1709,8 @@ the above fix was applied to these versions too.
 
 
 <div id="1991_westley">
-## [1991/westley](1991/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1991/westley/westley.c)
+## Winning entry: [1991/westley](1991/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1991/westley/westley.c)
 </div>
 
 [Cody](#cody) fixed a segfault in this program which prevented it from working. The
@@ -1719,7 +1724,7 @@ Cody also fixed the `ttt.sh` script that prevented the game from working and he
 also improved it so that warnings/errors/about to compile messages are not shown
 unless the `-e` option is used.  This is because the errors being shown kind of
 ruins the experience. Finally he made it pass
-[ShellCheck](https://github.com/koalaman/shellcheck).
+[ShellCheck](https://www.shellcheck.net).
 
 Cody also added the [alt version](%%REPO_URL%%/1991/westley/westley.alt.c) which
 is based on the author's remarks, a version that supposedly (:-) ) always wins.
@@ -1734,8 +1739,8 @@ should have been removed.
 
 
 <div id="1992_adrian">
-## [1992/adrian](1992/adrian/index.html)
-### Source code: [adrian.c](%%REPO_URL%%/1992/adrian/adrian.c)
+## Winning entry: [1992/adrian](1992/adrian/index.html)
+### Winning entry source code: [adrian.c](%%REPO_URL%%/1992/adrian/adrian.c)
 </div>
 
 [Cody](#cody) fixed the code so that it will try opening the file the code was compiled
@@ -1815,8 +1820,8 @@ generated.
 
 
 <div id="1992_albert">
-## [1992/albert](1992/albert/index.html)
-### Source code: [albert.c](%%REPO_URL%%/1992/albert/albert.c)
+## Winning entry: [1992/albert](1992/albert/index.html)
+### Winning entry source code: [albert.c](%%REPO_URL%%/1992/albert/albert.c)
 </div>
 
 [Cody](#cody) fixed this to compile with modern systems. Note that in 1996 a bug fix was
@@ -1832,8 +1837,8 @@ the alt code.
 
 
 <div id="1992_ant">
-## [1992/ant](1992/ant/index.html)
-### Source code: [ant.c](%%REPO_URL%%/1992/ant/ant.c)
+## Winning entry: [1992/ant](1992/ant/index.html)
+### Winning entry source code: [ant.c](%%REPO_URL%%/1992/ant/ant.c)
 </div>
 
 [Cody](#cody) fixed the Makefile so that the program will actually work with it (or at
@@ -1857,8 +1862,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1992/ant/try.sh) script.
 
 
 <div id="1992_buzzard.1">
-## [1992/buzzard.1](1992/buzzard.1/index.html)
-### Source code: [buzzard.1.c](%%REPO_URL%%/1992/buzzard.1/buzzard.1.c)
+## Winning entry: [1992/buzzard.1](1992/buzzard.1/index.html)
+### Winning entry source code: [buzzard.1.c](%%REPO_URL%%/1992/buzzard.1/buzzard.1.c)
 </div>
 
 [Cody](#cody) added a check for the right number of args, exiting 1 if not enough (2)
@@ -1871,8 +1876,8 @@ commands that we suggested and some additional ones that he provide for some fun
 
 
 <div id="1992_buzzard.2">
-## [1992/buzzard.2](1992/buzzard.2/index.html)
-### Source code: [buzzard.2.c](%%REPO_URL%%/1992/buzzard.2/buzzard.2.c)
+## Winning entry: [1992/buzzard.2](1992/buzzard.2/index.html)
+### Winning entry source code: [buzzard.2.c](%%REPO_URL%%/1992/buzzard.2/buzzard.2.c)
 </div>
 
 [Cody](#cody) fixed the alt code to compile. The problem was it assumed that
@@ -1884,8 +1889,8 @@ and its alt code.
 
 
 <div id="1992_gson">
-## [1992/gson](1992/gson/index.html)
-### Source code: [gson.c](%%REPO_URL%%/1992/gson/gson.c)
+## Winning entry: [1992/gson](1992/gson/index.html)
+### Winning entry source code: [gson.c](%%REPO_URL%%/1992/gson/gson.c)
 </div>
 
 [Cody](#cody) fixed a crash that prevented this entry from working in some cases in some
@@ -1895,20 +1900,20 @@ Cody also added the [try.sh](%%REPO_URL%%/1992/gson/try.sh) script.
 
 Cody also added the [mkdict.sh](%%REPO_URL%%/1992/gson/mkdict.sh) script that the author
 included in their remarks. See the index.html for its purpose. It was NOT fixed
-for [ShellCheck](https://github.com/koalaman/shellcheck)
+for [ShellCheck](https://www.shellcheck.net)
 because the author deliberately obfuscated it so **PLEASE *DO NOT* FIX THIS OR
 MODERNISE IT**.
 
 Cody also changed the buffer size in such a way that `gets(3)` should be safe
 (well, theoretically) as it comes from the command line (though it can also read input
 from `stdin` after starting the program). Ideally `fgets(3)` would be used but this
-is a more problematic. See [1992/gson in bugs.html](bugs.html#1992-gson) for more
+is a more problematic. See [1992/gson in bugs.html](bugs.html#1992_gson) for more
 details if you're interested in trying to understand it (or fix?).
 
 
 <div id="1992_imc">
-## [1992/imc](1992/imc/index.html)
-### Source code: [imc.c](%%REPO_URL%%/1992/imc/imc.c)
+## Winning entry: [1992/imc](1992/imc/index.html)
+### Winning entry source code: [imc.c](%%REPO_URL%%/1992/imc/imc.c)
 </div>
 
 [Cody](#cody) provided the [try.sh](%%REPO_URL%%/1992/imc/try.sh) script.
@@ -1921,8 +1926,8 @@ operator so that it could be used in binary expressions.
 
 
 <div id="1992_kivinen">
-## [1992/kivinen](1992/kivinen/index.html)
-### Source code: [kivinen.c](%%REPO_URL%%/1992/kivinen/kivinen.c)
+## Winning entry: [1992/kivinen](1992/kivinen/index.html)
+### Winning entry source code: [kivinen.c](%%REPO_URL%%/1992/kivinen/kivinen.c)
 </div>
 
 It was observed that on modern systems this goes much too quick. [Yusuke](#yusuke) created
@@ -1950,12 +1955,13 @@ it moves towards the right but if you click the mouse it goes back.
 
 
 <div id="1992_lush">
-## [1992/lush](1992/lush/index.html)
-### Source code: [lush.c](%%REPO_URL%%/1992/lush/lush.c)
+## Winning entry: [1992/lush](1992/lush/index.html)
+### Winning entry source code: [lush.c](%%REPO_URL%%/1992/lush/lush.c)
 </div>
 
-[Yusuke](#yusuke) supplied a patch which makes this work with `gcc`. Due to how it works (see
-Judges' remarks in the index.html file) this will not work with `clang`.
+[Yusuke](#yusuke) supplied a patch which makes this work with `gcc`. Due to how
+it works (see [Judges' remarks in the index.html
+file](1992/lush/index.html#judges-remarks)) this will not work with `clang`.
 
 [Cody](#cody) also provided the [lush.sh](%%REPO_URL%%/1992/lush/lush.sh) script to
 demonstrate it as using make was problematic.
@@ -1964,22 +1970,22 @@ Cody made it use `fgets()` instead of `gets()`. See [FAQ 4.1  - Why were some ca
 the libc function gets&#x29;3&#x28; changed to use
 fgets&#x28;3&#x29;?](faq.html#faq4_1) for why this was done.
 
-
 NOTE: this entry cannot work with `clang` due to different compiler messages (it
-will compile fine but it won't work). See [bugs.html](bugs.html) for details.
+will compile fine but it won't work). See [1992/lush in
+bugs.html](bugs.html#1992_lush) for details.
 
 
 <div id="1992_marangon">
-## [1992/marangon](1992/marangon/index.html)
-### Source code: [marangon.c](%%REPO_URL%%/1992/marangon/marangon.c)
+## Winning entry: [1992/marangon](1992/marangon/index.html)
+### Winning entry source code: [marangon.c](%%REPO_URL%%/1992/marangon/marangon.c)
 </div>
 
 [Cody](#cody) made this more portable by changing the `void main()` to be `int main()`.
 
 
 <div id="1992_nathan">
-## [1992/nathan](1992/nathan/index.html)
-### Source code: [nathan.c](%%REPO_URL%%/1992/nathan/nathan.c)
+## Winning entry: [1992/nathan](1992/nathan/index.html)
+### Winning entry source code: [nathan.c](%%REPO_URL%%/1992/nathan/nathan.c)
 </div>
 
 [Cody](#cody) added the original file back as it was deemed that the export restrictions
@@ -1995,8 +2001,8 @@ that we suggested as well as one he provided.
 
 
 <div id="1992_vern">
-## [1992/vern](1992/vern/index.html)
-### Source code: [vern.c](%%REPO_URL%%/1992/vern/vern.c)
+## Winning entry: [1992/vern](1992/vern/index.html)
+### Winning entry source code: [vern.c](%%REPO_URL%%/1992/vern/vern.c)
 </div>
 
 [Cody](#cody) fixed an infinite loop if one were to input numbers < `0` or > `077`. The
@@ -2015,8 +2021,8 @@ it used to be.
 
 
 <div id="1992_westley">
-## [1992/westley](1992/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1992/westley/westley.c)
+## Winning entry: [1992/westley](1992/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1992/westley/westley.c)
 </div>
 
 [Cody](#cody) fixed this to work for `clang` by changing the third and fourth arg of
@@ -2067,8 +2073,8 @@ encourage you to try the original without two args :-)
 
 
 <div id="1993_ant">
-## [1993/ant](1993/ant/index.html)
-### Source code: [ant.c](%%REPO_URL%%/1993/ant/ant.c)
+## Winning entry: [1993/ant](1993/ant/index.html)
+### Winning entry source code: [ant.c](%%REPO_URL%%/1993/ant/ant.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1993/ant/try.sh) script and a data file,
@@ -2076,19 +2082,20 @@ encourage you to try the original without two args :-)
 
 
 <div id="1993_cmills">
-## [1993/cmills](1993/cmills/index.html)
-### Source code: [cmills.c](%%REPO_URL%%/1993/cmills/cmills.c)
+## Winning entry: [1993/cmills](1993/cmills/index.html)
+### Winning entry source code: [cmills.c](%%REPO_URL%%/1993/cmills/cmills.c)
 </div>
 
 [Yusuke](#yusuke) suggested that with modern systems this goes too fast so he added a call
 to `usleep(3)` in a patch he made. [Cody](#cody) made it configurable at compilation by
-using a macro. This is in the alt version which is the recommended one to try
+using a macro. This is in the [alt
+version](%%REPO_URL%%/1993/cmills/cmills.alt.c) which is the recommended one to try
 first.
 
 
 <div id="1993_dgibson">
-## [1993/dgibson](1993/dgibson/index.html)
-### Source code: [dgibson.c](%%REPO_URL%%/1993/dgibson/dgibson.c)
+## Winning entry: [1993/dgibson](1993/dgibson/index.html)
+### Winning entry source code: [dgibson.c](%%REPO_URL%%/1993/dgibson/dgibson.c)
 </div>
 
 [Cody](#cody) fixed the [dgibson.sh](%%REPO_URL%%/1993/dgibson/dgibson.sh) script to work
@@ -2099,20 +2106,21 @@ mentioned script on all the data files.
 
 
 <div id="1993_ejb">
-## [1993/ejb](1993/ejb/index.html)
-### Source code: [ejb.c](%%REPO_URL%%/1993/ejb/ejb.c)
+## Winning entry: [1993/ejb](1993/ejb/index.html)
+### Winning entry source code: [ejb.c](%%REPO_URL%%/1993/ejb/ejb.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1993/ejb/try.sh) script.
 
 
 <div id="1993_jonth">
-## [1993/jonth](1993/jonth/index.html)
-### Source code: [jonth.c](%%REPO_URL%%/1993/jonth/jonth.c)
+## Winning entry: [1993/jonth](1993/jonth/index.html)
+### Winning entry source code: [jonth.c](%%REPO_URL%%/1993/jonth/jonth.c)
 </div>
 
 Both [Cody](#cody) and [Yusuke](#yusuke) fixed this so that it will work with modern systems. Yusuke
-provided some fixes of the X code and Cody fixed the C pre-processor directives
+provided some fixes of the X code (it is not known at the time of writing this
+what changed) and Cody fixed the C pre-processor directives
 so that it would compile. It used to be that you could get away with code like:
 
 ``` <!---c-->
@@ -2126,8 +2134,8 @@ prepended to them.
 
 
 <div id="1993_leo">
-## [1993/leo](1993/leo/index.html)
-### Source code: [leo.c](%%REPO_URL%%/1993/leo/leo.c)
+## Winning entry: [1993/leo](1993/leo/index.html)
+### Winning entry source code: [leo.c](%%REPO_URL%%/1993/leo/leo.c)
 </div>
 
 [Cody](#cody) fixed this to work with modern compilers. This involved different header
@@ -2135,12 +2143,12 @@ files for functions.
 
 
 <div id="1993_lmfjyh">
-## [1993/lmfjyh](1993/lmfjyh/index.html)
-### Source code: [lmfjyh.c](%%REPO_URL%%/1993/lmfjyh/lmfjyh.c)
+## Winning entry: [1993/lmfjyh](1993/lmfjyh/index.html)
+### Winning entry source code: [lmfjyh.c](%%REPO_URL%%/1993/lmfjyh/lmfjyh.c)
 </div>
 
 [Cody](#cody) added an [alternate
-version](1993/lmfjyh/index.html#alternate-code) which does what the program did
+version](%%REPO_URL%%/1993/lmfjyh/lmfjyh.alt.c) which does what the program did
 with `gcc` < 2.3.3. See the index.html file for details and for why this was made
 the alternate version, not the actual entry.
 
@@ -2150,17 +2158,17 @@ highly unlikely).
 
 
 <div id="1993_plummer">
-## [1993/plummer](1993/plummer/index.html)
-### Source code: [plummer.c](%%REPO_URL%%/1993/plummer/plummer.c)
+## Winning entry: [1993/plummer](1993/plummer/index.html)
+### Winning entry source code: [plummer.c](%%REPO_URL%%/1993/plummer/plummer.c)
 </div>
 
 [Cody](#cody) added check for two args during a time that this was considered a
 bug to fix.
 
-Cody also added an [alternate version](%%REPO_URL%%/1993/plummer/plummer.alt.c) which uses
-`usleep(3)` so you can see what is happening with faster systems. This version
-also checks for two args and it is the one we recommend one try first. See the
-index.html files for details.
+Cody also added an [alternate version](%%REPO_URL%%/1993/plummer/plummer.alt.c)
+which uses `usleep(3)` so you can see how this entry used to look, if you're
+using a more modern system. This version also checks for two args and it is the
+one we recommend one try first. See the index.html files for details.
 
 Cody also added the [try.sh](%%REPO_URL%%/1993/plummer/try.sh) and
 [try.alt.sh](%%REPO_URL%%/1993/plummer/try.alt.sh) scripts that correspond to the original
@@ -2169,8 +2177,8 @@ of the alt one allowing one to change the amount to sleep).
 
 
 <div id="1993_rince">
-## [1993/rince](1993/rince/index.html)
-### Source code: [rince.c](%%REPO_URL%%/1993/rince/rince.c)
+## Winning entry: [1993/rince](1993/rince/index.html)
+### Winning entry source code: [rince.c](%%REPO_URL%%/1993/rince/rince.c)
 </div>
 
 [Yusuke](#yusuke) supplied a patch to get this to work in modern systems. This fix also
@@ -2187,8 +2195,8 @@ compile time. See the index.html for details.
 
 
 <div id="1993_schnitzi">
-## [1993/schnitzi](1993/schnitzi/index.html)
-### Source code: [schnitzi.c](%%REPO_URL%%/1993/schnitzi/schnitzi.c)
+## Winning entry: [1993/schnitzi](1993/schnitzi/index.html)
+### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1993/schnitzi/schnitzi.c)
 </div>
 
 [Cody](#cody) made this use `fgets(3)` not `gets(3)`. See [FAQ 4.1  - Why were some calls to
@@ -2198,8 +2206,8 @@ fgets&#x28;3&#x29;?](faq.html#faq4_1) for why this was done.
 
 
 <div id="1993_vanb">
-## [1993/vanb](1993/vanb/index.html)
-### Source code: [vanb.c](%%REPO_URL%%/1993/vanb/vanb.c)
+## Winning entry: [1993/vanb](1993/vanb/index.html)
+### Winning entry source code: [vanb.c](%%REPO_URL%%/1993/vanb/vanb.c)
 </div>
 
 [Cody](#cody) fixed this to work with `clang`. The problem was that the third arg to main()
@@ -2237,8 +2245,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1993/vanb/try.sh) script.
 
 
 <div id="1994_dodsond2">
-## [1994/dodsond2](1994/dodsond2/index.html)
-### Source code: [1994/dodsond2](%%REPO_URL%%/1994/dodsond2/dodsond2.c)
+## Winning entry: [1994/dodsond2](1994/dodsond2/index.html)
+### Winning entry source code: [1994/dodsond2](%%REPO_URL%%/1994/dodsond2/dodsond2.c)
 </div>
 
 [Cody](#cody) fixed an infinite loop that could happen when you shoot an arrow
@@ -2251,8 +2259,8 @@ if you shoot your last arrow it would not move you to the room you shoot into
 (whereas if you had more arrows it would).
 
 Cody added an alt version that allows one to cheat by specifying how many arrows
-to start with (this was for fun but it turned out a good way to debug the above
-infinite loop too which hanged the program).
+to start with (this does make for fun but it allowed to easily debug the above
+mentioned infinite loop which hanged the program).
 
 As in some places it would properly say that you have '1 arrow' or else, if you
 have any other number of arrows (including 0), it would say 'arrows', Cody fixed
@@ -2271,8 +2279,8 @@ that already existed, how many you had and how many were stolen.
 
 
 <div id="1994_horton">
-## [1994/horton](1994/horton/index.html)
-### Source code: [1994/horton](%%REPO_URL%%/1994/horton/horton.c)
+## Winning entry: [1994/horton](1994/horton/index.html)
+### Winning entry source code: [1994/horton](%%REPO_URL%%/1994/horton/horton.c)
 </div>
 
 [Cody](#cody) fixed this to check that four args were specified (at a time it
@@ -2292,8 +2300,8 @@ Finally he added the article (written by the entry's author) cited in
 
 
 <div id="1994_imc">
-## [1994/imc](1994/imc/index.html)
-### Source code: [imc.c](%%REPO_URL%%/1994/imc/imc.c)
+## Winning entry: [1994/imc](1994/imc/index.html)
+### Winning entry source code: [imc.c](%%REPO_URL%%/1994/imc/imc.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1994/imc/try.sh) script.
@@ -2305,8 +2313,8 @@ entries that actually did not work because of missing or incorrect prototypes).
 
 
 <div id="1994_ldb">
-## [1994/ldb](1994/ldb/index.html)
-### Source code: [ldb.c](%%REPO_URL%%/1994/ldb/ldb.c)
+## Winning entry: [1994/ldb](1994/ldb/index.html)
+### Winning entry source code: [ldb.c](%%REPO_URL%%/1994/ldb/ldb.c)
 </div>
 
 [Cody](#cody) fixed this so it would compile and work with modern compilers. The problem
@@ -2337,8 +2345,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1994/ldb/try.sh) script.
 
 
 <div id="1994_schnitzi">
-## [1994/schnitzi](1994/schnitzi/index.html)
-### Source code: [schnitzi.c](%%REPO_URL%%/1994/schnitzi/schnitzi.c)
+## Winning entry: [1994/schnitzi](1994/schnitzi/index.html)
+### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1994/schnitzi/schnitzi.c)
 </div>
 
 [Cody](#cody) added two alt versions, [one which uses
@@ -2346,14 +2354,14 @@ fgets_&#x28;&#x29;](%%REPO_URL%%/1994/schnitzi/schnitzi.alt.c) but when fed its 
 generate code that compile and another [one with a bigger buffer
 size](%%REPO_URL%%/1994/schnitzi/schnitzi.alt2.c) which, when fed its own source code, will
 generate compilable code but not with the same buffer size but rather the
-original buffer size. Cody explains this in the at [1994/schnitzi in
+original buffer size. Cody explains this at [1994/schnitzi in
 bugs.html](bugs.html#1994-schnitzi).
 
 The purpose for these versions it both demonstrate how the magic works behind it
 and to help others, should they wish, get the code to work with `fgets(3)`, with
 or without an increase in buffer size. Note that without this feeding longer
 files, say the index.html file, will crash the program. See [1994/schnitzi in
-bugs.html](bugs.html#1994-schnitzi) where Cody also explains the magic for more
+bugs.html](bugs.html#1994_schnitzi) where Cody also explains the magic for more
 details. Later on, if nobody takes up the task, Cody might resume it, but for
 now there is more important work to do so that the next contest can run.
 
@@ -2362,8 +2370,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1994/schnitzi/try.sh) and
 
 
 <div id="1994_shapiro">
-## [1994/shapiro](1994/shapiro/index.html)
-### Source code: [shapiro.c](%%REPO_URL%%/1994/shapiro/shapiro.c)
+## Winning entry: [1994/shapiro](1994/shapiro/index.html)
+### Winning entry source code: [shapiro.c](%%REPO_URL%%/1994/shapiro/shapiro.c)
 </div>
 
 [Cody](#cody) fixed a bug on systems where `EOF != -1`. The problem is that `getc()` and
@@ -2373,25 +2381,26 @@ assumed that `getc()` will return `-1` on EOF or error, not `EOF`. On systems
 where `EOF != -1` it could result in an infinite loop.
 
 For an interesting problem that occurred here and what was done to solve it,
-check the [bugs.html](bugs.html) file.
+check [1994/shapiro in bugs.html](bugs.html#1994_shapiro).
 
 
 <div id="1994_smr">
-## [1994/smr](1994/smr/index.html)
-### Source code: [smr.c](%%REPO_URL%%/1994/smr/smr.c)
+## Winning entry: [1994/smr](1994/smr/index.html)
+### Winning entry source code: [smr.c](%%REPO_URL%%/1994/smr/smr.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1994/smr/try.sh) script.
 
 
 <div id="1994_tvr">
-## [1994/tvr](1994/tvr/index.html)
-### Source code: [1994/tvr](%%REPO_URL%%/1994/tvr/tvr.c)
+## Winning entry: [1994/tvr](1994/tvr/index.html)
+### Winning entry source code: [1994/tvr](%%REPO_URL%%/1994/tvr/tvr.c)
 </div>
 
 [Cody](#cody) added the try scripts, four total, colour and black and white
 pairs for the original entry and the alt code. These scripts are
-[try.color.sh](%%REPO_URL%%/1994/tvr/try.color.sh), [try.bw.sh](%%REPO_URL%%/1994/tvr/try.bw.sh),
+[try.color.sh](%%REPO_URL%%/1994/tvr/try.color.sh) (color to match the author's
+remarks), [try.bw.sh](%%REPO_URL%%/1994/tvr/try.bw.sh),
 [try.alt.color.sh](%%REPO_URL%%/1994/tvr/try.alt.color.sh) and
 [try.alt.bw.sh](%%REPO_URL%%/1994/tvr/try.alt.bw.sh), respectively. The scripts go through
 each mode allowed with two sizes, 128 and 256, allowing one to quit or skip each
@@ -2409,8 +2418,8 @@ also changed to use `fgets(3)`.
 
 
 <div id="1994_weisberg">
-## [1994/weisberg](1994/weisberg/index.html)
-### Source code: [weisberg.c](%%REPO_URL%%/1994/weisberg/weisberg.c)
+## Winning entry: [1994/weisberg](1994/weisberg/index.html)
+### Winning entry source code: [weisberg.c](%%REPO_URL%%/1994/weisberg/weisberg.c)
 </div>
 
 [Cody](#cody) changed the Makefile to make this program more user friendly and easier to
@@ -2426,8 +2435,8 @@ primes.
 
 
 <div id="1994_westley">
-## [1994/westley](1994/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1994/westley/westley.c)
+## Winning entry: [1994/westley](1994/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1994/westley/westley.c)
 </div>
 
 [Cody](#cody) converted the spoiler compiler options (provided by the author) to be
@@ -2435,25 +2444,26 @@ compiler commands and added a script [try.sh](%%REPO_URL%%/1994/westley/try.sh) 
 automate the spoiler commands to make it easier to see the game in action from
 start to finish.
 
-Cody also added the alternate version that will look fine on terminals not set
-to 80 columns and the [try.alt.sh](%%REPO_URL%%/1994/westley/try.alt.sh) script to automate
-the play along the lines of the [try.sh](%%REPO_URL%%/1994/westley/try.sh) script.
+Cody also added the [alternate version](%%REPO_URL%%/1994/westley/westley.alt.c)
+that will look fine on terminals not set to 80 columns and the
+[try.alt.sh](%%REPO_URL%%/1994/westley/try.alt.sh) script to automate the play
+along the lines of the [try.sh](%%REPO_URL%%/1994/westley/try.sh) script.
 
 
 <div id="1995">
-# 1995
+# [1995](1995/index.html)
 </div>
 
 
 <div id="1995_cdua">
-## [1995/cdua](1995/cdua/index.html)
-### Source code: [cdua.c](%%REPO_URL%%/1995/cdua/cdua.c)
+## Winning entry: [1995/cdua](1995/cdua/index.html)
+### Winning entry source code: [cdua.c](%%REPO_URL%%/1995/cdua/cdua.c)
 </div>
 
 [Cody](#cody) fixed this so that it would work with macOS. Once it could compile it
 additionally segfaulted under macOS which he also fixed.
 
-Cody also provided the [Alternate code](%%REPO_URL%%/1995/cdua/cdua.alt.c) for fun :-) ) (in
+Cody also provided the [alternate code](%%REPO_URL%%/1995/cdua/cdua.alt.c) for fun :-) ) (in
 particular to make it easier to see the program do what it does in systems that
 are too fast ... if there is such a thing anyway :-) ). See the index.html for
 details on this.
@@ -2467,8 +2477,8 @@ function as the error message claims.
 
 
 <div id="1995_dodsond1">
-## [1995/dodsond1](1995/dodsond1/index.html)
-### Source code: [dodsond1.c](%%REPO_URL%%/1995/dodsond1/dodsond1.c)
+## Winning entry: [1995/dodsond1](1995/dodsond1/index.html)
+### Winning entry source code: [dodsond1.c](%%REPO_URL%%/1995/dodsond1/dodsond1.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/dodsond1/try.sh) script that uses the text file he
@@ -2476,16 +2486,16 @@ provided which is input we suggested one try with the entry.
 
 
 <div id="1995_esde">
-## [1995/esde](1995/esde/index.html)
-### Source code: [esde.c](%%REPO_URL%%/1995/esde/esde.c)
+## Winning entry: [1995/esde](1995/esde/index.html)
+### Winning entry source code: [esde.c](%%REPO_URL%%/1995/esde/esde.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/esde/try.sh) script.
 
 
 <div id="1995_garry">
-## [1995/garry](1995/garry/index.html)
-### Source code: [garry.c](%%REPO_URL%%/1995/garry/garry.c)
+## Winning entry: [1995/garry](1995/garry/index.html)
+### Winning entry source code: [garry.c](%%REPO_URL%%/1995/garry/garry.c)
 </div>
 
 [Cody](#cody) fixed the alt code so that it will compile with modern compilers. The
@@ -2503,16 +2513,16 @@ added.
 
 
 <div id="1995_heathbar">
-## [1995/heathbar](1995/heathbar/index.html)
-### Source code: [1995/heathbar](%%REPO_URL%%/1995/heathbar/heathbar.c)
+## Winning entry: [1995/heathbar](1995/heathbar/index.html)
+### Winning entry source code: [1995/heathbar](%%REPO_URL%%/1995/heathbar/heathbar.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/heathbar/try.sh) script.
 
 
 <div id="1995_leo">
-## [1995/leo](1995/leo/index.html)
-### Source code: [leo.c](%%REPO_URL%%/1995/leo/leo.c)
+## Winning entry: [1995/leo](1995/leo/index.html)
+### Winning entry source code: [leo.c](%%REPO_URL%%/1995/leo/leo.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/leo/try.sh) script.
@@ -2522,8 +2532,8 @@ by the author, putting it in [spoiler1.html](1995/leo/spoiler1.html).
 
 
 <div id="1995_makarios">
-## [1995/makarios](1995/makarios/index.html)
-### Source code: [makarios.c](%%REPO_URL%%/1995/makarios/makarios.c)
+## Winning entry: [1995/makarios](1995/makarios/index.html)
+### Winning entry source code: [makarios.c](%%REPO_URL%%/1995/makarios/makarios.c)
 </div>
 
 [Cody](#cody) fixed this so that it will compile with versions of `clang` that has a defect
@@ -2533,24 +2543,24 @@ calls which has the four args.
 
 
 <div id="1995_savastio">
-## [1995/savastio](1995/savastio/index.html)
-### Source code: [savastio.c](%%REPO_URL%%/1995/savastio/savastio.c)
+## Winning entry: [1995/savastio](1995/savastio/index.html)
+### Winning entry source code: [savastio.c](%%REPO_URL%%/1995/savastio/savastio.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/savastio/try.sh) script.
 
 
 <div id="1995_schnitzi">
-## [1995/schnitzi](1995/schnitzi/index.html)
-### Source code: [schnitzi.c](%%REPO_URL%%/1995/schnitzi/schnitzi.c)
+## Winning entry: [1995/schnitzi](1995/schnitzi/index.html)
+### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1995/schnitzi/schnitzi.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/schnitzi/try.sh) script.
 
 
 <div id="1995_vanschnitz">
-## [1995/vanschnitz](1995/vanschnitz/index.html)
-### Source code: [vanschnitz.c](%%REPO_URL%%/1995/vanschnitz/vanschnitz.c)
+## Winning entry: [1995/vanschnitz](1995/vanschnitz/index.html)
+### Winning entry source code: [vanschnitz.c](%%REPO_URL%%/1995/vanschnitz/vanschnitz.c)
 </div>
 
 [Cody](#cody) added the authors' [spoiler as a C
@@ -2563,13 +2573,13 @@ Cody also added the [try.sh](%%REPO_URL%%/1995/vanschnitz/try.sh) script.
 
 
 <div id="1996">
-# 1996
+# [1996](1996/index.html)
 </div>
 
 
 <div id="1996_august">
-## [1996/august](1996/august/index.html)
-### Source code: [august.c](%%REPO_URL%%/1996/august/august.c)
+## Winning entry: [1996/august](1996/august/index.html)
+### Winning entry source code: [august.c](%%REPO_URL%%/1996/august/august.c)
 </div>
 
 [Cody](#cody) fixed a segfault in this program that prevented it from working right and
@@ -2587,8 +2597,8 @@ applied.
 
 
 <div id="1996_dalbec">
-## [1996/dalbec](1996/dalbec/index.html)
-### Source code: [dalbec.c](%%REPO_URL%%/1996/dalbec/dalbec.c)
+## Winning entry: [1996/dalbec](1996/dalbec/index.html)
+### Winning entry source code: [dalbec.c](%%REPO_URL%%/1996/dalbec/dalbec.c)
 </div>
 
 [Cody](#cody) proposed a fix for this to compile with `clang` and Landon implemented it
@@ -2609,8 +2619,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1996/dalbec/try.sh) script.
 
 
 <div id="1996_eldby">
-## [1996/eldby](1996/eldby/index.html)
-### Source code: [eldby.c](%%REPO_URL%%/1996/eldby/eldby.c)
+## Winning entry: [1996/eldby](1996/eldby/index.html)
+### Winning entry source code: [eldby.c](%%REPO_URL%%/1996/eldby/eldby.c)
 </div>
 
 [Cody](#cody) provided an [alternate version](%%REPO_URL%%/1996/eldby/eldby.alt.c) which uses
@@ -2622,8 +2632,8 @@ these reasons.
 
 
 <div id="1996_gandalf">
-## [1996/gandalf](1996/gandalf/index.html)
-### Source code: [gandalf.c](%%REPO_URL%%/1996/gandalf/gandalf.c)
+## Winning entry: [1996/gandalf](1996/gandalf/index.html)
+### Winning entry source code: [gandalf.c](%%REPO_URL%%/1996/gandalf/gandalf.c)
 </div>
 
 [Cody](#cody) fixed this to compile and work with modern systems. As he loved the
@@ -2639,16 +2649,16 @@ BTW: it is perilous to try the patience of
 
 
 <div id="1996_huffman">
-## [1996/huffman](1996/huffman/index.html)
-### Source code: [huffman.c](%%REPO_URL%%/1996/huffman/huffman.c)
+## Winning entry: [1996/huffman](1996/huffman/index.html)
+### Winning entry source code: [huffman.c](%%REPO_URL%%/1996/huffman/huffman.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1996/huffman/try.sh) script.
 
 
 <div id="1996_jonth">
-## [1996/jonth](1996/jonth/index.html)
-### Source code: [jonth.c](%%REPO_URL%%/1996/jonth/jonth.c)
+## Winning entry: [1996/jonth](1996/jonth/index.html)
+### Winning entry source code: [jonth.c](%%REPO_URL%%/1996/jonth/jonth.c)
 </div>
 
 [Cody](#cody) fixed this to not segfault under macOS. The problem was that the function
@@ -2659,16 +2669,16 @@ NOTE: if there is no X server running this program will still crash.
 
 
 <div id="1996_rcm">
-## [1996/rcm](1996/rcm/index.html)
-### Source code: [rcm.c](%%REPO_URL%%/1996/rcm/rcm.c)
+## Winning entry: [1996/rcm](1996/rcm/index.html)
+### Winning entry source code: [rcm.c](%%REPO_URL%%/1996/rcm/rcm.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1996/rcm/try.sh) script.
 
 
 <div id="1996_schweikh1">
-## [1996/schweikh1](1996/schweikh1/index.html)
-### Source code: [schweikh1.c](%%REPO_URL%%/1996/schweikh1/schweikh1.c)
+## Winning entry: [1996/schweikh1](1996/schweikh1/index.html)
+### Winning entry source code: [schweikh1.c](%%REPO_URL%%/1996/schweikh1/schweikh1.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1996/schweikh1/try.sh) script.
@@ -2683,8 +2693,8 @@ the Makefile despite the fact that very few probably use Solaris nowadays.
 
 
 <div id="1996_schweikh2">
-## [1996/schweikh2](1996/schweikh2/index.html)
-### Source code: [schweikh2.c](%%REPO_URL%%/1996/schweikh2/schweikh2.c)
+## Winning entry: [1996/schweikh2](1996/schweikh2/index.html)
+### Winning entry source code: [schweikh2.c](%%REPO_URL%%/1996/schweikh2/schweikh2.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1996/schweikh2/try.sh) script with a few commands to try
@@ -2694,7 +2704,7 @@ loop so having it in a script is less desired).
 
 
 <div id="1996_schweikh3">
-## [1996/schweikh3](1996/schweikh3/index.html)
+## Winning entry: [1996/schweikh3](1996/schweikh3/index.html)
 ## Source code: [schweikh3.c](%%REPO_URL%%/1996/schweikh3/schweikh3.c)
 </div>
 
@@ -2704,8 +2714,8 @@ running a more complicated command: now one can just run `make`.
 
 
 <div id="1996_westley">
-## [1996/westley](1996/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/1996/westley/westley.c)
+## Winning entry: [1996/westley](1996/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/1996/westley/westley.c)
 </div>
 
 [Cody](#cody) fixed a segfault in this entry as well as it displaying environmental
@@ -2728,13 +2738,13 @@ provided by the author, Cody added '.sh' to the `clock[1-3].sh` scripts.
 
 
 <div id="1998">
-# 1998
+# [1998](1998/index.html)
 </div>
 
 
 <div id="1998_banks">
-## [1998/banks](1998/banks/index.html)
-### Source code: [/banks.c](%%REPO_URL%%/1998/banks/banks.c)
+## Winning entry: [1998/banks](1998/banks/index.html)
+### Winning entry source code: [/banks.c](%%REPO_URL%%/1998/banks/banks.c)
 </div>
 
 [Cody](#cody) improved the Makefile to allow for easier redefining the control
@@ -2751,8 +2761,8 @@ you can configure them all in both builds it shouldn't matter.
 
 
 <div id="1998_bas1">
-## [1998/bas1](1998/bas1/index.html)
-### Source code: [bas1.c](%%REPO_URL%%/1998/bas1/bas1.c)
+## Winning entry: [1998/bas1](1998/bas1/index.html)
+### Winning entry source code: [bas1.c](%%REPO_URL%%/1998/bas1/bas1.c)
 </div>
 
 [Cody](#cody), out of an abundance of caution, added a second arg to `main()` as some
@@ -2767,8 +2777,8 @@ program.
 
 
 <div id="1998_bas2">
-## [1998/bas2](1998/bas2/index.html)
-### Source code: [bas2.c](%%REPO_URL%%/1998/bas2/bas2.c)
+## Winning entry: [1998/bas2](1998/bas2/index.html)
+### Winning entry source code: [bas2.c](%%REPO_URL%%/1998/bas2/bas2.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1998/bas2/try.sh) script which runs some default actions
@@ -2776,8 +2786,8 @@ as well as allowing one to pass in different file names or strings.
 
 
 <div id="1998_chaos">
-## [1998/chaos](1998/chaos/index.html)
-### Source code: [chaos.c](%%REPO_URL%%/1998/chaos/chaos.c)
+## Winning entry: [1998/chaos](1998/chaos/index.html)
+### Winning entry source code: [chaos.c](%%REPO_URL%%/1998/chaos/chaos.c)
 </div>
 
 [Cody](#cody) added a call to `endwin()` to restore terminal sanity (echo etc.) when
@@ -2789,8 +2799,8 @@ prior to each run.
 
 
 <div id="1998_df">
-## [1998/df](1998/df/index.html)
-### Source code: [df.c](%%REPO_URL%%/1998/df/df.c)
+## Winning entry: [1998/df](1998/df/index.html)
+### Winning entry source code: [df.c](%%REPO_URL%%/1998/df/df.c)
 </div>
 
 [Cody](#cody) changed a `int *` used for `fopen(3)` to be a `FILE *` to be more correct
@@ -2807,8 +2817,8 @@ a way to cheat very easily. Can you figure out how?
 
 
 <div id="1998_dlowe">
-## [1998/dlowe](1998/dlowe/index.html)
-### Source code: [dlowe.c](%%REPO_URL%%/1998/dlowe/dlowe.c)
+## Winning entry: [1998/dlowe](1998/dlowe/index.html)
+### Winning entry source code: [dlowe.c](%%REPO_URL%%/1998/dlowe/dlowe.c)
 </div>
 
 [Cody](#cody) made the program more portable by changing the void return type of `main()`
@@ -2823,8 +2833,8 @@ pootify scripts.
 
 
 <div id="1998_dloweneil">
-## [c1998/dloweneil](1998/dloweneil/index.html)
-### Source code: [dloweneil.c](%%REPO_URL%%/1998/dloweneil/dloweneil.c)
+## Winning entry: [c1998/dloweneil](1998/dloweneil/index.html)
+### Winning entry source code: [dloweneil.c](%%REPO_URL%%/1998/dloweneil/dloweneil.c)
 </div>
 
 [Cody](#cody) added [alt code](%%REPO_URL%%/1998/dloweneil/dloweneil.alt.c) which has vi(m) movement
@@ -2833,16 +2843,16 @@ space) keys as well as allowing one to quit the game.
 
 
 <div id="1998_dorssel">
-## [1998/dorssel](1998/dorssel/index.html)
-### Source code: [dorssel.c](%%REPO_URL%%/1998/dorssel/dorssel.c)
+## Winning entry: [1998/dorssel](1998/dorssel/index.html)
+### Winning entry source code: [dorssel.c](%%REPO_URL%%/1998/dorssel/dorssel.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1998/dorssel/try.sh) script.
 
 
 <div id="1998_fanf">
-## [1998/fanf.html](1998/fanf/index.html)
-### Source code: [fanf.c](%%REPO_URL%%/1998/fanf/fanf.c)
+## Winning entry: [1998/fanf.html](1998/fanf/index.html)
+### Winning entry source code: [fanf.c](%%REPO_URL%%/1998/fanf/fanf.c)
 </div>
 
 [Cody](#cody) fixed this to compile. The problem was the intermediate steps to get to the
@@ -2865,8 +2875,8 @@ of the expressions that we selected.
 
 
 <div id="1998_schnitzi">
-## [1998/schnitzi](1998/schnitzi/index.html)
-### Source code: [schnitzi.c](%%REPO_URL%%/1998/schnitzi/schnitzi.c)
+## Winning entry: [1998/schnitzi](1998/schnitzi/index.html)
+### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1998/schnitzi/schnitzi.c)
 </div>
 
 [Cody](#cody) fixed invalid data types which prevented this entry from working, causing a
@@ -2893,8 +2903,8 @@ commands that we recommended as well as some added by him.
 
 
 <div id="1998_schweikh1">
-## [index.html](1998/schweikh1/index.html)
-### Source code: [1998/schweikh1](%%REPO_URL%%/1998/schweikh1/schweikh1.c)
+## Winning entry: [index.html](1998/schweikh1/index.html)
+### Winning entry source code: [1998/schweikh1](%%REPO_URL%%/1998/schweikh1/schweikh1.c)
 </div>
 
 [Cody](#cody) fixed this for modern systems (it did not work at all) and added an
@@ -2954,8 +2964,8 @@ in the file [charcount.pl](%%REPO_URL%%/1998/schweikh1/charcount.pl).
 
 
 <div id="1998_schweikh2">
-## [1998/schweikh2](1998/schweikh2/index.html)
-### Source code: [schweikh2.c](%%REPO_URL%%/1998/schweikh2/schweikh2.c)
+## Winning entry: [1998/schweikh2](1998/schweikh2/index.html)
+### Winning entry source code: [schweikh2.c](%%REPO_URL%%/1998/schweikh2/schweikh2.c)
 </div>
 
 [Cody](#cody) fixed the code to not trigger an internal compiler error in `gcc`:
@@ -2980,8 +2990,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1998/schweikh2/try.sh) script.
 
 
 <div id="1998_schweikh3">
-## [1998/schweikh3](1998/schweikh3/index.html)
-### Source code: [schweikh3.c](%%REPO_URL%%/1998/schweikh3/schweikh3.c)
+## Winning entry: [1998/schweikh3](1998/schweikh3/index.html)
+### Winning entry source code: [schweikh3.c](%%REPO_URL%%/1998/schweikh3/schweikh3.c)
 </div>
 
 [Cody](#cody) added the [alternate code](1998/schweikh3/index.html#alternate-code) which allows one
@@ -3018,8 +3028,8 @@ information for the entry. It has not been added to any JSON file.
 
 
 <div id="1998_tomtorfs">
-## [1998/tomtorfs](1998/tomtorfs/index.html)
-### Source code: /tomtorfs.c](%%REPO_URL%%/1998/tomtorfs/tomtorfs.c)
+## Winning entry: [1998/tomtorfs](1998/tomtorfs/index.html)
+### Winning entry source code: /tomtorfs.c](%%REPO_URL%%/1998/tomtorfs/tomtorfs.c)
 </div>
 
 [Cody](#cody) fixed the assumption that `EOF` is `-1` (the author noted that it assumes
@@ -3036,13 +3046,13 @@ commands that we recommended.
 
 
 <div id="2000">
-# 2000
+# [2000](2000/index.html)
 </div>
 
 
 <div id="2000_anderson">
-## [2000/anderson](2000/anderson/index.html)
-### Source code: [anderson.c](%%REPO_URL%%/2000/anderson//anderson.c)
+## Winning entry: [2000/anderson](2000/anderson/index.html)
+### Winning entry source code: [anderson.c](%%REPO_URL%%/2000/anderson//anderson.c)
 </div>
 
 [Cody](#cody) changed this entry to use `fgets(3)` instead of `gets(3)`.
@@ -3055,8 +3065,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2000/anderson/try.sh) script.
 
 
 <div id="2000_bmeyer">
-## [2000/bmeyer](2000/bmeyer/index.html)
-### Source code: [bmeyer.c](%%REPO_URL%%/2000/bmeyer//bmeyer.c)
+## Winning entry: [2000/bmeyer](2000/bmeyer/index.html)
+### Winning entry source code: [bmeyer.c](%%REPO_URL%%/2000/bmeyer//bmeyer.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2000/bmeyer/try.sh) script with some improvements to the
@@ -3065,8 +3075,8 @@ terminal.
 
 
 <div id="2000_briddlebane">
-## [2000/briddlebane](2000/briddlebane/index.html)
-### Source code: [briddlebane.c](%%REPO_URL%%/2000/briddlebane//briddlebane.c)
+## Winning entry: [2000/briddlebane](2000/briddlebane/index.html)
+### Winning entry source code: [briddlebane.c](%%REPO_URL%%/2000/briddlebane//briddlebane.c)
 </div>
 
 [Cody](#cody) fixed this to compile in systems that require one to explicitly link in
@@ -3077,8 +3087,8 @@ feeling a bit too confident, cocky or even happy :-)
 
 
 <div id="2000_dhyang">
-## [2000/dhyang](2000/dhyang/index.html)
-### Source code: [dhyang.c](%%REPO_URL%%/2000/dhyang//dhyang.c)
+## Winning entry: [2000/dhyang](2000/dhyang/index.html)
+### Winning entry source code: [dhyang.c](%%REPO_URL%%/2000/dhyang//dhyang.c)
 </div>
 
 [Cody](#cody) made this more portable by changing the `void main` to `int main`.
@@ -3087,8 +3097,8 @@ He also added the [try.sh](%%REPO_URL%%/2000/dhyang/try.sh) script.
 
 
 <div id="2000_dlowe">
-## [2000/dlowe](2000/dlowe/index.html)
-### Source code: [dlowe.c](%%REPO_URL%%/2000/dlowe//dlowe.c)
+## Winning entry: [2000/dlowe](2000/dlowe/index.html)
+### Winning entry source code: [dlowe.c](%%REPO_URL%%/2000/dlowe//dlowe.c)
 </div>
 
 [Cody](#cody) fixed this to compile with more recent perl versions; the symbol that's now
@@ -3099,8 +3109,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2000/dlowe/try.sh) script.
 
 
 <div id="2000_jarijyrki">
-## [2000/jarijyrki](2000/jarijyrki/index.html)
-### Source code: [jarijyrki.c](%%REPO_URL%%/2000/jarijyrki//jarijyrki.c)
+## Winning entry: [2000/jarijyrki](2000/jarijyrki/index.html)
+### Winning entry source code: [jarijyrki.c](%%REPO_URL%%/2000/jarijyrki//jarijyrki.c)
 </div>
 
 [Cody](#cody) made it easier to compile this in some cases by adding `X11/` to the
@@ -3108,8 +3118,8 @@ includes of `Xlib.h` and `keysym.h`.
 
 
 <div id="2000_natori">
-## [2000/natori](2000/natori/index.html)
-### Source code: [natori.c](%%REPO_URL%%/2000/natori//natori.c)
+## Winning entry: [2000/natori](2000/natori/index.html)
+### Winning entry source code: [natori.c](%%REPO_URL%%/2000/natori//natori.c)
 </div>
 
 [Cody](#cody) fixed this for modern compilers. Depending on the compiler it would either
@@ -3136,8 +3146,8 @@ more confusing (even if not confusing).
 
 
 <div id="2000_primenum">
-## [2000/primenum](2000/primenum/index.html)
-### Source code: [primenum.c](%%REPO_URL%%/2000/primenum//primenum.c)
+## Winning entry: [2000/primenum](2000/primenum/index.html)
+### Winning entry source code: [primenum.c](%%REPO_URL%%/2000/primenum//primenum.c)
 </div>
 
 [Cody](#cody) made this more portable by changing the `void main` to `int main`.
@@ -3146,16 +3156,16 @@ Cody also added the [try.sh](%%REPO_URL%%/2000/primenum/try.sh) script.
 
 
 <div id="2000_rince">
-## [2000/rince](2000/rince/index.html)
-### Source code: [rince.c](%%REPO_URL%%/2000/rince//rince.c)
+## Winning entry: [2000/rince](2000/rince/index.html)
+### Winning entry source code: [rince.c](%%REPO_URL%%/2000/rince//rince.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2000/rince/try.sh) script.
 
 
 <div id="2000_robison">
-## [2000/robison](2000/robison/index.html)
-### Source code: [robison.c](%%REPO_URL%%/2000/robison//robison.c)
+## Winning entry: [2000/robison](2000/robison/index.html)
+### Winning entry source code: [robison.c](%%REPO_URL%%/2000/robison//robison.c)
 </div>
 
 [Cody](#cody) fixed an infinite loop that occurred if invalid input was entered, flooding
@@ -3171,16 +3181,16 @@ on it to assign to the `int`s, much like with `1987/lievaart`. The strings are
 
 
 <div id="2000_schneiderwent">
-## [2000/schneiderwent](2000/schneiderwent/index.html)
-### Source code: [schneiderwent.c](%%REPO_URL%%/2000/schneiderwent//schneiderwent.c)
+## Winning entry: [2000/schneiderwent](2000/schneiderwent/index.html)
+### Winning entry source code: [schneiderwent.c](%%REPO_URL%%/2000/schneiderwent//schneiderwent.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2000/schneiderwent/try.sh) script.
 
 
 <div id="2000_thadgavin">
-## [2000/thadgavin](2000/thadgavin/index.html)
-### Source code: [thadgavin.c](%%REPO_URL%%/2000/thadgavin//thadgavin.c)
+## Winning entry: [2000/thadgavin](2000/thadgavin/index.html)
+### Winning entry source code: [thadgavin.c](%%REPO_URL%%/2000/thadgavin//thadgavin.c)
 </div>
 
 [Cody](#cody) fixed the code and added an appropriate make rule so that the
@@ -3225,8 +3235,8 @@ other version in.
 
 
 <div id="2000_tomx">
-## [2000/tomx](2000/tomx/index.html)
-### Source code: [tomx.c](%%REPO_URL%%/2000/tomx//tomx.c)
+## Winning entry: [2000/tomx](2000/tomx/index.html)
+### Winning entry source code: [tomx.c](%%REPO_URL%%/2000/tomx//tomx.c)
 </div>
 
 [Cody](#cody) added the [alt code](2000/tomx/index.html#alternate-code) based on the
@@ -3239,13 +3249,13 @@ details) the source code is now executable by default.
 
 
 <div id="2001">
-# 2001
+# [2001](2001/index.html)
 </div>
 
 
 <div id="2001_anonymous">
-## [2001/anonymous](2001/anonymous/index.html)
-### Source code: [anonymous.c](%%REPO_URL%%/2001/anonymous//anonymous.c)
+## Winning entry: [2001/anonymous](2001/anonymous/index.html)
+### Winning entry source code: [anonymous.c](%%REPO_URL%%/2001/anonymous//anonymous.c)
 </div>
 
 [Cody](#cody) fixed both the supplementary program and the program itself (both of which
@@ -3334,8 +3344,8 @@ it will at least run the supplementary program as a 64-bit program directly.
 
 
 <div id="2001_bellard">
-## [2001/bellard](2001/bellard/index.html)
-### Source code: [bellard.c](%%REPO_URL%%/2001/bellard//bellard.c)
+## Winning entry: [2001/bellard](2001/bellard/index.html)
+### Winning entry source code: [bellard.c](%%REPO_URL%%/2001/bellard//bellard.c)
 </div>
 
 [Cody](#cody) fixed this to compile with `clang` but according to the author this will not
@@ -3383,8 +3393,8 @@ by Yusuke.
 
 
 <div id="2001_cheong">
-## [2001/cheong](2001/cheong/index.html)
-### Source code: [cheong.c](%%REPO_URL%%/2001/cheong//cheong.c)
+## Winning entry: [2001/cheong](2001/cheong/index.html)
+### Winning entry source code: [cheong.c](%%REPO_URL%%/2001/cheong//cheong.c)
 </div>
 
 [Cody](#cody) fixed this to work with `clang` by adding another function that is allowed to
@@ -3399,8 +3409,8 @@ He also fixed it to check the number of args.
 
 
 <div id="2001_coupard">
-## [2001/coupard](2001/coupard/index.html)
-### Source code: [coupard.c](%%REPO_URL%%/2001/coupard//coupard.c)
+## Winning entry: [2001/coupard](2001/coupard/index.html)
+### Winning entry source code: [coupard.c](%%REPO_URL%%/2001/coupard//coupard.c)
 </div>
 
 [Cody](#cody) added a value to `return` in `main()` to make it more portable.
@@ -3432,8 +3442,8 @@ Cody added the [try.sh](%%REPO_URL%%/2001/coupard/try.sh).
 
 
 <div id="2001_ctk">
-## [2001/ctk](2001/ctk/index.html)
-### Source code: [ctk.c](%%REPO_URL%%/2001/ctk//ctk.c)
+## Winning entry: [2001/ctk](2001/ctk/index.html)
+### Winning entry source code: [ctk.c](%%REPO_URL%%/2001/ctk//ctk.c)
 </div>
 
 The ANSI escape codes were no longer valid but [Yusuke](#yusuke) provided a patch to fix
@@ -3449,8 +3459,8 @@ vi(m) movement keys.
 
 
 <div id="2001_dgbeards">
-## [2001/dgbeards](2001/dgbeards/index.html)
-### Source code: [dgbeards.c](%%REPO_URL%%/2001/dgbeards//dgbeards.c)
+## Winning entry: [2001/dgbeards](2001/dgbeards/index.html)
+### Winning entry source code: [dgbeards.c](%%REPO_URL%%/2001/dgbeards//dgbeards.c)
 </div>
 
 The author provided two changes: one to speed it up and one to make it not crash
@@ -3463,8 +3473,8 @@ very quickly. Do you know what it is?
 
 
 <div id="2001_herrmann1">
-## [2001/herrmann1](2001/herrmann1/index.html)
-### Source code: [herrmann1.c](%%REPO_URL%%/2001/herrmann1//herrmann1.c)
+## Winning entry: [2001/herrmann1](2001/herrmann1/index.html)
+### Winning entry source code: [herrmann1.c](%%REPO_URL%%/2001/herrmann1//herrmann1.c)
 </div>
 
 [Cody](#cody) fixed this so that the when compiling the code the program is not executed
@@ -3490,8 +3500,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2001/herrmann1/try.sh) script.
 
 
 <div id="2001_herrmann2">
-## [2001/herrmann2](2001/herrmann2/index.html)
-### Source code: [herrmann2.c](%%REPO_URL%%/2001/herrmann2//herrmann2.c)
+## Winning entry: [2001/herrmann2](2001/herrmann2/index.html)
+### Winning entry source code: [herrmann2.c](%%REPO_URL%%/2001/herrmann2//herrmann2.c)
 </div>
 
 [Cody](#cody) fixed this to work with both 64-bit and 32-bit compilers by changing most
@@ -3508,8 +3518,8 @@ added to `.gitignore` by accident) but Cody restored it from the archive.
 
 
 <div id="2001_kev">
-## [2001/kev](2001/kev/index.html)
-### Source code: [kev.c](%%REPO_URL%%/2001/kev//kev.c)
+## Winning entry: [2001/kev](2001/kev/index.html)
+### Winning entry source code: [kev.c](%%REPO_URL%%/2001/kev//kev.c)
 </div>
 
 [Cody](#cody) improved the Makefile to allow one to more easily set up the port,
@@ -3531,8 +3541,8 @@ without having to sacrifice playability by running `make`.
 
 
 <div id="2001_ollinger">
-## [2001/ollinger](2001/ollinger/index.html)
-### Source code: [ollinger.c](%%REPO_URL%%/2001/ollinger//ollinger.c)
+## Winning entry: [2001/ollinger](2001/ollinger/index.html)
+### Winning entry source code: [ollinger.c](%%REPO_URL%%/2001/ollinger//ollinger.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2001/ollinger/try.sh) script.
@@ -3543,8 +3553,8 @@ worse.
 
 
 <div id="2001_schweikh">
-## [2001/schweikh](2001/schweikh/index.html)
-### Source code: [schweikh.c](%%REPO_URL%%/2001/schweikh//schweikh.c)
+## Winning entry: [2001/schweikh](2001/schweikh/index.html)
+### Winning entry source code: [schweikh.c](%%REPO_URL%%/2001/schweikh//schweikh.c)
 </div>
 
 [Cody](#cody) fixed this to not crash if not enough args as this was not documented by
@@ -3555,8 +3565,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2001/schweikh/try.sh) script.
 
 
 <div id="2001_westley">
-## [2001/westley](2001/westley/index.html)
-### Source code: [westley.c](%%REPO_URL%%/2001/westley//westley.c)
+## Winning entry: [2001/westley](2001/westley/index.html)
+### Winning entry source code: [westley.c](%%REPO_URL%%/2001/westley//westley.c)
 </div>
 
 [Cody](#cody) added the script [try.sh](%%REPO_URL%%/2001/westley/try.sh) to automate a heap of commands
@@ -3566,21 +3576,21 @@ described in the index.html, based on the author's remarks.
 
 
 <div id="2004">
-# 2004
+# [2004](2004/index.html)
 </div>
 
 
 <div id="2004_anonymous">
-## [2004/anonymous](2004/anonymous/index.html)
-### Source code: [anonymous.c](%%REPO_URL%%/2004/anonymous//anonymous.c)
+## Winning entry: [2004/anonymous](2004/anonymous/index.html)
+### Winning entry source code: [anonymous.c](%%REPO_URL%%/2004/anonymous//anonymous.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/anonymous/try.sh) script.
 
 
 <div id="2004_arachnid">
-## [2004/arachnid](2004/arachnid/index.html)
-### Source code: [arachnid.c](%%REPO_URL%%/2004/arachnid//arachnid.c)
+## Winning entry: [2004/arachnid](2004/arachnid/index.html)
+### Winning entry source code: [arachnid.c](%%REPO_URL%%/2004/arachnid//arachnid.c)
 </div>
 
 [Cody](#cody) added an [alternate version](2004/arachnid/index.html#alternate-code) which
@@ -3595,8 +3605,8 @@ browsers knowing what to do with it.
 
 
 <div id="2004_burley">
-## [2004/burley](2004/burley/index.html)
-### Source code: [burley.c](%%REPO_URL%%/2004/burley//burley.c)
+## Winning entry: [2004/burley](2004/burley/index.html)
+### Winning entry source code: [burley.c](%%REPO_URL%%/2004/burley//burley.c)
 </div>
 
 [Cody](#cody) fixed this to compile with `clang` and to work with both `gcc` and
@@ -3633,8 +3643,8 @@ this, forcing `-O0`.
 
 
 <div id="2004_gavare">
-## [2004/gavare](2004/gavare/index.html)
-### Source code: [gavare.c](%%REPO_URL%%/2004/gavare//gavare.c)
+## Winning entry: [2004/gavare](2004/gavare/index.html)
+### Winning entry source code: [gavare.c](%%REPO_URL%%/2004/gavare//gavare.c)
 </div>
 
 [Cody](#cody) added three different [alternate
@@ -3651,8 +3661,8 @@ entry](https://gavare.se/ioccc/ioccc_gavare.c.html).
 
 
 <div id="2004_gavin">
-## [2004/gavin](2004/gavin/index.html)
-### Source code: [gavin.c](%%REPO_URL%%/2004/gavin//gavin.c)
+## Winning entry: [2004/gavin](2004/gavin/index.html)
+### Winning entry source code: [gavin.c](%%REPO_URL%%/2004/gavin//gavin.c)
 </div>
 
 [Cody](#cody) provided the [alt code](2004/gavin/index.html#alternate-code) for
@@ -3668,8 +3678,8 @@ files and causing `make clobber` to wipe some of them out.
 
 
 <div id="2004_hibachi">
-## [2004/hibachi](2004/hibachi/index.html)
-### Source code: [hibachi.c](%%REPO_URL%%/2004/hibachi//hibachi.c)
+## Winning entry: [2004/hibachi](2004/hibachi/index.html)
+### Winning entry source code: [hibachi.c](%%REPO_URL%%/2004/hibachi//hibachi.c)
 </div>
 
 [Cody](#cody) fixed a bunch of links in the index.html provided with the entry
@@ -3680,16 +3690,16 @@ Wayback Machine.
 
 
 <div id="2004_hoyle">
-## [2004/hoyle](2004/hoyle/index.html)
-### Source code: [hoyle.c](%%REPO_URL%%/2004/hoyle//hoyle.c)
+## Winning entry: [2004/hoyle](2004/hoyle/index.html)
+### Winning entry source code: [hoyle.c](%%REPO_URL%%/2004/hoyle//hoyle.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/hoyle/try.sh) script.
 
 
 <div id="2004_jdalbec">
-## [2004/jdalbec](2004/jdalbec/index.html)
-### Source code: [jdalbec.c](%%REPO_URL%%/2004/jdalbec//jdalbec.c)
+## Winning entry: [2004/jdalbec](2004/jdalbec/index.html)
+### Winning entry source code: [jdalbec.c](%%REPO_URL%%/2004/jdalbec//jdalbec.c)
 </div>
 
 [Cody](#cody) fixed this to compile with `gcc` (it worked with `clang`). The problem was the
@@ -3726,8 +3736,8 @@ Finally Cody added [try.sh](%%REPO_URL%%/2004/jdalbec/try.sh) and
 
 
 <div id="2004_kopczynski">
-## [2004/kopczynski](2004/kopczynski/index.html)
-### Source code: [kopczynski.c](%%REPO_URL%%/2004/kopczynski//kopczynski.c)
+## Winning entry: [2004/kopczynski](2004/kopczynski/index.html)
+### Winning entry source code: [kopczynski.c](%%REPO_URL%%/2004/kopczynski//kopczynski.c)
 </div>
 
 [Cody](#cody) reported that this entry cannot be optimised by the compiler as otherwise
@@ -3745,8 +3755,8 @@ get it to work, that being `kopczynski-10-rev`.
 
 
 <div id="2004_newbern">
-## [2004/newbern](2004/newbern/index.html)
-### Source code: [newbern.c](%%REPO_URL%%/2004/newbern//newbern.c)
+## Winning entry: [2004/newbern](2004/newbern/index.html)
+### Winning entry source code: [newbern.c](%%REPO_URL%%/2004/newbern//newbern.c)
 </div>
 
 [Cody](#cody) and Landon individually fixed this to work with `clang`.
@@ -3757,16 +3767,16 @@ chose the word `IOCCC` instead of `AAA`).
 
 
 <div id="2004_omoikane">
-## [2004/omoikane](2004/omoikane/index.html)
-### Source code: [omoikane.c](%%REPO_URL%%/2004/omoikane//omoikane.c)
+## Winning entry: [2004/omoikane](2004/omoikane/index.html)
+### Winning entry source code: [omoikane.c](%%REPO_URL%%/2004/omoikane//omoikane.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/omoikane/try.sh) script.
 
 
 <div id="2004_schnitzi">
-## [2004/schnitzi](2004/schnitzi/index.html)
-### Source code: [schnitzi.c](%%REPO_URL%%/2004/schnitzi//schnitzi.c)
+## Winning entry: [2004/schnitzi](2004/schnitzi/index.html)
+### Winning entry source code: [schnitzi.c](%%REPO_URL%%/2004/schnitzi//schnitzi.c)
 </div>
 
 [Cody](#cody) made this use `fgets(3)`.  See [FAQ 4.1  - Why were some calls to
@@ -3782,8 +3792,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2004/schnitzi/try.sh) script.
 
 
 <div id="2004_sds">
-## [2004/sds](2004/sds/index.html)
-### Source code: [sds.c](%%REPO_URL%%/2004/sds//sds.c)
+## Winning entry: [2004/sds](2004/sds/index.html)
+### Winning entry source code: [sds.c](%%REPO_URL%%/2004/sds//sds.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/sds/try.sh) script.
@@ -3794,8 +3804,8 @@ to the repo for the script instead.
 
 
 <div id="2004_vik2">
-## [2004/vik2](2004/vik2/index.html)
-### Source code: [vik2.c](%%REPO_URL%%/2004/vik2//vik2.c)
+## Winning entry: [2004/vik2](2004/vik2/index.html)
+### Winning entry source code: [vik2.c](%%REPO_URL%%/2004/vik2//vik2.c)
 </div>
 
 [Cody](#cody) fixed this to compile in Linux. Although it compiled cleanly in macOS (and
@@ -3857,13 +3867,13 @@ just to make it a bit easier to compile.
 
 
 <div id="2005">
-# 2005
+# [2005](2005/index.html)
 </div>
 
 
 <div id="2005_aidan">
-## [2005/aidan](2005/aidan/index.html)
-### Source code: [aidan.c](%%REPO_URL%%/2005/aidan//aidan.c)
+## Winning entry: [2005/aidan](2005/aidan/index.html)
+### Winning entry source code: [aidan.c](%%REPO_URL%%/2005/aidan//aidan.c)
 </div>
 
 [Cody](#cody) fixed the test script, described by the author in their remarks, to refer
@@ -3884,8 +3894,8 @@ suite.
 
 
 <div id="2005_anon">
-## [2005/anon](2005/anon/index.html)
-### Source code: [anon.c](%%REPO_URL%%/2005/anon//anon.c)
+## Winning entry: [2005/anon](2005/anon/index.html)
+### Winning entry source code: [anon.c](%%REPO_URL%%/2005/anon//anon.c)
 </div>
 
 [Cody](#cody) fixed a problem where in some systems (like macOS) the `stty sane` would
@@ -3901,8 +3911,8 @@ movements.
 
 
 <div id="2005_boutines">
-## [2005/boutines](2005/boutines/index.html)
-### Source code: [boutines.c](%%REPO_URL%%/2005/boutines//boutines.c)
+## Winning entry: [2005/boutines](2005/boutines/index.html)
+### Winning entry source code: [boutines.c](%%REPO_URL%%/2005/boutines//boutines.c)
 </div>
 
 [Cody](#cody) added the [input.txt](2005/boutines/input.txt) data file based on suggested
@@ -3912,8 +3922,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2005/boutines/try.sh) script.
 
 
 <div id="2005_giljade">
-## [2005/giljade](2005/giljade/index.html)
-### Source code: [giljade.c](%%REPO_URL%%/2005/giljade//giljade.c)
+## Winning entry: [2005/giljade](2005/giljade/index.html)
+### Winning entry source code: [giljade.c](%%REPO_URL%%/2005/giljade//giljade.c)
 </div>
 
 After Landon fixed the entry to compile with `clang` [Cody](#cody) noticed this
@@ -3983,8 +3993,8 @@ error; otherwise it is success. It uses [test.sh](%%REPO_URL%%/2005/giljade/test
 
 
 <div id="2005_jetro">
-## [2005/jetro](2005/jetro/index.html)
-### Source code: [jetro.c](%%REPO_URL%%/2005/jetro//jetro.c)
+## Winning entry: [2005/jetro](2005/jetro/index.html)
+### Winning entry source code: [jetro.c](%%REPO_URL%%/2005/jetro//jetro.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) for systems like Linux that seem to
@@ -3993,16 +4003,16 @@ not do it implicitly (like macOS does).
 
 
 <div id="2005_klausler">
-## [2005/klausler](2005/klausler/index.html)
-### Source code: [klausler.c](%%REPO_URL%%/2005/klausler//klausler.c)
+## Winning entry: [2005/klausler](2005/klausler/index.html)
+### Winning entry source code: [klausler.c](%%REPO_URL%%/2005/klausler//klausler.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2005/klausler/try.sh) script.
 
 
 <div id="2005_mikeash">
-## [2005/mikeash](2005/mikeash/index.html)
-### Source code: [mikeash.c](%%REPO_URL%%/2005/mikeash//mikeash.c)
+## Winning entry: [2005/mikeash](2005/mikeash/index.html)
+### Winning entry source code: [mikeash.c](%%REPO_URL%%/2005/mikeash//mikeash.c)
 </div>
 
 [Cody](#cody) fixed this to work in Linux. The problem was an unknown escape sequence,
@@ -4036,8 +4046,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2005/mikeash/try.sh) script.
 
 
 <div id="2005_mynx">
-## [2005/mynx](2005/mynx/index.html)
-### Source code: [mynx.c](%%REPO_URL%%/2005/mynx//mynx.c)
+## Winning entry: [2005/mynx](2005/mynx/index.html)
+### Winning entry source code: [mynx.c](%%REPO_URL%%/2005/mynx//mynx.c)
 </div>
 
 [Cody](#cody) fixed this so that the [configure](%%REPO_URL%%/2005/mynx/source/configure) script (which is not
@@ -4051,8 +4061,8 @@ wants to add the necessary code.
 
 
 <div id="2005_persano">
-## [2005/persano](2005/persano/index.html)
-### Source code: [persano.c](%%REPO_URL%%/2005/persano//persano.c)
+## Winning entry: [2005/persano](2005/persano/index.html)
+### Winning entry source code: [persano.c](%%REPO_URL%%/2005/persano//persano.c)
 </div>
 
 [Cody](#cody) added the (untested) [alternate
@@ -4064,8 +4074,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2005/persano/try.sh) script.
 
 
 <div id="2005_sykes">
-## [2005/sykes](2005/sykes/index.html)
-### Source code: [sykes.c](%%REPO_URL%%/2005/sykes//sykes.c)
+## Winning entry: [2005/sykes](2005/sykes/index.html)
+### Winning entry source code: [sykes.c](%%REPO_URL%%/2005/sykes//sykes.c)
 </div>
 
 [Cody](#cody) added the saved (with the `SAVE` command) BASIC program `PET` which was:
@@ -4106,8 +4116,8 @@ interrupt is set to in order to exit the program.
 
 
 <div id="2005_timwi">
-## [2005/timwi](2005/timwi/index.html)
-### Source code: [timwi.c](%%REPO_URL%%/2005/timwi//timwi.c)
+## Winning entry: [2005/timwi](2005/timwi/index.html)
+### Winning entry source code: [timwi.c](%%REPO_URL%%/2005/timwi//timwi.c)
 </div>
 
 [Cody](#cody) added [try.sh](%%REPO_URL%%/2005/timwi/try.sh). It only has one command as he doesn't
@@ -4116,8 +4126,8 @@ he doesn't want to damage anyone else's brain either. :-)
 
 
 <div id="2005_toledo">
-## [2005/toledo](2005/toledo/index.html)
-### Source code: [toledo.c](%%REPO_URL%%/2005/toledo//toledo.c)
+## Winning entry: [2005/toledo](2005/toledo/index.html)
+### Winning entry source code: [toledo.c](%%REPO_URL%%/2005/toledo//toledo.c)
 </div>
 
 [Cody](#cody) fixed this to compile with some versions of `clang` which have an additional
@@ -4128,8 +4138,8 @@ The alternate versions were also fixed.
 
 
 <div id="2005_vince">
-## [2005/vince](2005/vince/index.html)
-### Source code: [vince.c](%%REPO_URL%%/2005/vince//vince.c)
+## Winning entry: [2005/vince](2005/vince/index.html)
+### Winning entry source code: [vince.c](%%REPO_URL%%/2005/vince//vince.c)
 </div>
 
 [Cody](#cody) fixed this in the case that the program is compiled or linked/copies to
@@ -4144,13 +4154,13 @@ if one runs it from another directory, specifying the directory, it'll not catch
 
 
 <div id="2006">
-# 2006
+# [2006](2006/index.html)
 </div>
 
 
 <div id="2006_birken">
-## [2006/birken](2006/birken/index.html)
-### Source code: [birken.c](%%REPO_URL%%/2006/birken//birken.c)
+## Winning entry: [2006/birken](2006/birken/index.html)
+### Winning entry source code: [birken.c](%%REPO_URL%%/2006/birken//birken.c)
 </div>
 
 [Cody](#cody) fixed a segfault in macOS with this entry. The problem was a missing `+1`
@@ -4160,8 +4170,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2006/birken/try.sh) script.
 
 
 <div id="2006_borsanyi">
-## [2006/borsanyi](2006/borsanyi/index.html)
-### Source code: [borsanyi.c](%%REPO_URL%%/2006/borsanyi//borsanyi.c)
+## Winning entry: [2006/borsanyi](2006/borsanyi/index.html)
+### Winning entry source code: [borsanyi.c](%%REPO_URL%%/2006/borsanyi//borsanyi.c)
 </div>
 
 [Cody](#cody) fixed the Makefile to work in systems where the `lpthread` is not
@@ -4171,16 +4181,16 @@ Cody also added the [try.sh](%%REPO_URL%%/2006/borsanyi/try.sh) script.
 
 
 <div id="2006_grothe">
-## [2006/grothe](2006/grothe/index.html)
-### Source code: [grothe.c](%%REPO_URL%%/2006/grothe//grothe.c)
+## Winning entry: [2006/grothe](2006/grothe/index.html)
+### Winning entry source code: [grothe.c](%%REPO_URL%%/2006/grothe//grothe.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2006/grothe/try.sh) script.
 
 
 <div id="2006_hamre">
-## [2006/hamre](2006/hamre/index.html)
-### Source code: [hamre.c](%%REPO_URL%%/2006/hamre//hamre.c)
+## Winning entry: [2006/hamre](2006/hamre/index.html)
+### Winning entry source code: [hamre.c](%%REPO_URL%%/2006/hamre//hamre.c)
 </div>
 
 [Cody](#cody) fixed this so that it will not crash without an arg after it was suggested
@@ -4190,8 +4200,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2006/hamre/try.sh) script.
 
 
 <div id="2006_monge">
-## [2006/monge](2006/monge/index.html)
-### Source code: [monge.c](%%REPO_URL%%/2006/monge//monge.c)
+## Winning entry: [2006/monge](2006/monge/index.html)
+### Winning entry source code: [monge.c](%%REPO_URL%%/2006/monge//monge.c)
 </div>
 
 [Cody](#cody) added the [alternate code](2006/monge/index.html#alternate-code) that lets
@@ -4213,8 +4223,8 @@ bugs.html](bugs.html#2006-monge).
 
 
 <div id="2006_night">
-## [2006/night](2006/night/index.html)
-### Source code: [night.c](%%REPO_URL%%/2006/night//night.c)
+## Winning entry: [2006/night](2006/night/index.html)
+### Winning entry source code: [night.c](%%REPO_URL%%/2006/night//night.c)
 </div>
 
 As [Cody](#cody) is a lost :-) `vim` user he took the author's remarks to add support
@@ -4222,8 +4232,8 @@ back for arrow keys in the [alternate version](%%REPO_URL%%/2006/night/night.alt
 
 
 <div id="2006_sloane">
-## [2006/sloane](2006/sloane/index.html)
-### Source code: [sloane.c](%%REPO_URL%%/2006/sloane//sloane.c)
+## Winning entry: [2006/sloane](2006/sloane/index.html)
+### Winning entry source code: [sloane.c](%%REPO_URL%%/2006/sloane//sloane.c)
 </div>
 
 [Cody](#cody) fixed this entry to work with `clang` which has a defect with the args to
@@ -4254,8 +4264,8 @@ program in some systems he also added `-include ...` to the Makefile as well.
 
 
 <div id="2006_stewart">
-## [2006/stewart](2006/stewart/index.html)
-### Source code: [stewart.c](%%REPO_URL%%/2006/stewart//stewart.c)
+## Winning entry: [2006/stewart](2006/stewart/index.html)
+### Winning entry source code: [stewart.c](%%REPO_URL%%/2006/stewart//stewart.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2006/stewart/try.sh) script.
@@ -4266,8 +4276,8 @@ bug to fix.
 
 
 <div id="2006_sykes1">
-## [2006/sykes1](2006/sykes1/index.html)
-### Source code: [sykes1.c](%%REPO_URL%%/2006/sykes1//sykes1.c)
+## Winning entry: [2006/sykes1](2006/sykes1/index.html)
+### Winning entry source code: [sykes1.c](%%REPO_URL%%/2006/sykes1//sykes1.c)
 </div>
 
 [Cody](#cody) provided the [alt code](2006/sykes1/index.html#alternate-code) based on the
@@ -4282,8 +4292,8 @@ it to the repo as well.
 
 
 <div id="2006_sykes2">
-## [2006/sykes2](2006/sykes2/index.html)
-### Source code: [sykes2.c](%%REPO_URL%%/2006/sykes2//sykes2.c)
+## Winning entry: [2006/sykes2](2006/sykes2/index.html)
+### Winning entry source code: [sykes2.c](%%REPO_URL%%/2006/sykes2//sykes2.c)
 </div>
 
 [Cody](#cody), out of an abundance of caution for `clang`'s defects, made `main()` have
@@ -4295,16 +4305,16 @@ entry to show the clock update in real time.
 
 
 <div id="2006_toledo1">
-## [2006/toledo1](2006/toledo1/index.html)
-### Source code: [toledo1.c](%%REPO_URL%%/2006/toledo1//toledo1.c)
+## Winning entry: [2006/toledo1](2006/toledo1/index.html)
+### Winning entry source code: [toledo1.c](%%REPO_URL%%/2006/toledo1//toledo1.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2006/toledo1/try.sh) script.
 
 
 <div id="2006_toledo2">
-## [2006/toledo2](2006/toledo2/index.html)
-### Source code: [toledo2.c](%%REPO_URL%%/2006/toledo2//toledo2.c)
+## Winning entry: [2006/toledo2](2006/toledo2/index.html)
+### Winning entry source code: [toledo2.c](%%REPO_URL%%/2006/toledo2//toledo2.c)
 </div>
 
 [Cody](#cody) fixed a segfault in this program which was making it fail to work under
@@ -4325,8 +4335,8 @@ where appears the `IMPORT.COM` and `HALT.COM` files.
 
 
 <div id="2006_toledo3">
-## [2006/toledo3](2006/toledo3/index.html)
-### Source code: [toledo3.c](%%REPO_URL%%/2006/toledo3//toledo3.c)
+## Winning entry: [2006/toledo3](2006/toledo3/index.html)
+### Winning entry source code: [toledo3.c](%%REPO_URL%%/2006/toledo3//toledo3.c)
 </div>
 
 [Cody](#cody) fixed a crash and a display problem in this entry so that it now works in
@@ -4341,29 +4351,29 @@ We're not able to test this.
 
 
 <div id="2011">
-# 2011
+# [2011](2011/index.html)
 </div>
 
 
 <div id="2011_akari">
-## [2011/akari](2011/akari/index.html)
-### Source code: [akari.c](%%REPO_URL%%/2011/akari//akari.c)
+## Winning entry: [2011/akari](2011/akari/index.html)
+### Winning entry source code: [akari.c](%%REPO_URL%%/2011/akari//akari.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/akari/try.sh) script.
 
 
 <div id="2011_blakely">
-## [2011/blakely](2011/blakely/index.html)
-### Source code: [blakely.c](%%REPO_URL%%/2011/blakely//blakely.c)
+## Winning entry: [2011/blakely](2011/blakely/index.html)
+### Winning entry source code: [blakely.c](%%REPO_URL%%/2011/blakely//blakely.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/blakely/try.sh) script.
 
 
 <div id="2011_borsanyi">
-## [2011/borsanyi](2011/borsanyi/index.html)
-### Source code: [borsanyi.c](%%REPO_URL%%/2011/borsanyi//borsanyi.c)
+## Winning entry: [2011/borsanyi](2011/borsanyi/index.html)
+### Winning entry source code: [borsanyi.c](%%REPO_URL%%/2011/borsanyi//borsanyi.c)
 </div>
 
 [Cody](#cody), out of an abundance of caution, added a second arg to `main()` as some
@@ -4374,16 +4384,16 @@ Cody also added the [try.sh](%%REPO_URL%%/2011/borsanyi/try.sh) script.
 
 
 <div id="2011_dlowe">
-## [2011/dlowe](2011/dlowe/index.html)
-### Source code: [dlowe.c](%%REPO_URL%%/2011/dlowe//dlowe.c)
+## Winning entry: [2011/dlowe](2011/dlowe/index.html)
+### Winning entry source code: [dlowe.c](%%REPO_URL%%/2011/dlowe//dlowe.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/dlowe/try.sh) script.
 
 
 <div id="2011_eastman">
-## [2011/eastman](2011/eastman/index.html)
-### Source code: [eastman.c](%%REPO_URL%%/2011/eastman//eastman.c)
+## Winning entry: [2011/eastman](2011/eastman/index.html)
+### Winning entry source code: [eastman.c](%%REPO_URL%%/2011/eastman//eastman.c)
 </div>
 
 [Cody](#cody) added the video file [boing-ball.mp4](%%REPO_URL%%/2011/eastman) which is the demo the
@@ -4391,16 +4401,16 @@ author referred to.
 
 
 <div id="2011_fredriksson">
-## [2011/fredriksson](2011/fredriksson/index.html)
-### Source code: [fredriksson.c](%%REPO_URL%%/2011/fredriksson//fredriksson.c)
+## Winning entry: [2011/fredriksson](2011/fredriksson/index.html)
+### Winning entry source code: [fredriksson.c](%%REPO_URL%%/2011/fredriksson//fredriksson.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/fredriksson/try.sh) script.
 
 
 <div id="2011_goren">
-## [2011/goren](2011/goren/index.html)
-### Source code: [goren.c](%%REPO_URL%%/2011/goren//goren.c)
+## Winning entry: [2011/goren](2011/goren/index.html)
+### Winning entry source code: [goren.c](%%REPO_URL%%/2011/goren//goren.c)
 </div>
 
 [Cody](#cody) fixed this for macOS.  Before the fix it segfaulted. It worked fine under
@@ -4415,8 +4425,8 @@ Cody added the following words of wisdom: `'"this" is not a pipe but "!" is'`.
 
 
 <div id="2011_hamaji">
-## [2011/hamaji](2011/hamaji/index.html)
-### Source code: [hamaji.c](%%REPO_URL%%/2011/hamaji//hamaji.c)
+## Winning entry: [2011/hamaji](2011/hamaji/index.html)
+### Winning entry source code: [hamaji.c](%%REPO_URL%%/2011/hamaji//hamaji.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/hamaji/try.sh) script and the `.nono` files
@@ -4430,16 +4440,16 @@ and the others were from the authors' remarks.
 
 
 <div id="2011_hou">
-## [2011/hou](2011/hou/index.html)
-### Source code: [hou.c](%%REPO_URL%%/2011/hou//hou.c)
+## Winning entry: [2011/hou](2011/hou/index.html)
+### Winning entry source code: [hou.c](%%REPO_URL%%/2011/hou//hou.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/hou/try.sh) script.
 
 
 <div id="2011_konno">
-## [2011/konno](2011/konno/index.html)
-### Source code: [konno.c](%%REPO_URL%%/2011/konno//konno.c)
+## Winning entry: [2011/konno](2011/konno/index.html)
+### Winning entry source code: [konno.c](%%REPO_URL%%/2011/konno//konno.c)
 </div>
 
 [Cody](#cody) fixed the program to not crash if no arg was specified as this was not a
@@ -4449,8 +4459,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2011/konno/try.sh) script.
 
 
 <div id="2011_richards">
-## [2011/richards](2011/richards/index.html)
-### Source code: [richards.c](%%REPO_URL%%/2011/richards//richards.c)
+## Winning entry: [2011/richards](2011/richards/index.html)
+### Winning entry source code: [richards.c](%%REPO_URL%%/2011/richards//richards.c)
 </div>
 
 [Cody](#cody) fixed a minor problem that showed up in both Linux and macOS. He notes
@@ -4471,8 +4481,8 @@ bugs.html](bugs.html#2011-richards) for more details).
 
 
 <div id="2011_toledo">
-## [2011/toledo](2011/toledo/index.html)
-### Source code: [toledo.c](%%REPO_URL%%/2011/toledo//toledo.c)
+## Winning entry: [2011/toledo](2011/toledo/index.html)
+### Winning entry source code: [toledo.c](%%REPO_URL%%/2011/toledo//toledo.c)
 </div>
 
 [Cody](#cody) added two [alternate versions](2011/toledo/index.html#alternate-code): one that
@@ -4485,8 +4495,8 @@ controls, width and height.
 
 
 <div id="2011_vik">
-## [2011/vik](2011/vik/index.html)
-### Source code: [vik.c](%%REPO_URL%%/2011/vik//vik.c)
+## Winning entry: [2011/vik](2011/vik/index.html)
+### Winning entry source code: [vik.c](%%REPO_URL%%/2011/vik//vik.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/vik/try.sh) script.
@@ -4497,8 +4507,8 @@ header files). To build try the alt rule of the Makefile.
 
 
 <div id="2011_zucker">
-## [2011/zucker](2011/zucker/index.html)
-### Source code: [zucker.c](%%REPO_URL%%/2011/zucker//zucker.c)
+## Winning entry: [2011/zucker](2011/zucker/index.html)
+### Winning entry source code: [zucker.c](%%REPO_URL%%/2011/zucker//zucker.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/zucker/try.sh) script.
@@ -4513,13 +4523,13 @@ eventually dies.
 
 
 <div id="2012">
-# 2012
+# [2012](2012/index.html)
 </div>
 
 
 <div id="2012_blakely">
-## [2012/blakely](2012/blakely/index.html)
-### Source code: [blakely.c](%%REPO_URL%%/2012/blakely//blakely.c)
+## Winning entry: [2012/blakely](2012/blakely/index.html)
+### Winning entry source code: [blakely.c](%%REPO_URL%%/2012/blakely//blakely.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) as not all systems do this
@@ -4529,16 +4539,16 @@ Cody also added the [try.sh](%%REPO_URL%%/2012/blakely/try.sh) script.
 
 
 <div id="2012_deckmyn">
-## [2012/deckmyn](2012/deckmyn/index.html)
-### Source code: [deckmyn.c](%%REPO_URL%%/2012/deckmyn//deckmyn.c)
+## Winning entry: [2012/deckmyn](2012/deckmyn/index.html)
+### Winning entry source code: [deckmyn.c](%%REPO_URL%%/2012/deckmyn//deckmyn.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/deckmyn/try.sh) script.
 
 
 <div id="2012_endoh1">
-## [2012/endoh1](2012/endoh1/index.html)
-### Source code: [endoh1.c](%%REPO_URL%%/2012/endoh1//endoh1.c)
+## Winning entry: [2012/endoh1](2012/endoh1/index.html)
+### Winning entry source code: [endoh1.c](%%REPO_URL%%/2012/endoh1//endoh1.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) as not all systems do this
@@ -4574,8 +4584,8 @@ The [endoh1.alt2.c](%%REPO_URL%%/2012/endoh1/endoh1.alt2.c) was provided by the 
 
 
 <div id="2012_endoh2">
-## [2012/endoh2](2012/endoh2/index.html)
-### Source code: [endoh2.c](%%REPO_URL%%/2012/endoh2//endoh2.c)
+## Winning entry: [2012/endoh2](2012/endoh2/index.html)
+### Winning entry source code: [endoh2.c](%%REPO_URL%%/2012/endoh2//endoh2.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/endoh2/try.sh) script that runs
@@ -4586,8 +4596,8 @@ Cody also fixed a typo in the ruby script
 
 
 <div id="2012_grothe">
-## [2012/grothe](2012/grothe/index.html)
-### Source code: [grothe.c](%%REPO_URL%%/2012/grothe//grothe.c)
+## Winning entry: [2012/grothe](2012/grothe/index.html)
+### Winning entry source code: [grothe.c](%%REPO_URL%%/2012/grothe//grothe.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/grothe/try.sh) script.
@@ -4608,8 +4618,8 @@ which the recipe file now links to.
 
 
 <div id="2012_hamano">
-## [2012/hamano](2012/hamano/index.html)
-### Source code: [hamano.c](%%REPO_URL%%/2012/hamano//hamano.c)
+## Winning entry: [2012/hamano](2012/hamano/index.html)
+### Winning entry source code: [hamano.c](%%REPO_URL%%/2012/hamano//hamano.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/hamano/try.sh) script and the helper
@@ -4618,8 +4628,8 @@ procedure for both `hint.pdf` and `hello.pdf` as well as compiling them as C.
 
 
 <div id="2012_hou">
-## [2012/hou](2012/hou/index.html)
-### Source code: [hou.c](%%REPO_URL%%/2012/hou//hou.c)
+## Winning entry: [2012/hou](2012/hou/index.html)
+### Winning entry source code: [hou.c](%%REPO_URL%%/2012/hou//hou.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/hou/try.sh) script and restored the original [hint
@@ -4630,8 +4640,8 @@ title and stylesheet) and other formatting changes.
 
 
 <div id="2012_kang">
-## [2012/kang](2012/kang/index.html)
-### Source code: [kang.c](%%REPO_URL%%/2012/kang//kang.c)
+## Winning entry: [2012/kang](2012/kang/index.html)
+### Winning entry source code: [kang.c](%%REPO_URL%%/2012/kang//kang.c)
 </div>
 
 [Cody](#cody) added alt code that fixes a problem where in German 'v' sounds like 'f'
@@ -4663,16 +4673,16 @@ respectively. Notice how a single letter changes so much!
 
 
 <div id="2012_konno">
-## [2012/konno](2012/konno/index.html)
-### Source code: [konno.c](%%REPO_URL%%/2012/konno//konno.c)
+## Winning entry: [2012/konno](2012/konno/index.html)
+### Winning entry source code: [konno.c](%%REPO_URL%%/2012/konno//konno.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/konno/try.sh) script.
 
 
 <div id="2012_omoikane">
-## [2012/omoikane](2012/omoikane/index.html)
-### Source code: [omoikane.c](%%REPO_URL%%/2012/omoikane//omoikane.c)
+## Winning entry: [2012/omoikane](2012/omoikane/index.html)
+### Winning entry source code: [omoikane.c](%%REPO_URL%%/2012/omoikane//omoikane.c)
 </div>
 
 [Cody](#cody) added the [alternate versions](2012/omoikane/index.html#alternate-code)
@@ -4687,16 +4697,16 @@ Cody also added the [try.sh](%%REPO_URL%%/2012/omoikane/try.sh) and
 
 
 <div id="2012_tromp">
-## [2012/tromp](2012/tromp/index.html)
-### Source code: [tromp.c](%%REPO_URL%%/2012/tromp//tromp.c)
+## Winning entry: [2012/tromp](2012/tromp/index.html)
+### Winning entry source code: [tromp.c](%%REPO_URL%%/2012/tromp//tromp.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/tromp/try.sh) script.
 
 
 <div id="2012_vik">
-## [2012/vik](2012/vik/index.html)
-### Source code: [vik.c](%%REPO_URL%%/2012/vik//vik.c)
+## Winning entry: [2012/vik](2012/vik/index.html)
+### Winning entry source code: [vik.c](%%REPO_URL%%/2012/vik//vik.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/vik/try.sh) script.
@@ -4707,8 +4717,8 @@ does this for the few who might use Windows.
 
 
 <div id="2012_zeitak">
-## [2012/zeitak](2012/zeitak/index.html)
-### Source code: [zeitak.c](%%REPO_URL%%/2012/zeitak//zeitak.c)
+## Winning entry: [2012/zeitak](2012/zeitak/index.html)
+### Winning entry source code: [zeitak.c](%%REPO_URL%%/2012/zeitak//zeitak.c)
 </div>
 
 [Cody](#cody) added the [test.sh](%%REPO_URL%%/2012/zeitak/test.sh) script and the `make test` rule
@@ -4729,13 +4739,13 @@ it easier for those who do not know how, and to make it more obvious to try it.
 
 
 <div id="2013">
-# 2013
+# [2013](2013/index.html)
 </div>
 
 
 <div id="2013_birken">
-## [2013/birken](2013/birken/index.html)
-### Source code: [birken.c](%%REPO_URL%%/2013/birken//birken.c)
+## Winning entry: [2013/birken](2013/birken/index.html)
+### Winning entry source code: [birken.c](%%REPO_URL%%/2013/birken//birken.c)
 </div>
 
 [Cody](#cody) changed the `return 0;` at the end of the program to be `return
@@ -4755,8 +4765,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/birken/try.sh) script for the ent
 
 
 <div id="2013_cable1">
-## [2013/cable1](2013/cable1/index.html)
-### Source code: [cable1.c](%%REPO_URL%%/2013/cable1//cable1.c)
+## Winning entry: [2013/cable1](2013/cable1/index.html)
+### Winning entry source code: [cable1.c](%%REPO_URL%%/2013/cable1//cable1.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/cable1/try.sh) script which also has an
@@ -4764,16 +4774,16 @@ joke Easter egg in it based on the judges' remarks.
 
 
 <div id="2013_cable2">
-## [2013/cable2](2013/cable2/index.html)
-### Source code: [cable2.c](%%REPO_URL%%/2013/cable2//cable2.c)
+## Winning entry: [2013/cable2](2013/cable2/index.html)
+### Winning entry source code: [cable2.c](%%REPO_URL%%/2013/cable2//cable2.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/cable2/try.sh) script.
 
 
 <div id="2013_cable3">
-## [2013/cable3](2013/cable3/index.html)
-### Source code: [cable3.c](%%REPO_URL%%/2013/cable3//cable3.c)
+## Winning entry: [2013/cable3](2013/cable3/index.html)
+### Winning entry source code: [cable3.c](%%REPO_URL%%/2013/cable3//cable3.c)
 </div>
 
 [Cody](#cody) fixed this to compile with modern systems. The problems were that
@@ -4814,8 +4824,8 @@ author linked to at `https://bitly.com/1bU8URK`.
 
 
 <div id="2013_dlowe">
-## [2013/dlowe](2013/dlowe/index.html)
-### Source code: [dlowe.c](%%REPO_URL%%/2013/dlowe//dlowe.c)
+## Winning entry: [2013/dlowe](2013/dlowe/index.html)
+### Winning entry source code: [dlowe.c](%%REPO_URL%%/2013/dlowe//dlowe.c)
 </div>
 
 [Cody](#cody) added the source code that we suggested one should compile and run with
@@ -4842,16 +4852,16 @@ commands to try that he suggested to see how different lengths look.
 
 
 <div id="2013_endoh1">
-## [2013/endoh1](2013/endoh1/index.html)
-### Source code: [endoh1.c](%%REPO_URL%%/2013/endoh1//endoh1.c)
+## Winning entry: [2013/endoh1](2013/endoh1/index.html)
+### Winning entry source code: [endoh1.c](%%REPO_URL%%/2013/endoh1//endoh1.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/endoh1/try.sh) script.
 
 
 <div id="2013_endoh2">
-## [2013/endoh2](2013/endoh2/index.html)
-### Source code: [endoh2.c](%%REPO_URL%%/2013/endoh2//endoh2.c)
+## Winning entry: [2013/endoh2](2013/endoh2/index.html)
+### Winning entry source code: [endoh2.c](%%REPO_URL%%/2013/endoh2//endoh2.c)
 </div>
 
 [Cody](#cody) fixed the Makefile `check` rule so that it `checks` :-) that both
@@ -4875,8 +4885,8 @@ The entry can still be enjoyed if you do not have these tools, however.
 
 
 <div id="2013_endoh3">
-## [2013/endoh3](2013/endoh3/index.html)
-### Source code: [endoh3.c](%%REPO_URL%%/2013/endoh3//endoh3.c)
+## Winning entry: [2013/endoh3](2013/endoh3/index.html)
+### Winning entry source code: [endoh3.c](%%REPO_URL%%/2013/endoh3//endoh3.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/endoh3/try.sh) script.
@@ -4886,8 +4896,8 @@ arg type and count to `main()`) added a second (unused) arg to `main()`.
 
 
 <div id="2013_endoh4">
-## [2013/endoh4](2013/endoh4/index.html)
-### Source code: [endoh4.c](%%REPO_URL%%/2013/endoh4//endoh4.c)
+## Winning entry: [2013/endoh4](2013/endoh4/index.html)
+### Winning entry source code: [endoh4.c](%%REPO_URL%%/2013/endoh4//endoh4.c)
 </div>
 
 [Cody](#cody) added the [endoh4.sh](%%REPO_URL%%/2013/endoh4/endoh4.sh) script which temporarily
@@ -4903,8 +4913,8 @@ allows one to redefine it as well.
 
 
 <div id="2013_hou">
-## [2013/hou](2013/hou/index.html)
-### Source code: [hou.c](%%REPO_URL%%/2013/hou//hou.c)
+## Winning entry: [2013/hou](2013/hou/index.html)
+### Winning entry source code: [hou.c](%%REPO_URL%%/2013/hou//hou.c)
 </div>
 
 [Cody](#cody) fixed the Makefile so that this would work properly. Before this
@@ -4945,7 +4955,7 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/hou/try.sh) script.
 
 
 <div id="2013_mills">
-## [2013/mills](2013/mills/index.html)
+## Winning entry: [2013/mills](2013/mills/index.html)
 ## Source code: [mills.c](%%REPO_URL%%/2013/mills/mills.c)
 </div>
 
@@ -4958,16 +4968,16 @@ Firefox both had the problem.
 
 
 <div id="2013_misaka">
-## [2013/misaka](2013/misaka/index.html)
-### Source code: [misaka.c](%%REPO_URL%%/2013/misaka//misaka.c)
+## Winning entry: [2013/misaka](2013/misaka/index.html)
+### Winning entry source code: [misaka.c](%%REPO_URL%%/2013/misaka//misaka.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/misaka/try.sh) script.
 
 
 <div id="2013_morgan1">
-## [2013/morgan1](2013/morgan1/index.html)
-### Source code: [morgan1.c](%%REPO_URL%%/2013/morgan1//morgan1.c)
+## Winning entry: [2013/morgan1](2013/morgan1/index.html)
+### Winning entry source code: [morgan1.c](%%REPO_URL%%/2013/morgan1//morgan1.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) as not all systems do this
@@ -4977,21 +4987,21 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/morgan1/try.sh) script.
 
 
 <div id="2013_robison">
-## [2013/robison](2013/robison/index.html)
-### Source code: [robison.c](%%REPO_URL%%/2013/robison//robison.c)
+## Winning entry: [2013/robison](2013/robison/index.html)
+### Winning entry source code: [robison.c](%%REPO_URL%%/2013/robison//robison.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/robison/try.sh) script.
 
 
 <div id="2014">
-# 2014
+# [2014](2014/index.html)
 </div>
 
 
 <div id="2014_birken">
-## [2014/birken](2014/birken/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/birken//prog.c)
+## Winning entry: [2014/birken](2014/birken/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/birken//prog.c)
 </div>
 
 [Cody](#cody) provided the [alternate
@@ -5004,8 +5014,8 @@ redefine the port and timing constant.
 
 
 <div id="2014_deak">
-## [2014/deak](2014/deak/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/deak//prog.c)
+## Winning entry: [2014/deak](2014/deak/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/deak//prog.c)
 </div>
 
 [Cody](#cody) added [alt code](2014/deak/index.html#alternate-code) that lets
@@ -5027,8 +5037,8 @@ Cody also added the [try.alt.sh](%%REPO_URL%%/2014/deak/try.alt.sh) script.
 
 
 <div id="2014_endoh1">
-## [2014/endoh1](2014/endoh1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/endoh1//prog.c)
+## Winning entry: [2014/endoh1](2014/endoh1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/endoh1//prog.c)
 </div>
 
 [Cody](#cody) added the [rake.sh](%%REPO_URL%%/2014/endoh1/rake.sh) script and `make rake`
@@ -5056,16 +5066,16 @@ it is a file with spoilers (and too close to index.html?).
 
 
 <div id="2014_endoh2">
-## [2014/endoh2](2014/endoh2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/endoh2//prog.c)
+## Winning entry: [2014/endoh2](2014/endoh2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/endoh2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/endoh2/try.sh) script.
 
 
 <div id="2014_maffiodo1">
-## [2014/maffiodo1](2014/maffiodo1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/maffiodo1//prog.c)
+## Winning entry: [2014/maffiodo1](2014/maffiodo1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/maffiodo1//prog.c)
 </div>
 
 [Cody](#cody) fixed the build for this entry: it does not require
@@ -5079,8 +5089,8 @@ which let one configure the width and height of the game.
 
 
 <div id="2014_maffiodo2">
-## [2014/maffiodo2](2014/maffiodo2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/maffiodo2//prog.c)
+## Winning entry: [2014/maffiodo2](2014/maffiodo2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/maffiodo2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/maffiodo2/try.sh) script.
@@ -5090,16 +5100,16 @@ provided by the author.
 
 
 <div id="2014_morgan">
-## [2014/morgan](2014/morgan/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/morgan//prog.c)
+## Winning entry: [2014/morgan](2014/morgan/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/morgan//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/morgan/try.sh) script.
 
 
 <div id="2014_sinon">
-## [2014/sinon](2014/sinon/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/sinon//prog.c)
+## Winning entry: [2014/sinon](2014/sinon/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/sinon//prog.c)
 </div>
 
 [Cody](#cody) fixed the code so that the game can play automatically like it
@@ -5118,8 +5128,8 @@ kill it). This is done this way in case it jams (see index.html for details).
 
 
 <div id="2014_skeggs">
-## [2014/skeggs](2014/skeggs/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/skeggs//prog.c)
+## Winning entry: [2014/skeggs](2014/skeggs/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/skeggs//prog.c)
 </div>
 
 [Cody](#cody) fixed the Makefile to compile this entry in modern systems. The problem was
@@ -5139,8 +5149,8 @@ clean`) removes those files and so that they are ignored by `.gitignore`.
 
 
 <div id="2014_vik">
-## [2014/vik](2014/vik/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/vik//prog.c)
+## Winning entry: [2014/vik](2014/vik/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/vik//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/vik/try.sh) script. Cody notes that there
@@ -5154,8 +5164,8 @@ that would break it we do not know.
 
 
 <div id="2014_wiedijk">
-## [2014/wiedijk](2014/wiedijk/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2014/wiedijk//prog.c)
+## Winning entry: [2014/wiedijk](2014/wiedijk/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2014/wiedijk//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/wiedijk/try.sh) script which is based on
@@ -5167,13 +5177,13 @@ output.
 
 
 <div id="2015">
-# 2015
+# [2015](2015/index.html)
 </div>
 
 
 <div id="2015_burton">
-## [2015/burton](2015/burton/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/burton//prog.c)
+## Winning entry: [2015/burton](2015/burton/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/burton//prog.c)
 </div>
 
 
@@ -5216,8 +5226,8 @@ add a `./` to the commands in the man page/index.html.
 
 
 <div id="2015_dogon">
-## [2015/dogon](2015/dogon/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/dogon//prog.c)
+## Winning entry: [2015/dogon](2015/dogon/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/dogon//prog.c)
 </div>
 
 [Cody](#cody) improved the Makefile so that one can easily change the dimensions
@@ -5229,24 +5239,24 @@ they avoided.
 
 
 <div id="2015_duble">
-## [2015/duble](2015/duble/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/duble//prog.c)
+## Winning entry: [2015/duble](2015/duble/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/duble//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/duble/try.sh) script.
 
 
 <div id="2015_endoh2">
-## [2015/endoh2](2015/endoh2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/endoh2//prog.c)
+## Winning entry: [2015/endoh2](2015/endoh2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/endoh2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/endoh2/try.sh) script.
 
 
 <div id="2015_endoh3">
-## [2015/endoh3](2015/endoh3/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/endoh3//prog.c)
+## Winning entry: [2015/endoh3](2015/endoh3/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/endoh3//prog.c)
 </div>
 
 [Cody](#cody) fixed this to compile with Linux which was having a problem with duplicate
@@ -5261,16 +5271,16 @@ simply typing `make back_to` or `make mullender`) and then runs the famous
 
 
 <div id="2015_endoh4">
-## [2015/endoh4](2015/endoh4/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/endoh4//prog.c)
+## Winning entry: [2015/endoh4](2015/endoh4/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/endoh4//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/endoh4/try.sh) script.
 
 
 <div id="2015_hou">
-## [2015/hou](2015/hou/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/hou//prog.c)
+## Winning entry: [2015/hou](2015/hou/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/hou//prog.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) for systems that do not do this
@@ -5285,8 +5295,8 @@ file now links to.
 
 
 <div id="2015_howe">
-## [2015/howe](2015/howe/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/howe//prog.c)
+## Winning entry: [2015/howe](2015/howe/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/howe//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/howe/try.sh) script, downloaded the War
@@ -5297,8 +5307,8 @@ resulted in standard input errors in piping to `bc(1)`) and added the
 
 
 <div id="2015_mills1">
-## [2015/mills1](2015/mills1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/mills1//prog.c)
+## Winning entry: [2015/mills1](2015/mills1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/mills1//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/mills1/try.sh) script which changes the
@@ -5310,24 +5320,24 @@ past).
 
 
 <div id="2015_mills2">
-## [2015/mills2](2015/mills2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/mills2//prog.c)
+## Winning entry: [2015/mills2](2015/mills2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/mills2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/mills2/try.sh) script.
 
 
 <div id="2015_muth">
-## [2015/muth](2015/muth/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/muth//prog.c)
+## Winning entry: [2015/muth](2015/muth/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/muth//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/muth/try.sh) script.
 
 
 <div id="2015_schweikhardt">
-## [2015/schweikhardt](2015/schweikhardt/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/schweikhardt//prog.c)
+## Winning entry: [2015/schweikhardt](2015/schweikhardt/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/schweikhardt//prog.c)
 </div>
 
 [Cody](#cody) fixed the build so that `EOF` will be `-1` as the program assumes
@@ -5339,8 +5349,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2015/schweikhardt/try.sh) script.
 
 
 <div id="2015_yang">
-## [2015/yang](2015/yang/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2015/yang//prog.c)
+## Winning entry: [2015/yang](2015/yang/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2015/yang//prog.c)
 </div>
 
 [Cody](#cody) fixed an unfortunate typo in the Makefile that was preventing some of the
@@ -5353,13 +5363,13 @@ He also added the [try.sh](%%REPO_URL%%/2015/yang/try.sh) script.
 
 
 <div id="2018">
-# 2018
+# [2018](2018/index.html)
 </div>
 
 
 <div id="2018_anderson">
-## [2018/anderson](2018/anderson/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/anderson//prog.c)
+## Winning entry: [2018/anderson](2018/anderson/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/anderson//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/anderson/try.sh) and
@@ -5367,8 +5377,8 @@ He also added the [try.sh](%%REPO_URL%%/2015/yang/try.sh) script.
 
 
 <div id="2018_algmyr">
-## [2018/algmyr](2018/algmyr/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/algmyr//prog.c)
+## Winning entry: [2018/algmyr](2018/algmyr/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/algmyr//prog.c)
 </div>
 
 
@@ -5376,8 +5386,8 @@ He also added the [try.sh](%%REPO_URL%%/2015/yang/try.sh) script.
 
 
 <div id="2018_bellard">
-## [2018/bellard](2018/bellard/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/bellard//prog.c)
+## Winning entry: [2018/bellard](2018/bellard/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/bellard//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/bellard/try.sh) script.
@@ -5398,8 +5408,8 @@ version as well.
 
 
 <div id="2018_burton1">
-## [2018/burton1](2018/burton1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/burton1//prog.c)
+## Winning entry: [2018/burton1](2018/burton1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/burton1//prog.c)
 </div>
 
 [Cody](#cody) fixed the `scripthd` script (referred to `prog` not `./prog`) and
@@ -5411,8 +5421,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2018/burton1/try.sh) script which also
 
 
 <div id="2018_burton2">
-## [2018/burton2](2018/burton2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/burton2//prog.c)
+## Winning entry: [2018/burton2](2018/burton2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/burton2//prog.c)
 </div>
 
 [Cody](#cody) fixed the `make test` rule: it tried to run `tac(1)` (in systems
@@ -5438,8 +5448,8 @@ Finally Cody added the [try.sh](%%REPO_URL%%/2018/burton2/try.sh) script.
 
 
 <div id="2018_ciura">
-## [2018/ciura](2018/ciura/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/ciura//prog.c)
+## Winning entry: [2018/ciura](2018/ciura/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/ciura//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/ciura/try.sh) and
@@ -5449,8 +5459,8 @@ Internet Wayback Machine.
 
 
 <div id="2018_endoh1">
-## [2018/endoh1](2018/endoh1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/endoh1//prog.c)
+## Winning entry: [2018/endoh1](2018/endoh1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/endoh1//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/endoh1/try.sh) script which shows the
@@ -5463,8 +5473,8 @@ remarks. The input files offered includes the prog.c as the author,
 
 
 <div id="2018_endoh2">
-## [2018/endoh2](2018/endoh2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/endoh2//prog.c)
+## Winning entry: [2018/endoh2](2018/endoh2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/endoh2//prog.c)
 </div>
 
 [Cody](#cody) fixed the [run.sh](%%REPO_URL%%/2018/endoh2/run.sh) script (had commands that didn't
@@ -5478,8 +5488,8 @@ run the respective scripts.
 
 
 <div id="2018_ferguson">
-## [2018/ferguson](2018/ferguson/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/ferguson//prog.c)
+## Winning entry: [2018/ferguson](2018/ferguson/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/ferguson//prog.c)
 </div>
 
 [Cody](#cody), with irony well intended :-), fixed the [test.sh
@@ -5494,8 +5504,8 @@ that's probably true: let's just say that for the IOCCC I'm (Cody) a weasel! :-)
 
 
 <div id="2018_hou">
-## [2018/hou](2018/hou/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/hou//prog.c)
+## Winning entry: [2018/hou](2018/hou/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/hou//prog.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) for systems that do not do this
@@ -5505,8 +5515,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2018/hou/try.sh) script.
 
 
 <div id="2018_mills">
-## [2018/mills](2018/mills/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/mills//prog.c)
+## Winning entry: [2018/mills](2018/mills/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/mills//prog.c)
 </div>
 
 [Cody](#cody), based on the author's remarks, made it possible to save state
@@ -5520,8 +5530,8 @@ details on the bug.
 
 
 <div id="2018_poikola">
-## [2018/poikola](2018/poikola/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/poikola//prog.c)
+## Winning entry: [2018/poikola](2018/poikola/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/poikola//prog.c)
 </div>
 
 [Cody](#cody) added the missing `docs` rule to the Makefile that forms a PDF
@@ -5536,16 +5546,16 @@ configuration).
 
 
 <div id="2018_vokes">
-## [2018/vokes](2018/vokes/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/vokes//prog.c)
+## Winning entry: [2018/vokes](2018/vokes/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/vokes//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/vokes/try.sh) script.
 
 
 <div id="2018_yang">
-## [2018/yang](2018/yang/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2018/yang//prog.c)
+## Winning entry: [2018/yang](2018/yang/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2018/yang//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/yang/try.sh) script. This script will ask
@@ -5555,13 +5565,13 @@ if the user wants to see some of the spoilers and only show them if they type
 
 
 <div id="2019">
-# 2019
+# [2019](2019/index.html)
 </div>
 
 
 <div id="2019_adamovsky">
-## [2019/adamovsky](2019/adamovsky/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/adamovsky//prog.c)
+## Winning entry: [2019/adamovsky](2019/adamovsky/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/adamovsky//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/adamovsky/try.sh) script and the Unlambda
@@ -5570,8 +5580,8 @@ to what can crash it - but it's not a bug, it's a feature.
 
 
 <div id="2019_burton">
-## [2019/burton](2019/burton/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/burton//prog.c)
+## Winning entry: [2019/burton](2019/burton/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/burton//prog.c)
 </div>
 
 [Cody](#cody) fixed the Makefile which had a bad character, a '%' instead of a '$' which
@@ -5594,8 +5604,8 @@ browsers/GitHub.
 
 
 <div id="2019_ciura">
-## [2019/ciura](2019/ciura/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/ciura//prog.c)
+## Winning entry: [2019/ciura](2019/ciura/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/ciura//prog.c)
 </div>
 
 [Cody](#cody) fixed an invalid bytes error in `tr` in the scripts. This does not
@@ -5620,8 +5630,8 @@ bugs.html](bugs.html#2019-ciura) for more details.
 
 
 <div id="2019_diels-grabsch1">
-## [2019/diels-grabsch1](2019/diels-grabsch1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/diels-grabsch1//prog.c)
+## Winning entry: [2019/diels-grabsch1](2019/diels-grabsch1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/diels-grabsch1//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/diels-grabsch1/try.sh) script.
@@ -5634,8 +5644,8 @@ having tarballs for each individual entry as a convenience.
 
 
 <div id="2019_diels-grabsch2">
-## [2019/diels-grabsch2](2019/diels-grabsch2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/diels-grabsch2//prog.c)
+## Winning entry: [2019/diels-grabsch2](2019/diels-grabsch2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/diels-grabsch2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/diels-grabsch2/try.sh) script. This
@@ -5646,8 +5656,8 @@ own sha512sum value.
 
 
 <div id="2019_dogon">
-## [2019/dogon](2019/dogon/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/dogon//prog.c)
+## Winning entry: [2019/dogon](2019/dogon/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/dogon//prog.c)
 </div>
 
 [Cody](#cody) added explicit linking of libm (`-lm`) for systems that do not do this
@@ -5667,8 +5677,8 @@ else).
 
 
 <div id="2019_duble">
-## [2019/duble](2019/duble/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/duble//prog.c)
+## Winning entry: [2019/duble](2019/duble/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/duble//prog.c)
 </div>
 
 [Cody](#cody) made the `make fullscreen` more portable by not relying on
@@ -5683,8 +5693,8 @@ how to easily compile the program to a specific size. Note that `LINES` and
 
 
 <div id="2019_endoh">
-## [2019/endoh](2019/endoh/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/endoh//prog.c)
+## Winning entry: [2019/endoh](2019/endoh/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/endoh//prog.c)
 </div>
 
 As this is a backtrace quine having the optimiser enabled is not a good idea so
@@ -5700,16 +5710,16 @@ quine.
 
 
 <div id="2019_giles">
-## [2019/giles](2019/giles/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/giles//prog.c)
+## Winning entry: [2019/giles](2019/giles/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/giles//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/giles/try.sh) script.
 
 
 <div id="2019_karns">
-## [2019/karns](2019/karns/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/karns//prog.c)
+## Winning entry: [2019/karns](2019/karns/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/karns//prog.c)
 </div>
 
 [Cody](#cody) reported that with `-O` level > 0 this program segfaults (sometimes?). He's
@@ -5723,8 +5733,8 @@ bit more easily.
 
 
 <div id="2019_lynn">
-## [2019/lynn](2019/lynn/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/lynn//prog.c)
+## Winning entry: [2019/lynn](2019/lynn/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/lynn//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/lynn/try.sh) script.
@@ -5736,16 +5746,16 @@ entry existing.
 
 
 <div id="2019_mills">
-## [2019/mills](2019/mills/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/mills//prog.c)
+## Winning entry: [2019/mills](2019/mills/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/mills//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/mills/try.sh) script.
 
 
 <div id="2019_poikola">
-## [2019/poikola](2019/poikola/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/poikola//prog.c)
+## Winning entry: [2019/poikola](2019/poikola/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/poikola//prog.c)
 </div>
 
 [Cody](#cody) added the missing `docs` rule to the Makefile that forms a PDF
@@ -5766,8 +5776,8 @@ tested: `gnu17` was not tested but `gnu11` was so the standard was set to
 
 
 <div id="2019_yang">
-## [2019/yang](2019/yang/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2019/yang//prog.c)
+## Winning entry: [2019/yang](2019/yang/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2019/yang//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/yang/try.sh) script which also involved
@@ -5777,13 +5787,13 @@ shouldn't) and adding the [ioccc.txt](2019/yang/ioccc.txt) file.
 
 
 <div id="2020">
-# 2020
+# [2020](2020/index.html)
 </div>
 
 
 <div id="2020_burton">
-## [2020/burton](2020/burton/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/burton//prog.c)
+## Winning entry: [2020/burton](2020/burton/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/burton//prog.c)
 </div>
 
 [Cody](#cody) fixed the script [check_be.sh](%%REPO_URL%%/2020/burton/check_be.sh): it
@@ -5798,8 +5808,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2020/burton/try.sh) script.
 
 
 <div id="2020_carlini">
-## [2020/carlini](2020/carlini/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/carlini//prog.c)
+## Winning entry: [2020/carlini](2020/carlini/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/carlini//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/carlini/try.sh) script which although at
@@ -5809,8 +5819,8 @@ a friend, whether that's real or imagined.
 
 
 <div id="2020_endoh2">
-## [2020/endoh2](2020/endoh2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/endoh2//prog.c)
+## Winning entry: [2020/endoh2](2020/endoh2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/endoh2//prog.c)
 </div>
 
 [Cody](#cody) copied the files from the spoiler.zip file (from his copy during
@@ -5821,8 +5831,8 @@ He also added the [try.sh](%%REPO_URL%%/2020/endoh2/try.sh) script.
 
 
 <div id="2020_endoh3">
-## [2020/endoh3](2020/endoh3/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/endoh3//prog.c)
+## Winning entry: [2020/endoh3](2020/endoh3/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/endoh3//prog.c)
 </div>
 
 [Cody](#cody) fixed the script [run_clock.sh](%%REPO_URL%%/2020/endoh3/run_clock.sh) which gave a
@@ -5866,8 +5876,8 @@ alt code provided by the author, Yusuke.
 
 
 <div id="2020_ferguson1">
-## [2020/ferguson1](2020/ferguson1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/ferguson1//prog.c)
+## Winning entry: [2020/ferguson1](2020/ferguson1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/ferguson1//prog.c)
 </div>
 
 [Cody](#cody), with intentional irony here :-), fixed formatting, links and typos in
@@ -5889,8 +5899,8 @@ and I encourage you to do so as the cake is quite picky!
 
 
 <div id="2020_ferguson2">
-## [2020/ferguson2](2020/ferguson2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/ferguson2//prog.c)
+## Winning entry: [2020/ferguson2](2020/ferguson2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/ferguson2//prog.c)
 </div>
 
 [Cody](#cody), with intentional irony here :-), fixed formatting, links and typos in
@@ -5916,8 +5926,8 @@ and I encourage you to do so as the cake is quite picky!
 
 
 <div id="2020_giles">
-## [2020/giles](2020/giles/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/giles//prog.c)
+## Winning entry: [2020/giles](2020/giles/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/giles//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/giles/try.sh) script. This script does
@@ -5933,16 +5943,16 @@ use the program to play the WAV files (and in one case `stdout`).
 
 
 <div id="2020_kurdyukov1">
-## [2020/kurdyukov1](2020/kurdyukov1/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/kurdyukov1//prog.c)
+## Winning entry: [2020/kurdyukov1](2020/kurdyukov1/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/kurdyukov1//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov1/try.sh) script.
 
 
 <div id="2020_kurdyukov2">
-## [2020/kurdyukov2](2020/kurdyukov2/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/kurdyukov2//prog.c)
+## Winning entry: [2020/kurdyukov2](2020/kurdyukov2/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/kurdyukov2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov2/try.sh) script.
@@ -5960,8 +5970,8 @@ entry if not installed or it fails).
 
 
 <div id="2020_kurdyukov3">
-## [2020/kurdyukov3](2020/kurdyukov3/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/kurdyukov3//prog.c)
+## Winning entry: [2020/kurdyukov3](2020/kurdyukov3/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/kurdyukov3//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov3/try.sh) script.
@@ -5972,8 +5982,8 @@ more jumbled but we know of others too.
 
 
 <div id="2020_kurdyukov4">
-## [2020/kurdyukov4](2020/kurdyukov4/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/kurdyukov4//prog.c)
+## Winning entry: [2020/kurdyukov4](2020/kurdyukov4/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/kurdyukov4//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov4/try.sh) script.
@@ -5990,8 +6000,8 @@ J.R.R. Tolkien).
 
 
 <div id="2020_otterness">
-## [2020/otterness](2020/otterness/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/otterness//prog.c)
+## Winning entry: [2020/otterness](2020/otterness/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/otterness//prog.c)
 </div>
 
 
@@ -6004,8 +6014,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2020/otterness/try.sh) script.
 
 
 <div id="2020_tsoj">
-## [2020/tsoj](2020/tsoj/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/tsoj//prog.c)
+## Winning entry: [2020/tsoj](2020/tsoj/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/tsoj//prog.c)
 </div>
 
 [Cody](#cody) added [alternate code](2020/tsoj/index.html#alternate-code) that will feel
@@ -6014,8 +6024,8 @@ file) but probably a lot less :-)
 
 
 <div id="2020_yang">
-## [2020/yang](2020/yang/index.html)
-### Source code: [prog.c](%%REPO_URL%%/2020/yang//prog.c)
+## Winning entry: [2020/yang](2020/yang/index.html)
+### Winning entry source code: [prog.c](%%REPO_URL%%/2020/yang//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/yang/try.sh) script.


### PR DESCRIPTION

This includes broken links and typos but also a stylistic change as
well. In particular each index.html file is preceded with the text:

    Winning entry:

and the next line, the source code, is preceded with:

    Winning entry source code:

This is to make them stand out more. It's not, maybe, immediately
obvious that the first links to index.html but I have not come up with a
way to make it obvious that looks nice as adding 'index.html' to
'Winning entry' might take from the fact that the section below is about
the fixes to the entry (or I might be taking it too literally too which
is entirely possible :-) ).

Missing links were also added for the years beyond 1995 at least for the
YYYY/index.html links. Those have not been checked for typos but when I
get to those years I will check those too.

I hope to get this file done in another two edits but probably no more
than three will be required.

Regenerated thanks-for-help.html file.