### PR TITLE
Restore bug status in 1984/laman

### DIFF
--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -5,6 +5,18 @@
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+    STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1984/laman in bugs.html](../../bugs.html#1984_laman).
+
+
+
 ## To use:
 
 ``` <!---sh-->

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -403,6 +403,10 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <!-- BEFORE: 1st line of markdown file: 1984/laman/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
+<p>For more detailed information see <a href="../../bugs.html#1984_laman">1984/laman in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./laman &lt;positive number&gt;</code></pre>
 <h2 id="try">Try:</h2>

--- a/1984/laman/laman.c
+++ b/1984/laman/laman.c
@@ -1,5 +1,5 @@
 a[900];		b;c;d=1		;e=1;f;		g;h;O;		main(k,
-l)char*		*l;{if(k>1)	{g=atoi(*	++l);		for(k=
+l)char*		*l;{g=		atoi(*		++l);		for(k=
 0;k*k<		g;b=k		++>>1)		;for(h=		0;h*h<=
 g;++h);		--h;c=(		(h+=g>h		*(h+1))		-1)>>1;
 while(d		<=g){		++O;for		(f=0;f<		O&&d<=g
@@ -9,4 +9,4 @@ while(d		<=g){		++O;for		(f=0;f<		O&&d<=g
 b){if(b		<k/2)a[		b<<5|c]		^=a[(k		-(b+1))
 <<5|c]^=	a[b<<5		|c]^=a[		(k-(b+1		))<<5|c]
 ;printf(	a[b<<5|c	]?"%-4d"	:"    "		,a[b<<5
-|c]);}		putchar(	'\n');}}}	/*Mike		Laman*/
+|c]);}		putchar(	'\n');}}	/*Mike		Laman*/

--- a/bugs.html
+++ b/bugs.html
@@ -660,11 +660,11 @@ the entry. Nonetheless they are noteworthy.</p>
 something was noted by the author, the judges, a consequence of earlier
 requirements for winning entries or the purpose was to do something that might
 appear to be buggy. An example of system specific entries:</p>
-<p><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">1984/mullender</a> (see below and the <a href="faq.html">FAQ</a>
-for a version that works in modern systems) is very system specific and was
-before system specific winning entries were discouraged. This is an all time
-personal favourite of Landon Curt Noll. Run the alternate code to understand why
-this might be (along with how strange the source code is :-) ).</p>
+<p><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">1984/mullender</a> (see below for a
+version that works in modern systems) is very system specific and was before
+system specific winning entries were discouraged. This is an all time personal
+favourite of Landon Curt Noll. Run the alternate code to understand why this
+might be (along with how strange the source code is :-) ).</p>
 <p>An example where a crash is not a bug: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh</a> is
 supposed to crash. There are others that are also supposed to crash or that are
 known to segfault but are considered features.</p>
@@ -702,10 +702,17 @@ you should see something like:</p>
     &#39;&quot;,x);      /*
     \</code></pre>
 <p>without a newline after the <code>\</code>. This is not a bug.</p>
+<div id="1984_laman">
+<h2 id="laman">1984/laman</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-2">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-1984lamandedot.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">1984/laman/dedot.c</a></h3>
+<h3 id="information-1984lamanindex.html">Information: <a href="1984/laman/index.html">1984/laman/index.html</a></h3>
+<p>This program will very likely crash or do something funny without an arg.</p>
 <div id="1984_mullender">
 <h2 id="mullender">1984/mullender</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-2">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-3">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1984mullendermullender.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">1984/mullender/mullender.c</a></h3>
 <h3 id="information-1984mullenderindex.html">Information: <a href="1984/mullender/index.html">1984/mullender/index.html</a></h3>
 <p>Although there is an alt version and supplementary program added by Cody that
@@ -732,7 +739,7 @@ emulator to test it) but running the code on the binary itself produces a
 <div id="1986_august">
 <h2 id="august">1986/august</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-3">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-4">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1986augustaugust.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/august/august.c">1986/august/august.c</a></h3>
 <h3 id="information-1986augustindex.html">Information: <a href="1986/august/index.html">1986/august/index.html</a></h3>
 <p>This entry is known to segfault after printing its output. It was documented by
@@ -751,7 +758,7 @@ the judges and shouldn’t be fixed.</p>
 <div id="1988_dale">
 <h2 id="dale">1988/dale</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-4">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-5">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1988daledale.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/dale.c">1988/dale/dale.c</a></h3>
 <h3 id="information-1988daleindex.html">Information: <a href="1988/dale/index.html">1988/dale/index.html</a></h3>
 <p>In linux it might happen that despite no error message or message about doing
@@ -776,7 +783,7 @@ errors.</p>
 <div id="1989_robison">
 <h2 id="robison">1989/robison</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-5">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-6">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1989robisonrobison.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/robison.c">1989/robison/robison.c</a></h3>
 <h3 id="information-1989robisonindex.html">Information: <a href="1989/robison/index.html">1989/robison/index.html</a></h3>
 <p>This program will very likely crash or break into tiny bits :-) if you feed it
@@ -876,7 +883,7 @@ Enjoy! :-)</p>
 <div id="1990_baruch">
 <h2 id="baruch">1990/baruch</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-6">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-7">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990baruchbaruch.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/baruch.c">1990/baruch/baruch.c</a></h3>
 <h3 id="information-1990baruchindex.html">Information: <a href="1990/baruch/index.html">1990/baruch/index.html</a></h3>
 <p>A point worth considering is that as the number passed into the program gets
@@ -976,7 +983,7 @@ defeat the purpose. This would ideally be fixed.</p>
 <div id="1990_tbr">
 <h2 id="tbr">1990/tbr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-7">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-8">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990tbrtbr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/tbr/tbr.c">1990/tbr/tbr.c</a></h3>
 <h3 id="information-1990tbrindex.html">Information: <a href="1990/tbr/index.html">1990/tbr/index.html</a></h3>
 <p>The authors provided a list of features in the
@@ -984,7 +991,7 @@ defeat the purpose. This would ideally be fixed.</p>
 <div id="1990_theorem">
 <h2 id="theorem">1990/theorem</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-8">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-9">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990theoremtheorem.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/theorem/theorem.c">1990/theorem/theorem.c</a></h3>
 <h3 id="information-1990theoremindex.html">Information: <a href="1990/theorem/index.html">1990/theorem/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed many bugs that
@@ -1000,7 +1007,7 @@ where this occurred was fixed but this one should not be fixed. Thank you.</p>
 <div id="1991_buzzard">
 <h2 id="buzzard">1991/buzzard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-9">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991buzzardbuzzard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">1991/buzzard/buzzard.c</a></h3>
 <h3 id="information-1991buzzardindex.html">Information: <a href="1991/buzzard/index.html">1991/buzzard/index.html</a></h3>
 <p>If the maze file cannot be opened, either because the path specified does not
@@ -1010,7 +1017,7 @@ file does not exist in the directory, this program will very likely crash.</p>
 <div id="1991_westley">
 <h2 id="westley-1">1991/westley</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">1991/westley/westley.c</a></h3>
 <h3 id="information-1991westleyindex.html">Information: <a href="1991/westley/index.html">1991/westley/index.html</a></h3>
 <p>There is a very simple way to always win. The program doesn’t catch you and as
@@ -1027,7 +1034,7 @@ when you’re cheating it ends up winning! Can you figure that out as well?</p>
 <div id="1992_adrian">
 <h2 id="adrian">1992/adrian</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992adrianadrian.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">1992/adrian/adrian.c</a></h3>
 <h3 id="information-1992adrianindex.html">Information: <a href="1992/adrian/index.html">1992/adrian/index.html</a></h3>
 <p>The author stated that if the file cannot be opened then it will print a system
@@ -1188,7 +1195,7 @@ than that. For instance this is what it looks like with clang:</p>
 <div id="1992_vern">
 <h2 id="vern">1992/vern</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992vernvern.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">1992/vern/vern.c</a></h3>
 <h3 id="information-1992vernindex.html">Information: <a href="1992/vern/index.html">1992/vern/index.html</a></h3>
 <p>When your own checkmate is imminent it prints <code>"Har har"</code> but does not exit so
@@ -1197,7 +1204,7 @@ it yourself through ctrl-c or killing it in some other fashion.</p>
 <div id="1992_westley">
 <h2 id="westley-2">1992/westley</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">1992/westley/westley.c</a></h3>
 <h3 id="information-1992westleyindex.html">Information: <a href="1992/westley/index.html">1992/westley/index.html</a></h3>
 <p>Cody improved the usability of this program by making it so that as long as the
@@ -1223,7 +1230,7 @@ not a misunderstanding).</p>
 <h1 id="section-9">1993</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
-<h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993antant.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">1993/ant/ant.c</a></h3>
 <h3 id="information-1993antindex.html">Information: <a href="1993/ant/index.html">1993/ant/index.html</a></h3>
 <p>The author stated that:</p>
@@ -1246,7 +1253,7 @@ system), this entry just shows a blank screen.</p>
 <div id="1993_lmfjyh">
 <h2 id="lmfjyh">1993/lmfjyh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993lmfjyhlmfjyh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">1993/lmfjyh/lmfjyh.c</a></h3>
 <h3 id="information-1993lmfjyhindex.html">Information: <a href="1993/lmfjyh/index.html">1993/lmfjyh/index.html</a></h3>
 <p>This entry relied on a bug in gcc that was fixed with gcc version 2.3.3. This
@@ -1256,7 +1263,7 @@ the index.html file for details.</p>
 <div id="1993_rince">
 <h2 id="rince">1993/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">1993/rince/rince.c</a></h3>
 <h3 id="information-1993rinceindex.html">Information: <a href="1993/rince/index.html">1993/rince/index.html</a></h3>
 <p>Although the code checks if the file can be opened or not, badly formatted files
@@ -1266,7 +1273,7 @@ through ctrl-c or such.</p>
 <div id="1993_schnitzi">
 <h2 id="schnitzi">1993/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">1993/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1993schnitziindex.html">Information: <a href="1993/schnitzi/index.html">1993/schnitzi/index.html</a></h3>
 <p>If the file cannot be opened it will very likely segfault. This should not be
@@ -1292,7 +1299,7 @@ question you might cause an error. For instance don’t do this:</p>
 <p>Of course if you do something like:</p>
 <pre><code>    What is &#39;foo&#39;?</code></pre>
 <p>it will work fine.</p>
-<h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993vanbvanb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">1993/vanb/vanb.c</a></h3>
 <h3 id="information-1993vanbindex.html">Information: <a href="1993/vanb/index.html">1993/vanb/index.html</a></h3>
 <p>No spaces are allowed in the expression.</p>
@@ -1308,7 +1315,7 @@ not <code>d-46</code>.</p>
 <div id="1994_dodsond2">
 <h2 id="dodsond2">1994/dodsond2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994dodsond2dodsond2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2/dodsond2.c</a></h3>
 <h3 id="information-1994dodsond2index.html">Information: <a href="1994/dodsond2/index.html">1994/dodsond2/index.html</a></h3>
 <p>When you initiate shooting via the <code>s</code> command you immediately lose an arrow
@@ -1318,7 +1325,7 @@ pit room you will end up dying even though you didn’t explicitly move there.</
 <div id="1994_ldb">
 <h2 id="ldb">1994/ldb</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994ldbldb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">1994/ldb/ldb.c</a></h3>
 <h3 id="information-1994ldbindex.html">Information: <a href="1994/ldb/index.html">1994/ldb/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this to compile
@@ -1421,7 +1428,7 @@ compiled!</p>
 <div id="1994_shapiro">
 <h2 id="shapiro">1994/shapiro</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994shapiroshapiro.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">1994/shapiro/shapiro.c</a></h3>
 <h3 id="information-1994shapiroindex.html">Information: <a href="1994/shapiro/index.html">1994/shapiro/index.html</a></h3>
 <p>This program will likely crash if the source code file (by the name of the file
@@ -1468,7 +1475,7 @@ doesn’t break something else.</p>
 <div id="1995_cdua">
 <h2 id="cdua">1995/cdua</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995cduacdua.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">1995/cdua/cdua.c</a></h3>
 <h3 id="information-1995cduaindex.html">Information: <a href="1995/cdua/index.html">1995/cdua/index.html</a></h3>
 <p>This did not originally compile under macOS and after it did compile under
@@ -1500,7 +1507,7 @@ it would be good if it was fixed.</p>
 <div id="1995_savastio">
 <h2 id="savastio">1995/savastio</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995savastiosavastio.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">1995/savastio/savastio.c</a></h3>
 <h3 id="information-1995savastioindex.html">Information: <a href="1995/savastio/index.html">1995/savastio/index.html</a></h3>
 <p>This program expects a POSITIVE number. If you specify a negative number it will
@@ -1565,7 +1572,7 @@ almost be done except that some of the output of the
 <div id="1996_jonth">
 <h2 id="jonth">1996/jonth</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1996jonthjonth.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">1996/jonth/jonth.c</a></h3>
 <h3 id="information-1996jonthindex.html">Information: <a href="1996/jonth/index.html">1996/jonth/index.html</a></h3>
 <p>If X is not running this program will very likely crash or do something funny.
@@ -1608,7 +1615,7 @@ to the page as well! You’ll have IOCCC fame for reviving a pootifier! :-)</p>
 <div id="1998_schnitzi">
 <h2 id="schnitzi-2">1998/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">1998/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1998schnitziindex.html">Information: <a href="1998/schnitzi/index.html">1998/schnitzi/index.html</a></h3>
 <p>A point worth considering is that as the number passed into the program gets
@@ -1765,7 +1772,7 @@ on the stack at that point:</p>
     5</code></pre>
 <p>which might (?) suggest that the <code>+</code> operator is unimplemented. Unfortunately it
 has been many years since I have used perl and I was never a guru either.</p>
-<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states that in perl &lt; 5.6.0 there is a bug with a core dump in what
 they said is in <code>Perl_sv_upgrade</code>. As this is documented it is not considered a
 bug to be fixed. For the curious this will crash in macOS. Cody notes that the
@@ -1807,7 +1814,7 @@ of 92 warnings! Nonetheless neither works okay and both crash.</p>
 <div id="2000_primenum">
 <h2 id="primenum">2000/primenum</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000primenumprimenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/primenum.c">2000/primenum/primenum.c</a></h3>
 <h3 id="information-2000primenumindex.html">Information: <a href="2000/primenum/index.html">2000/primenum/index.html</a></h3>
 <p>This program does not do what you might think it does! Running it like:</p>
@@ -1825,7 +1832,7 @@ make a pull request.</p>
 <div id="2000_rince">
 <h2 id="rince-1">2000/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/rince.c">2000/rince/rince.c</a></h3>
 <h3 id="information-2000rinceindex.html">Information: <a href="2000/rince/index.html">2000/rince/index.html</a></h3>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash, do something strange
@@ -1839,7 +1846,7 @@ fire</a>! :-) ).</p>
 <div id="2001_anonymous">
 <h2 id="anonymous">2001/anonymous</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001anonymousanonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.c">2001/anonymous/anonymous.c</a></h3>
 <h3 id="information-2001anonymousindex.html">Information: <a href="2001/anonymous/index.html">2001/anonymous/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this so that it
@@ -1858,7 +1865,7 @@ elves of Imladris :-(</p>
 <div id="2001_bellard">
 <h2 id="bellard">2001/bellard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix">STATUS: doesn’t work with some platforms - please help us fix</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
@@ -1907,14 +1914,14 @@ before the fixes there.</p>
 <div id="2001_cheong">
 <h2 id="cheong">2001/cheong</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
 <h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
 <p>This program will crash without an arg.</p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
@@ -1935,7 +1942,7 @@ appreciate your help!</p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
 <p>Sometimes when one player presses <code>q</code> it will result in broken pipe on the other
@@ -1953,7 +1960,7 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
 <div id="2001_ollinger">
 <h2 id="ollinger">2001/ollinger</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
 <h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
 <p>This program will very likely crash or do something unexpected if you do not
@@ -1969,7 +1976,7 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
@@ -2137,13 +2144,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2168,7 +2175,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2181,7 +2188,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2195,7 +2202,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2204,7 +2211,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2238,7 +2245,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2252,7 +2259,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2293,7 +2300,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2302,7 +2309,7 @@ with possibly corrupt GIF files.</p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
@@ -2321,12 +2328,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
@@ -2334,7 +2341,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2351,7 +2358,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2398,7 +2405,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2421,7 +2428,7 @@ bins at the edges.</p>
 instead being something else entirely. The Internet Wayback Machine, although it
 archived it, did not load scripts. Do you know if the domain was moved? Do you
 have an archive or mirror? Please provide us it! Thank you.</p>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2434,7 +2441,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2606,7 +2613,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2620,7 +2627,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2629,7 +2636,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2662,7 +2669,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2676,7 +2683,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2697,7 +2704,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2713,7 +2720,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2733,7 +2740,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2752,7 +2759,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2768,7 +2775,7 @@ section</a>.</p>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2781,14 +2788,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2796,7 +2803,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2813,7 +2820,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2837,7 +2844,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2878,7 +2885,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2903,7 +2910,7 @@ result. Error messages become garbled, though.</p></li>
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2912,7 +2919,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -2945,7 +2952,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -2964,7 +2971,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -2989,7 +2996,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -3004,7 +3011,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3054,7 +3061,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3062,7 +3069,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3070,7 +3077,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3102,7 +3109,7 @@ ideal if this was not the case.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3131,7 +3138,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3139,7 +3146,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3169,7 +3176,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3179,7 +3186,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3199,7 +3206,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3208,7 +3215,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3223,7 +3230,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3234,7 +3241,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3248,7 +3255,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3258,7 +3265,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3267,7 +3274,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -401,11 +401,11 @@ something was noted by the author, the judges, a consequence of earlier
 requirements for winning entries or the purpose was to do something that might
 appear to be buggy. An example of system specific entries:
 
-[1984/mullender](%%REPO_URL%%/1984/mullender/mullender.c) (see below and the [FAQ](faq.html)
-for a version that works in modern systems) is very system specific and was
-before system specific winning entries were discouraged. This is an all time
-personal favourite of Landon Curt Noll. Run the alternate code to understand why
-this might be (along with how strange the source code is :-) ).
+[1984/mullender](%%REPO_URL%%/1984/mullender/mullender.c) (see below for a
+version that works in modern systems) is very system specific and was before
+system specific winning entries were discouraged. This is an all time personal
+favourite of Landon Curt Noll. Run the alternate code to understand why this
+might be (along with how strange the source code is :-) ).
 
 An example where a crash is not a bug: [2019/endoh](%%REPO_URL%%/2019/endoh/prog.c) is
 supposed to crash. There are others that are also supposed to crash or that are
@@ -464,6 +464,17 @@ you should see something like:
 ```
 
 without a newline after the `\`. This is not a bug.
+
+
+<div id="1984_laman">
+## 1984/laman
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1984/laman/dedot.c](%%REPO_URL%%/1984/laman/laman.c)
+### Information: [1984/laman/index.html](1984/laman/index.html)
+
+This program will very likely crash or do something funny without an arg.
 
 
 <div id="1984_mullender">

--- a/faq.html
+++ b/faq.html
@@ -2520,7 +2520,7 @@ a country, such as “Antarctica” or a User-assigned code.</p>
 <p>There <strong>MUST</strong> be one and only one <code>email</code> <em>JSON member</em> and the <em>JSON value</em> <strong>MUST</strong>
 be a <em>JSON string</em> or it <strong>MUST</strong> be a <em>JSON null</em>.</p>
 <p>If the author wishes to not specify an email address, or if the email address is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
 For example:</p>
 <pre><code>    &quot;email&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
@@ -2529,24 +2529,24 @@ For example:</p>
 <p>This <em>JSON member</em> holds the URL of the author’s home page.</p>
 <p>There <strong>MUST</strong> be one and only one <code>url</code> <em>JSON member</em> and the <em>JSON value</em> <strong>MUST</strong>
 be a <em>JSON string</em> or it <strong>MUST</strong> be a <em>JSON null</em>.</p>
-<p>If the author wishes to not specify an email address, or if the URL is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
-For example:</p>
+<p>If the author wishes to not specify a URL or if the URL is
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON
+member</em>. For example:</p>
 <pre><code>    &quot;url&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
 <h5 id="alt_url">alt_url</h5>
 <pre><code>    &quot;alt_url&quot; : null,</code></pre>
 <p>This <em>JSON member</em> holds an alternate or 2nd URL a home page for the author.</p>
-<p>There <strong>MUST</strong> be one and only one <code>url</code> <em>JSON member</em> and the <em>JSON value</em> <strong>MUST</strong>
+<p>There <strong>MUST</strong> be one and only one <code>alt_url</code> <em>JSON member</em> and the <em>JSON value</em> <strong>MUST</strong>
 be a <em>JSON string</em> or it <strong>MUST</strong> be a <em>JSON null</em>.</p>
 <p>In some cases the author may wish to record a special URL for their IOCCC entry,
 or a 2nd URL such as a work or school or personal home page. For example,
 Cody as of <em>Thu Nov 30 23:51:12 UTC 2023</em> used:</p>
 <pre><code>    &quot;alt_url&quot; : &quot;https://ioccc.xexyl.net&quot;,</code></pre>
-<p>If the author wishes to not specify an email address, or if the alternate URL is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
-For example:</p>
-<pre><code>    &quot;url&quot; : null,</code></pre>
+<p>If the author wishes to not specify an alternate URL, or if the alternate URL is
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON
+member</em>. For example:</p>
+<pre><code>    &quot;alt_url&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
 <h5 id="deprecated_twitter_handle">deprecated_twitter_handle</h5>
 <p>This <em>JSON member</em> used to hold the twitter handle of the author.</p>
@@ -2557,8 +2557,8 @@ and so the <code>deprecated_twitter_handle</code> is <strong>no longer used</str
 not a <em>JSON null</em> is kept for only historic reasons. For example, Anthony C. Howe
 once used:</p>
 <pre><code>    &quot;deprecated_twitter_handle&quot; : &quot;@SirWumpus&quot;,</code></pre>
-<p>If the author wishes to not specify an twitter handle, or if the twitter handle is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
+<p>If the author wishes to not specify a twitter handle, or if the twitter handle is
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
 For example:</p>
 <pre><code>    &quot;deprecated_twitter_handle&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
@@ -2581,7 +2581,7 @@ as the opening and closing of a new IOCCC, changes to the IOCCC web
 site, updates during the judging process, and when new IOCCC entries
 are selected. We recommend you follow us on Mastodon.</p>
 <p>If the author wishes to not specify an Mastodon handle, or if the Mastodon handle is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
 For example:</p>
 <pre><code>    &quot;mastodon&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
@@ -2598,7 +2598,7 @@ For example, if the Mastodon handle is:</p>
 <p>Then the <code>mastodon_url</code> would be:</p>
 <pre><code>    https://server.domain/@user</code></pre>
 <p>If the author wishes to not specify an Mastodon URL, or if the Mastodon URL is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
 For example:</p>
 <pre><code>    &quot;mastodon_url&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
@@ -2615,7 +2615,7 @@ and hosts <a href="https://www.ioccc.org">official IOCCC web site</a> on GitHub 
 <p>The IOCCC GitHub handle is:</p>
 <pre><code>    @ioccc-src</code></pre>
 <p>If the author wishes to not specify an GitHub handle, or if the GitHub handle is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
 For example:</p>
 <pre><code>    &quot;github&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>
@@ -2629,7 +2629,7 @@ It is recommended that the affiliation <em>JSON string</em> be the formal affili
 For example, the affiliation for the IOCCC would be:</p>
 <pre><code>    The International Obfuscared C Code Contest</code></pre>
 <p>If the author wishes to not specify an affiliation, or if the affiliation is
-unknown, they should use the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
+unknown, it should be the <em>JSON null</em> as the <em>JSON value</em> of this <em>JSON member</em>.
 For example:</p>
 <pre><code>    &quot;affiliation&quot; : null,</code></pre>
 <p>NOTE: The <em>JSON null</em> is <strong>NOT</strong> enclosed in quotes!</p>

--- a/faq.html
+++ b/faq.html
@@ -442,6 +442,7 @@
 other inconsistencies with the original entry?</a></li>
 <li><a href="#faq4_4">4.4 - What is the meaning of the file ending in .orig.c in IOCCC entries?</a></li>
 <li><a href="#faq4_5">4.5 - Why were alternate versions added to some entries when the original entry worked fine and well?</a></li>
+<li><a href="#faq4_6">4.6 - Why was arg count and/or type changed in main() in some older entries?</a></li>
 </ul>
 <h2 id="section-5---helping-the-ioccc">Section 5 - <a href="#faq5">Helping the IOCCC</a></h2>
 <ul>
@@ -2019,6 +2020,21 @@ prevented the entry from working properly and it seemed like it should be added
 as well, for fun.</p>
 <p>In some cases it might be better to not have them but as noted this is a
 judgement call.</p>
+<div id="faq4_6">
+<h3 id="faq-4.6-why-was-arg-count-andor-type-changed-in-main-in-some-older-entries">FAQ 4.6: Why was arg count and/or type changed in main() in some older entries?</h3>
+</div>
+<p>There are a number of reasons this was done but they usually come down to a
+mis-feature or defect in the <code>clang</code> compiler.</p>
+<p>In all versions of <code>clang</code> the first arg must be an <code>int</code> and the rest must be a
+<code>char **</code> but in some versions it also objects to the number of args in
+<code>main()</code>. In the versions observed that complain about the number of args it
+says that there must be 0, 2 or 3 args. This only was triggered with 4 args, not
+1, but to future proof the entry entries that had only one arg to <code>main()</code> were
+changed to two.</p>
+<p>The above also meant that some entries that were recursive calls to <code>main()</code>
+could no longer be so: <code>main()</code> instead had to call another function that has
+the body of the old <code>main()</code> and that function would call itself again. In some
+cases, however, this had to be done even without <code>clang</code> objections.</p>
 <div id="faq5">
 <h2 id="section-5-updating-or-correcting-ioccc-web-site-content">Section 5: Updating or correcting IOCCC web site content</h2>
 </div>

--- a/faq.md
+++ b/faq.md
@@ -3140,7 +3140,7 @@ There **MUST** be one and only one `email` _JSON member_ and the _JSON value_ **
 be a _JSON string_ or it **MUST** be a _JSON null_.
 
 If the author wishes to not specify an email address, or if the email address is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON member_.
 For example:
 
 ``` <!---json-->
@@ -3161,9 +3161,9 @@ This _JSON member_ holds the URL of the author's home page.
 There **MUST** be one and only one `url` _JSON member_ and the _JSON value_ **MUST**
 be a _JSON string_ or it **MUST** be a _JSON null_.
 
-If the author wishes to not specify an email address, or if the URL is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
-For example:
+If the author wishes to not specify a URL or if the URL is
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON
+member_.  For example:
 
 ``` <!---json-->
     "url" : null,
@@ -3180,7 +3180,7 @@ NOTE: The _JSON null_ is **NOT** enclosed in quotes!
 
 This _JSON member_ holds an alternate or 2nd URL a home page for the author.
 
-There **MUST** be one and only one `url` _JSON member_ and the _JSON value_ **MUST**
+There **MUST** be one and only one `alt_url` _JSON member_ and the _JSON value_ **MUST**
 be a _JSON string_ or it **MUST** be a _JSON null_.
 
 In some cases the author may wish to record a special URL for their IOCCC entry,
@@ -3191,12 +3191,12 @@ Cody as of  _Thu Nov 30 23:51:12 UTC 2023_ used:
     "alt_url" : "https://ioccc.xexyl.net",
 ```
 
-If the author wishes to not specify an email address, or if the alternate URL is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
-For example:
+If the author wishes to not specify an alternate URL, or if the alternate URL is
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON
+member_.  For example:
 
 ``` <!---json-->
-    "url" : null,
+    "alt_url" : null,
 ```
 
 NOTE: The _JSON null_ is **NOT** enclosed in quotes!
@@ -3218,8 +3218,8 @@ once used:
     "deprecated_twitter_handle" : "@SirWumpus",
 ```
 
-If the author wishes to not specify an twitter handle, or if the twitter handle is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
+If the author wishes to not specify a twitter handle, or if the twitter handle is
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON member_.
 For example:
 
 ``` <!---json-->
@@ -3260,7 +3260,7 @@ site, updates during the judging process, and when new IOCCC entries
 are selected.  We recommend you follow us on Mastodon.
 
 If the author wishes to not specify an Mastodon handle, or if the Mastodon handle is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON member_.
 For example:
 
 ``` <!---json-->
@@ -3297,7 +3297,7 @@ Then the `mastodon_url` would be:
 ```
 
 If the author wishes to not specify an Mastodon URL, or if the Mastodon URL is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON member_.
 For example:
 
 ``` <!---json-->
@@ -3332,7 +3332,7 @@ The IOCCC GitHub handle is:
 ```
 
 If the author wishes to not specify an GitHub handle, or if the GitHub handle is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON member_.
 For example:
 
 ``` <!---json-->
@@ -3362,7 +3362,7 @@ For example, the affiliation for the IOCCC would be:
 ```
 
 If the author wishes to not specify an affiliation, or if the affiliation is
-unknown, they should use the _JSON null_ as the _JSON value_ of this _JSON member_.
+unknown, it should be the _JSON null_ as the _JSON value_ of this _JSON member_.
 For example:
 
 ``` <!---json-->

--- a/faq.md
+++ b/faq.md
@@ -59,6 +59,7 @@
 other inconsistencies with the original entry?](#faq4_3)
 - [4.4  - What is the meaning of the file ending in .orig.c in IOCCC entries?](#faq4_4)
 - [4.5  - Why were alternate versions added to some entries when the original entry worked fine and well?](#faq4_5)
+- [4.6  - Why was arg count and/or type changed in main&#x28;&#x29; in some older entries?](#faq4_6)
 
 
 ## Section  5 - [Helping the IOCCC](#faq5)
@@ -2406,6 +2407,26 @@ as well, for fun.
 
 In some cases it might be better to not have them but as noted this is a
 judgement call.
+
+
+<div id="faq4_6">
+### FAQ 4.6: Why was arg count and/or type changed in main&#x28;&#x29; in some older entries?
+</div>
+
+There are a number of reasons this was done but they usually come down to a
+mis-feature or defect in the `clang` compiler.
+
+In all versions of `clang` the first arg must be an `int` and the rest must be a
+`char **` but in some versions it also objects to the number of args in
+`main()`. In the versions observed that complain about the number of args it
+says that there must be 0, 2 or 3 args. This only was triggered with 4 args, not
+1, but to future proof the entry entries that had only one arg to `main()` were
+changed to two.
+
+The above also meant that some entries that were recursive calls to `main()`
+could no longer be so: `main()` instead had to call another function that has
+the body of the old `main()` and that function would call itself again. In some
+cases, however, this had to be done even without `clang` objections.
 
 
 <div id="faq5">

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -466,7 +466,7 @@ allow this. Some versions of <code>clang</code> say that <code>main()</code> mus
 args but these versions do not object to 1 arg. However as the <code>char</code> macro
 seems more obscure and it is possible that a new version of <code>clang</code> will be even
 more strict the <code>int i</code> parameter in <code>main()</code> was moved to be inside <code>main()</code>,
-set to non-zero (setting <code>i</code> to 0 will not work). This is way <code>main()</code> has zero
+set to non-zero (setting <code>i</code> to 0 will not work). This is why <code>main()</code> has zero
 args.</p>
 <p>Observe how on line 29 there is a call to <code>main()</code> which does pass in a
 parameter. It has never been observed to be an error to pass in too many
@@ -487,10 +487,6 @@ but not <code>clang</code> - or at least some versions.</p>
 <h3 id="winning-entry-source-code-laman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">laman.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/try.sh">try.sh</a> script.</p>
-<p>Cody also fixed this to not crash when no arg is specified. Note that if the arg
-is not a positive number it will not do anything useful or anything at all.
-This was fixed on 30 October 2023 after the bug status was changed from INABIAF
-(it’s not a bug it’s a feature) to bug.</p>
 <div id="1984_mullender">
 <h2 id="winning-entry-1984mullender">Winning entry: <a href="1984/mullender/index.html">1984/mullender</a></h2>
 <h3 id="winning-entry-source-code-mullender.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">mullender.c</a></h3>
@@ -543,7 +539,9 @@ returning to the shell. The original code does not have this change.</p>
 versions of <code>clang</code> object to the number of args of <code>main()</code>, saying that it must
 be 0, 2 or 3. The version this has been observed in does not actually object to
 1 arg but it is entirely possible that this changes so a second arg (that’s not
-needed and is unused) has been added just in case.</p>
+needed and is unused) has been added just in case. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also added the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/august/primes.sh">primes.sh</a> which allows one
 to check the output for the first <code>N</code> prime numbers of the output, where <code>N</code> is
 either the default or user specified. The inspiration was the previous <code>try</code>
@@ -1749,7 +1747,9 @@ start and end character.</p>
 defect with the number of args to <code>main()</code> though when it comes to 1 arg it is
 only in an error message if say 4 args are used. This is out of an abundance of
 caution as it’s quite possible that <code>clang</code> or the ANSI C committee end up further
-changing this.</p>
+changing this. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back.</p>
 <div id="1992_lush">
@@ -2135,7 +2135,9 @@ details on this.</p>
 type of args. In particular some versions supposedly only allow 0, 2 or 3 args.
 It actually appears to allow 1 but if you specify 4 it says 0, 2 or 3 and it is
 an error but it’s entirely possible that they will eventually make the defect
-function as the error message claims.</p>
+function as the error message claims. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <div id="1995_dodsond1">
 <h2 id="winning-entry-1995dodsond1">Winning entry: <a href="1995/dodsond1/index.html">1995/dodsond1</a></h2>
 <h3 id="winning-entry-source-code-dodsond1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/dodsond1/dodsond1.c">dodsond1.c</a></h3>
@@ -2348,7 +2350,9 @@ versions of <code>clang</code> whine about the number of args on top of what typ
 In particular some versions claim that they only allow 0, 2 or 3 args. It
 appears that they do allow 1 but for instance 4 is not allowed. However as it’s
 quite possible they will ‘fix’ this defect it would be better to have this not
-be a problem at such a time.</p>
+be a problem at such a time. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas1/bas1.sh">bas1.sh</a> script to simplify running the
 program.</p>
 <div id="1998_bas2">
@@ -2412,11 +2416,13 @@ final code that is compiled. The code is now what it essentially becomes when
 processed completely. The intermediate steps can now be performed to see how it
 expands but it can still compile and be used.</p>
 <p>Cody also added a second arg to <code>main()</code> out of an abundance of caution as some
-versions of <code>clang</code> whine about the number of args to <code>main()</code>. These versions
+versions of <code>clang</code> complain about the number of args to <code>main()</code>. These versions
 claim that only 0, 2 or 3 are allowed but it does allow 1 anyway. It is quite
 possible though that this will change so it is fixed in case this happens. As it
 is mostly just through the C pre-processor Cody added a new macro to make the
-code look like the original with just an extra arg.</p>
+code look like the original with just an extra arg. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>In some versions of <code>clang</code> <code>-Wno-int-conversion</code> had to be added to the
 <code>CSILENCE</code> variable of the Makefile.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/fanf/try.sh">try.sh</a> script to show the output of some
@@ -2513,7 +2519,9 @@ occurs.</p>
 <p>Cody made <code>main()</code> have two args out of an abundance of caution as some versions
 of <code>clang</code> say that <code>main()</code> can only have 0, 2 or 3 args. These versions accept 1
 arg but it is entirely possible that they fix this so this should prevent it
-from breaking if that happens.</p>
+from breaking if that happens. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/try.sh">try.sh</a> script to make it easier to try
 the commands that we suggested. One command was not added, that of the to use
 command.</p>
@@ -3039,7 +3047,9 @@ a lot of numbers this will be harder to see).</p>
 discovered it will not work otherwise.</p>
 <p>Cody, out of an abundance of caution for <code>clang</code>, added a second arg to <code>main()</code>
 as some versions complain about the number of args and although they accept 1 it
-is entirely possible it will eventually be that they don’t.</p>
+is entirely possible it will eventually be that they don’t. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski/try.sh">try.sh</a> script and various data
 files: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski/kopczynski-a">kopczynski-a</a> to demonstrate what happens when art more
 like a letter is fed to the program and the <code>kopczynski*-rev</code> files which are
@@ -3424,7 +3434,9 @@ it to the repo as well.</p>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution for <code>clang</code>’s defects, made <code>main()</code> have
 2 args instead of 1 as some versions report that <code>main()</code> must have 0, 2 or 3
-args, even though at least one of those versions allows 1 arg only.</p>
+args, even though at least one of those versions allows 1 arg only. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2/try.sh">try.sh</a> script for easier use of the
 entry to show the clock update in real time.</p>
 <div id="2006_toledo1">
@@ -3480,7 +3492,9 @@ We’re not able to test this.</p>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution, added a second arg to <code>main()</code> as some
 versions of <code>clang</code> complain about not only the type of each arg to <code>main()</code> but
-the number of args as well.</p>
+the number of args as well. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/try.sh">try.sh</a> script.</p>
 <div id="2011_dlowe">
 <h2 id="winning-entry-2011dlowe">Winning entry: <a href="2011/dlowe/index.html">2011/dlowe</a></h2>
@@ -3491,7 +3505,8 @@ the number of args as well.</p>
 <h2 id="winning-entry-2011eastman">Winning entry: <a href="2011/eastman/index.html">2011/eastman</a></h2>
 <h3 id="winning-entry-source-code-eastman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/eastman//eastman.c">eastman.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added the video file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/eastman">boing-ball.mp4</a> which is the demo the
+<p><a href="#cody">Cody</a> added the video file
+<a href="2011/eastman/boing-ball.mp4">boing-ball.mp4</a> which is the demo the
 author referred to.</p>
 <div id="2011_fredriksson">
 <h2 id="winning-entry-2011fredriksson">Winning entry: <a href="2011/fredriksson/index.html">2011/fredriksson</a></h2>
@@ -3508,7 +3523,7 @@ for 64-bit so it was then tested as a 32-bit binary (Linux) and 64-bit binary
 (Linux, macOS) and both work. It was fixed by changing some <code>int</code>s to <code>long</code>s
 and now it does work with 64-bit systems as well as 32-bit systems.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/goren/try.sh">try.sh</a> script.</p>
-<p>Cody added the following words of wisdom: <code>'"this" is not a pipe but "!" is'</code>.</p>
+<p>Cody added the following words of wisdom: <code>'"this" is not a pipe but "|" is'</code>.</p>
 <div id="2011_hamaji">
 <h2 id="winning-entry-2011hamaji">Winning entry: <a href="2011/hamaji/index.html">2011/hamaji</a></h2>
 <h3 id="winning-entry-source-code-hamaji.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hamaji//hamaji.c">hamaji.c</a></h3>
@@ -3636,10 +3651,12 @@ everything, filtered through less.</p>
 <h3 id="winning-entry-source-code-grothe.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/grothe//grothe.c">grothe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/grothe/try.sh">try.sh</a> script.</p>
-<p>Cody also changed <code>argv</code> to be not <code>const char ** but</code>char <strong>, mostly out of an
+<p>Cody also changed <code>argv</code> to be not <code>const char **</code> but <code>char **</code>, mostly out of an
 abundance of caution in case <code>clang</code>, which already imposes restrictions on the
-types of args to <code>main()</code> including to do with `char </strong>, decides to further
-restrict them.</p>
+types of args to <code>main()</code> including to do with <code>char **</code>, decides to further
+restrict them. See <a href="faq.html#faq4_6">FAQ 4.6 - Why was arg
+count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also restored the original code from the archive.</p>
 <p>And although the URL works for now (via redirect), Cody changed the website
 linked to in the recipe file to the domain that the old one currently redirects
@@ -3847,7 +3864,9 @@ not found.</p>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/try.sh">try.sh</a> script.</p>
 <p>Cody also (out of an abundance of caution for <code>clang(1)</code> which is strict with
-arg type and count to <code>main()</code>) added a second (unused) arg to <code>main()</code>.</p>
+arg type and count to <code>main()</code>) added a second (unused) arg to <code>main()</code>. See
+<a href="faq.html#faq4_6">FAQ 4.6 - Why was arg count and/or type changed in main() in some
+older entries?</a> for more details.</p>
 <div id="2013_endoh4">
 <h2 id="winning-entry-2013endoh4">Winning entry: <a href="2013/endoh4/index.html">2013/endoh4</a></h2>
 <h3 id="winning-entry-source-code-endoh4.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4//endoh4.c">endoh4.c</a></h3>
@@ -4196,7 +4215,9 @@ files from compiling properly, trying instead to compile already compiled code.<
 some versions of <code>clang</code> object to the number of args of <code>main()</code>, saying that it
 must be 0, 2 or 3. The version this has been observed in does not actually
 object to 1 arg but it is entirely possible that this changes so a second arg
-(that’s not needed and is unused) has been added just in case.</p>
+(that’s not needed and is unused) has been added just in case. See <a href="faq.html#faq4_6">FAQ 4.6 -
+Why was arg count and/or type changed in main() in some older
+entries?</a> for more details.</p>
 <p>Cody also added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added <a href="2018/bellard/index.html#alternate-code">alternate code</a> that should

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -108,7 +108,7 @@ allow this. Some versions of `clang` say that `main()` must have either 0, 2 or 
 args but these versions do not object to 1 arg. However as the `char` macro
 seems more obscure and it is possible that a new version of `clang` will be even
 more strict the `int i` parameter in `main()` was moved to be inside `main()`,
-set to non-zero (setting `i` to 0 will not work). This is way `main()` has zero
+set to non-zero (setting `i` to 0 will not work). This is why `main()` has zero
 args.
 
 Observe how on line 29 there is a call to `main()` which does pass in a
@@ -139,11 +139,6 @@ To see the difference from start to fixed:
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1984/laman/try.sh) script.
-
-Cody also fixed this to not crash when no arg is specified. Note that if the arg
-is not a positive number it will not do anything useful or anything at all.
-This was fixed on 30 October 2023 after the bug status was changed from INABIAF
-(it's not a bug it's a feature) to bug.
 
 
 <div id="1984_mullender">
@@ -213,7 +208,9 @@ returning to the shell. The original code does not have this change.
 versions of `clang` object to the number of args of `main()`, saying that it must
 be 0, 2 or 3. The version this has been observed in does not actually object to
 1 arg but it is entirely possible that this changes so a second arg (that's not
-needed and is unused) has been added just in case.
+needed and is unused) has been added just in case. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
 
 Cody also added the script [primes.sh](%%REPO_URL%%/1985/august/primes.sh) which allows one
 to check the output for the first `N` prime numbers of the output, where `N` is
@@ -1948,7 +1945,10 @@ Cody made `main()` have two args, not one, as some versions of `clang` have a
 defect with the number of args to `main()` though when it comes to 1 arg it is
 only in an error message if say 4 args are used. This is out of an abundance of
 caution as it's quite possible that `clang` or the ANSI C committee end up further
-changing this.
+changing this.  See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back.
@@ -2473,7 +2473,10 @@ Out of an abundance of caution with `clang`, Cody also added a second arg to
 type of args. In particular some versions supposedly only allow 0, 2 or 3 args.
 It actually appears to allow 1 but if you specify 4 it says 0, 2 or 3 and it is
 an error but it's entirely possible that they will eventually make the defect
-function as the error message claims.
+function as the error message claims.  See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 
 <div id="1995_dodsond1">
@@ -2770,7 +2773,10 @@ versions of `clang` whine about the number of args on top of what type they are
 In particular some versions claim that they only allow 0, 2 or 3 args. It
 appears that they do allow 1 but for instance 4 is not allowed. However as it's
 quite possible they will 'fix' this defect it would be better to have this not
-be a problem at such a time.
+be a problem at such a time. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Cody also added the [bas1.sh](%%REPO_URL%%/1998/bas1/bas1.sh) script to simplify running the
 program.
@@ -2861,11 +2867,14 @@ processed completely. The intermediate steps can now be performed to see how it
 expands but it can still compile and be used.
 
 Cody also added a second arg to `main()` out of an abundance of caution as some
-versions of `clang` whine about the number of args to `main()`. These versions
+versions of `clang` complain about the number of args to `main()`. These versions
 claim that only 0, 2 or 3 are allowed but it does allow 1 anyway. It is quite
 possible though that this will change so it is fixed in case this happens. As it
 is mostly just through the C pre-processor Cody added a new macro to make the
-code look like the original with just an extra arg.
+code look like the original with just an extra arg. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 In some versions of `clang` `-Wno-int-conversion` had to be added to the
 `CSILENCE` variable of the Makefile.
@@ -3002,7 +3011,10 @@ occurs.
 Cody made `main()` have two args out of an abundance of caution as some versions
 of `clang` say that `main()` can only have 0, 2 or 3 args. These versions accept 1
 arg but it is entirely possible that they fix this so this should prevent it
-from breaking if that happens.
+from breaking if that happens. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Cody added the [try.sh](%%REPO_URL%%/1998/schweikh3/try.sh) script to make it easier to try
 the commands that we suggested. One command was not added, that of the to use
@@ -3745,7 +3757,9 @@ discovered it will not work otherwise.
 
 Cody, out of an abundance of caution for `clang`, added a second arg to `main()`
 as some versions complain about the number of args and although they accept 1 it
-is entirely possible it will eventually be that they don't.
+is entirely possible it will eventually be that they don't. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
 
 Cody also added the [try.sh](%%REPO_URL%%/2004/kopczynski/try.sh) script and various data
 files: [kopczynski-a](%%REPO_URL%%/2004/kopczynski/kopczynski-a) to demonstrate what happens when art more
@@ -4295,7 +4309,10 @@ it to the repo as well.
 
 [Cody](#cody), out of an abundance of caution for `clang`'s defects, made `main()` have
 2 args instead of 1 as some versions report that `main()` must have 0, 2 or 3
-args, even though at least one of those versions allows 1 arg only.
+args, even though at least one of those versions allows 1 arg only.  See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Cody also added the [try.sh](%%REPO_URL%%/2006/sykes2/try.sh) script for easier use of the
 entry to show the clock update in real time.
@@ -4376,7 +4393,10 @@ We're not able to test this.
 
 [Cody](#cody), out of an abundance of caution, added a second arg to `main()` as some
 versions of `clang` complain about not only the type of each arg to `main()` but
-the number of args as well.
+the number of args as well. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Cody also added the [try.sh](%%REPO_URL%%/2011/borsanyi/try.sh) script.
 
@@ -4394,7 +4414,8 @@ Cody also added the [try.sh](%%REPO_URL%%/2011/borsanyi/try.sh) script.
 ### Winning entry source code: [eastman.c](%%REPO_URL%%/2011/eastman//eastman.c)
 </div>
 
-[Cody](#cody) added the video file [boing-ball.mp4](%%REPO_URL%%/2011/eastman) which is the demo the
+[Cody](#cody) added the video file
+[boing-ball.mp4](2011/eastman/boing-ball.mp4) which is the demo the
 author referred to.
 
 
@@ -4419,7 +4440,7 @@ and now it does work with 64-bit systems as well as 32-bit systems.
 
 Cody also added the [try.sh](%%REPO_URL%%/2011/goren/try.sh) script.
 
-Cody added the following words of wisdom: `'"this" is not a pipe but "!" is'`.
+Cody added the following words of wisdom: `'"this" is not a pipe but "|" is'`.
 
 
 <div id="2011_hamaji">
@@ -4600,10 +4621,13 @@ Cody also fixed a typo in the ruby script
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/grothe/try.sh) script.
 
-Cody also changed `argv` to be not `const char ** but `char **, mostly out of an
+Cody also changed `argv` to be not `const char **` but `char **`, mostly out of an
 abundance of caution in case `clang`, which already imposes restrictions on the
-types of args to `main()` including to do with `char **, decides to further
-restrict them.
+types of args to `main()` including to do with `char **`, decides to further
+restrict them. See [FAQ 4.6  - Why was arg
+count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Cody also restored the original code from the archive.
 
@@ -4890,7 +4914,11 @@ The entry can still be enjoyed if you do not have these tools, however.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/endoh3/try.sh) script.
 
 Cody also (out of an abundance of caution for `clang(1)` which is strict with
-arg type and count to `main()`) added a second (unused) arg to `main()`.
+arg type and count to `main()`) added a second (unused) arg to `main()`. See
+[FAQ 4.6  - Why was arg count and/or type changed in main&#x28;&#x29; in some
+older entries?](faq.html#faq4_6) for more details.
+
+
 
 
 <div id="2013_endoh4">
@@ -5394,7 +5422,10 @@ Cody also, out of abundance of caution, added a second arg to `main()` because
 some versions of `clang` object to the number of args of `main()`, saying that it
 must be 0, 2 or 3. The version this has been observed in does not actually
 object to 1 arg but it is entirely possible that this changes so a second arg
-(that's not needed and is unused) has been added just in case.
+(that's not needed and is unused) has been added just in case. See [FAQ 4.6  -
+Why was arg count and/or type changed in main&#x28;&#x29; in some older
+entries?](faq.html#faq4_6) for more details.
+
 
 Cody also added explicit linking of libm (`-lm`) for systems that do not do this
 (Linux doesn't seem to but macOS does).


### PR DESCRIPTION

The bugs.{md,html} files, 1984/laman/README.md (and index.html) file and
thanks files were updated. The thanks file has some additional fixes 
that were already in place but are relevant to this commit.