### PR TITLE
Restore a first char in line in 1984/decot

### DIFF
--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -6,7 +6,7 @@
 extern double floor(double);
 double (x1, y1) b;
 char x {sizeof(
-     double(%s,%D)(*)())
+    double(%s,%D)(*)())
 ,};
 struct tag{int x0,*xO;};
 

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -137,8 +137,7 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: this will very likely crash without an arg and will enter an infinite loop"
-	@echo "with an arg that is not a number > 0."
+	@echo "NOTE: this will very likely crash without an arg"
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # alternative executable

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -5,6 +5,18 @@
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+    STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1990/westley in bugs.html](../../bugs.html#1990_westley).
+
+
+
 ## To use:
 
 ``` <!---sh-->

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -403,6 +403,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 1990/westley/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
+<p>For more detailed information see <a href="../../bugs.html#1990_westley">1990/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./westley &lt;number&gt;</code></pre>
 <p>The number should be greater than 0.</p>

--- a/1990/westley/westley.c
+++ b/1990/westley/westley.c
@@ -11,7 +11,7 @@ char*lie;
 
 dear; (char)lotte--;
 
-	if (ly < 2 || atoi(die[1])<1) exit(1);
+	if (atoi(die[1])<1) exit(1);
 	for(get= !me;; not){
 
 	1 -  out & out ;lie;{

--- a/bugs.html
+++ b/bugs.html
@@ -999,6 +999,15 @@ prevented this from working properly (including segfaults) but one thing to note
 is that if you pass two zeroes to <code>theorem_bkp</code> or <code>fibonacci</code> the program
 will enter an infinite loop, printing 0 over and over again; another condition
 where this occurred was fixed but this one should not be fixed. Thank you.</p>
+<div id="1990_westley">
+<h2 id="westley-1">1990/westley</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-1990westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.c">1990/westley/westley.c</a></h3>
+<h3 id="information-1990westleyindex.html">Information: <a href="1990/westley/index.html">1990/westley/index.html</a></h3>
+<p>Although Cody fixed this to not enter an infinite loop if the arg (converted to
+a number) is &lt; 0 the lack of an arg check at all was kept in to make it like the
+original. The reason for the &lt; 0 check is it floods the screen.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1991">
 <h1 id="section-7">1991</h1>
@@ -1007,7 +1016,7 @@ where this occurred was fixed but this one should not be fixed. Thank you.</p>
 <div id="1991_buzzard">
 <h2 id="buzzard">1991/buzzard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991buzzardbuzzard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">1991/buzzard/buzzard.c</a></h3>
 <h3 id="information-1991buzzardindex.html">Information: <a href="1991/buzzard/index.html">1991/buzzard/index.html</a></h3>
 <p>If the maze file cannot be opened, either because the path specified does not
@@ -1015,9 +1024,9 @@ exist or because the default (whatever the source file was at compilation time)
 file does not exist in the directory, this program will very likely crash.</p>
 <p>This is a feature, not a bug.</p>
 <div id="1991_westley">
-<h2 id="westley-1">1991/westley</h2>
+<h2 id="westley-2">1991/westley</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">1991/westley/westley.c</a></h3>
 <h3 id="information-1991westleyindex.html">Information: <a href="1991/westley/index.html">1991/westley/index.html</a></h3>
 <p>There is a very simple way to always win. The program doesn’t catch you and as
@@ -1034,7 +1043,7 @@ when you’re cheating it ends up winning! Can you figure that out as well?</p>
 <div id="1992_adrian">
 <h2 id="adrian">1992/adrian</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992adrianadrian.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">1992/adrian/adrian.c</a></h3>
 <h3 id="information-1992adrianindex.html">Information: <a href="1992/adrian/index.html">1992/adrian/index.html</a></h3>
 <p>The author stated that if the file cannot be opened then it will print a system
@@ -1195,16 +1204,16 @@ than that. For instance this is what it looks like with clang:</p>
 <div id="1992_vern">
 <h2 id="vern">1992/vern</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992vernvern.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">1992/vern/vern.c</a></h3>
 <h3 id="information-1992vernindex.html">Information: <a href="1992/vern/index.html">1992/vern/index.html</a></h3>
 <p>When your own checkmate is imminent it prints <code>"Har har"</code> but does not exit so
 it can ‘rub your nose in defeat’, as the author puts it. You will have to exit
 it yourself through ctrl-c or killing it in some other fashion.</p>
 <div id="1992_westley">
-<h2 id="westley-2">1992/westley</h2>
+<h2 id="westley-3">1992/westley</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">1992/westley/westley.c</a></h3>
 <h3 id="information-1992westleyindex.html">Information: <a href="1992/westley/index.html">1992/westley/index.html</a></h3>
 <p>Cody improved the usability of this program by making it so that as long as the
@@ -1230,7 +1239,7 @@ not a misunderstanding).</p>
 <h1 id="section-9">1993</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
-<h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993antant.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">1993/ant/ant.c</a></h3>
 <h3 id="information-1993antindex.html">Information: <a href="1993/ant/index.html">1993/ant/index.html</a></h3>
 <p>The author stated that:</p>
@@ -1253,7 +1262,7 @@ system), this entry just shows a blank screen.</p>
 <div id="1993_lmfjyh">
 <h2 id="lmfjyh">1993/lmfjyh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993lmfjyhlmfjyh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">1993/lmfjyh/lmfjyh.c</a></h3>
 <h3 id="information-1993lmfjyhindex.html">Information: <a href="1993/lmfjyh/index.html">1993/lmfjyh/index.html</a></h3>
 <p>This entry relied on a bug in gcc that was fixed with gcc version 2.3.3. This
@@ -1263,7 +1272,7 @@ the index.html file for details.</p>
 <div id="1993_rince">
 <h2 id="rince">1993/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">1993/rince/rince.c</a></h3>
 <h3 id="information-1993rinceindex.html">Information: <a href="1993/rince/index.html">1993/rince/index.html</a></h3>
 <p>Although the code checks if the file can be opened or not, badly formatted files
@@ -1273,7 +1282,7 @@ through ctrl-c or such.</p>
 <div id="1993_schnitzi">
 <h2 id="schnitzi">1993/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">1993/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1993schnitziindex.html">Information: <a href="1993/schnitzi/index.html">1993/schnitzi/index.html</a></h3>
 <p>If the file cannot be opened it will very likely segfault. This should not be
@@ -1299,7 +1308,7 @@ question you might cause an error. For instance don’t do this:</p>
 <p>Of course if you do something like:</p>
 <pre><code>    What is &#39;foo&#39;?</code></pre>
 <p>it will work fine.</p>
-<h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993vanbvanb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">1993/vanb/vanb.c</a></h3>
 <h3 id="information-1993vanbindex.html">Information: <a href="1993/vanb/index.html">1993/vanb/index.html</a></h3>
 <p>No spaces are allowed in the expression.</p>
@@ -1315,7 +1324,7 @@ not <code>d-46</code>.</p>
 <div id="1994_dodsond2">
 <h2 id="dodsond2">1994/dodsond2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994dodsond2dodsond2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2/dodsond2.c</a></h3>
 <h3 id="information-1994dodsond2index.html">Information: <a href="1994/dodsond2/index.html">1994/dodsond2/index.html</a></h3>
 <p>When you initiate shooting via the <code>s</code> command you immediately lose an arrow
@@ -1325,7 +1334,7 @@ pit room you will end up dying even though you didn’t explicitly move there.</
 <div id="1994_ldb">
 <h2 id="ldb">1994/ldb</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994ldbldb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">1994/ldb/ldb.c</a></h3>
 <h3 id="information-1994ldbindex.html">Information: <a href="1994/ldb/index.html">1994/ldb/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this to compile
@@ -1428,7 +1437,7 @@ compiled!</p>
 <div id="1994_shapiro">
 <h2 id="shapiro">1994/shapiro</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994shapiroshapiro.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">1994/shapiro/shapiro.c</a></h3>
 <h3 id="information-1994shapiroindex.html">Information: <a href="1994/shapiro/index.html">1994/shapiro/index.html</a></h3>
 <p>This program will likely crash if the source code file (by the name of the file
@@ -1475,7 +1484,7 @@ doesn’t break something else.</p>
 <div id="1995_cdua">
 <h2 id="cdua">1995/cdua</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995cduacdua.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">1995/cdua/cdua.c</a></h3>
 <h3 id="information-1995cduaindex.html">Information: <a href="1995/cdua/index.html">1995/cdua/index.html</a></h3>
 <p>This did not originally compile under macOS and after it did compile under
@@ -1507,7 +1516,7 @@ it would be good if it was fixed.</p>
 <div id="1995_savastio">
 <h2 id="savastio">1995/savastio</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995savastiosavastio.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">1995/savastio/savastio.c</a></h3>
 <h3 id="information-1995savastioindex.html">Information: <a href="1995/savastio/index.html">1995/savastio/index.html</a></h3>
 <p>This program expects a POSITIVE number. If you specify a negative number it will
@@ -1572,7 +1581,7 @@ almost be done except that some of the output of the
 <div id="1996_jonth">
 <h2 id="jonth">1996/jonth</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1996jonthjonth.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">1996/jonth/jonth.c</a></h3>
 <h3 id="information-1996jonthindex.html">Information: <a href="1996/jonth/index.html">1996/jonth/index.html</a></h3>
 <p>If X is not running this program will very likely crash or do something funny.
@@ -1615,7 +1624,7 @@ to the page as well! You’ll have IOCCC fame for reviving a pootifier! :-)</p>
 <div id="1998_schnitzi">
 <h2 id="schnitzi-2">1998/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">1998/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1998schnitziindex.html">Information: <a href="1998/schnitzi/index.html">1998/schnitzi/index.html</a></h3>
 <p>A point worth considering is that as the number passed into the program gets
@@ -1772,7 +1781,7 @@ on the stack at that point:</p>
     5</code></pre>
 <p>which might (?) suggest that the <code>+</code> operator is unimplemented. Unfortunately it
 has been many years since I have used perl and I was never a guru either.</p>
-<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states that in perl &lt; 5.6.0 there is a bug with a core dump in what
 they said is in <code>Perl_sv_upgrade</code>. As this is documented it is not considered a
 bug to be fixed. For the curious this will crash in macOS. Cody notes that the
@@ -1814,7 +1823,7 @@ of 92 warnings! Nonetheless neither works okay and both crash.</p>
 <div id="2000_primenum">
 <h2 id="primenum">2000/primenum</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000primenumprimenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/primenum.c">2000/primenum/primenum.c</a></h3>
 <h3 id="information-2000primenumindex.html">Information: <a href="2000/primenum/index.html">2000/primenum/index.html</a></h3>
 <p>This program does not do what you might think it does! Running it like:</p>
@@ -1832,7 +1841,7 @@ make a pull request.</p>
 <div id="2000_rince">
 <h2 id="rince-1">2000/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/rince.c">2000/rince/rince.c</a></h3>
 <h3 id="information-2000rinceindex.html">Information: <a href="2000/rince/index.html">2000/rince/index.html</a></h3>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash, do something strange
@@ -1846,7 +1855,7 @@ fire</a>! :-) ).</p>
 <div id="2001_anonymous">
 <h2 id="anonymous">2001/anonymous</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001anonymousanonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.c">2001/anonymous/anonymous.c</a></h3>
 <h3 id="information-2001anonymousindex.html">Information: <a href="2001/anonymous/index.html">2001/anonymous/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this so that it
@@ -1865,7 +1874,7 @@ elves of Imladris :-(</p>
 <div id="2001_bellard">
 <h2 id="bellard">2001/bellard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix">STATUS: doesn’t work with some platforms - please help us fix</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
@@ -1914,14 +1923,14 @@ before the fixes there.</p>
 <div id="2001_cheong">
 <h2 id="cheong">2001/cheong</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
 <h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
 <p>This program will crash without an arg.</p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
@@ -1942,7 +1951,7 @@ appreciate your help!</p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
 <p>Sometimes when one player presses <code>q</code> it will result in broken pipe on the other
@@ -1960,7 +1969,7 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
 <div id="2001_ollinger">
 <h2 id="ollinger">2001/ollinger</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
 <h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
 <p>This program will very likely crash or do something unexpected if you do not
@@ -1976,14 +1985,14 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
 details and a workaround.</p>
 <p>There’s also no way to escape meta characters.</p>
 <div id="2001_westley">
-<h2 id="westley-3">2001/westley</h2>
+<h2 id="westley-4">2001/westley</h2>
 </div>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-3">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-2001westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley/westley.c">2001/westley/westley.c</a></h3>
@@ -2144,13 +2153,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2175,7 +2184,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2188,7 +2197,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2202,7 +2211,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2211,7 +2220,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2245,7 +2254,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2259,7 +2268,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2300,7 +2309,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2309,7 +2318,7 @@ with possibly corrupt GIF files.</p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
@@ -2328,12 +2337,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
@@ -2341,7 +2350,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2358,7 +2367,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2405,7 +2414,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2428,7 +2437,7 @@ bins at the edges.</p>
 instead being something else entirely. The Internet Wayback Machine, although it
 archived it, did not load scripts. Do you know if the domain was moved? Do you
 have an archive or mirror? Please provide us it! Thank you.</p>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2441,7 +2450,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2451,7 +2460,7 @@ remarks</a> instead.</p>
 <div id="2011_konno">
 <h2 id="konno">2011/konno</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011konnokonno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/konno.c">2011/konno/konno.c</a></h3>
 <h3 id="information-2011konnoindex.html">Information: <a href="2011/konno/index.html">2011/konno/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
@@ -2620,7 +2629,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2634,7 +2643,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2643,7 +2652,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2676,7 +2685,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2690,7 +2699,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2711,7 +2720,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2727,7 +2736,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2747,7 +2756,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2766,7 +2775,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2782,7 +2791,7 @@ section</a>.</p>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2795,14 +2804,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2810,7 +2819,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2827,7 +2836,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2851,7 +2860,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2892,7 +2901,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2917,7 +2926,7 @@ result. Error messages become garbled, though.</p></li>
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2926,7 +2935,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -2959,7 +2968,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -2978,7 +2987,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -3003,7 +3012,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -3018,7 +3027,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3068,7 +3077,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3076,7 +3085,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3084,7 +3093,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3116,7 +3125,7 @@ ideal if this was not the case.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3145,7 +3154,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3153,7 +3162,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3183,7 +3192,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3193,7 +3202,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3213,7 +3222,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3222,7 +3231,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3237,7 +3246,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3248,7 +3257,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3262,7 +3271,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3272,7 +3281,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3281,7 +3290,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -884,6 +884,20 @@ will enter an infinite loop, printing 0 over and over again; another condition
 where this occurred was fixed but this one should not be fixed. Thank you.
 
 
+<div id="1990_westley">
+## 1990/westley
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1990/westley/westley.c](%%REPO_URL%%/1990/westley/westley.c)
+### Information: [1990/westley/index.html](1990/westley/index.html)
+
+Although Cody fixed this to not enter an infinite loop if the arg (converted to
+a number) is < 0 the lack of an arg check at all was kept in to make it like the
+original. The reason for the < 0 check is it floods the screen.
+
+
+
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1991">
 # 1991

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -1390,11 +1390,9 @@ instructional to see the differences he has provided an alternate version,
 code.</p>
 <p>He also changed the <code>argc</code> to be an <code>int</code>, not a <code>char</code>, even though it might
 often be the same (this in particular was done for <code>clang</code>).</p>
-<p>He also fixed the code to not enter an infinite loop if arg is a number not &gt; 0
-and to not crash if no arg is specified. This was done during a time it was
-deemed a problem to be fixed.</p>
-<p>NOTE: the alternate code did NOT have arg checks added as it is actually a copy of the
-original code.</p>
+<p>He also fixed the code to not enter an infinite loop if arg is a number not &gt; 0.
+To be more like the original the number of args passed to the program has not
+been fixed so that if one passes no arg it will still likely crash.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/try.sh">try.sh</a> script.</p>
 <div id="1991">
 <h1 id="the-8th-ioccc"><a href="1991/index.html">1991 - The 8th IOCCC</a></h1>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1429,12 +1429,9 @@ code.
 He also changed the `argc` to be an `int`, not a `char`, even though it might
 often be the same (this in particular was done for `clang`).
 
-He also fixed the code to not enter an infinite loop if arg is a number not > 0
-and to not crash if no arg is specified. This was done during a time it was
-deemed a problem to be fixed.
-
-NOTE: the alternate code did NOT have arg checks added as it is actually a copy of the
-original code.
+He also fixed the code to not enter an infinite loop if arg is a number not > 0.
+To be more like the original the number of args passed to the program has not
+been fixed so that if one passes no arg it will still likely crash.
 
 Cody also added the [try.sh](%%REPO_URL%%/1990/westley/try.sh) script.
 


### PR DESCRIPTION

One of the lines in the fix (which is the same code as the original) had
an extra space in front of the first char which showed a difference. Not
a big deal but fixes should modify as little as possible.