### PR TITLE
Minor fixes and improvements in thanks file

### DIFF
--- a/1996/august/README.md
+++ b/1996/august/README.md
@@ -5,17 +5,6 @@
 ```
 
 
-### Bugs and (Mis)features:
-
-The current status of this entry is:
-
-```
-    STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers
-```
-
-For more detailed information see [1996/august in bugs.html](../../bugs.html#1996_august).
-
-
 ## To use:
 
 ``` <!---sh-->

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -397,10 +397,6 @@ Location: <a href="../../location.html#SE">SE</a> - <em>Kingdom of Sweden</em> (
 <!-- BEFORE: 1st line of markdown file: 1996/august/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
-<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
-<p>The current status of this entry is:</p>
-<pre><code>    STATUS: doesn&#39;t work with some compilers - please provide alternative code or fix for more compilers</code></pre>
-<p>For more detailed information see <a href="../../bugs.html#1996_august">1996/august in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    cat august.c test.oc | ./august &gt; test.oo
     ./august &lt; test.oo</code></pre>

--- a/2020/kurdyukov4/README.md
+++ b/2020/kurdyukov4/README.md
@@ -62,7 +62,7 @@ Example:
 Try using the same random seed and varying the context size.
 
 BTW: what on Middle-earth is `lámatyávë`? It's Quenya, one of the languages of
-the Elves in Tolkien's Legendarium. It means sound taste (plural is lámatyáver)
+the Elves in Tolkien's Legendarium. It means sound taste (plural is `lámatyáver`)
 and it refers to phonaesthesia - in other words, it refers to the pleasure of
 sound and form of words. It's discussed in [Morgoth's
 Ring](https://en.wikipedia.org/wiki/Morgoth%27s_Ring), volume X of [History of

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -426,7 +426,7 @@ Example:</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Try using the same random seed and varying the context size.</p>
 <p>BTW: what on Middle-earth is <code>lámatyávë</code>? It’s Quenya, one of the languages of
-the Elves in Tolkien’s Legendarium. It means sound taste (plural is lámatyáver)
+the Elves in Tolkien’s Legendarium. It means sound taste (plural is <code>lámatyáver</code>)
 and it refers to phonaesthesia - in other words, it refers to the pleasure of
 sound and form of words. It’s discussed in <a href="https://en.wikipedia.org/wiki/Morgoth%27s_Ring">Morgoth’s
 Ring</a>, volume X of <a href="https://en.wikipedia.org/wiki/The_History_of_Middle-earth">History of

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -401,7 +401,7 @@ on an IOCCC entry by entry basis.</p>
 <li><a href="#neglect">Did we neglect to credit you?</a></li>
 </ul>
 <div id="1984">
-<h1 id="section"><a href="1984/index.html">1984</a></h1>
+<h1 id="the-1st-ioccc"><a href="1984/index.html">1984 - The 1st IOCCC</a></h1>
 </div>
 <div id="1984_anonymous">
 <h2 id="winning-entry-1984anonymous">Winning entry: <a href="1984/anonymous/index.html">1984/anonymous</a></h2>
@@ -507,7 +507,7 @@ copy of it as to what it should have been at the time, in the fabulous <a href="
 History
 Repo</a>.</p>
 <div id="1985">
-<h1 id="section-1"><a href="1985/index.html">1985</a></h1>
+<h1 id="the-2nd-ioccc"><a href="1985/index.html">1985 - The 2nd IOCCC</a></h1>
 </div>
 <div id="1985_applin">
 <h2 id="winning-entry-1984applin">Winning entry: <a href="1985/applin/index.html">1984/applin</a></h2>
@@ -652,7 +652,7 @@ should they object to <code>main()</code> having only one arg.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/try.alt.sh">try.alt.sh</a> scripts.</p>
 <div id="1986">
-<h1 id="section-2"><a href="1986/index.html">1986</a></h1>
+<h1 id="the-3rd-ioccc"><a href="1986/index.html">1986 - The 3rd IOCCC</a></h1>
 </div>
 <div id="1986_applin">
 <h2 id="winning-entry-1986applin">Winning entry: <a href="1986/applin/index.html">1986/applin</a></h2>
@@ -811,7 +811,7 @@ work with <code>gcc</code> - but it still required <code>-traditional-cpp</code>
 </ul>
 <p>There might have been other changes as well.</p>
 <div id="1987">
-<h1 id="section-3"><a href="1987/index.html">1987</a></h1>
+<h1 id="the-4th-ioccc"><a href="1987/index.html">1987 - The 4th IOCCC</a></h1>
 </div>
 <div id="1987_biggar">
 <h2 id="winning-entry-1987biggar">Winning entry: <a href="1987/biggar/index.html">1987/biggar</a></h2>
@@ -899,7 +899,7 @@ instead as it does look more symmetrical now.</p>
 <p>Cody also added to the Makefile <code>-include stdio.h</code> in the nowadays very
 unlikely(?) but nevertheless suggested case that <code>putchar(3)</code> is not available.</p>
 <div id="1988">
-<h1 id="section-4"><a href="1988/index.html">1988</a></h1>
+<h1 id="the-5th-ioccc"><a href="1988/index.html">1988 - The 5th IOCCC</a></h1>
 </div>
 <div id="1988_dale">
 <h2 id="winning-entry-1988dale">Winning entry: <a href="1988/dale/index.html">1988/dale</a></h2>
@@ -1025,7 +1025,7 @@ entry as seeing the code with the result at once is far more beautiful.</p>
 <p>Cody also changed the <code>int</code>s to be <code>float</code> as that’s what they are printed as:
 not strictly necessary but nonetheless more correct, even if not warned against.</p>
 <div id="1989">
-<h1 id="section-5"><a href="1989/index.html">1989</a></h1>
+<h1 id="the-6th-ioccc"><a href="1989/index.html">1989 - The 6th IOCCC</a></h1>
 </div>
 <div id="1989_fubar">
 <h2 id="winning-entry-1989fubar">Winning entry: <a href="1989/fubar/index.html">1989/fubar</a></h2>
@@ -1232,7 +1232,7 @@ output.</p>
 <p>The <code>compile.sh</code> script allows one to specify the compiler with the <code>CC</code>
 environmental variable; see the index.html for details.</p>
 <div id="1990">
-<h1 id="section-6"><a href="1990/index.html">1990</a></h1>
+<h1 id="the-7th-ioccc"><a href="1990/index.html">1990 - The 7th IOCCC</a></h1>
 </div>
 <div id="1990_baruch">
 <h2 id="winning-entry-1990baruch">Winning entry: <a href="1990/baruch/index.html">1990/baruch</a></h2>
@@ -1393,7 +1393,7 @@ deemed a problem to be fixed.</p>
 original code.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/try.sh">try.sh</a> script.</p>
 <div id="1991">
-<h1 id="section-7"><a href="1991/index.html">1991</a></h1>
+<h1 id="the-8th-ioccc"><a href="1991/index.html">1991 - The 8th IOCCC</a></h1>
 </div>
 <div id="1991_ant">
 <h2 id="winning-entry-1991ant">Winning entry: <a href="1991/ant/index.html">1991/ant</a></h2>
@@ -1590,7 +1590,7 @@ is based on the author’s remarks, a version that supposedly (:-) ) always wins
 <p>Cody also fixed the make clobber rule where a file was left lying about when it
 should have been removed.</p>
 <div id="1992">
-<h1 id="section-8"><a href="1992/index.html">1992</a></h1>
+<h1 id="the-9th-ioccc"><a href="1992/index.html">1992 - The 9th IOCCC</a></h1>
 </div>
 <div id="1992_adrian">
 <h2 id="winning-entry-1992adrian">Winning entry: <a href="1992/adrian/index.html">1992/adrian</a></h2>
@@ -1653,7 +1653,7 @@ generated.</p>
 <p><a href="#cody">Cody</a> fixed this to compile with modern systems. Note that in 1996 a bug fix was
 applied to the code, provided as the alt code as that version is not obfuscated.
 Thus Cody’s fix applies to the original entry. The problems were that <code>malloc.h</code>
-is not the correct header file now (at least in some systems?) and a non-void
+is not the correct header file now (at least in some systems) and a non-void
 (implicit <code>int</code>) function returning without a value. That function was changed to
 return <code>void</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/try.sh">try.sh</a> and
@@ -1833,7 +1833,7 @@ world</a> or just the
 args (2). And not that we need the help or anything for this :-) but we
 encourage you to try the original without two args :-)</p>
 <div id="1993">
-<h1 id="section-9"><a href="1993/index.html">1993</a></h1>
+<h1 id="the-10th-ioccc"><a href="1993/index.html">1993 - The 10th IOCCC</a></h1>
 </div>
 <div id="1993_ant">
 <h2 id="winning-entry-1993ant">Winning entry: <a href="1993/ant/index.html">1993/ant</a></h2>
@@ -1950,7 +1950,7 @@ work).</p>
 this code. Other code is also described there.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/try.sh">try.sh</a> script.</p>
 <div id="1994">
-<h1 id="section-10"><a href="1994/index.html">1994</a></h1>
+<h1 id="the-11th-ioccc"><a href="1994/index.html">1994 - The 11th IOCCC</a></h1>
 </div>
 <div id="1994_dodsond2">
 <h2 id="winning-entry-1994dodsond2">Winning entry: <a href="1994/dodsond2/index.html">1994/dodsond2</a></h2>
@@ -2112,7 +2112,7 @@ that will look fine on terminals not set to 80 columns and the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.alt.sh">try.alt.sh</a> script to automate the play
 along the lines of the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.sh">try.sh</a> script.</p>
 <div id="1995">
-<h1 id="section-11"><a href="1995/index.html">1995</a></h1>
+<h1 id="the-12th-ioccc"><a href="1995/index.html">1995 - The 12th IOCCC</a></h1>
 </div>
 <div id="1995_cdua">
 <h2 id="winning-entry-1995cdua">Winning entry: <a href="1995/cdua/index.html">1995/cdua</a></h2>
@@ -2197,14 +2197,15 @@ extract it. The exception is when the files are created by the entry or the
 entry decrypts the text or something like that.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/try.sh">try.sh</a> script.</p>
 <div id="1996">
-<h1 id="section-12"><a href="1996/index.html">1996</a></h1>
+<h1 id="the-13th-ioccc"><a href="1996/index.html">1996 - The 13th IOCCC</a></h1>
 </div>
 <div id="1996_august">
 <h2 id="winning-entry-1996august">Winning entry: <a href="1996/august/index.html">1996/august</a></h2>
 <h3 id="winning-entry-source-code-august.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/august/august.c">august.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed a segfault in this program that prevented it from working right and
-also fixed an infinite loop in the try commands.</p>
+also fixed an infinite loop in the try commands. This infinite loop prevented it
+from working with some systems or compilers which we noted a long time ago.</p>
 <p>The problem with the infinite loop is that the file <code>august.oc</code> had to have
 lines starting with <code>#</code> removed and it was not being done. After this is done
 with say <code>sed(1)</code> (like <code>sed -i'' '/^#/d' august.oc</code> which has been added to
@@ -2227,18 +2228,16 @@ but he missed that Yusuke added a’…’ after the result which made him think
 the fix was wrong.</p>
 <p>Cody also made the recommended change of the author to make it so that each
 number is printed on a line by itself rather than having a long string of
-numbers on the same line. This was not put in an alternate version but perhaps
-it should be.</p>
+numbers on the same line.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/dalbec/try.sh">try.sh</a> script.</p>
 <div id="1996_eldby">
 <h2 id="winning-entry-1996eldby">Winning entry: <a href="1996/eldby/index.html">1996/eldby</a></h2>
 <h3 id="winning-entry-source-code-eldby.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/eldby/eldby.c">eldby.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/eldby/eldby.alt.c">alternate version</a> which uses
-<code>usleep()</code> in between writing the output to make it easier to see what is going
-on with faster systems and importantly also for those who are sensitive to text
-flashing by rapidly (it affects him too but he also thinks it moves too fast
-nowadays anyway). We recommend that you try the alternate version first due to
+<code>usleep()</code> in between writing the output to make it easier to see what it looked
+like back in 1996 with modern systems and importantly also for those who are sensitive to text
+flashing by rapidly. We recommend that you try the alternate version first due to
 these reasons.</p>
 <div id="1996_gandalf">
 <h2 id="winning-entry-1996gandalf">Winning entry: <a href="1996/gandalf/index.html">1996/gandalf</a></h2>
@@ -2317,7 +2316,7 @@ clocks, both with the fixed version and the original (alt) version.</p>
 <p>Also, to fix any potential problem with displaying in GitHub the scripts
 provided by the author, Cody added ‘.sh’ to the <code>clock[1-3].sh</code> scripts.</p>
 <div id="1998">
-<h1 id="section-13"><a href="1998/index.html">1998</a></h1>
+<h1 id="the-14th-ioccc"><a href="1998/index.html">1998 - The 14th IOCCC</a></h1>
 </div>
 <div id="1998_banks">
 <h2 id="winning-entry-1998banks">Winning entry: <a href="1998/banks/index.html">1998/banks</a></h2>
@@ -2536,7 +2535,7 @@ program had <code>return 1</code>).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/tomtorfs/try.sh">try.sh</a> script to try out a few
 commands that we recommended.</p>
 <div id="2000">
-<h1 id="section-14"><a href="2000/index.html">2000</a></h1>
+<h1 id="the-15th-ioccc"><a href="2000/index.html">2000 - The 15th IOCCC</a></h1>
 </div>
 <div id="2000_anderson">
 <h2 id="winning-entry-2000anderson">Winning entry: <a href="2000/anderson/index.html">2000/anderson</a></h2>
@@ -2678,7 +2677,7 @@ the main code and the alt code respectively.</p>
 <p>And although the scripts do <code>chmod +x</code> on the source code (see the index.html for
 details) the source code is now executable by default.</p>
 <div id="2001">
-<h1 id="section-15"><a href="2001/index.html">2001</a></h1>
+<h1 id="the-16th-ioccc"><a href="2001/index.html">2001 - The 16th IOCCC</a></h1>
 </div>
 <div id="2001_anonymous">
 <h2 id="winning-entry-2001anonymous">Winning entry: <a href="2001/anonymous/index.html">2001/anonymous</a></h2>
@@ -2901,7 +2900,7 @@ that we, the IOCCC judges, suggested, as well as some additional ones that he
 thought would be fun. He also provided the sort and punch card versions,
 described in the index.html, based on the author’s remarks.</p>
 <div id="2004">
-<h1 id="section-16"><a href="2004/index.html">2004</a></h1>
+<h1 id="the-17th-ioccc"><a href="2004/index.html">2004 - The 17th IOCCC</a></h1>
 </div>
 <div id="2004_anonymous">
 <h2 id="winning-entry-2004anonymous">Winning entry: <a href="2004/anonymous/index.html">2004/anonymous</a></h2>
@@ -3121,7 +3120,7 @@ which used to be generated by the Makefile via <code>cc -E</code>.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/vik2/vik2.possible.cat.death.c">vik2.possible.cat.death.c</a>!) <code>__FILE__</code>
 just to make it a bit easier to compile.</p>
 <div id="2005">
-<h1 id="section-17"><a href="2005/index.html">2005</a></h1>
+<h1 id="the-18th-ioccc"><a href="2005/index.html">2005 - The 18th IOCCC</a></h1>
 </div>
 <div id="2005_aidan">
 <h2 id="winning-entry-2005aidan">Winning entry: <a href="2005/aidan/index.html">2005/aidan</a></h2>
@@ -3317,7 +3316,7 @@ find it’ but the source code file name is not always the same as the executabl
 with the appropriate extension so this might be called a bug fix as well though
 if one runs it from another directory, specifying the directory, it’ll not catch it.</p>
 <div id="2006">
-<h1 id="section-18"><a href="2006/index.html">2006</a></h1>
+<h1 id="the-19th-ioccc"><a href="2006/index.html">2006 - The 19th IOCCC</a></h1>
 </div>
 <div id="2006_birken">
 <h2 id="winning-entry-2006birken">Winning entry: <a href="2006/birken/index.html">2006/birken</a></h2>
@@ -3454,7 +3453,7 @@ have been a problem in Linux with the old <code>int</code>s but this is no longe
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>, based on the author’s remarks.
 We’re not able to test this.</p>
 <div id="2011">
-<h1 id="section-19"><a href="2011/index.html">2011</a></h1>
+<h1 id="the-20th-ioccc"><a href="2011/index.html">2011 - The 20th IOCCC</a></h1>
 </div>
 <div id="2011_akari">
 <h2 id="winning-entry-2011akari">Winning entry: <a href="2011/akari/index.html">2011/akari</a></h2>
@@ -3573,7 +3572,7 @@ and text then <code>stdout</code> needs to be set to binary mode.</p>
 <a href="2011/zucker/sphere-tracing.pdf">sphere-tracing.pdf</a> in case the link
 eventually dies.</p>
 <div id="2012">
-<h1 id="section-20"><a href="2012/index.html">2012</a></h1>
+<h1 id="the-21st-ioccc"><a href="2012/index.html">2012 - The 21st IOCCC</a></h1>
 </div>
 <div id="2012_blakely">
 <h2 id="winning-entry-2012blakely">Winning entry: <a href="2012/blakely/index.html">2012/blakely</a></h2>
@@ -3729,7 +3728,7 @@ look at the program source with tab space of 4 characters so Cody added the
 command to do this in vim for those who use it, in the judges’ remarks, to make
 it easier for those who do not know how, and to make it more obvious to try it.</p>
 <div id="2013">
-<h1 id="section-21"><a href="2013/index.html">2013</a></h1>
+<h1 id="the-22nd-ioccc"><a href="2013/index.html">2013 - The 22nd IOCCC</a></h1>
 </div>
 <div id="2013_birken">
 <h2 id="winning-entry-2013birken">Winning entry: <a href="2013/birken/index.html">2013/birken</a></h2>
@@ -3907,7 +3906,7 @@ implicitly (Linux doesn’t seem to but macOS does).</p>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/robison/try.sh">try.sh</a> script.</p>
 <div id="2014">
-<h1 id="section-22"><a href="2014/index.html">2014</a></h1>
+<h1 id="the-23rd-ioccc"><a href="2014/index.html">2014 - The 23rd IOCCC</a></h1>
 </div>
 <div id="2014_birken">
 <h2 id="winning-entry-2014birken">Winning entry: <a href="2014/birken/index.html">2014/birken</a></h2>
@@ -4040,7 +4039,7 @@ should they want to. It also checks that both of these two tools exist and are
 executable and it pipes it through less as it’s longer than a page worth of
 output.</p>
 <div id="2015">
-<h1 id="section-23"><a href="2015/index.html">2015</a></h1>
+<h1 id="the-24th-ioccc"><a href="2015/index.html">2015 - The 24th IOCCC</a></h1>
 </div>
 <div id="2015_burton">
 <h2 id="winning-entry-2015burton">Winning entry: <a href="2015/burton/index.html">2015/burton</a></h2>
@@ -4166,7 +4165,7 @@ files from compiling properly, trying instead to compile already compiled code.<
 (Linux seems to not but macOS does).</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/yang/try.sh">try.sh</a> script.</p>
 <div id="2018">
-<h1 id="section-24"><a href="2018/index.html">2018</a></h1>
+<h1 id="the-25th-ioccc"><a href="2018/index.html">2018 - The 25th IOCCC</a></h1>
 </div>
 <div id="2018_anderson">
 <h2 id="winning-entry-2018anderson">Winning entry: <a href="2018/anderson/index.html">2018/anderson</a></h2>
@@ -4309,7 +4308,7 @@ configuration).</p>
 if the user wants to see some of the spoilers and only show them if they type
 <code>y</code> or <code>Y</code>.</p>
 <div id="2019">
-<h1 id="section-25"><a href="2019/index.html">2019</a></h1>
+<h1 id="the-26th-ioccc"><a href="2019/index.html">2019 - The 26th IOCCC</a></h1>
 </div>
 <div id="2019_adamovsky">
 <h2 id="winning-entry-2019adamovsky">Winning entry: <a href="2019/adamovsky/index.html">2019/adamovsky</a></h2>
@@ -4468,7 +4467,7 @@ slightly updating the <a href="2019/yang/sample_input.txt">sample_input.txt</a> 
 (removed trailing newlines as it resulted in <code>diff</code> showing differences when it
 shouldn’t) and adding the <a href="2019/yang/ioccc.txt">ioccc.txt</a> file.</p>
 <div id="2020">
-<h1 id="section-26"><a href="2020/index.html">2020</a></h1>
+<h1 id="the-27th-ioccc"><a href="2020/index.html">2020 - The 27th IOCCC</a></h1>
 </div>
 <div id="2020_burton">
 <h2 id="winning-entry-2020burton">Winning entry: <a href="2020/burton/index.html">2020/burton</a></h2>
@@ -4609,13 +4608,17 @@ more jumbled but we know of others too.</p>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4/try.sh">try.sh</a> script.</p>
 <p>Cody also added from <a href="2019/mills/index.html">2019/mills</a> the text file
-<a href="2020/kurdyukov4/Shakespeare.txt">Shakespeare.txt</a> as we are considering to
-have each entry have a tarball with the entry by itself.</p>
-<p>Also, to explain the confusing to most people award, Cody gave a quick
-translation of <code>lámatyávë</code>, which comes from History of Middle-earth [HoMe],
-volume X, Morgoth’s Ring, which he also has (and which is part of the 12 volume
-set by the late Christopher Tolkien, son and literary executor and heir to
-J.R.R. Tolkien).</p>
+<a href="2020/kurdyukov4/Shakespeare.txt">Shakespeare.txt</a> as we now provide a tarball
+of each entry by itself.</p>
+<p>Also, as a fellow Tolkienist, to explain the confusing (to most people) award
+title, Cody gave a quick translation of <code>lámatyávë</code>, which comes from <a href="https://en.wikipedia.org/wiki/Morgoth%27s_Ring">Morgoth’s
+Ring</a>, volume X of the 12
+volume <a href="https://en.wikipedia.org/wiki/The_History_of_Middle-earth">History of
+Middle-earth</a> (known
+to us Tolkienists as <code>HoMe</code>), which he naturally :-) has, by the late and great
+<a href="https://en.wikipedia.org/wiki/Christopher_Tolkien">Christopher Tolkien</a>, son
+and literary executor and heir to <a href="https://www.tolkienestate.com/life/biography/">J.R.R.
+Tolkien</a>.</p>
 <div id="2020_otterness">
 <h2 id="winning-entry-2020otterness">Winning entry: <a href="2020/otterness/index.html">2020/otterness</a></h2>
 <h3 id="winning-entry-source-code-prog.c-63">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness//prog.c">prog.c</a></h3>
@@ -4719,7 +4722,7 @@ although some might not make as much sense unless one looks into the entry.</p>
 changes</strong>, fixes and <strong>many important improvements</strong> that we
 wish to <strong>especially thank</strong>.</p>
 <h3 id="authors">Authors</h3>
-<p>A good number of the <a href="authors.html">wining entries of the
+<p>A good number of the <a href="authors.html">winning entries of the
 IOCCC</a> tested, identified and helped correct
 and/or improve the write-ups of fellow IOCCC entries for the year that they won.
 The list of those entries is too long to mention: nevertheless the <a href="judges.html">IOCCC
@@ -4762,7 +4765,8 @@ inconsistent award titles in the README files and CSV file (that he generated
 from the SQL file).</p>
 <p>Additionally Cody greatly improved the manifest of the winning entries and
 checked that the generated html files, index.html and otherwise, look well and
-presentable.</p>
+presentable and suggested a CSS rule for <code>&lt;img&gt;</code> to make images more responsive
+on smaller screens.</p>
 <p><strong>THANK YOU VERY MUCH</strong> for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC entries and fixing almost all past entries for modern
 systems!</p>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -30,7 +30,7 @@ on an IOCCC entry by entry basis.
 
 
 <div id="1984">
-# [1984](1984/index.html)
+# [1984 - The 1st IOCCC](1984/index.html)
 </div>
 
 
@@ -173,7 +173,7 @@ Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
 
 <div id="1985">
-# [1985](1985/index.html)
+# [1985 - The 2nd IOCCC](1985/index.html)
 </div>
 
 
@@ -371,7 +371,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 
 
 <div id="1986">
-# [1986](1986/index.html)
+# [1986 - The 3rd IOCCC](1986/index.html)
 </div>
 
 
@@ -624,7 +624,7 @@ There might have been other changes as well.
 
 
 <div id="1987">
-# [1987](1987/index.html)
+# [1987 - The 4th IOCCC](1987/index.html)
 </div>
 
 
@@ -747,7 +747,7 @@ unlikely(?) but nevertheless suggested case that `putchar(3)` is not available.
 
 
 <div id="1988">
-# [1988](1988/index.html)
+# [1988 - The 5th IOCCC](1988/index.html)
 </div>
 
 
@@ -929,7 +929,7 @@ not strictly necessary but nonetheless more correct, even if not warned against.
 
 
 <div id="1989">
-# [1989](1989/index.html)
+# [1989 - The 6th IOCCC](1989/index.html)
 </div>
 
 
@@ -1208,7 +1208,7 @@ environmental variable; see the index.html for details.
 
 
 <div id="1990">
-# [1990](1990/index.html)
+# [1990 - The 7th IOCCC](1990/index.html)
 </div>
 
 
@@ -1444,7 +1444,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1990/westley/try.sh) script.
 
 
 <div id="1991">
-# [1991](1991/index.html)
+# [1991 - The 8th IOCCC](1991/index.html)
 </div>
 
 
@@ -1734,7 +1734,7 @@ should have been removed.
 
 
 <div id="1992">
-# [1992](1992/index.html)
+# [1992 - The 9th IOCCC](1992/index.html)
 </div>
 
 
@@ -1827,7 +1827,7 @@ generated.
 [Cody](#cody) fixed this to compile with modern systems. Note that in 1996 a bug fix was
 applied to the code, provided as the alt code as that version is not obfuscated.
 Thus Cody's fix applies to the original entry. The problems were that `malloc.h`
-is not the correct header file now (at least in some systems?) and a non-void
+is not the correct header file now (at least in some systems) and a non-void
 (implicit `int`) function returning without a value. That function was changed to
 return `void`.
 
@@ -2068,7 +2068,7 @@ encourage you to try the original without two args :-)
 
 
 <div id="1993">
-# [1993](1993/index.html)
+# [1993 - The 10th IOCCC](1993/index.html)
 </div>
 
 
@@ -2240,7 +2240,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1993/vanb/try.sh) script.
 
 
 <div id="1994">
-# [1994](1994/index.html)
+# [1994 - The 11th IOCCC](1994/index.html)
 </div>
 
 
@@ -2451,7 +2451,7 @@ along the lines of the [try.sh](%%REPO_URL%%/1994/westley/try.sh) script.
 
 
 <div id="1995">
-# [1995](1995/index.html)
+# [1995 - The 12th IOCCC](1995/index.html)
 </div>
 
 
@@ -2573,7 +2573,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1995/vanschnitz/try.sh) script.
 
 
 <div id="1996">
-# [1996](1996/index.html)
+# [1996 - The 13th IOCCC](1996/index.html)
 </div>
 
 
@@ -2583,7 +2583,8 @@ Cody also added the [try.sh](%%REPO_URL%%/1995/vanschnitz/try.sh) script.
 </div>
 
 [Cody](#cody) fixed a segfault in this program that prevented it from working right and
-also fixed an infinite loop in the try commands.
+also fixed an infinite loop in the try commands. This infinite loop prevented it
+from working with some systems or compilers which we noted a long time ago.
 
 The problem with the infinite loop is that the file `august.oc` had to have
 lines starting with `#` removed and it was not being done. After this is done
@@ -2612,8 +2613,7 @@ the fix was wrong.
 
 Cody also made the recommended change of the author to make it so that each
 number is printed on a line by itself rather than having a long string of
-numbers on the same line. This was not put in an alternate version but perhaps
-it should be.
+numbers on the same line.
 
 Cody also added the [try.sh](%%REPO_URL%%/1996/dalbec/try.sh) script.
 
@@ -2624,10 +2624,9 @@ Cody also added the [try.sh](%%REPO_URL%%/1996/dalbec/try.sh) script.
 </div>
 
 [Cody](#cody) provided an [alternate version](%%REPO_URL%%/1996/eldby/eldby.alt.c) which uses
-`usleep()` in between writing the output to make it easier to see what is going
-on with faster systems and importantly also for those who are sensitive to text
-flashing by rapidly (it affects him too but he also thinks it moves too fast
-nowadays anyway). We recommend that you try the alternate version first due to
+`usleep()` in between writing the output to make it easier to see what it looked
+like back in 1996 with modern systems and importantly also for those who are sensitive to text
+flashing by rapidly. We recommend that you try the alternate version first due to
 these reasons.
 
 
@@ -2738,7 +2737,7 @@ provided by the author, Cody added '.sh' to the `clock[1-3].sh` scripts.
 
 
 <div id="1998">
-# [1998](1998/index.html)
+# [1998 - The 14th IOCCC](1998/index.html)
 </div>
 
 
@@ -3046,7 +3045,7 @@ commands that we recommended.
 
 
 <div id="2000">
-# [2000](2000/index.html)
+# [2000 - The 15th IOCCC](2000/index.html)
 </div>
 
 
@@ -3249,7 +3248,7 @@ details) the source code is now executable by default.
 
 
 <div id="2001">
-# [2001](2001/index.html)
+# [2001 - The 16th IOCCC](2001/index.html)
 </div>
 
 
@@ -3576,7 +3575,7 @@ described in the index.html, based on the author's remarks.
 
 
 <div id="2004">
-# [2004](2004/index.html)
+# [2004 - The 17th IOCCC](2004/index.html)
 </div>
 
 
@@ -3867,7 +3866,7 @@ just to make it a bit easier to compile.
 
 
 <div id="2005">
-# [2005](2005/index.html)
+# [2005 - The 18th IOCCC](2005/index.html)
 </div>
 
 
@@ -4154,7 +4153,7 @@ if one runs it from another directory, specifying the directory, it'll not catch
 
 
 <div id="2006">
-# [2006](2006/index.html)
+# [2006 - The 19th IOCCC](2006/index.html)
 </div>
 
 
@@ -4351,7 +4350,7 @@ We're not able to test this.
 
 
 <div id="2011">
-# [2011](2011/index.html)
+# [2011 - The 20th IOCCC](2011/index.html)
 </div>
 
 
@@ -4523,7 +4522,7 @@ eventually dies.
 
 
 <div id="2012">
-# [2012](2012/index.html)
+# [2012 - The 21st IOCCC](2012/index.html)
 </div>
 
 
@@ -4739,7 +4738,7 @@ it easier for those who do not know how, and to make it more obvious to try it.
 
 
 <div id="2013">
-# [2013](2013/index.html)
+# [2013 - The 22nd IOCCC](2013/index.html)
 </div>
 
 
@@ -4995,7 +4994,7 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/morgan1/try.sh) script.
 
 
 <div id="2014">
-# [2014](2014/index.html)
+# [2014 - The 23rd IOCCC](2014/index.html)
 </div>
 
 
@@ -5177,7 +5176,7 @@ output.
 
 
 <div id="2015">
-# [2015](2015/index.html)
+# [2015 - The 24th IOCCC](2015/index.html)
 </div>
 
 
@@ -5363,7 +5362,7 @@ He also added the [try.sh](%%REPO_URL%%/2015/yang/try.sh) script.
 
 
 <div id="2018">
-# [2018](2018/index.html)
+# [2018 - The 25th IOCCC](2018/index.html)
 </div>
 
 
@@ -5565,7 +5564,7 @@ if the user wants to see some of the spoilers and only show them if they type
 
 
 <div id="2019">
-# [2019](2019/index.html)
+# [2019 - The 26th IOCCC](2019/index.html)
 </div>
 
 
@@ -5787,7 +5786,7 @@ shouldn't) and adding the [ioccc.txt](2019/yang/ioccc.txt) file.
 
 
 <div id="2020">
-# [2020](2020/index.html)
+# [2020 - The 27th IOCCC](2020/index.html)
 </div>
 
 
@@ -5989,14 +5988,18 @@ more jumbled but we know of others too.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov4/try.sh) script.
 
 Cody also added from [2019/mills](2019/mills/index.html) the text file
-[Shakespeare.txt](2020/kurdyukov4/Shakespeare.txt) as we are considering to
-have each entry have a tarball with the entry by itself.
+[Shakespeare.txt](2020/kurdyukov4/Shakespeare.txt) as we now provide a tarball
+of each entry by itself.
 
-Also, to explain the confusing to most people award, Cody gave a quick
-translation of `lámatyávë`, which comes from History of Middle-earth [HoMe],
-volume X, Morgoth's Ring, which he also has (and which is part of the 12 volume
-set by the late Christopher Tolkien, son and literary executor and heir to
-J.R.R. Tolkien).
+Also, as a fellow Tolkienist, to explain the confusing (to most people) award
+title, Cody gave a quick translation of `lámatyávë`, which comes from [Morgoth's
+Ring](https://en.wikipedia.org/wiki/Morgoth%27s_Ring), volume X of the 12
+volume [History of
+Middle-earth](https://en.wikipedia.org/wiki/The_History_of_Middle-earth) (known
+to us Tolkienists as `HoMe`), which he naturally :-) has, by the late and great
+[Christopher Tolkien](https://en.wikipedia.org/wiki/Christopher_Tolkien), son
+and literary executor and heir to [J.R.R.
+Tolkien](https://www.tolkienestate.com/life/biography/).
 
 
 <div id="2020_otterness">
@@ -6145,7 +6148,7 @@ wish to **especially thank**.
 ### Authors
 </div>
 
-A good number of the [wining entries of the
+A good number of the [winning entries of the
 IOCCC](authors.html) tested, identified and helped correct
 and/or improve the write-ups of fellow IOCCC entries for the year that they won.
 The list of those entries is too long to mention: nevertheless the [IOCCC
@@ -6193,7 +6196,8 @@ from the SQL file).
 
 Additionally Cody greatly improved the manifest of the winning entries and
 checked that the generated html files, index.html and otherwise, look well and
-presentable.
+presentable and suggested a CSS rule for `<img>` to  make images more responsive
+on smaller screens.
 
 **THANK YOU VERY MUCH** for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC entries and fixing almost all past entries for modern


### PR DESCRIPTION

For each year it now shows which IOCCC it was. In other words for 1984
the link title is now:

    1984 - The 1st IOCCC

and 1985 is:

    1985 - The 2nd IOCCC

and 1986 is:

    1986 - The 3rd IOCCC

and so on up to 2020 which is:

    2020 - The 27th IOCCC

This helps it stand out better and it shows which contest it was.

There were a few other fixes. This edit does NOT check further years
from yesterday's commit 2647827d94a48d89cd70c5dfb387d32fb9127bec and it
is possible I won't do more years until another day (though I started 
1996 but nothing needed to be fixed, I think).

Other minor fixes in formatting were also made.

Rebuilt thanks-for-help.html.
