### PR TITLE
Improve FAQ 3.0 - about Makefile rules

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1162,11 +1162,17 @@ not compiled)</li>
 <li>everything: equivalent to <code>make all alt</code>.</li>
 </ul>
 <p>Are there any other rules? You tell us!</p>
+<p>The top level and the year (e.g. <code>1984/Makefile</code>, <code>1985/Makefile</code> etc.)
+<code>Makefile</code>s recurse into the subdirectories for each entry so you can compile
+individual entries, entries of a given year or all entries, based on what you
+wish to do.</p>
 <p>NOTE about the above rules: the Makefile default assumes <code>cc</code> which might be a
 gcc-based compiler, or a clang-based compiler, or some other compiler. Only by
 forcing <code>CC=clang</code> or <code>CC=gcc</code> will one invoke a specific compiler to, say,
 enable or disable additional warnings or flags. Even so different versions or
-compilers might do different things, have different defects or other issues.</p>
+compilers might do different things, have different defects or other issues.
+Note that the <code>Makefile</code>s check the <code>CC</code> variable by substrings so that if you
+were to do something like <code>make CC=gcc=mp-12</code> it would register as <code>gcc</code>.</p>
 <div id="faq3_1">
 <h3 id="faq-3.1-why-doesnt-this-ioccc-entry-compile">FAQ 3.1: Why doesn’t this IOCCC entry compile?</h3>
 </div>

--- a/faq.md
+++ b/faq.md
@@ -1012,11 +1012,18 @@ clobber` depends on `clean` so running `make clobber` will invoke `make clean`.
 
 Are there any other rules? You tell us!
 
+The top level and the year (e.g. `1984/Makefile`, `1985/Makefile` etc.)
+`Makefile`s recurse into the subdirectories for each entry so you can compile
+individual entries, entries of a given year or all entries, based on what you
+wish to do.
+
 NOTE about the above rules: the Makefile default assumes `cc` which might be a
 gcc-based compiler, or a clang-based compiler, or some other compiler. Only by
 forcing `CC=clang` or `CC=gcc` will one invoke a specific compiler to, say,
 enable or disable additional warnings or flags. Even so different versions or
 compilers might do different things, have different defects or other issues.
+Note that the `Makefile`s check the `CC` variable by substrings so that if you
+were to do something like `make CC=gcc=mp-12` it would register as `gcc`.
 
 
 <div id="faq3_1">


### PR DESCRIPTION
It now clarifies that the CC=... checks by substring so that one can do make CC=gcc-mp-12, for example, and it will register as gcc.

It also clarifies that the top level Makefile and the year Makefiles recurse into subdirectories so that one can compile individual entries, entries for a given year or all entries.