### PR TITLE
Fix find_missing_links or 2004/anonymous

### DIFF
--- a/2004/anonymous/README.md
+++ b/2004/anonymous/README.md
@@ -49,8 +49,7 @@ It was not until a sequel was called for that this was changed.
 
 If you want to read the first edition they reprinted it some years back: `The
 Hobbit Facsimile First Edition`. The details are also discussed in [History of
-Middle-earth
-(HoMe)](https://tolkiengateway.net/wiki/The_History_of_Middle-earth) VI, [The Return of the
+Middle-earth &#40;HoMe&#41;](https://tolkiengateway.net/wiki/The_History_of_Middle-earth) VI, [The Return of the
 Shadow](https://tolkiengateway.net/wiki/The_Return_of_the_Shadow), part one of
 the history of [The Lord of the
 Rings](https://en.wikipedia.org/wiki/The_Lord_of_the_Rings) of a twelve volume set - as well as in [The

--- a/2004/anonymous/README.md
+++ b/2004/anonymous/README.md
@@ -72,8 +72,8 @@ earlier drafts sometimes the `û` had no diacritic but `h` after the `u` in
 it (and other times nothing). The real text is:
 
 ```
-    Ash nazg durbatulûk, ash nazg gimbatul, ash nazg thrakatulûk, agh
-    burzum-ishi krimpatul.
+    Ash nazg durbatulûk, ash nazg gimbatul,
+    ash nazg thrakatulûk agh burzum-ishi krimpatul.
 ```
 
 which when translated from [Black

--- a/2004/anonymous/README.md
+++ b/2004/anonymous/README.md
@@ -84,7 +84,7 @@ Speech](https://www.glyphweb.com/arda/b/blackspeech.html):
  alt="The inscription, in the Black Speech of Mordor, on the One Ring"
  width=690 height=127>
 
-into the Common Tongue reads:
+into the [Common Tongue](https://www.glyphweb.com/arda/c/commontongue.html) reads:
 
 ```
     One Ring to rule them all, One Ring to find them,

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -432,8 +432,7 @@ point that Bilbo slipped the ring on and Gollum saw him vanish and understood
 that he already found it. But there was no call of thief and no hatred of Bilbo.
 It was not until a sequel was called for that this was changed.</p>
 <p>If you want to read the first edition they reprinted it some years back: <code>The Hobbit Facsimile First Edition</code>. The details are also discussed in <a href="https://tolkiengateway.net/wiki/The_History_of_Middle-earth">History of
-Middle-earth
-(HoMe)</a> VI, <a href="https://tolkiengateway.net/wiki/The_Return_of_the_Shadow">The Return of the
+Middle-earth (HoMe)</a> VI, <a href="https://tolkiengateway.net/wiki/The_Return_of_the_Shadow">The Return of the
 Shadow</a>, part one of
 the history of <a href="https://en.wikipedia.org/wiki/The_Lord_of_the_Rings">The Lord of the
 Rings</a> of a twelve volume set - as well as in <a href="https://tolkiengateway.net/wiki/The_History_of_The_Hobbit">The

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -455,7 +455,7 @@ Speech</a>:</p>
 <p><img src="One_Ring_inscription.png"
  alt="The inscription, in the Black Speech of Mordor, on the One Ring"
  width=690 height=127></p>
-<p>into the Common Tongue reads:</p>
+<p>into the <a href="https://www.glyphweb.com/arda/c/commontongue.html">Common Tongue</a> reads:</p>
 <pre><code>    One Ring to rule them all, One Ring to find them,
     One Ring to bring them all and in the darkness bind them.</code></pre>
 <h2 id="authors-remarks">Author’s remarks:</h2>

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -448,8 +448,8 @@ You’ll find out the source of the text above though you’ll see that there ar
 some circumflexes missing! That’s okay though due to I/O of the entry and in
 earlier drafts sometimes the <code>û</code> had no diacritic but <code>h</code> after the <code>u</code> in
 it (and other times nothing). The real text is:</p>
-<pre><code>    Ash nazg durbatulûk, ash nazg gimbatul, ash nazg thrakatulûk, agh
-    burzum-ishi krimpatul.</code></pre>
+<pre><code>    Ash nazg durbatulûk, ash nazg gimbatul,
+    ash nazg thrakatulûk agh burzum-ishi krimpatul.</code></pre>
 <p>which when translated from <a href="https://www.glyphweb.com/arda/b/blackspeech.html">Black
 Speech</a>:</p>
 <p><img src="One_Ring_inscription.png"


### PR DESCRIPTION
The problem is that the link itself had ()s and the script did not expect this. Instead use the html '&' codes.