### PR TITLE
Fix URLs in bin/md2html.sh

### DIFF
--- a/bin/md2html.sh
+++ b/bin/md2html.sh
@@ -8,7 +8,7 @@
 #
 # For general information on how IOCCC HTML files are generated, see:
 #
-#	https://www.ioccc.org/bin/README.md#how
+#	https://www.ioccc.org/bin/index.html#how
 #
 ####
 #
@@ -28,7 +28,7 @@
 #
 # For more information on "getopt phases", RTFS :-) or see:
 #
-#	https://www.ioccc.org/bin/README.md#getopt
+#	https://www.ioccc.org/bin/index.html#getopt
 #
 ####
 #
@@ -52,7 +52,7 @@
 #
 # For more information on "HTML phases", RTFS :-) or see:
 #
-#	https://www.ioccc.org/bin/README.md#html
+#	https://www.ioccc.org/bin/index.html#html
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #

--- a/news.html
+++ b/news.html
@@ -414,11 +414,12 @@ a single day.</p>
 update the FAQ with screenshots from the IOCCC Submit server as
 well as the <strong>IOCCC registration process</strong> prior to starting the
 <strong>Great Fork Merge</strong>.</p>
-<p>We have decided to not hold an <strong>IOCCC mock</strong> content, but instead
+<p>We have decided to <strong>NOT</strong> hold an <strong>IOCCC mock</strong> contest, but instead
 ask for beta testing of the new <strong>IOCCC registration process</strong> and
-<strong>IOCCC Submit server</strong> when the have left alpha testing phase.
+<strong>IOCCC Submit server</strong> when they have left alpha testing phase.
 This will speed up the start date of IOCCC28.</p>
-<p>It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the IOCCC.</p>
+<p>It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the
+IOCCC.</p>
 <h2 id="section-1">2024-04-30</h2>
 <p>The web site now is viewing by mobile devices such as cell phones
 and tablets. Devices with a screen resolution 1024 pixels and

--- a/news.md
+++ b/news.md
@@ -41,12 +41,13 @@ update the FAQ with screenshots from the IOCCC Submit server as
 well as the **IOCCC registration process** prior to starting the
 **Great Fork Merge**.
 
-We have decided to not hold an **IOCCC mock** content, but instead
+We have decided to **NOT** hold an **IOCCC mock** contest, but instead
 ask for beta testing of the new **IOCCC registration process** and
-**IOCCC Submit server** when the have left alpha testing phase.
+**IOCCC Submit server** when they have left alpha testing phase.
 This will speed up the start date of IOCCC28.
 
-It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the IOCCC.
+It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the
+IOCCC.
 
 
 ## 2024-04-30


### PR DESCRIPTION

There were URLs that linked to https://www.ioccc.org/bin/README.md#foo 
but at ioccc.org it will be index.html so the README.md has been changed
to index.html.