### PR TITLE
Remove outdated bug status in 1996/august

### DIFF
--- a/1996/august/README.md
+++ b/1996/august/README.md
@@ -5,17 +5,6 @@
 ```
 
 
-### Bugs and (Mis)features:
-
-The current status of this entry is:
-
-```
-    STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers
-```
-
-For more detailed information see [1996/august in bugs.html](../../bugs.html#1996_august).
-
-
 ## To use:
 
 ``` <!---sh-->

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -397,10 +397,6 @@ Location: <a href="../../location.html#SE">SE</a> - <em>Kingdom of Sweden</em> (
 <!-- BEFORE: 1st line of markdown file: 1996/august/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
-<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
-<p>The current status of this entry is:</p>
-<pre><code>    STATUS: doesn&#39;t work with some compilers - please provide alternative code or fix for more compilers</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1996_august">1996/august in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    cat august.c test.oc | ./august &gt; test.oo
     ./august &lt; test.oo</code></pre>


### PR DESCRIPTION
I fixed the problem of it not working with some compilers/systems ages ago but the README.md file still had:

    STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers

Rebuilt index.html.