### PR TITLE
Add back bug status to 2001/cheong

### DIFF
--- a/2001/cheong/README.md
+++ b/2001/cheong/README.md
@@ -5,6 +5,19 @@
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+    STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2001/cheong in bugs.html](../../bugs.html#2001_cheong).
+
+
+
+
 ## To use:
 
 ``` <!---sh-->

--- a/2001/cheong/cheong.c
+++ b/2001/cheong/cheong.c
@@ -11,4 +11,4 @@ c=o+     (D[I]+82)%10-(I>l/2)*
 :!(o=pain(c/10,O,I-1))*((c+999
 )%10-(D[I]+92)%10);}return o;}
 int main(int o,char **O)     {
-return o>1?pain(o, O, l):1;  }
+return pain(o, O, l);        }

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -397,6 +397,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 2001/cheong/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
+<p>For more detailed information see <a href="../../bugs.html#2001_cheong">2001/cheong in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./cheong digits</code></pre>
 <h2 id="try">Try:</h2>

--- a/bugs.html
+++ b/bugs.html
@@ -1884,9 +1884,7 @@ modification by Yusuke noted in the <a href="thanks-for-help.html">thanks</a>
 file) but it appears this <em>also</em> requires i386 linux; indeed looking at the code
 it hard codes paths that are i386 specific to linux.</p>
 <p>Another point of interest is that the author provided de-obfuscated versions
-which might be of value to look at. I might do that as well but this entry is
-very likely never going to work for 64-bit linux so that’s not that likely since
-there are other things that are more important.</p>
+which might be of value to look at.</p>
 <p>If you have a fix for 64-bit systems this is welcome as an alternate version, as
 stated above. You might like to look at the otccelf version but note that it (at
 least in 64-bit linux and macOS) has compilation errors.</p>
@@ -1900,10 +1898,17 @@ the compiler won’t work there.</p>
 <p>Also the supplementary program, which did not work at all, was fixed (by Cody)
 and it can be run by itself for fun in modern systems, which was not possible
 before the fixes there.</p>
+<div id="2001_cheong">
+<h2 id="cheong">2001/cheong</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
+<h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
+<p>This program will crash without an arg.</p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
@@ -1924,7 +1929,7 @@ appreciate your help!</p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
 <p>Sometimes when one player presses <code>q</code> it will result in broken pipe on the other
@@ -1950,7 +1955,7 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
@@ -2118,13 +2123,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2149,7 +2154,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2162,7 +2167,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2176,7 +2181,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2185,7 +2190,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2219,7 +2224,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2233,7 +2238,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2274,7 +2279,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2295,12 +2300,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2317,7 +2322,7 @@ welcome to try and fix it if you wish to!</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2364,7 +2369,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2387,7 +2392,7 @@ bins at the edges.</p>
 instead being something else entirely. The Internet Wayback Machine, although it
 archived it, did not load scripts. Do you know if the domain was moved? Do you
 have an archive or mirror? Please provide us it! Thank you.</p>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2400,7 +2405,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2572,7 +2577,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2586,7 +2591,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2595,7 +2600,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2628,7 +2633,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2642,7 +2647,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2663,7 +2668,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2679,7 +2684,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2699,7 +2704,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2718,7 +2723,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2734,7 +2739,7 @@ section</a>.</p>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2747,14 +2752,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2762,7 +2767,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2779,7 +2784,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2803,7 +2808,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2844,7 +2849,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2869,7 +2874,7 @@ result. Error messages become garbled, though.</p></li>
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2878,7 +2883,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -2911,7 +2916,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -2930,7 +2935,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -2955,7 +2960,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -2970,7 +2975,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3020,7 +3025,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3028,7 +3033,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3036,7 +3041,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3068,7 +3073,7 @@ ideal if this was not the case.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3097,7 +3102,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3105,7 +3110,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3135,7 +3140,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3145,7 +3150,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3165,7 +3170,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3174,7 +3179,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3189,7 +3194,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3200,7 +3205,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3214,7 +3219,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3224,7 +3229,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3233,7 +3238,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -2205,13 +2205,12 @@ file) but it appears this *also* requires i386 linux; indeed looking at the code
 it hard codes paths that are i386 specific to linux.
 
 Another point of interest is that the author provided de-obfuscated versions
-which might be of value to look at. I might do that as well but this entry is
-very likely never going to work for 64-bit linux so that's not that likely since
-there are other things that are more important.
+which might be of value to look at.
 
 If you have a fix for 64-bit systems this is welcome as an alternate version, as
 stated above. You might like to look at the otccelf version but note that it (at
 least in 64-bit linux and macOS) has compilation errors.
+
 
 ### Aside: why were there changes made if INABIAF ?
 
@@ -2225,6 +2224,16 @@ the compiler won't work there.
 Also the supplementary program, which did not work at all, was fixed (by Cody)
 and it can be run by itself for fun in modern systems, which was not possible
 before the fixes there.
+
+<div id="2001_cheong">
+## 2001/cheong
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2001/cheong/cheong.c](%%REPO_URL%%/2001/cheong/cheong.c)
+### Information: [2001/cheong/index.html](2001/cheong/index.html)
+
+This program will crash without an arg.
 
 
 <div id="2001_dgbeards">

--- a/news.html
+++ b/news.html
@@ -378,7 +378,7 @@
 <!-- BEFORE: 1st line of markdown file: news.md -->
 <h1 id="for-more-news-try-mastodon">For more news, try mastodon</h1>
 <h3 id="please-follow-the-ioccc-on-mastodon">Please follow** the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a></h3>
-<p>We use Mastodon to make minor announcements, in addition announcing
+<p>We use Mastodon to make minor announcements, in addition to announcing
 major events such as the opening of a new IOCCC, or who won.</p>
 <p>See “<a href="faq.html#try_mastodon">FAQ 6.12: What is Mastodon and why does IOCCC use it?</a>” for more
 information on Mastodon.</p>

--- a/news.md
+++ b/news.md
@@ -2,7 +2,7 @@
 
 ### Please follow** the [IOCCC on Mastodon](https://fosstodon.org/@ioccc)
 
-We use Mastodon to make minor announcements, in addition announcing
+We use Mastodon to make minor announcements, in addition to announcing
 major events such as the opening of a new IOCCC, or who won.
 
 See "[FAQ 6.12: What is Mastodon and why does IOCCC use it?](faq.html#try_mastodon)" for more

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -2736,11 +2736,12 @@ wish to see, try the following commands from the <code>2001/anonymous</code> dir
 <pre><code>    git diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..4bc03de321612869aebf855850c6500df95cb6ef anonymous.c</code></pre>
 <p>or to not use <code>git</code>:</p>
 <pre><code>    make diff_orig_prog</code></pre>
-<p>Cody also added a <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.bed.c">program</a> like
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.ten.c">anonymous.ten.c</a> which ‘sings’ the
-lyrics to <a href="https://en.wikipedia.org/wiki/Ten_Green_Bottles">Ten Green Bottles</a>
+<p>Cody also added a <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.bed.c">supplementary program</a> like
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.ten.c">anonymous.ten.c</a> (which ‘sings’ the
+lyrics to <a href="https://en.wikipedia.org/wiki/Ten_Green_Bottles">Ten Green Bottles</a>)
 but which sings <a href="https://allnurseryrhymes.com/ten-in-the-bed/">Ten in the Bed</a>
-instead.</p>
+instead (the way it’s implemented is different and this allows showing more of
+what the entry supports).</p>
 <p>As well he added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/try.sh">try.sh</a> script so that one can
 attempt to use the program as it was designed but if compiling as 32-bit fails
 it will at least run the supplementary program as a 64-bit program directly.</p>
@@ -2750,7 +2751,8 @@ it will at least run the supplementary program as a 64-bit program directly.</p>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with <code>clang</code> but according to the author this will not
 work without i386 Linux. It generates i386 32-bit code (not bytecode) but
-unfortunately it will not work without i386 Linux. See <a href="bugs.html">bugs.html</a>.</p>
+unfortunately it will not work without i386 Linux. See <a href="bugs.html#2001_bellard">2001/bellard in
+bugs.html</a>.</p>
 <p>Cody fixed an earlier segfault so that it can at least now open the file should
 you have an i386 Linux machine (it can open it in other platforms too, of
 course, but it won’t work). This involved pointer updates and also changing an
@@ -2760,10 +2762,11 @@ case of <code>main()</code> this was not possible.</p>
 compilers besides what Cody did.</p>
 <p>Cody entirely fixed the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.otccex.c">supplementary
 bellard.otccex.c</a> so it does not segfault and
-works as well (it did not work at all). The main problem was that some ints were
-being used as pointers. This includes, for example, an int used as a <code>char *</code>,
-an int used as a function pointer and an int to access <code>argv</code> as well as there
-being invalid access to <code>argv</code>. He updated the Makefile so that this program
+works as well (it did not work at all though it is possible it would work in
+older systems). The main problem was that some <code>int</code>s were
+being used as pointers. This includes, for example, an <code>int</code> used as a <code>char *</code>,
+an <code>int</code> used as a function pointer and an <code>int</code> to access <code>argv</code> as well as there
+being invalid access to <code>argv</code>. He updated the <code>Makefile</code> so that this program
 will compile by default.</p>
 <p>Also the Fibonacci sequence (<code>fib()</code>) will overflow at <code>n &gt; 48</code> so this is
 checked prior to running the function just like the author did for the factorial
@@ -2774,9 +2777,7 @@ this entry by Yusuke.</p>
 <p>With a tip from Yusuke we rediscovered the author’s <a href="https://bellard.org/otcc/">web page for this
 program</a> where it is stated that this will only work
 in i386 Linux. The author also stated in the remarks in this document that they
-used <a href="https://ftp.gnu.org/gnu/%60gcc%60/%60gcc%60-2.95.2/%60gcc%60-everything-2.95.2.tar.gz"><code>gcc</code>
-2.95.2</a> but
-we don’t know if that’s relevant or not.</p>
+used <code>gcc 2.95.2</code> but we do not know if that’s relevant or not.</p>
 <p>Yusuke offered a modification which is not needed with <code>gcc</code> but with some
 versions of <code>clang</code> it is. With <code>gcc</code> we can get away with <code>-rdynamic -fno-pie -Wl,-z,execstack</code> which solves the problem of execution in memory but any
 compiler that does not support this would not work. Thus we use the modification
@@ -2785,12 +2786,12 @@ by Yusuke.</p>
 <h2 id="winning-entry-2001cheong">Winning entry: <a href="2001/cheong/index.html">2001/cheong</a></h2>
 <h3 id="winning-entry-source-code-cheong.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong//cheong.c">cheong.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> fixed this to work with <code>clang</code> by adding another function that is allowed to
-have a third arg as an int, not a <code>char **. He chose</code>pain()<code>because it's a four letter word that would match the format and because it's pain that</code>clang` forces
+<p><a href="#cody">Cody</a> fixed this to compile with <code>clang</code> by adding another function that is allowed to
+have a third arg as an int, not a <code>char **</code>. He chose <code>pain()</code> because it’s a four
+letter word that would match the format and because it’s pain that <code>clang</code> forces
 this. :-) This fix makes a point of the author’s notes on portability no longer
 valid, BTW.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/try.sh">try.sh</a> script.</p>
-<p>He also fixed it to check the number of args.</p>
 <div id="2001_coupard">
 <h2 id="winning-entry-2001coupard">Winning entry: <a href="2001/coupard/index.html">2001/coupard</a></h2>
 <h3 id="winning-entry-source-code-coupard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard//coupard.c">coupard.c</a></h3>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3335,11 +3335,12 @@ or to not use `git`:
     make diff_orig_prog
 ```
 
-Cody also added a [program](%%REPO_URL%%/2001/anonymous/anonymous.bed.c) like
-[anonymous.ten.c](%%REPO_URL%%/2001/anonymous/anonymous.ten.c) which 'sings' the
-lyrics to [Ten Green Bottles](https://en.wikipedia.org/wiki/Ten_Green_Bottles)
+Cody also added a [supplementary program](%%REPO_URL%%/2001/anonymous/anonymous.bed.c) like
+[anonymous.ten.c](%%REPO_URL%%/2001/anonymous/anonymous.ten.c) (which 'sings' the
+lyrics to [Ten Green Bottles](https://en.wikipedia.org/wiki/Ten_Green_Bottles))
 but which sings [Ten in the Bed](https://allnurseryrhymes.com/ten-in-the-bed/)
-instead.
+instead (the way it's implemented is different and this allows showing more of
+what the entry supports).
 
 As well he added the [try.sh](%%REPO_URL%%/2001/anonymous/try.sh) script so that one can
 attempt to use the program as it was designed but if compiling as 32-bit fails
@@ -3353,7 +3354,8 @@ it will at least run the supplementary program as a 64-bit program directly.
 
 [Cody](#cody) fixed this to compile with `clang` but according to the author this will not
 work without i386 Linux. It generates i386 32-bit code (not bytecode) but
-unfortunately it will not work without i386 Linux. See [bugs.html](bugs.html).
+unfortunately it will not work without i386 Linux. See [2001/bellard in
+bugs.html](bugs.html#2001_bellard).
 
 Cody fixed an earlier segfault so that it can at least now open the file should
 you have an i386 Linux machine (it can open it in other platforms too, of
@@ -3366,10 +3368,11 @@ compilers besides what Cody did.
 
 Cody entirely fixed the [supplementary
 bellard.otccex.c](%%REPO_URL%%/2001/bellard/bellard.otccex.c) so it does not segfault and
-works as well (it did not work at all). The main problem was that some ints were
-being used as pointers.  This includes, for example, an int used as a `char *`,
-an int used as a function pointer and an int to access `argv` as well as there
-being invalid access to `argv`. He updated the Makefile so that this program
+works as well (it did not work at all though it is possible it would work in
+older systems). The main problem was that some `int`s were
+being used as pointers.  This includes, for example, an `int` used as a `char *`,
+an `int` used as a function pointer and an `int` to access `argv` as well as there
+being invalid access to `argv`. He updated the `Makefile` so that this program
 will compile by default.
 
 Also the Fibonacci sequence (`fib()`) will overflow at `n > 48` so this is
@@ -3384,9 +3387,7 @@ this entry by Yusuke.
 With a tip from Yusuke we rediscovered the author's [web page for this
 program](https://bellard.org/otcc/) where it is stated that this will only work
 in i386 Linux.  The author also stated in the remarks in this document that they
-used [`gcc`
-2.95.2](https://ftp.gnu.org/gnu/`gcc`/`gcc`-2.95.2/`gcc`-everything-2.95.2.tar.gz) but
-we don't know if that's relevant or not.
+used `gcc 2.95.2` but we do not know if that's relevant or not.
 
 Yusuke offered a modification which is not needed with `gcc` but with some
 versions of `clang` it is. With `gcc` we can get away with `-rdynamic -fno-pie
@@ -3400,15 +3401,13 @@ by Yusuke.
 ### Winning entry source code: [cheong.c](%%REPO_URL%%/2001/cheong//cheong.c)
 </div>
 
-[Cody](#cody) fixed this to work with `clang` by adding another function that is allowed to
-have a third arg as an int, not a `char **. He chose `pain()` because it's a four
+[Cody](#cody) fixed this to compile with `clang` by adding another function that is allowed to
+have a third arg as an int, not a `char **`. He chose `pain()` because it's a four
 letter word that would match the format and because it's pain that `clang` forces
 this. :-) This fix makes a point of the author's notes on portability no longer
 valid, BTW.
 
 Cody also added the [try.sh](%%REPO_URL%%/2001/cheong/try.sh) script.
-
-He also fixed it to check the number of args.
 
 
 <div id="2001_coupard">


### PR DESCRIPTION

Once upon a time after I had put in the bugs file that there is no arg 
check and it was a feature, not a bug, it was changed to bug status.
This was a very simple fix that I then made but it's not necessary
either so I have undone it to make it more like the original. Now the 
only difference from the original is my fix so that it compiles with
clang. This means the bugs file was also updated as was the index.html 
file and the thanks file (which also has some other fixes that are
unrelated).
