### PR TITLE
Add note about top prio issue 2006 to news

### DIFF
--- a/bin/md2html.sh
+++ b/bin/md2html.sh
@@ -8,7 +8,7 @@
 #
 # For general information on how IOCCC HTML files are generated, see:
 #
-#	https://www.ioccc.org/bin/README.md#how
+#	https://www.ioccc.org/bin/index.html#how
 #
 ####
 #
@@ -28,7 +28,7 @@
 #
 # For more information on "getopt phases", RTFS :-) or see:
 #
-#	https://www.ioccc.org/bin/README.md#getopt
+#	https://www.ioccc.org/bin/index.html#getopt
 #
 ####
 #
@@ -52,7 +52,7 @@
 #
 # For more information on "HTML phases", RTFS :-) or see:
 #
-#	https://www.ioccc.org/bin/README.md#html
+#	https://www.ioccc.org/bin/index.html#html
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #

--- a/news.html
+++ b/news.html
@@ -398,11 +398,14 @@ number to 5260 commits to date. The
 repo is now 5159 commits ahead of the [IOCCC
 winner[(https://github.com/ioccc-src/winner) repo.</p>
 <p>Multiple <strong>((top priority))</strong> issues have been resolved or completed.
-Only one <strong>((top priority))</strong> <a href="https://github.com/ioccc-src/temp-test-ioccc/issues/2006">issue
+Only one <strong>((top priority))</strong> issue, <a href="https://github.com/ioccc-src/temp-test-ioccc/issues/2006">issue
 2006</a>
 remains before we begin the final steps to perform the <strong>Great Fork
 Merge</strong> when the <a href="https://www.ioccc.org/index.html">Official IOCCC web
-site</a> will be updated.</p>
+site</a> will be updated. And although there are
+a lot of files to look at for this issue, most of them should go relatively
+quickly, once these are started. One of the slower files is almost done and then
+there are two more before we can look at the other files.</p>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/issues/2239">issue 2239</a>
 TODO list has 10 out of 51 sub-tasks completed. That might not
 seem like much progress, but keep in mind that some of those 10

--- a/news.html
+++ b/news.html
@@ -414,11 +414,12 @@ a single day.</p>
 update the FAQ with screenshots from the IOCCC Submit server as
 well as the <strong>IOCCC registration process</strong> prior to starting the
 <strong>Great Fork Merge</strong>.</p>
-<p>We have decided to not hold an <strong>IOCCC mock</strong> content, but instead
+<p>We have decided to <strong>NOT</strong> hold an <strong>IOCCC mock</strong> contest, but instead
 ask for beta testing of the new <strong>IOCCC registration process</strong> and
-<strong>IOCCC Submit server</strong> when the have left alpha testing phase.
+<strong>IOCCC Submit server</strong> when they have left alpha testing phase.
 This will speed up the start date of IOCCC28.</p>
-<p>It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the IOCCC.</p>
+<p>It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the
+IOCCC.</p>
 <h2 id="section-1">2024-04-30</h2>
 <p>The web site now is viewing by mobile devices such as cell phones
 and tablets. Devices with a screen resolution 1024 pixels and

--- a/news.md
+++ b/news.md
@@ -22,11 +22,14 @@ repo is now 5159 commits ahead of the [IOCCC
 winner[(https://github.com/ioccc-src/winner) repo.
 
 Multiple **((top priority))** issues have been resolved or completed.
-Only one **((top priority))** [issue
+Only one **((top priority))** issue, [issue
 2006](https://github.com/ioccc-src/temp-test-ioccc/issues/2006)
 remains before we begin the final steps to perform the **Great Fork
 Merge** when the [Official IOCCC web
-site](https://www.ioccc.org/index.html) will be updated.
+site](https://www.ioccc.org/index.html) will be updated. And although there are
+a lot of files to look at for this issue, most of them should go relatively
+quickly, once these are started. One of the slower files is almost done and then
+there are two more before we can look at the other files.
 
 The [issue 2239](https://github.com/ioccc-src/temp-test-ioccc/issues/2239)
 TODO list has 10 out of 51 sub-tasks completed.  That might not

--- a/news.md
+++ b/news.md
@@ -41,12 +41,13 @@ update the FAQ with screenshots from the IOCCC Submit server as
 well as the **IOCCC registration process** prior to starting the
 **Great Fork Merge**.
 
-We have decided to not hold an **IOCCC mock** content, but instead
+We have decided to **NOT** hold an **IOCCC mock** contest, but instead
 ask for beta testing of the new **IOCCC registration process** and
-**IOCCC Submit server** when the have left alpha testing phase.
+**IOCCC Submit server** when they have left alpha testing phase.
 This will speed up the start date of IOCCC28.
 
-It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the IOCCC.
+It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the
+IOCCC.
 
 
 ## 2024-04-30


### PR DESCRIPTION

It might be useful to know that the majority of the files should be 
relatively quick to review and that of the three slower files one is 
almost done.

I did not change the date of the news update but this seems like a
useful change (though maybe better wording could be used). If the date 
is changed it would allow to update the status.json and status.html file
news date.