### PR TITLE
Restore bug status to 2001/ollinger

### DIFF
--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -5,6 +5,18 @@
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+    STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [2001/ollinger in bugs.html](../../bugs.html#2001_ollinger).
+
+
+
 ## To use:
 
 ``` <!---sh-->

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -403,6 +403,10 @@ Location: <a href="../../location.html#FR">FR</a> - <em>French Republic</em> (<e
 <!-- BEFORE: 1st line of markdown file: 2001/ollinger/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
+<p>For more detailed information see <a href="../../bugs.html#2001_ollinger">2001/ollinger in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ollinger integer</code></pre>
 <h2 id="try">Try:</h2>

--- a/2001/ollinger/ollinger.c
+++ b/2001/ollinger/ollinger.c
@@ -11,7 +11,6 @@ char e[]="**3<HRZcir+3@OXakt;=GOXds*\?HRZcir*7HNZ`i19JS\\p*H[m1:CJSz*>H[`mr25\
 int main(int j,char *k[]) {
   int a,b,c,d,g,h,i=19;
 
-  if (j<2)exit(1);
   printf("       ");
   for(g=0[f=(char *)calloc(80+(h=atoi(1[k])),1)]=1; g<=h; g++) {
     if ((g>30)&&(f[i-2]+f[i-1]!=0)) i++;

--- a/bugs.html
+++ b/bugs.html
@@ -1950,6 +1950,14 @@ program can segfault.</p>
 points.</p>
 <p>Although it is independent of endianness both systems need the same character
 set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
+<div id="2001_ollinger">
+<h2 id="ollinger">2001/ollinger</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
+<h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
+<p>This program will very likely crash or do something unexpected if you do not
+provide enough args.</p>
 <div id="2001_rosten">
 <h2 id="rosten">2001/rosten</h2>
 </div>
@@ -1961,7 +1969,7 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
@@ -2129,13 +2137,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2160,7 +2168,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2173,7 +2181,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2187,7 +2195,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2196,7 +2204,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2230,7 +2238,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2244,7 +2252,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2285,7 +2293,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2306,12 +2314,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2328,7 +2336,7 @@ welcome to try and fix it if you wish to!</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2375,7 +2383,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2398,7 +2406,7 @@ bins at the edges.</p>
 instead being something else entirely. The Internet Wayback Machine, although it
 archived it, did not load scripts. Do you know if the domain was moved? Do you
 have an archive or mirror? Please provide us it! Thank you.</p>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2411,7 +2419,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2583,7 +2591,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2597,7 +2605,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2606,7 +2614,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2639,7 +2647,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2653,7 +2661,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2674,7 +2682,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2690,7 +2698,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2710,7 +2718,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2729,7 +2737,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2745,7 +2753,7 @@ section</a>.</p>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2758,14 +2766,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2773,7 +2781,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2790,7 +2798,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2814,7 +2822,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2855,7 +2863,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2880,7 +2888,7 @@ result. Error messages become garbled, though.</p></li>
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2889,7 +2897,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -2922,7 +2930,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -2941,7 +2949,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -2966,7 +2974,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -2981,7 +2989,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3031,7 +3039,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3039,7 +3047,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3047,7 +3055,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3079,7 +3087,7 @@ ideal if this was not the case.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3108,7 +3116,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3116,7 +3124,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3146,7 +3154,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3156,7 +3164,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3176,7 +3184,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3185,7 +3193,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3200,7 +3208,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3211,7 +3219,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3225,7 +3233,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3235,7 +3243,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3244,7 +3252,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -2296,6 +2296,18 @@ Although it is independent of endianness both systems need the same character
 set. In other words both have to be ASCII or EBCDIC - not one of each.
 
 
+<div id="2001_ollinger">
+## 2001/ollinger
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2001/ollinger/ollinger.c](%%REPO_URL%%/2001/ollinger/ollinger.c)
+### Information: [2001/ollinger/index.html](2001/ollinger/index.html)
+
+This program will very likely crash or do something unexpected if you do not
+provide enough args.
+
+
 <div id="2001_rosten">
 ## 2001/rosten
 </div>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -2793,7 +2793,7 @@ by Yusuke.</p>
 <h3 id="winning-entry-source-code-cheong.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong//cheong.c">cheong.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to compile with <code>clang</code> by adding another function that is allowed to
-have a third arg as an int, not a <code>char **</code>. He chose <code>pain()</code> because it’s a four
+have a third arg as an <code>int</code>, not a <code>char **</code>. He chose <code>pain()</code> because it’s a four
 letter word that would match the format and because it’s pain that <code>clang</code> forces
 this. :-) This fix makes a point of the author’s notes on portability no longer
 valid, BTW.</p>
@@ -2811,16 +2811,13 @@ support implicit int:</p>
     coupard.c:31:8: error: parameter &#39;n&#39; was not declared, defaults to &#39;int&#39;; ISO C99 and later do not support implicit int [-Wimplicit-int]
     void e(n,h){
            ^</code></pre>
-<p>and for some reason it was being reported as an error. This was not really worth
-a thanks per se but it was originally done by adding <code>int</code>. The better solution
-is to disable the warning which is what was done later on to make it more like
-the original.</p>
+<p>and for some reason it was being reported as an error.</p>
+<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard/try.sh">try.sh</a> script.</p>
 <p><a href="#yusuke">Yusuke</a> provided a proper command line for those without <code>/dev/audio</code>
 or <code>/dev/sound/dsp</code> (which is most everyone nowadays, it seems, and especially
 those with macOS) (to do with sound; see his
-<a href="2013/endoh3/index.html">/2013/endoh3/index.html</a> entry where he also refers to
+<a href="2013/endoh3/index.html">2013/endoh3/index.html</a> entry where he also refers to
 sound devices in macOS).</p>
-<p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard/try.sh">try.sh</a>.</p>
 <div id="2001_ctk">
 <h2 id="winning-entry-2001ctk">Winning entry: <a href="2001/ctk/index.html">2001/ctk</a></h2>
 <h3 id="winning-entry-source-code-ctk.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ctk//ctk.c">ctk.c</a></h3>
@@ -2831,17 +2828,19 @@ the ANSI escape codes. This works with both Linux and macOS.</p>
 etc.) after exiting even if you don’t press ‘q’, if you crash or if you kill the
 program prematurely. This was done by adding an explicit call to <code>e()</code> at the
 end of <code>main()</code>.</p>
-<p>Cody also added the <a href="2001/ctk/index.html#alternate-code">alt code</a> that adds
+<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ctk/ctk.alt.c">alt code</a> that adds
 vi(m) movement keys.</p>
 <div id="2001_dgbeards">
 <h2 id="winning-entry-2001dgbeards">Winning entry: <a href="2001/dgbeards/index.html">2001/dgbeards</a></h2>
 <h3 id="winning-entry-source-code-dgbeards.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards//dgbeards.c">dgbeards.c</a></h3>
 </div>
 <p>The author provided two changes: one to speed it up and one to make it not crash
-on losing. <a href="#cody">Cody</a> provided an alternate version which does the former but he felt
-that the idea of crashing on losing (see the index.html for details on why that
-might be) too good to get rid of so he kept that in.</p>
-<p>He also points out that there is a way to get the computer to automatically lose
+on losing. <a href="#cody">Cody</a> provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.alt.c">alternate
+version</a> which does the former but
+not the latter as he he felt that the idea of crashing on losing (see the
+index.html for details on why that might be) too good to get rid. The author
+explains how to make this change, however.</p>
+<p>Cody also points out that there is a way to get the computer to automatically lose
 very quickly. Do you know what it is?</p>
 <div id="2001_herrmann1">
 <h2 id="winning-entry-2001herrmann1">Winning entry: <a href="2001/herrmann1/index.html">2001/herrmann1</a></h2>
@@ -2849,7 +2848,7 @@ very quickly. Do you know what it is?</p>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that the when compiling the code the program is not executed
 itself by itself which just showed the usage string and exited. The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.sh">script
-herrmann1.sh</a> is used to compile the program but
+herrmann1.sh</a> is how one should compile the program but
 it’s also how you invoke the program.</p>
 <p>Cody provided the file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/plus1.turing">plus1.turing</a> based on the
 author’s remarks.</p>
@@ -2865,7 +2864,9 @@ shellcheck. In particular there were quite a few:</p>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with both 64-bit and 32-bit compilers by changing most
 of the <code>int</code>s (all but that in <code>main(int ...)</code>) to <code>long</code>s. He also fixed it to
-compile with <code>clang</code> by changing the args of main to be <code>int</code> and <code>char **, respectively, and changing specific references to the</code>argv<code>arg, casting to</code>long<code>(was</code>int<code>but the 64-bit fix requires</code>long`) which was its old type.</p>
+compile with <code>clang</code> by changing the args of <code>main</code> to be <code>int</code> and <code>char **</code>,
+respectively, and changing specific references to the <code>argv</code> arg, casting to
+<code>long</code> (was <code>int</code> but the 64-bit fix requires <code>long</code>) which was its old type.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann2/try.sh">try.sh</a> script which might be more
 useful than any other place as the command to try is quite long with C code.</p>
 <p>For some reason the original code was missing (presumingly because it had been
@@ -2874,27 +2875,24 @@ added to <code>.gitignore</code> by accident) but Cody restored it from the arch
 <h2 id="winning-entry-2001kev">Winning entry: <a href="2001/kev/index.html">2001/kev</a></h2>
 <h3 id="winning-entry-source-code-kev.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev//kev.c">kev.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> improved the Makefile to allow one to more easily set up the port,
+<p><a href="#cody">Cody</a> improved the <code>Makefile</code> to allow one to more easily set up the port,
 speed and <code>socket(2)</code> call that the author had set up.</p>
 <p>Cody also slowed down the ball just a tad (it was already a <code>-D</code> macro that was used
 in the code) as it went too fast for the speed at which the paddles move even
 when holding down the movement keys (but see below).</p>
 <p>Cody also provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.alt.c">alternate version</a> which lets you use
 the arrow keys on your keyboard instead of the more awkward ‘<code>,</code>’ and ‘<code>.</code>’.</p>
-<p>He updated both versions to have <code>#ifndef..#endif</code> pairs for the macros so one
+<p>Cody updated both versions to have <code>#ifndef..#endif</code> pairs for the macros so one
 can more easily configure different settings without having to specify all of
 them (though this change became unnecessary with an improvement on how it was
-done). The speed, <code>SPEED</code>, will be set to 50 if it’s not defined at the compiler
-line as 50 is what it used to be set to. This way it’s more to the original but
+done). The speed, <code>SPEED</code>, will be set to <code>50</code> if it’s not defined at the compiler
+line as <code>50</code> is what it used to be set to. This way it’s more to the original but
 without having to sacrifice playability by running <code>make</code>.</p>
 <div id="2001_ollinger">
 <h2 id="winning-entry-2001ollinger">Winning entry: <a href="2001/ollinger/index.html">2001/ollinger</a></h2>
 <h3 id="winning-entry-source-code-ollinger.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger//ollinger.c">ollinger.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/try.sh">try.sh</a> script.</p>
-<p>Cody also fixed it to not crash if not enough args, exiting 1 instead. This was
-done at a time where it was said to be a bug that should be fixed, for better or
-worse.</p>
 <div id="2001_schweikh">
 <h2 id="winning-entry-2001schweikh">Winning entry: <a href="2001/schweikh/index.html">2001/schweikh</a></h2>
 <h3 id="winning-entry-source-code-schweikh.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh//schweikh.c">schweikh.c</a></h3>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3402,7 +3402,7 @@ by Yusuke.
 </div>
 
 [Cody](#cody) fixed this to compile with `clang` by adding another function that is allowed to
-have a third arg as an int, not a `char **`. He chose `pain()` because it's a four
+have a third arg as an `int`, not a `char **`. He chose `pain()` because it's a four
 letter word that would match the format and because it's pain that `clang` forces
 this. :-) This fix makes a point of the author's notes on portability no longer
 valid, BTW.
@@ -3429,18 +3429,16 @@ support implicit int:
 	   ^
 ```
 
-and for some reason it was being reported as an error. This was not really worth
-a thanks per se but it was originally done by adding `int`. The better solution
-is to disable the warning which is what was done later on to make it more like
-the original.
+and for some reason it was being reported as an error.
+
+Cody also added the [try.sh](%%REPO_URL%%/2001/coupard/try.sh) script.
 
 [Yusuke](#yusuke) provided a proper command line for those without `/dev/audio`
 or `/dev/sound/dsp` (which is most everyone nowadays, it seems, and especially
 those with macOS) (to do with sound; see his
-[/2013/endoh3/index.html](2013/endoh3/index.html) entry where he also refers to
+[2013/endoh3/index.html](2013/endoh3/index.html) entry where he also refers to
 sound devices in macOS).
 
-Cody added the [try.sh](%%REPO_URL%%/2001/coupard/try.sh).
 
 
 <div id="2001_ctk">
@@ -3456,7 +3454,7 @@ etc.) after exiting even if you don't press 'q', if you crash or if you kill the
 program prematurely. This was done by adding an explicit call to `e()` at the
 end of `main()`.
 
-Cody also added the [alt code](2001/ctk/index.html#alternate-code) that adds
+Cody also added the [alt code](%%REPO_URL%%/2001/ctk/ctk.alt.c) that adds
 vi(m) movement keys.
 
 
@@ -3466,11 +3464,13 @@ vi(m) movement keys.
 </div>
 
 The author provided two changes: one to speed it up and one to make it not crash
-on losing. [Cody](#cody) provided an alternate version which does the former but he felt
-that the idea of crashing on losing (see the index.html for details on why that
-might be) too good to get rid of so he kept that in.
+on losing. [Cody](#cody) provided an [alternate
+version](%%REPO_URL%%/2001/dgbeards/dgbeards.alt.c) which does the former but
+not the latter as he he felt that the idea of crashing on losing (see the
+index.html for details on why that might be) too good to get rid. The author
+explains how to make this change, however.
 
-He also points out that there is a way to get the computer to automatically lose
+Cody also points out that there is a way to get the computer to automatically lose
 very quickly. Do you know what it is?
 
 
@@ -3481,7 +3481,7 @@ very quickly. Do you know what it is?
 
 [Cody](#cody) fixed this so that the when compiling the code the program is not executed
 itself by itself which just showed the usage string and exited. The [script
-herrmann1.sh](%%REPO_URL%%/2001/herrmann1/herrmann1.sh) is used to compile the program but
+herrmann1.sh](%%REPO_URL%%/2001/herrmann1/herrmann1.sh) is how one should compile the program but
 it's also how you invoke the program.
 
 Cody provided the file [plus1.turing](%%REPO_URL%%/2001/herrmann1/plus1.turing) based on the
@@ -3508,7 +3508,7 @@ Cody also added the [try.sh](%%REPO_URL%%/2001/herrmann1/try.sh) script.
 
 [Cody](#cody) fixed this to work with both 64-bit and 32-bit compilers by changing most
 of the `int`s (all but that in `main(int ...)`) to `long`s. He also fixed it to
-compile with `clang` by changing the args of main to be `int` and `char **,
+compile with `clang` by changing the args of `main` to be `int` and `char **`,
 respectively, and changing specific references to the `argv` arg, casting to
 `long` (was `int` but the 64-bit fix requires `long`) which was its old type.
 
@@ -3524,7 +3524,7 @@ added to `.gitignore` by accident) but Cody restored it from the archive.
 ### Winning entry source code: [kev.c](%%REPO_URL%%/2001/kev//kev.c)
 </div>
 
-[Cody](#cody) improved the Makefile to allow one to more easily set up the port,
+[Cody](#cody) improved the `Makefile` to allow one to more easily set up the port,
 speed and `socket(2)` call that the author had set up.
 
 Cody also slowed down the ball just a tad (it was already a `-D` macro that was used
@@ -3534,11 +3534,11 @@ when holding down the movement keys (but see below).
 Cody also provided an [alternate version](%%REPO_URL%%/2001/kev/kev.alt.c) which lets you use
 the arrow keys on your keyboard instead of the more awkward '`,`' and '`.`'.
 
-He updated both versions to have `#ifndef..#endif` pairs for the macros so one
+Cody updated both versions to have `#ifndef..#endif` pairs for the macros so one
 can more easily configure different settings without having to specify all of
 them (though this change became unnecessary with an improvement on how it was
-done). The speed, `SPEED`, will be set to 50 if it's not defined at the compiler
-line as 50 is what it used to be set to. This way it's more to the original but
+done). The speed, `SPEED`, will be set to `50` if it's not defined at the compiler
+line as `50` is what it used to be set to. This way it's more to the original but
 without having to sacrifice playability by running `make`.
 
 
@@ -3549,9 +3549,6 @@ without having to sacrifice playability by running `make`.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2001/ollinger/try.sh) script.
 
-Cody also fixed it to not crash if not enough args, exiting 1 instead. This was
-done at a time where it was said to be a bug that should be fixed, for better or
-worse.
 
 
 <div id="2001_schweikh">


### PR DESCRIPTION
Once upon a time after adding the entry to the bugs file it was changed so that it should be a bug to be fixed and when verifying things since it was very quick to fix I added it. It now has been restored to the original.

The bugs file was updated and the thanks file was updated accordingly along with the index.html and README.md files.