### PR TITLE
Fix 'web site' to 'website'

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1984/decot/decot.c
+++ b/1984/decot/decot.c
@@ -6,7 +6,7 @@
 extern double floor(double);
 double (x1, y1) b;
 char x {sizeof(
-     double(%s,%D)(*)())
+    double(%s,%D)(*)())
 ,};
 struct tag{int x0,*xO;};
 

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1984/index.html
+++ b/1984/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1985/index.html
+++ b/1985/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/index.html
+++ b/1986/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/index.html
+++ b/1987/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/index.html
+++ b/1988/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/index.html
+++ b/1989/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/index.html
+++ b/1990/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -137,8 +137,7 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "NOTE: this will very likely crash without an arg and will enter an infinite loop"
-	@echo "with an arg that is not a number > 0."
+	@echo "NOTE: this will very likely crash without an arg"
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 
 # alternative executable

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -5,6 +5,18 @@
 ```
 
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+```
+    STATUS: INABIAF - please **DO NOT** fix
+```
+
+For more detailed information see [1990/westley in bugs.html](../../bugs.html#1990_westley).
+
+
+
 ## To use:
 
 ``` <!---sh-->

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -403,6 +403,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 1990/westley/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<pre><code>    STATUS: INABIAF - please **DO NOT** fix</code></pre>
+<p>For more detailed information see <a href="../../bugs.html#1990_westley">1990/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./westley &lt;number&gt;</code></pre>
 <p>The number should be greater than 0.</p>

--- a/1990/westley/westley.c
+++ b/1990/westley/westley.c
@@ -11,7 +11,7 @@ char*lie;
 
 dear; (char)lotte--;
 
-	if (ly < 2 || atoi(die[1])<1) exit(1);
+	if (atoi(die[1])<1) exit(1);
 	for(get= !me;; not){
 
 	1 -  out & out ;lie;{

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/index.html
+++ b/1991/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/guidelines.txt
+++ b/1992/guidelines.txt
@@ -520,7 +520,7 @@ FOR MORE INFORMATION:
     One may obtain a copy of the current rules, guidelines or mkentry
     program may be obtained from the judges using the email address above.
 
-    See the official IOCCC web site:
+    See the official IOCCC website:
 
 	https://www.ioccc.org
 

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/index.html
+++ b/1992/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/rules.txt
+++ b/1992/rules.txt
@@ -165,7 +165,7 @@ FOR MORE INFORMATION:
     prior to submitting entries.  The IOCCC rules, guidelines and mkentry
     program may be obtained from the judges using the email address above.
 
-    See the official IOCCC web site:
+    See the official IOCCC website:
 
 	https://www.ioccc.org
 

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/index.html
+++ b/1993/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/index.html
+++ b/1994/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/index.html
+++ b/1995/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/leo/spoiler1.html
+++ b/1995/leo/spoiler1.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/index.html
+++ b/1996/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/index.html
+++ b/1998/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/index.html
+++ b/2000/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/README.md
+++ b/2001/README.md
@@ -8,7 +8,7 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.  The
+The IOCCC has a website and now has a number of international mirrors.  The
 primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use `make` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/guidelines.txt
+++ b/2001/guidelines.txt
@@ -769,7 +769,7 @@ ANNOUNCEMENT OF WINNERS:
 
     In Jan or Feb 2002 the judges will post an initial announcement of who     |
     won, the name of their award, and a very brief description of the	       |
-    winning entry on the IOCCC web site:				       |
+    winning entry on the IOCCC website:				       |
 									       |
 	    https://www.ioccc.org/whowon.html				       |
 									       |
@@ -786,7 +786,7 @@ ANNOUNCEMENT OF WINNERS:
 									       |
     Sometime after the initial announcement, and once the review by	       |
     the winners has been completed (perhaps Feb or Mar 2002), the winning      |
-    source will be posted to the IOCCC web site:		               |
+    source will be posted to the IOCCC website:		               |
 									       |
 	    https://www.ioccc.org/years.html				       |
 									       |

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/index.html
+++ b/2001/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors. The
+<p>The IOCCC has a website and now has a number of international mirrors. The
 primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use <code>make</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/README.md
+++ b/2004/README.md
@@ -8,7 +8,7 @@ on how to compile the entry and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <https://www.ioccc.org/>.
 
 Use `make(1)` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/guidelines.txt
+++ b/2004/guidelines.txt
@@ -477,7 +477,7 @@ ANNOUNCEMENT OF WINNERS:
 
     The judges will post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 									  
 	    https://www.ioccc.org/whowon.html				  
 									  
@@ -494,7 +494,7 @@ ANNOUNCEMENT OF WINNERS:
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
 	    https://www.ioccc.org/years.html
 

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/hibachi/src/localhost/index.html
+++ b/2004/hibachi/src/localhost/index.html
@@ -207,10 +207,10 @@ ln -s localhost www.ioccc.org
 
 <p>
 <span class="hibachi">HIBACHI</span> can server multiple 
-web sites from the same machine simply by creating content directories with the same 
+websites from the same machine simply by creating content directories with the same 
 name as the URL domain names within the document root tree. Domain and/or IP aliases are simply symbolic links 
 to content directories. There is never any need to restart <span class="hibachi">HIBACHI</span>
-when web sites are published or aliases added.
+when websites are published or aliases added.
 
 Assuming the server is running and that port 8008 is not blocked by any firewall, 
 you should be able to access the server from the Internet using an IP or host name URL similar to:</p>
@@ -253,7 +253,7 @@ and <a href="https://www.cygwin.com">Cygwin</a>.
 <dt><a href="test/perl/">Perl Example</a></dt>
 <dd>
 <a href="https://www.perl.com/"><img alt="Powered by Perl" src="Img/rectangle_power_perl.gif" width="88" height="31" border="0" hspace="20" align="right"></a>
-This example queries the Yahoo web site for a stock quote to insert into a web page.
+This example queries the Yahoo website for a stock quote to insert into a web page.
 <u><i>This example requires a browser with JavaScript support </i></u> and
 should work for all Unix variants and <a href="https://www.cygwin.com">Cygwin</a>, when Perl is installed.
 </dd>
@@ -269,7 +269,7 @@ something human readable suitable for sending by email.
 
 <p>
 The Windows PHP CGI binary distribution from the
-<a href="https://www.php.net/">PHP</a> web site does not work within the <a href="https://www.cygwin.com">Cygwin</a>
+<a href="https://www.php.net/">PHP</a> website does not work within the <a href="https://www.cygwin.com">Cygwin</a>
 environment.  Instead, download the source distribution and build the PHP CGI and CLI versions from scratch
 from within Cygwin. <!-- The CLI is desired, since it behaves more like an nph-CGI. -->
 The following commands were used to build:

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/index.html
+++ b/2004/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 on how to compile the entry and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org/" class="uri">https://www.ioccc.org/</a>.</p>
 <p>Use <code>make(1)</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the <code>Makefile</code> needs to be changed. See the <code>Makefile</code> for details.</p>

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/README.md
+++ b/2005/README.md
@@ -8,7 +8,7 @@ on how to compile the entry and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <https://www.ioccc.org/>.
 
 Use `make(1)` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/guidelines.txt
+++ b/2005/guidelines.txt
@@ -484,7 +484,7 @@ ANNOUNCEMENT OF WINNERS:
 
     The judges will post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 									  
 	    https://www.ioccc.org/whowon.html				  
 									  
@@ -501,7 +501,7 @@ ANNOUNCEMENT OF WINNERS:
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
 	    https://www.ioccc.org/years.html
 

--- a/2005/index.html
+++ b/2005/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 on how to compile the entry and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org/" class="uri">https://www.ioccc.org/</a>.</p>
 <p>Use <code>make(1)</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the <code>Makefile</code> needs to be changed. See the <code>Makefile</code> for details.</p>

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/README.md
+++ b/2006/README.md
@@ -8,7 +8,7 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use `make` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/borsanyi/README.md
+++ b/2006/borsanyi/README.md
@@ -52,7 +52,7 @@ anti-CAPTCHA tools.
 
 ### Introduction:
 
-Most spam robots collect email addresses from the web sites of
+Most spam robots collect email addresses from the websites of
 innocent people, like you. Conference organizers cannot disclose
 the participant's address to prevent malicious users from
 grabbing them. One solution is to write as `my_email _at_ address

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">
@@ -425,7 +425,7 @@ anti-CAPTCHA tools.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <h3 id="email-address-to-gif-converter">Email address to gif converter</h3>
 <h3 id="introduction">Introduction:</h3>
-<p>Most spam robots collect email addresses from the web sites of
+<p>Most spam robots collect email addresses from the websites of
 innocent people, like you. Conference organizers cannot disclose
 the participant’s address to prevent malicious users from
 grabbing them. One solution is to write as <code>my_email _at_ address _dot_ com</code>. But robots are clever enough to sort that out. A

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/guidelines.txt
+++ b/2006/guidelines.txt
@@ -487,7 +487,7 @@ ANNOUNCEMENT OF WINNERS:
 
     The judges will post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 									  
 	    https://www.ioccc.org/whowon.html				  
 									  
@@ -504,7 +504,7 @@ ANNOUNCEMENT OF WINNERS:
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
 	    https://www.ioccc.org/years.html
 

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/index.html
+++ b/2006/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use <code>make</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/README.md
+++ b/2011/README.md
@@ -8,7 +8,7 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use `make` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/dlowe/dlowe-aux-data/english-1/Wireless_Days_2011_CFP.txt
+++ b/2011/dlowe/dlowe-aux-data/english-1/Wireless_Days_2011_CFP.txt
@@ -48,7 +48,7 @@ Papers Submission:
 Submissions should be original and limited to 5 double-column pages,
 and should follow IEEE paper templates. Paper with more pages can be
 accepted however they need to be reduced to 5 pages for publication.
-Papers are to be submitted electronically on the EDAS web site of the
+Papers are to be submitted electronically on the EDAS website of the
 conference in PDF format.
 
 http://edas.info//N10969

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/guidelines.txt
+++ b/2011/guidelines.txt
@@ -523,7 +523,7 @@ ANNOUNCEMENT OF WINNERS:
 
     The judges will post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 									  
 	    https://www.ioccc.org/whowon.html				  
 									  
@@ -540,7 +540,7 @@ ANNOUNCEMENT OF WINNERS:
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
 	    https://www.ioccc.org/years.html
 

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/index.html
+++ b/2011/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use <code>make</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/README.md
+++ b/2012/README.md
@@ -8,7 +8,7 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use `make` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/guidelines.txt
+++ b/2012/guidelines.txt
@@ -655,7 +655,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
 	    https://www.ioccc.org/whowon.html
 
@@ -672,7 +672,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
 	    https://www.ioccc.org/years.html
 
@@ -689,7 +689,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/index.html
+++ b/2012/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use <code>make</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/README.md
+++ b/2013/README.md
@@ -8,7 +8,7 @@ compile the entry and how to run the winning program.  Look at the winning
 source and try to figure how it does what it does!  You may then wish to look at
 the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use `make` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/guidelines.txt
+++ b/2013/guidelines.txt
@@ -635,7 +635,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -653,7 +653,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -769,7 +769,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -786,7 +786,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -802,7 +802,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#fix_author">

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/index.html
+++ b/2013/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 compile the entry and how to run the winning program. Look at the winning
 source and try to figure how it does what it does! You may then wish to look at
 the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use <code>make</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/README.md
+++ b/2014/README.md
@@ -8,7 +8,7 @@ compile the entry and how to run the winning program.  Look at the winning
 source and try to figure how it does what it does!  You may then wish to look at
 the Author's remarks for even more details.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use make to compile entries.  It is possible that on non-Unix / non-Linux
@@ -76,7 +76,7 @@ our planned schedule for building the tarball of this year's winning entries.
 
 During some of these forced delays, we took the time to better automate
 some of the tools needed to package the source for the winning entries to review
-and to post the edited entries to the web site.  It is our intent that
+and to post the edited entries to the website.  It is our intent that
 these changes made during those delays will make releasing future winning IOCCC
 entries a faster procedure.
 

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/endoh1/spoilers.html
+++ b/2014/endoh1/spoilers.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/guidelines.txt
+++ b/2014/guidelines.txt
@@ -650,7 +650,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -755,7 +755,7 @@ ANNOUNCEMENT OF WINNERS:
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -773,7 +773,7 @@ ANNOUNCEMENT OF WINNERS:
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -789,7 +789,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2014/index.html
+++ b/2014/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -392,7 +392,7 @@
 compile the entry and how to run the winning program. Look at the winning
 source and try to figure how it does what it does! You may then wish to look at
 the Author’s remarks for even more details.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use make to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>
@@ -441,7 +441,7 @@ business travel, the death of an IOCCC judge’s mother, etc. that impacted
 our planned schedule for building the tarball of this year’s winning entries.</p>
 <p>During some of these forced delays, we took the time to better automate
 some of the tools needed to package the source for the winning entries to review
-and to post the edited entries to the web site. It is our intent that
+and to post the edited entries to the website. It is our intent that
 these changes made during those delays will make releasing future winning IOCCC
 entries a faster procedure.</p>
 <p>p.s. The final advice given to Landon by his mom: “Have fun.”

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/README.md
+++ b/2015/README.md
@@ -9,7 +9,7 @@ source and try to figure how it does what it does!  You may then wish to look at
 the Author's remarks for even more details. This year we included most of the
 information included by the submitter.
 
-The IOCCC has a web site and now has a number of international mirrors.
+The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 Use `make` to compile entries.  It is possible that on non-Unix / non-Linux

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/burton/spoilers.html
+++ b/2015/burton/spoilers.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/guidelines.txt
+++ b/2015/guidelines.txt
@@ -78,8 +78,8 @@ End of important 2023 update to this historic note.
 |   will be available and active on or slightly before the start of this IOCCC.
 |
 |   The official rules, guidelines and iocccsize.c tool will be available
-|   on the official IOCCC web site on or slightly before start of this IOCCC.
-|   Please check the IOCCC web site "How to enter" link:
+|   on the official IOCCC website on or slightly before start of this IOCCC.
+|   Please check the IOCCC website "How to enter" link:
 |
 |	https://www.ioccc.org/index.html#enter
 |
@@ -703,7 +703,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -827,7 +827,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -850,7 +850,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -867,7 +867,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -883,7 +883,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/index.html
+++ b/2015/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -393,7 +393,7 @@ compile the entry and how to run the winning program. Look at the winning
 source and try to figure how it does what it does! You may then wish to look at
 the Author’s remarks for even more details. This year we included most of the
 information included by the submitter.</p>
-<p>The IOCCC has a web site and now has a number of international mirrors.
+<p>The IOCCC has a website and now has a number of international mirrors.
 The primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Use <code>make</code> to compile entries. It is possible that on non-Unix / non-Linux
 systems the Makefile needs to be changed. See the Makefile for details.</p>

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/rules.txt
+++ b/2015/rules.txt
@@ -45,8 +45,8 @@ GOALS OF THE CONTEST:
 |   will be available and active on or slightly before the start of this IOCCC.
 |
 |   The official rules, guidelines and iocccsize.c tool will be available
-|   on the official IOCCC web site on or slightly before start of this IOCCC.
-|   Please check the IOCCC web site "How to enter" link:
+|   on the official IOCCC website on or slightly before start of this IOCCC.
+|   Please check the IOCCC website "How to enter" link:
 |
 |	https://www.ioccc.org/index.html#enter
 |

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/ferguson/FILES.html
+++ b/2018/ferguson/FILES.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/guidelines.txt
+++ b/2018/guidelines.txt
@@ -84,8 +84,8 @@ End of important 2023 update to this historic note.
     will be available and active on or slightly before the start of this IOCCC.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 
@@ -798,7 +798,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -918,7 +918,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -935,7 +935,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -951,7 +951,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/index.html
+++ b/2018/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/rules.txt
+++ b/2018/rules.txt
@@ -45,8 +45,8 @@ GOALS OF THE CONTEST:
     will be available and active on or slightly before the start of this IOCCC.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/diels-grabsch1/guidelines.txt
+++ b/2019/diels-grabsch1/guidelines.txt
@@ -86,8 +86,8 @@ End of important 2023 update to this historic note.
 |   Please wait to submit your entries until after that time.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 
@@ -918,7 +918,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -935,7 +935,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -951,7 +951,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/guidelines.txt
+++ b/2019/guidelines.txt
@@ -86,8 +86,8 @@ End of important 2023 update to this historic note.
 |   Please wait to submit your entries until after that time.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 
@@ -804,7 +804,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -926,7 +926,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -943,7 +943,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -959,7 +959,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2019/index.html
+++ b/2019/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2019/rules.txt
+++ b/2019/rules.txt
@@ -46,8 +46,8 @@ GOALS OF THE CONTEST:
 |   Please wait to submit your entries until after that time.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/endoh2/spoiler/index.html
+++ b/2020/endoh2/spoiler/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#fix_author">

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/spoilers.html
+++ b/2020/ferguson1/spoilers.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/guidelines.txt
+++ b/2020/guidelines.txt
@@ -87,8 +87,8 @@ End of important 2023 update to this historic note.
     Please wait to submit your entries until after that time.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 
@@ -839,7 +839,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 
@@ -961,7 +961,7 @@ End of important 2023 update to this historic note.
 
     The judges will then post an initial announcement of who won, the name
     of their award, and a very brief description of the winning entry
-    on the IOCCC web site:
+    on the IOCCC website:
 
         https://www.ioccc.org/whowon.html
 
@@ -978,7 +978,7 @@ End of important 2023 update to this historic note.
 
     Sometime after the initial announcement, and once the review
     by the winners has been completed, the winning source will be
-    posted to the IOCCC web site:
+    posted to the IOCCC website:
 
         https://www.ioccc.org/years.html
 
@@ -994,7 +994,7 @@ by a git commit to the IOCCC entries repo:
 
 	https://github.com/ioccc-src/winner
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 	https://www.ioccc.org/index.html
 

--- a/2020/index.html
+++ b/2020/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/rules.txt
+++ b/2020/rules.txt
@@ -46,8 +46,8 @@ GOALS OF THE CONTEST:
     Please wait to submit your entries until after that time.
 
     The official rules, guidelines and iocccsize.c tool will be available
-    on the official IOCCC web site on or slightly before start of this IOCCC.
-    Please check the IOCCC web site "How to enter" link:
+    on the official IOCCC website on or slightly before start of this IOCCC.
+    Please check the IOCCC website "How to enter" link:
 
  	https://www.ioccc.org/index.html#enter
 

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ SHELL= bash
 include var.mk
 
 #################################
-# IOCCC web site maintenance tulz
+# IOCCC website maintenance tulz
 #################################
 
 # NOTE: The "tulz" (tools) in this section are intended to be used by those
@@ -45,7 +45,7 @@ include var.mk
 #
 # We file "tulz" paths should be relative to the top directory of the repo.
 # We need only list those "tulz" that are invoked directly by the
-# "IOCCC web site maintenance rulz" section below.
+# "IOCCC website maintenance rulz" section below.
 
 ALL_RUN= bin/all-run.sh
 ALL_YEARS= bin/all-years.sh
@@ -226,7 +226,7 @@ indent.c:
 
 
 #################################
-# IOCCC web site maintenance rulz
+# IOCCC website maintenance rulz
 #################################
 
 # NOTE: The rules in this section are intended to be used by those
@@ -250,7 +250,7 @@ indent.c:
 # Suggest rules in this section
 #
 # This may not be much help to people who are not already familiar with
-# the tools needed to build the web site, but it does print out a friendly
+# the tools needed to build the website, but it does print out a friendly
 # reminder to those who understand it. For all else, there is "RTFS". :-)
 #
 # Note: there is one rule that should not be in this list. We want to make sure
@@ -275,7 +275,7 @@ help:
 	@echo 'make diff_alt_orig	- diff alternative source and original source'
 	@echo 'make diff_orig_alt	- diff original source and alternative source'
 	@echo
-	@echo '# Rules for building a local copy of the IOCCC web site:'
+	@echo '# Rules for building a local copy of the IOCCC website:'
 	@echo
 	@echo 'make genpath		 - form top level .top, YYYY level .year and winner .path files'
 	@echo 'make genfilelist	 - generate YYYY level .filelist'
@@ -290,12 +290,12 @@ help:
 	@echo 'make quick_entry_index	 - build winner index.html files that might be out of date'
 	@echo 'make find_missing_links	 - find markdown links to missing local files'
 	@echo
-	@echo '# Compound make rules for building a local copy of the IOCCC web site:'
+	@echo '# Compound make rules for building a local copy of the IOCCC website:'
 	@echo
 	@echo 'make quick_www		 - generate html files more quickly, checking timestamps'
-	@echo 'make www		 - build html pages for web site'
+	@echo 'make www		 - build html pages for website'
 	@echo
-	@echo '# Rules that are useful only for those IOCCC judges who mainain the official IOCCC web site:'
+	@echo '# Rules that are useful only for those IOCCC judges who mainain the official IOCCC website:'
 	@echo
 	@echo 'make sort_gitignore	 - sort .gitignore files according to rules in bin/sgi.sh'
 	@echo
@@ -310,7 +310,7 @@ help:
 	@echo 'make gen_sitemap	 - generate the XML sitemap'
 	@echo 'make timestamp		 - generate things with timestamps (status, sitemap etc.)'
 	@echo
-	@echo 'make update		 - update everything in a local copy of the web site'
+	@echo 'make update		 - update everything in a local copy of the website'
 
 # form the top level .top, YYYY level .year and winner level .path files
 #
@@ -465,7 +465,7 @@ find_missing_links:
 	${FIND_MISSING_LINKS} -v 1
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
-# do work to build HTML content for the web site
+# do work to build HTML content for the website
 #
 # This rule uses quick_entry_index, not slow_entry_index, so
 # some winner index.html files that seem to be up to date
@@ -495,7 +495,7 @@ quick_www:
 	${MAKE} find_missing_links
 	@echo '=-=-=-=-=-= IOCCC complete make $@ =-=-=-=-=-='
 
-# do everything needed to build HTML content for the web site
+# do everything needed to build HTML content for the website
 #
 # Well, short of pushing changes to the GitHub repo, that is.  :-)
 #
@@ -587,7 +587,7 @@ timestamp:
 	${MAKE} gen_sitemap
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
-# update everything on the web site
+# update everything on the website
 #
 update:
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='

--- a/README.html
+++ b/README.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -383,12 +383,12 @@
 
 <!-- BEFORE: 1st line of markdown file: README.md -->
 <!-- XXX - This entire section goes away during the final stages of the Great Fork Merge -->
-<h3 id="this-is-not-the-official-ioccc-web-site">This is NOT the official IOCCC web site!</h3>
-<p>Please visit <a href="https://www.ioccc.org">www.ioccc.org</a> for the official <strong>IOCCC</strong> web site.</p>
-<p>Please do NOT bookmark or link to this <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental web site</a>.</p>
+<h3 id="this-is-not-the-official-ioccc-web-site">This is NOT the official IOCCC website!</h3>
+<p>Please visit <a href="https://www.ioccc.org">www.ioccc.org</a> for the official <strong>IOCCC</strong> website.</p>
+<p>Please do NOT bookmark or link to this <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental website</a>.</p>
 <p>When this experiment is finished, this site will go away!</p>
 <p>This test web tree is part of the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a>.</p>
-<p>This web site will be undergoing major changes, so expect many
+<p>This website will be undergoing major changes, so expect many
 broken links, typos and other problems. If you wish to recommend
 changes (understanding that things may be rapidly changing out from
 under your copy), then consider making pull requests against the
@@ -415,7 +415,7 @@ mealy-mouthed denials and obfuscations.</p>
 <p>late Middle English: from late Latin <strong>obfuscatio(n-)</strong>, from <strong>obfuscare</strong>
 ‘to darken or obscure’ (see <em>obfuscate</em>).</p></li>
 </ul>
-<p>The official IOCCC web site is <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
+<p>The official IOCCC website is <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="how-it-was-started">How it was started:</h2>
 <p>The original inspiration of the International Obfuscated C Code Contest came
 from the Bourne Shell source and the <code>finger(1)</code> command as distributed in

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <!-- XXX - This entire section goes away during the final stages of the Great Fork Merge -->
-### This is NOT the official IOCCC web site!
+### This is NOT the official IOCCC website!
 
-Please visit [www.ioccc.org](https://www.ioccc.org) for the official **IOCCC** web site.
+Please visit [www.ioccc.org](https://www.ioccc.org) for the official **IOCCC** website.
 
-Please do NOT bookmark or link to this [experimental web site](https://ioccc-src.github.io/temp-test-ioccc/).
+Please do NOT bookmark or link to this [experimental website](https://ioccc-src.github.io/temp-test-ioccc/).
 
 When this experiment is finished, this site will go away!
 
 This test web tree is part of the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc).
 
-This web site will be undergoing major changes, so expect many
+This website will be undergoing major changes, so expect many
 broken links, typos and other problems. If you wish to recommend
 changes (understanding that things may be rapidly changing out from
 under your copy), then consider making pull requests against the
@@ -42,7 +42,7 @@ mealy-mouthed denials and obfuscations.
     late Middle English: from late Latin **obfuscatio(n-)**, from **obfuscare**
     'to darken or obscure' (see *obfuscate*).
 
-The official IOCCC web site is [www.ioccc.org](https://www.ioccc.org).
+The official IOCCC website is [www.ioccc.org](https://www.ioccc.org).
 
 ## How it was started:
 

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#fix_author">

--- a/authors.html
+++ b/authors.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,7 +1,7 @@
 # bin
 
 The [bin directory](index.html) holds tools that build files, such as HTML
-content, for the [official IOCCC web site](https://www.ioccc.org).
+content, for the [official IOCCC website](https://www.ioccc.org).
 
 For HTML content, the [bin directory](index.html) tools make use of HTML
 fragments from the [inc directory](../inc/index.html) as well as various JSON
@@ -142,7 +142,7 @@ Usage:
 
 ### [gen-sitemap.sh](%%DOCROOT_SLASH%%bin/gen-sitemap.sh)
 
-Generate an XML sitemap for the IOCCC web site.
+Generate an XML sitemap for the IOCCC website.
 
 Usage:
 
@@ -197,7 +197,7 @@ We recommend that this tool be invoked via the top level `Makefile`:
 
 ### [gen-top-html.sh](%%DOCROOT_SLASH%%bin/gen-top-html.sh)
 
-Generate a number of top level HTML pages for the IOCCC web sites.
+Generate a number of top level HTML pages for the IOCCC websites.
 
 Usage:
 
@@ -741,10 +741,10 @@ how such command lines are used.
 # Use CAUTION when modifying inc files
 
 Some of the files under this directory are used to form **MOST** of the HTML content
-on the [official IOCCC web site](https://www.ioccc.org).
+on the [official IOCCC website](https://www.ioccc.org).
 
 These files are used to form **MOST** of the HTML content
-on the [experimental web site](https://ioccc-src.github.io/temp-test-ioccc/).
+on the [experimental website](https://ioccc-src.github.io/temp-test-ioccc/).
 
 ... and in particular files under [inc](../inc/index.html) that are of the form
 (called default HTML files) ...:
@@ -775,7 +775,7 @@ solutions available to form web pages.
 Here are some reasons why we are using these files and
 special tools to create HTML content / IOCCC web pages:
 
-We host [official IOCCC web site](https://www.ioccc.org) via [GitHub
+We host [official IOCCC website](https://www.ioccc.org) via [GitHub
 pages](https://pages.github.com).  As of the time this file written, **only
 static web pages are supported**.
 
@@ -813,7 +813,7 @@ by someone else who is not so generous.  While it is possible that GitHub might 
 suffer a similar fate, for the time being we are betting that GitHub will remain
 willing to host the IOCCC.
 
-The [official IOCCC web site](https://www.ioccc.org) is, after all, primarily C
+The [official IOCCC website](https://www.ioccc.org) is, after all, primarily C
 source code with some supporting documentation (sometimes :-) ).  As such it is
 a natural fit for GitHub and [GitHub pages](https://pages.github.com).
 
@@ -859,7 +859,7 @@ We do not use JavaScript to include HTML content.
 
 While the IOCCC may use JavaScript in the future to directly render things like
 C source code, we will do so in such a way that someone will be able to view
-[official IOCCC web site](https://www.ioccc.org) content with JavaScript
+[official IOCCC website](https://www.ioccc.org) content with JavaScript
 disabled.
 
 The IOCCC will **NOT MANDATE USE OF JavaScript** to view [official IOCCC web

--- a/bin/all-run.sh
+++ b/bin/all-run.sh
@@ -173,7 +173,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
 
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 	tool		the tool to run over all entries

--- a/bin/all-years.sh
+++ b/bin/all-years.sh
@@ -172,7 +172,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
 
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 	tool		the tool to run over all entries

--- a/bin/gen-authors.sh
+++ b/bin/gen-authors.sh
@@ -174,7 +174,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 NOTE: The '-v level' is passed as initial command line options to the 'markdown to html tool' (md2html.sh).

--- a/bin/gen-location.sh
+++ b/bin/gen-location.sh
@@ -144,7 +144,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 NOTE: The '-v level' is passed as initial command line options to the 'markdown to html tool' (md2html.sh).

--- a/bin/gen-other-html.sh
+++ b/bin/gen-other-html.sh
@@ -143,7 +143,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
 
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 NOTE: Any '-D docroot/', '-t tagline', '-T md2html.sh', '-p tool', '-u repo_url', '-w site_url'

--- a/bin/gen-sitemap.sh
+++ b/bin/gen-sitemap.sh
@@ -198,7 +198,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-n] [-N]
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
 
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 	-W		Warn if a file in the manifest is missing: (def: error if a file is missing)

--- a/bin/gen-status.sh
+++ b/bin/gen-status.sh
@@ -357,7 +357,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 	[p | pending]	Set the contest_status to pending

--- a/bin/gen-top-html.sh
+++ b/bin/gen-top-html.sh
@@ -176,7 +176,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 NOTE: The '-v level' is passed as initial command line options to the 'markdown to html tool' (md2html.sh).

--- a/bin/gen-year-index.sh
+++ b/bin/gen-year-index.sh
@@ -133,7 +133,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-n] [-N]
 	-T md2html.sh	run 'markdown to html tool' to convert markdown into HTML (def: $MD2HTML_SH)
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	YYYY		path from topdir to year directory: must contain the files: README.md, .path and .entry.json
 	[more_options]	additional tool command line options to use before the YYYY argument

--- a/bin/gen-years.sh
+++ b/bin/gen-years.sh
@@ -155,7 +155,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 NOTE: The '-v level' is passed as initial command line options to the 'markdown to html tool' (md2html.sh).

--- a/bin/index.html
+++ b/bin/index.html
@@ -12,8 +12,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 <title>The International Obfuscated C Code Contest</title>
 <link rel="icon" type="image/x-icon" href="../favicon.ico">
-<meta name="description" content="Tools used to build and maintain the IOCCC web site">
-<meta name="keywords" content="IOCCC, tools, web site tools, bin">
+<meta name="description" content="Tools used to build and maintain the IOCCC website">
+<meta name="keywords" content="IOCCC, tools, website tools, bin">
 </head>
 
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -363,7 +363,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>IOCCC tools used build and maintain the IOCCC web site</h2>
+  <h2>IOCCC tools used build and maintain the IOCCC website</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->
@@ -384,7 +384,7 @@
 <!-- BEFORE: 1st line of markdown file: bin/README.md -->
 <h1 id="bin">bin</h1>
 <p>The <a href="index.html">bin directory</a> holds tools that build files, such as HTML
-content, for the <a href="https://www.ioccc.org">official IOCCC web site</a>.</p>
+content, for the <a href="https://www.ioccc.org">official IOCCC website</a>.</p>
 <p>For HTML content, the <a href="index.html">bin directory</a> tools make use of HTML
 fragments from the <a href="../inc/index.html">inc directory</a> as well as various JSON
 files and other content from the <a href="https://github.com/ioccc-src/temp-test-ioccc">IOCCC GitHub
@@ -445,7 +445,7 @@ files.</p>
 <p>Usage:</p>
 <pre><code>    bin/gen-other-html.sh -v 1</code></pre>
 <h3 id="gen-sitemap.sh"><a href="../bin/gen-sitemap.sh">gen-sitemap.sh</a></h3>
-<p>Generate an XML sitemap for the IOCCC web site.</p>
+<p>Generate an XML sitemap for the IOCCC website.</p>
 <p>Usage:</p>
 <pre><code>    bin/gen-sitemap.sh -v 1</code></pre>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
@@ -465,7 +465,7 @@ and <code>news.html</code>.</p>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
 <pre><code>    make gen_status</code></pre>
 <h3 id="gen-top-html.sh"><a href="../bin/gen-top-html.sh">gen-top-html.sh</a></h3>
-<p>Generate a number of top level HTML pages for the IOCCC web sites.</p>
+<p>Generate a number of top level HTML pages for the IOCCC websites.</p>
 <p>Usage:</p>
 <pre><code>    bin/gen-top-html.sh -v 1</code></pre>
 <p>Examples of top level HTML pages built by this tool include:</p>
@@ -748,9 +748,9 @@ See also, the tool <a href="../bin/readme2index.sh">readme2index.sh</a> for an e
 how such command lines are used.</p>
 <h1 id="use-caution-when-modifying-inc-files">Use CAUTION when modifying inc files</h1>
 <p>Some of the files under this directory are used to form <strong>MOST</strong> of the HTML content
-on the <a href="https://www.ioccc.org">official IOCCC web site</a>.</p>
+on the <a href="https://www.ioccc.org">official IOCCC website</a>.</p>
 <p>These files are used to form <strong>MOST</strong> of the HTML content
-on the <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental web site</a>.</p>
+on the <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental website</a>.</p>
 <p>… and in particular files under <a href="../inc/index.html">inc</a> that are of the form
 (called default HTML files) …:</p>
 <pre><code>    *.default.html</code></pre>
@@ -768,7 +768,7 @@ solutions available to form web pages.</p>
 </div>
 <p>Here are some reasons why we are using these files and
 special tools to create HTML content / IOCCC web pages:</p>
-<p>We host <a href="https://www.ioccc.org">official IOCCC web site</a> via <a href="https://pages.github.com">GitHub
+<p>We host <a href="https://www.ioccc.org">official IOCCC website</a> via <a href="https://pages.github.com">GitHub
 pages</a>. As of the time this file written, <strong>only
 static web pages are supported</strong>.</p>
 <h2 id="we-cannot-use-server-side-include">We cannot use server side include</h2>
@@ -793,7 +793,7 @@ only to find that the generous benefactor moves on, or their service is purchase
 by someone else who is not so generous. While it is possible that GitHub might someday
 suffer a similar fate, for the time being we are betting that GitHub will remain
 willing to host the IOCCC.</p>
-<p>The <a href="https://www.ioccc.org">official IOCCC web site</a> is, after all, primarily C
+<p>The <a href="https://www.ioccc.org">official IOCCC website</a> is, after all, primarily C
 source code with some supporting documentation (sometimes :-) ). As such it is
 a natural fit for GitHub and <a href="https://pages.github.com">GitHub pages</a>.</p>
 <h2 id="we-cannot-use-the-html-object-element">We cannot use the HTML <code>&lt;object&gt;</code> element</h2>
@@ -823,7 +823,7 @@ all of those screen size contexts.</p>
 <p>We do not use JavaScript to include HTML content.</p>
 <p>While the IOCCC may use JavaScript in the future to directly render things like
 C source code, we will do so in such a way that someone will be able to view
-<a href="https://www.ioccc.org">official IOCCC web site</a> content with JavaScript
+<a href="https://www.ioccc.org">official IOCCC website</a> content with JavaScript
 disabled.</p>
 <p>The IOCCC will <strong>NOT MANDATE USE OF JavaScript</strong> to view <a href="https://www.ioccc.org">official IOCCC web
 site</a>.</p>

--- a/bin/md2html.sh
+++ b/bin/md2html.sh
@@ -2,7 +2,7 @@
 #
 # md2html.sh - convert markdown into an IOCCC HTML file via config file
 #
-# Convert a markdown file into a HTML file for the IOCCC web site,
+# Convert a markdown file into a HTML file for the IOCCC website,
 # using the inc/md2html.cfg configuration file.  Conversion from
 # markdown to HTML is performed via the 'pandoc wrapper tool'.
 #
@@ -228,7 +228,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 			NOTE: The '-u repo_url' is passed as leading options on -b tool, -a tool, and -o tool command lines.
 	-U url		URL of HTML being formed (def: $URL)
 			NOTE: The '-U url' is passed as leading options on -b tool, -a tool, and -o tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 	-m mdtag	string to write about the markdown file used to form HTML content (def: no markdown file is used)
 
 	-e string	output 'string', followed by newline, to stderr (def: do not)

--- a/bin/output-index-author.sh
+++ b/bin/output-index-author.sh
@@ -144,7 +144,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bin/output-index-inventory.sh
+++ b/bin/output-index-inventory.sh
@@ -144,7 +144,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bin/output-year-index.sh
+++ b/bin/output-year-index.sh
@@ -149,7 +149,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bin/quick-readme2index.sh
+++ b/bin/quick-readme2index.sh
@@ -158,7 +158,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 	tool		the tool to run over all entries

--- a/bin/readme2index.sh
+++ b/bin/readme2index.sh
@@ -149,7 +149,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 			NOTE: The '-u repo_url' is passed as leading options on tool command lines.
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 			NOTE: The '-w site_url' is passed as leading options on tool command lines.
 
 	YYYY/dir	path from topdir to entry directory: must contain the files: README.md, .path and .entry.json

--- a/bin/status2html.sh
+++ b/bin/status2html.sh
@@ -141,7 +141,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bin/subst.default.sh
+++ b/bin/subst.default.sh
@@ -132,7 +132,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bin/subst.entry-index.sh
+++ b/bin/subst.entry-index.sh
@@ -142,7 +142,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bin/subst.year-index.sh
+++ b/bin/subst.year-index.sh
@@ -142,7 +142,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-n] [-N]
 
 	-u repo_url	Base level URL of target git repo (def: $REPO_URL)
 	-U url		URL of HTML file being formed (def: $URL)
-	-w site_url	Base URL of the web site (def: $SITE_URL)
+	-w site_url	Base URL of the website (def: $SITE_URL)
 
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)

--- a/bugs.html
+++ b/bugs.html
@@ -999,6 +999,15 @@ prevented this from working properly (including segfaults) but one thing to note
 is that if you pass two zeroes to <code>theorem_bkp</code> or <code>fibonacci</code> the program
 will enter an infinite loop, printing 0 over and over again; another condition
 where this occurred was fixed but this one should not be fixed. Thank you.</p>
+<div id="1990_westley">
+<h2 id="westley-1">1990/westley</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-1990westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.c">1990/westley/westley.c</a></h3>
+<h3 id="information-1990westleyindex.html">Information: <a href="1990/westley/index.html">1990/westley/index.html</a></h3>
+<p>Although Cody fixed this to not enter an infinite loop if the arg (converted to
+a number) is &lt; 0 the lack of an arg check at all was kept in to make it like the
+original. The reason for the &lt; 0 check is it floods the screen.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1991">
 <h1 id="section-7">1991</h1>
@@ -1007,7 +1016,7 @@ where this occurred was fixed but this one should not be fixed. Thank you.</p>
 <div id="1991_buzzard">
 <h2 id="buzzard">1991/buzzard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991buzzardbuzzard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">1991/buzzard/buzzard.c</a></h3>
 <h3 id="information-1991buzzardindex.html">Information: <a href="1991/buzzard/index.html">1991/buzzard/index.html</a></h3>
 <p>If the maze file cannot be opened, either because the path specified does not
@@ -1015,9 +1024,9 @@ exist or because the default (whatever the source file was at compilation time)
 file does not exist in the directory, this program will very likely crash.</p>
 <p>This is a feature, not a bug.</p>
 <div id="1991_westley">
-<h2 id="westley-1">1991/westley</h2>
+<h2 id="westley-2">1991/westley</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">1991/westley/westley.c</a></h3>
 <h3 id="information-1991westleyindex.html">Information: <a href="1991/westley/index.html">1991/westley/index.html</a></h3>
 <p>There is a very simple way to always win. The program doesn’t catch you and as
@@ -1034,7 +1043,7 @@ when you’re cheating it ends up winning! Can you figure that out as well?</p>
 <div id="1992_adrian">
 <h2 id="adrian">1992/adrian</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992adrianadrian.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">1992/adrian/adrian.c</a></h3>
 <h3 id="information-1992adrianindex.html">Information: <a href="1992/adrian/index.html">1992/adrian/index.html</a></h3>
 <p>The author stated that if the file cannot be opened then it will print a system
@@ -1195,16 +1204,16 @@ than that. For instance this is what it looks like with clang:</p>
 <div id="1992_vern">
 <h2 id="vern">1992/vern</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992vernvern.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">1992/vern/vern.c</a></h3>
 <h3 id="information-1992vernindex.html">Information: <a href="1992/vern/index.html">1992/vern/index.html</a></h3>
 <p>When your own checkmate is imminent it prints <code>"Har har"</code> but does not exit so
 it can ‘rub your nose in defeat’, as the author puts it. You will have to exit
 it yourself through ctrl-c or killing it in some other fashion.</p>
 <div id="1992_westley">
-<h2 id="westley-2">1992/westley</h2>
+<h2 id="westley-3">1992/westley</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">1992/westley/westley.c</a></h3>
 <h3 id="information-1992westleyindex.html">Information: <a href="1992/westley/index.html">1992/westley/index.html</a></h3>
 <p>Cody improved the usability of this program by making it so that as long as the
@@ -1230,7 +1239,7 @@ not a misunderstanding).</p>
 <h1 id="section-9">1993</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
-<h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993antant.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">1993/ant/ant.c</a></h3>
 <h3 id="information-1993antindex.html">Information: <a href="1993/ant/index.html">1993/ant/index.html</a></h3>
 <p>The author stated that:</p>
@@ -1253,7 +1262,7 @@ system), this entry just shows a blank screen.</p>
 <div id="1993_lmfjyh">
 <h2 id="lmfjyh">1993/lmfjyh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993lmfjyhlmfjyh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">1993/lmfjyh/lmfjyh.c</a></h3>
 <h3 id="information-1993lmfjyhindex.html">Information: <a href="1993/lmfjyh/index.html">1993/lmfjyh/index.html</a></h3>
 <p>This entry relied on a bug in gcc that was fixed with gcc version 2.3.3. This
@@ -1263,7 +1272,7 @@ the index.html file for details.</p>
 <div id="1993_rince">
 <h2 id="rince">1993/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">1993/rince/rince.c</a></h3>
 <h3 id="information-1993rinceindex.html">Information: <a href="1993/rince/index.html">1993/rince/index.html</a></h3>
 <p>Although the code checks if the file can be opened or not, badly formatted files
@@ -1273,7 +1282,7 @@ through ctrl-c or such.</p>
 <div id="1993_schnitzi">
 <h2 id="schnitzi">1993/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">1993/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1993schnitziindex.html">Information: <a href="1993/schnitzi/index.html">1993/schnitzi/index.html</a></h3>
 <p>If the file cannot be opened it will very likely segfault. This should not be
@@ -1299,7 +1308,7 @@ question you might cause an error. For instance don’t do this:</p>
 <p>Of course if you do something like:</p>
 <pre><code>    What is &#39;foo&#39;?</code></pre>
 <p>it will work fine.</p>
-<h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993vanbvanb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">1993/vanb/vanb.c</a></h3>
 <h3 id="information-1993vanbindex.html">Information: <a href="1993/vanb/index.html">1993/vanb/index.html</a></h3>
 <p>No spaces are allowed in the expression.</p>
@@ -1315,7 +1324,7 @@ not <code>d-46</code>.</p>
 <div id="1994_dodsond2">
 <h2 id="dodsond2">1994/dodsond2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994dodsond2dodsond2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2/dodsond2.c</a></h3>
 <h3 id="information-1994dodsond2index.html">Information: <a href="1994/dodsond2/index.html">1994/dodsond2/index.html</a></h3>
 <p>When you initiate shooting via the <code>s</code> command you immediately lose an arrow
@@ -1325,7 +1334,7 @@ pit room you will end up dying even though you didn’t explicitly move there.</
 <div id="1994_ldb">
 <h2 id="ldb">1994/ldb</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994ldbldb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">1994/ldb/ldb.c</a></h3>
 <h3 id="information-1994ldbindex.html">Information: <a href="1994/ldb/index.html">1994/ldb/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this to compile
@@ -1428,7 +1437,7 @@ compiled!</p>
 <div id="1994_shapiro">
 <h2 id="shapiro">1994/shapiro</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994shapiroshapiro.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">1994/shapiro/shapiro.c</a></h3>
 <h3 id="information-1994shapiroindex.html">Information: <a href="1994/shapiro/index.html">1994/shapiro/index.html</a></h3>
 <p>This program will likely crash if the source code file (by the name of the file
@@ -1475,7 +1484,7 @@ doesn’t break something else.</p>
 <div id="1995_cdua">
 <h2 id="cdua">1995/cdua</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995cduacdua.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">1995/cdua/cdua.c</a></h3>
 <h3 id="information-1995cduaindex.html">Information: <a href="1995/cdua/index.html">1995/cdua/index.html</a></h3>
 <p>This did not originally compile under macOS and after it did compile under
@@ -1507,7 +1516,7 @@ it would be good if it was fixed.</p>
 <div id="1995_savastio">
 <h2 id="savastio">1995/savastio</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995savastiosavastio.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">1995/savastio/savastio.c</a></h3>
 <h3 id="information-1995savastioindex.html">Information: <a href="1995/savastio/index.html">1995/savastio/index.html</a></h3>
 <p>This program expects a POSITIVE number. If you specify a negative number it will
@@ -1572,7 +1581,7 @@ almost be done except that some of the output of the
 <div id="1996_jonth">
 <h2 id="jonth">1996/jonth</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1996jonthjonth.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">1996/jonth/jonth.c</a></h3>
 <h3 id="information-1996jonthindex.html">Information: <a href="1996/jonth/index.html">1996/jonth/index.html</a></h3>
 <p>If X is not running this program will very likely crash or do something funny.
@@ -1615,7 +1624,7 @@ to the page as well! You’ll have IOCCC fame for reviving a pootifier! :-)</p>
 <div id="1998_schnitzi">
 <h2 id="schnitzi-2">1998/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">1998/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1998schnitziindex.html">Information: <a href="1998/schnitzi/index.html">1998/schnitzi/index.html</a></h3>
 <p>A point worth considering is that as the number passed into the program gets
@@ -1772,7 +1781,7 @@ on the stack at that point:</p>
     5</code></pre>
 <p>which might (?) suggest that the <code>+</code> operator is unimplemented. Unfortunately it
 has been many years since I have used perl and I was never a guru either.</p>
-<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states that in perl &lt; 5.6.0 there is a bug with a core dump in what
 they said is in <code>Perl_sv_upgrade</code>. As this is documented it is not considered a
 bug to be fixed. For the curious this will crash in macOS. Cody notes that the
@@ -1814,7 +1823,7 @@ of 92 warnings! Nonetheless neither works okay and both crash.</p>
 <div id="2000_primenum">
 <h2 id="primenum">2000/primenum</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000primenumprimenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/primenum.c">2000/primenum/primenum.c</a></h3>
 <h3 id="information-2000primenumindex.html">Information: <a href="2000/primenum/index.html">2000/primenum/index.html</a></h3>
 <p>This program does not do what you might think it does! Running it like:</p>
@@ -1832,7 +1841,7 @@ make a pull request.</p>
 <div id="2000_rince">
 <h2 id="rince-1">2000/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/rince.c">2000/rince/rince.c</a></h3>
 <h3 id="information-2000rinceindex.html">Information: <a href="2000/rince/index.html">2000/rince/index.html</a></h3>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash, do something strange
@@ -1846,7 +1855,7 @@ fire</a>! :-) ).</p>
 <div id="2001_anonymous">
 <h2 id="anonymous">2001/anonymous</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001anonymousanonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.c">2001/anonymous/anonymous.c</a></h3>
 <h3 id="information-2001anonymousindex.html">Information: <a href="2001/anonymous/index.html">2001/anonymous/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this so that it
@@ -1865,7 +1874,7 @@ elves of Imladris :-(</p>
 <div id="2001_bellard">
 <h2 id="bellard">2001/bellard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix">STATUS: doesn’t work with some platforms - please help us fix</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
@@ -1914,14 +1923,14 @@ before the fixes there.</p>
 <div id="2001_cheong">
 <h2 id="cheong">2001/cheong</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
 <h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
 <p>This program will crash without an arg.</p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
@@ -1942,7 +1951,7 @@ appreciate your help!</p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
 <p>Sometimes when one player presses <code>q</code> it will result in broken pipe on the other
@@ -1960,7 +1969,7 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
 <div id="2001_ollinger">
 <h2 id="ollinger">2001/ollinger</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
 <h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
 <p>This program will very likely crash or do something unexpected if you do not
@@ -1976,14 +1985,14 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
 details and a workaround.</p>
 <p>There’s also no way to escape meta characters.</p>
 <div id="2001_westley">
-<h2 id="westley-3">2001/westley</h2>
+<h2 id="westley-4">2001/westley</h2>
 </div>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-3">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-2001westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley/westley.c">2001/westley/westley.c</a></h3>
@@ -2144,13 +2153,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2175,7 +2184,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2188,7 +2197,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2202,7 +2211,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2211,7 +2220,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2245,7 +2254,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2259,7 +2268,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2300,7 +2309,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2309,7 +2318,7 @@ with possibly corrupt GIF files.</p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
@@ -2328,12 +2337,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
@@ -2341,7 +2350,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2358,7 +2367,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2405,7 +2414,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2428,7 +2437,7 @@ bins at the edges.</p>
 instead being something else entirely. The Internet Wayback Machine, although it
 archived it, did not load scripts. Do you know if the domain was moved? Do you
 have an archive or mirror? Please provide us it! Thank you.</p>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2441,7 +2450,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2451,7 +2460,7 @@ remarks</a> instead.</p>
 <div id="2011_konno">
 <h2 id="konno">2011/konno</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011konnokonno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/konno.c">2011/konno/konno.c</a></h3>
 <h3 id="information-2011konnoindex.html">Information: <a href="2011/konno/index.html">2011/konno/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
@@ -2620,7 +2629,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2634,7 +2643,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2643,7 +2652,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2676,7 +2685,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2690,7 +2699,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2711,7 +2720,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2727,7 +2736,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2747,7 +2756,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2766,7 +2775,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2782,7 +2791,7 @@ section</a>.</p>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2795,14 +2804,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2810,7 +2819,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2827,7 +2836,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2851,7 +2860,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2892,7 +2901,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2917,7 +2926,7 @@ result. Error messages become garbled, though.</p></li>
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2926,7 +2935,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -2959,7 +2968,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -2978,7 +2987,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -3003,7 +3012,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -3018,7 +3027,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3068,7 +3077,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3076,7 +3085,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3084,7 +3093,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3116,7 +3125,7 @@ ideal if this was not the case.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3145,7 +3154,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3153,7 +3162,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3183,7 +3192,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3193,7 +3202,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3213,7 +3222,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3222,7 +3231,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3237,7 +3246,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3248,7 +3257,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3262,7 +3271,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3272,7 +3281,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3281,7 +3290,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.html
+++ b/bugs.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/bugs.md
+++ b/bugs.md
@@ -884,6 +884,20 @@ will enter an infinite loop, printing 0 over and over again; another condition
 where this occurred was fixed but this one should not be fixed. Thank you.
 
 
+<div id="1990_westley">
+## 1990/westley
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1990/westley/westley.c](%%REPO_URL%%/1990/westley/westley.c)
+### Information: [1990/westley/index.html](1990/westley/index.html)
+
+Although Cody fixed this to not enter an infinite loop if the arg (converted to
+a number) is < 0 the lack of an arg check at all was kept in to make it like the
+original. The reason for the < 0 check is it floods the screen.
+
+
+
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1991">
 # 1991

--- a/contact.html
+++ b/contact.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -387,7 +387,7 @@
 <ul>
 <li><strong>Fix a winning IOCCC entry</strong> - See <a href="faq.html#fix_an_entry">FAQ 5.2</a></li>
 <li><strong>Update winning author information</strong> - See <a href="faq.html#fix_author">FAQ 5.5</a></li>
-<li><strong>Correct a web site problem</strong> - See <a href="faq.html#fix_web_site">FAQ 5.4</a> or <a href="faq.html#fix_link">FAQ 5.6</a></li>
+<li><strong>Correct a website problem</strong> - See <a href="faq.html#fix_web_site">FAQ 5.4</a> or <a href="faq.html#fix_link">FAQ 5.6</a></li>
 </ul>
 <p>Instead of sending us Email, <strong>Please</strong> consider using the <a href="https://github.com/ioccc-src/winner/pulls">GitHub
 pull request</a> process
@@ -396,7 +396,7 @@ of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>.<
 <p>If you are trying to:</p>
 <ul>
 <li><strong>Report a bug in an IOCCC winning entry</strong> - See <a href="faq.html#report_bug">FAQ 5.1</a></li>
-<li><strong>Report an IOCCC web site problem</strong> - See <a href="faq.html#report_web_problem">FAQ 5.3</a></li>
+<li><strong>Report an IOCCC website problem</strong> - See <a href="faq.html#report_web_problem">FAQ 5.3</a></li>
 <li><strong>Report a broken or wrong web link</strong> - See <a href="faq.html#fix_link">FAQ 5.6</a></li>
 </ul>
 <p>Instead first look at the <a href="https://github.com/ioccc-src/winner/issues">IOCCC

--- a/contact.md
+++ b/contact.md
@@ -4,7 +4,7 @@ If you are trying to:
 
 * **Fix a winning IOCCC entry** - See [FAQ 5.2](faq.html#fix_an_entry)
 * **Update winning author information** - See [FAQ 5.5](faq.html#fix_author)
-* **Correct a web site problem** - See [FAQ 5.4](faq.html#fix_web_site) or [FAQ 5.6](faq.html#fix_link)
+* **Correct a website problem** - See [FAQ 5.4](faq.html#fix_web_site) or [FAQ 5.6](faq.html#fix_link)
 
 Instead of sending us Email, **Please** consider using the [GitHub
 pull request](https://github.com/ioccc-src/winner/pulls) process
@@ -14,7 +14,7 @@ of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner).
 If you are trying to:
 
 * **Report a bug in an IOCCC winning entry** - See [FAQ 5.1](faq.html#report_bug)
-* **Report an IOCCC web site problem** - See [FAQ 5.3](faq.html#report_web_problem)
+* **Report an IOCCC website problem** - See [FAQ 5.3](faq.html#report_web_problem)
 * **Report a broken or wrong web link** - See [FAQ 5.6](faq.html#fix_link)
 
 Instead first look at the [IOCCC

--- a/faq.html
+++ b/faq.html
@@ -1973,10 +1973,6 @@ warning in such a way that caused confusing output for the entry, looking like:<
 <pre><code>    $ ./tbr
     $ warning: this program uses gets(), which is unsafe.
     # nothing here, what to do?</code></pre>
-<p>In some cases changing the code to use <code>fgets()</code> is not so easy to fix and in
-one case at least there is an alternate version that has the fix instead due to
-a problem it creates (correct output but segfaults after the output in one of
-the forms of input).</p>
 <p>In some cases it is not possible to fix or at least it is highly unlikely and so
 those have mainly not been touched except one that has had the buffer size
 increased (which could be done for others that are not possible to change to
@@ -1984,6 +1980,8 @@ increased (which could be done for others that are not possible to change to
 <p>Some entries can be made to look almost identical to the original entry. For
 instance the fix to <a href="1988/reddy/index.html">1988/reddy</a> required only a single
 <code>#define</code> be added.</p>
+<p>In the cases it has not been done it is likely the entry can be found in the
+<a href="bugs.html">bugs.html</a> file.</p>
 <p>In the future we, the judges, would prefer that entries use <code>fgets()</code> to prevent
 these problems.</p>
 <p>An annoying fact is that for ‘“compatibility” reasons’ <code>fgets()</code> retains the

--- a/faq.html
+++ b/faq.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -397,7 +397,7 @@
 <ul>
 <li><a href="#faq1_0">1.0 - How did the IOCCC get started?</a></li>
 <li><a href="#faq1_1">1.1 - Why are some years missing IOCCC entries?</a></li>
-<li><a href="#faq1_2">1.2 - What is the history of the IOCCC web site?</a></li>
+<li><a href="#faq1_2">1.2 - What is the history of the IOCCC website?</a></li>
 <li><a href="#faq1_3">1.3 - How has the IOCCC size limit rule changed over the years?</a></li>
 </ul>
 <h2 id="section-2---ioccc-judging-process">Section 2 - <a href="#faq2">IOCCC Judging process</a></h2>
@@ -451,8 +451,8 @@ other inconsistencies with the original entry?</a></li>
 <li><a href="#faq5_0">5.0 - How may I help the IOCCC?</a></li>
 <li><a href="#faq5_1">5.1 - How do I report a bug in an IOCCC entry?</a></li>
 <li><a href="#faq5_2">5.2 - How may I submit a fix to an IOCCC entry?</a></li>
-<li><a href="#faq5_3">5.3 - How may I report an IOCCC web site problem?</a></li>
-<li><a href="#faq5_4">5.4 - How may I submit a fix to the IOCCC web site?</a></li>
+<li><a href="#faq5_3">5.3 - How may I report an IOCCC website problem?</a></li>
+<li><a href="#faq5_4">5.4 - How may I submit a fix to the IOCCC website?</a></li>
 <li><a href="#faq5_5">5.5 - How may I correct or update IOCCC author information?</a></li>
 <li><a href="#faq5_6">5.6 - What should I do if I find a broken or wrong web link?</a></li>
 </ul>
@@ -460,7 +460,7 @@ other inconsistencies with the original entry?</a></li>
 <ul>
 <li><a href="#faq6_0">6.0 - How did an entry that breaks the size rule 2 win the IOCCC?</a></li>
 <li><a href="#faq6_1">6.1 - Is there a list of known bugs and (mis)features of IOCCC entries?</a></li>
-<li><a href="#faq6_2">6.2 - May I mirror the IOCCC web site?</a></li>
+<li><a href="#faq6_2">6.2 - May I mirror the IOCCC website?</a></li>
 <li><a href="#faq6_3">6.3 - May I use parts of the IOCCC in an article, book, newsletter, or instructional material?</a></li>
 <li><a href="#faq6_4">6.4 - Why do you sometimes use the first person plural?</a></li>
 <li><a href="#faq6_5">6.5 - What is an author handle?</a></li>
@@ -735,7 +735,7 @@ For example, we <a href="faq.html#submit">submitting to the IOCCC</a>, we have p
 to submit remarks about entry in markdown format. Every
 <a href="years.html">winning IOCCC entry</a> uses a <code>README.md</code> markdown file
 as the basis for forming the <code>index.html</code> web page for that entry.
-All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC web site</a>
+All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>
 start with some markdown content.</p>
 <p><strong>IMPORTANT</strong>: Please read the <a href="markdown.html">IOCCC markdown best practices</a> guide
 as it lists things you <strong>should not use</strong> in markdown files.</p>
@@ -812,12 +812,12 @@ do not permit us to hold a new IOCCC.</p>
 <p>The pause during the 2021-2023 period was due to the IOCCC judges developing tools to
 make is much more likely for the IOCCC to be held in a yearly basis later on.</p>
 <div id="faq1_2">
-<h3 id="faq-1.2-what-is-the-history-of-the-ioccc-web-site">FAQ 1.2: What is the history of the IOCCC web site?</h3>
+<h3 id="faq-1.2-what-is-the-history-of-the-ioccc-web-site">FAQ 1.2: What is the history of the IOCCC website?</h3>
 </div>
 <h4 id="in-the-beginning-of-www.ioccc.org">In the beginning of www.ioccc.org</h4>
-<p>The long history of the <a href="https://www.ioccc.org">official IOCCC web site</a> can be
+<p>The long history of the <a href="https://www.ioccc.org">official IOCCC website</a> can be
 viewed at the <a href="https://web.archive.org">Internet Wayback Machine Wayback Machine</a>.</p>
-<p>One can <a href="https://web.archive.org/web/20230000000000*/www.ioccc.org">view several thousand snapshots showing how the IOCCC web site has
+<p>One can <a href="https://web.archive.org/web/20230000000000*/www.ioccc.org">view several thousand snapshots showing how the IOCCC website has
 evolved</a> going back
 as far as <a href="https://web.archive.org/web/19981212030016/https://www.ioccc.org/">1998 Dec 12
 www.ioccc.org</a>.</p>
@@ -825,7 +825,7 @@ www.ioccc.org</a>.</p>
 repo</a> on
 <a href="https://github.com">GitHub</a>. From this point on, the <a href="https://www.ioccc.org">official IOCCC web
 site</a> became a <a href="https://pages.github.com">GitHub Pages</a>
-web site.</p>
+website.</p>
 <h4 id="dec-28-bzip2-compressed-tarball-archive">2020 Dec 28 bzip2 compressed tarball archive</h4>
 <p>Furthermore, a bzip2 compressed tarball containing the released
 IOCCC entry source code may be found under the
@@ -853,7 +853,7 @@ and then on <strong>Wed Dec 30 16:57:03 2020 -0800</strong> added a preview of
 c0663537cb88d39b74285a930ff1a668c6d5968b</a>.</p>
 <p>On 2020 Dec 30, with <a href="https://github.com/ioccc-src/winner/commit/c0663537cb88d39b74285a930ff1a668c6d5968b">commit
 c0663537cb88d39b74285a930ff1a668c6d5968b</a>,
-the <a href="https://web.archive.org/web/20221231001721/https://www.ioccc.org/">official IOCCC web site of 2022 Dec
+the <a href="https://web.archive.org/web/20221231001721/https://www.ioccc.org/">official IOCCC website of 2022 Dec
 29</a> was
 uploaded into the <a href="https://github.com/ioccc-src/winner">Official IOCCC winner
 repo</a>.</p>
@@ -897,11 +897,11 @@ and <a href="https://github.com/ioccc-src/winner/commit/098a3e7e04d43e480ecc4b54
 an <a href="https://www.ioccc.org/judges.html">IOCCC judge</a> made edits to
 their local repository with occasional pushes to the <a href="https://github.com/ioccc-src/winner">Official IOCCC winner
 repo</a> and the <a href="https://www.ioccc.org/index.html">Official
-www.ioccc.org web site</a>. After
+www.ioccc.org website</a>. After
 that time and until the <strong>Great Fork Merge</strong>, very few changes
 were made to the <a href="https://github.com/ioccc-src/winner">Official IOCCC winner
 repo</a> and the <a href="https://www.ioccc.org/index.html">Official
-www.ioccc.org web site</a> most of
+www.ioccc.org website</a> most of
 which were news updates.</p>
 <p>While the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc
 repo</a> has history
@@ -911,11 +911,11 @@ the repo was forked on <strong>Sun Sep 18 17:30:00 2022 -0700</strong>. The
 first <a href="https://github.com/ioccc-src/temp-test-ioccc/commit/edbc3089e1b755d85a020af7975bbc7df3737a5f">push into the temp-test-ioccc
 repo</a>
 occurred on Sun Sep 18 11:15:49 2022 -0700.</p>
-<p>At this same time, the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc web site</a> went live.</p>
+<p>At this same time, the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc website</a> went live.</p>
 <p>Edits were made by an <a href="https://www.ioccc.org/judges.html">IOCCC judge</a>
 to their local <a href="https://git-scm.com">git</a> repository and <a href="https://github.com/ioccc-src/temp-test-ioccc/commit/2f20ae8451ada03f4601ac727d10e1d8630861a8">were pushed into the temp-test-ioccc
 repo</a>
-and to the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc web site</a>.</p>
+and to the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc website</a>.</p>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/pull/15">first accepted pull request</a>
 made directly to the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc
 repo</a> on
@@ -955,7 +955,7 @@ request</a>.</li>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/gen-years.sh">gen-years.sh</a> tool.</li>
 <li>Setting up to generate the top level <a href="authors.html">authors.html file</a>, renamed
 from <code>winners.html</code>, via the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/gen-authors.sh">gen-authors.sh</a> tool.</li>
-<li>Making use of a new and improved <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/ioccc.css">IOCCC CSS</a> for web site consistency</li>
+<li>Making use of a new and improved <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/ioccc.css">IOCCC CSS</a> for website consistency</li>
 <li>Etc.</li>
 </ul>
 <h4 id="y-mm-dd-the-great-fork-merge">202y mm dd The Great Fork Merge <!-- XXX - Fill in the date when Great Fork Merge happens --></h4>
@@ -965,7 +965,7 @@ there were <a href="https://github.com/ioccc-src/winner/compare/master...ioccc-s
 of the <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a>.</p>
 <p>On 202y mm dd, the temporary repo was merged back into the <a href="https://github.com/ioccc-src/winner">IOCCC winner
 repo</a> resulting in many, many substantial improvements
-to the <a href="https://www.ioccc.org">official IOCCC web site</a>.</p>
+to the <a href="https://www.ioccc.org">official IOCCC website</a>.</p>
 <div id="faq1_3">
 <div id="size_rule">
 <h3 id="faq-1.3-how-has-the-ioccc-size-limit-rule-changed-over-the-years">FAQ 1.3: How has the IOCCC size limit rule changed over the years?</h3>
@@ -1139,7 +1139,7 @@ registered email address.</p></li>
 <li><p>Announce who are authors of this year’s winning IOCCC entries via the <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> mastodon
 feed</a>.</p></li>
 <li><p>Upload the winning code to the <a href="https://github.com/ioccc-src/winner">Official IOCCC winner repo</a></p></li>
-<li><p>Update the <a href="index.html">Official IOCCC web site</a>, and in particular
+<li><p>Update the <a href="index.html">Official IOCCC website</a>, and in particular
 display this year’s winning IOCCC entries at the top of the <a href="years.html">IOCCC
 winning entries page</a>.</p></li>
 <li><p>Update the <a href="news.html">IOCCC news</a> page.</p></li>
@@ -1333,7 +1333,7 @@ sharing might not work sometime, but it is the future. Fedora, also developed by
 RHEL, has switched to a Wayland session as it’s default windowing system (And it
 works flawlessly on my Laptop).</p>
 </blockquote>
-<p>See the <a href="https://wayland.freedesktop.org">Wayland</a> web site for more details.</p>
+<p>See the <a href="https://wayland.freedesktop.org">Wayland</a> website for more details.</p>
 <p><strong>IMPORTANT NOTE</strong>: We do <strong>NOT</strong> know if IOCCC entries will run under
 <strong>Wayland</strong>. Some IOCCC entries that use X11 might be OK while other IOCCC
 entries that use X11 in an unusual way might fail under <strong>Wayland</strong>.</p>
@@ -1415,7 +1415,7 @@ may be helpful:</p>
 See the above note for details.</p>
 <h4 id="package-website">Package website</h4>
 <p>First, see the above note on <a href="#X11_general">installing and starting Xorg</a>.</p>
-<p>See the <a href="https://x.org/wiki/">X.org</a> foundation web site.</p>
+<p>See the <a href="https://x.org/wiki/">X.org</a> foundation website.</p>
 <p><strong>IMPORTANT NOTE</strong>: The <a href="#Xorg_deprecated">X.org server has been deprecated</a>.
 See the above note for details.</p>
 <div id="faq3_8">
@@ -1863,13 +1863,13 @@ it like:</p>
 </div>
 </div>
 <p>Although one can clone the entire <a href="https://github.com/ioccc-src/winner">winner
-repo</a> to get the entire web site and all
+repo</a> to get the entire website and all
 entries, we also provide, as a convenience, a way to download individual entries
 as well as a way to download a year’s winning entries.</p>
 <p>Please note that some of the links in the html files will not work! This is
 because you are not downloading the full website. If you want to view the entry
 with links intact you should clone the repo or view it on the <a href="https://www.ioccc.org">official IOCCC
-web site</a> instead.</p>
+website</a> instead.</p>
 <h4 id="individual-winning-entry-tarballs">Individual winning entry tarballs</h4>
 <p>The individual entry tarballs are named in the form of
 <code>YYYY/winner/YYYY_winner.tar.bz2</code> (e.g.
@@ -2127,7 +2127,7 @@ could no longer be so: <code>main()</code> instead had to call another function 
 the body of the old <code>main()</code> and that function would call itself again. In some
 cases, however, this had to be done even without <code>clang</code> objections.</p>
 <div id="faq5">
-<h2 id="section-5-updating-or-correcting-ioccc-web-site-content">Section 5: Updating or correcting IOCCC web site content</h2>
+<h2 id="section-5-updating-or-correcting-ioccc-web-site-content">Section 5: Updating or correcting IOCCC website content</h2>
 </div>
 <div id="faq5_0">
 <div id="how_to_help">
@@ -2145,7 +2145,7 @@ in question. Note that in several cases what you may have discovered,
 while a (mis)feature is not considered a bug and should <strong>not be fixed</strong>.
 In cases where the bug is known, the entry’s <a href="bugs.html">known bugs</a> file
 section may offer you important fixing clues.</p>
-<h3 id="we-welcome-your-help-on-fixing-the-ioccc-web-site">We welcome your help on fixing the IOCCC web site</h3>
+<h3 id="we-welcome-your-help-on-fixing-the-ioccc-web-site">We welcome your help on fixing the IOCCC website</h3>
 <div id="faq5_1">
 <div id="report_bug">
 <h3 id="faq-5.1-how-do-i-report-a-bug-in-an-ioccc-entry">FAQ 5.1: How do I report a bug in an IOCCC entry?</h3>
@@ -2206,20 +2206,20 @@ request</a> for more information about pull requests.</p>
 have the final say in the matter.</p>
 <div id="faq5_3">
 <div id="report_web_problem">
-<h3 id="faq-5.3-how-may-i-report-an-ioccc-web-site-problem">FAQ 5.3: How may I report an IOCCC web site problem?</h3>
+<h3 id="faq-5.3-how-may-i-report-an-ioccc-web-site-problem">FAQ 5.3: How may I report an IOCCC website problem?</h3>
 </div>
 </div>
-<p>If you discover a problem with the IOCCC web site that is related
+<p>If you discover a problem with the IOCCC website that is related
 to a particular IOCCC entry, please see <a href="#report_bug">FAQ 5.1</a> for
 information about reporting a bug in an IOCCC entry, and see <a href="#fix_an_entry">FAQ
 5.2</a> for information on how to submit a fix to an IOCCC entry.</p>
-<p>If you discover a problem with the IOCCC web site (such as a broken link, which
+<p>If you discover a problem with the IOCCC website (such as a broken link, which
 may or may not be specific to a particular IOCCC entry) that is <strong>not related
 to a particular IOCCC entry</strong>, the best way you can help is to submit a fix to
-the IOCCC web site. See <a href="#fix_web_site">FAQ 5.4</a> for information on submitting fixes
-to the IOCCC web site.</p>
-<p>If you do not have a IOCCC web site fix, and just wish to report a
-general IOCCC web site problem, we ask that you first look at the
+the IOCCC website. See <a href="#fix_web_site">FAQ 5.4</a> for information on submitting fixes
+to the IOCCC website.</p>
+<p>If you do not have a IOCCC website fix, and just wish to report a
+general IOCCC website problem, we ask that you first look at the
 <a href="https://github.com/ioccc-src/winner/issues">IOCCC issues</a> to see
 if the problem has already been reported. If it has been reported,
 feel free to add a comment to the issue. If you do not find an it
@@ -2227,10 +2227,10 @@ has been reported, then fee free to open a <a href="https://github.com/ioccc-src
 issue</a>.</p>
 <div id="faq5_4">
 <div id="fix_web_site">
-<h3 id="faq-5.4-how-may-i-submit-a-fix-to-the-ioccc-web-site">FAQ 5.4: How may I submit a fix to the IOCCC web site?</h3>
+<h3 id="faq-5.4-how-may-i-submit-a-fix-to-the-ioccc-web-site">FAQ 5.4: How may I submit a fix to the IOCCC website?</h3>
 </div>
 </div>
-<p>For IOCCC web site problems that relate to a particular IOCCC entry, please
+<p>For IOCCC website problems that relate to a particular IOCCC entry, please
 see <a href="#fix_an_entry">FAQ 5.2</a> for information on how submit a fix to an IOCCC entry.</p>
 <p>You may open a <a href="https://github.com/ioccc-src/winner/pulls">GitHub pull request</a>
 against the master <a href="https://github.com/ioccc-src/winner/branches">branch</a>
@@ -2241,7 +2241,7 @@ entry</a>. See also the <a href="#ull_request">FAQ 6.10 How does someone
 make a change to a file and submit that change as a GitHub pull
 request</a> for more information about pull requests.</p>
 <h4 id="some-html-files-should-not-be-directly-modified">Some HTML files should NOT be directly modified</h4>
-<p>Nearly all HTML files on the <a href="https://www.ioccc.org">IOCCC web site</a>
+<p>Nearly all HTML files on the <a href="https://www.ioccc.org">IOCCC website</a>
 are built from <a href="https://daringfireball.net/projects/markdown/">markdown</a> files.
 If you see lines containing:</p>
 <pre><code>    &lt;!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! --&gt;
@@ -2377,7 +2377,7 @@ variety of kinds.</p>
 not an issue and note that some issues are simply missing files, dead URL(s) or
 something like that.</p>
 <div id="faq6_2">
-<h3 id="faq-6.2-may-i-mirror-the-ioccc-web-site">FAQ 6.2: May I mirror the IOCCC web site?</h3>
+<h3 id="faq-6.2-may-i-mirror-the-ioccc-web-site">FAQ 6.2: May I mirror the IOCCC website?</h3>
 </div>
 <p>We are not accepting mirror requests at this time, sorry. However you are free to fork the <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a>. We do ask that your fork keep up to date with the latest changes when possible.</p>
 <div id="faq6_3">
@@ -2476,7 +2476,7 @@ in the case of <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 information about authors of IOCCC entries and is used to help form
 HTML files as well to contact an author.</p>
 <p>The content of these JSON files are used by tools from a <a href="bin/index.html">bin directory tool</a>
-to help build HTML content for the <a href="https://www.ioccc.org">official IOCCC web site</a>.
+to help build HTML content for the <a href="https://www.ioccc.org">official IOCCC website</a>.
 For example, the <code>index.html</code> file for each IOCCC entry contains
 selected information about the authors. Tools from the <a href="bin/index.html">bin directory</a>
 use the content of these JSON files to generate the <code>index.html</code> files for each IOCCC
@@ -2551,7 +2551,7 @@ be the exact <em>JSON string</em> as shown above.</p>
 As of <em>Thu Nov 30 23:51:12 UTC 2023</em>, the <em>JSON value</em> <strong>MUST</strong> be <em>“1.0 2023-06-10”</em>.</p>
 <p>The <em>author_JSON_format_version</em> would only changed when the overall format
 of the these files is modified: and then only those who maintain the
-<a href="https://www.ioccc.org">official IOCCC web site</a> would be the one to do this
+<a href="https://www.ioccc.org">official IOCCC website</a> would be the one to do this
 in conjunction with changes to <a href="bin/index.html">bin directory tools</a>.</p>
 <h5 id="author_handle">author_handle</h5>
 <pre><code>    &quot;author_handle&quot; : &quot;Yusuke_Endoh&quot;,</code></pre>
@@ -2702,7 +2702,7 @@ information on Mastodon.</p>
 be a <em>JSON string</em> or it <strong>MUST</strong> be a <em>JSON null</em>. The <code>github</code> <em>JSON string</em> <strong>MUST</strong>
 start with an at sign (_<span class="citation" data-cites="_">@_</span>) and <strong>MUST</strong> be a valid GitHub username.</p>
 <p>The IOCCC uses GitHub to hold the <a href="https://github.com/ioccc-src/winner">official winner repo of the IOCCC</a>,
-and hosts <a href="https://www.ioccc.org">official IOCCC web site</a> on GitHub pages.</p>
+and hosts <a href="https://www.ioccc.org">official IOCCC website</a> on GitHub pages.</p>
 <p>The IOCCC GitHub handle is:</p>
 <pre><code>    @ioccc-src</code></pre>
 <p>If the author wishes to not specify an GitHub handle, or if the GitHub handle is

--- a/faq.md
+++ b/faq.md
@@ -2349,10 +2349,6 @@ warning in such a way that caused confusing output for the entry, looking like:
     # nothing here, what to do?
 ```
 
-In some cases changing the code to use `fgets()` is not so easy to fix and in
-one case at least there is an alternate version that has the fix instead due to
-a problem it creates (correct output but segfaults after the output in one of
-the forms of input).
 
 In some cases it is not possible to fix or at least it is highly unlikely and so
 those have mainly not been touched except one that has had the buffer size
@@ -2362,6 +2358,9 @@ increased (which could be done for others that are not possible to change to
 Some entries can be made to look almost identical to the original entry. For
 instance the fix to [1988/reddy](1988/reddy/index.html) required only a single
 `#define` be added.
+
+In the cases it has not been done it is likely the entry can be found in the
+[bugs.html](bugs.html) file.
 
 In the future we, the judges, would prefer that entries use `fgets()` to prevent
 these problems.

--- a/faq.md
+++ b/faq.md
@@ -14,7 +14,7 @@
 ## Section  1 - [History of the IOCCC](#faq1)
 - [1.0  - How did the IOCCC get started?](#faq1_0)
 - [1.1  - Why are some years missing IOCCC entries?](#faq1_1)
-- [1.2  - What is the history of the IOCCC web site?](#faq1_2)
+- [1.2  - What is the history of the IOCCC website?](#faq1_2)
 - [1.3  - How has the IOCCC size limit rule changed over the years?](#faq1_3)
 
 
@@ -68,8 +68,8 @@ other inconsistencies with the original entry?](#faq4_3)
 - [5.0  - How may I help the IOCCC?](#faq5_0)
 - [5.1  - How do I report a bug in an IOCCC entry?](#faq5_1)
 - [5.2  - How may I submit a fix to an IOCCC entry?](#faq5_2)
-- [5.3  - How may I report an IOCCC web site problem?](#faq5_3)
-- [5.4  - How may I submit a fix to the IOCCC web site?](#faq5_4)
+- [5.3  - How may I report an IOCCC website problem?](#faq5_3)
+- [5.4  - How may I submit a fix to the IOCCC website?](#faq5_4)
 - [5.5  - How may I correct or update IOCCC author information?](#faq5_5)
 - [5.6  - What should I do if I find a broken or wrong web link?](#faq5_6)
 
@@ -77,7 +77,7 @@ other inconsistencies with the original entry?](#faq4_3)
 ## Section  6 - [Miscellaneous IOCCC](#faq6)
 - [6.0  - How did an entry that breaks the size rule 2 win the IOCCC?](#faq6_0)
 - [6.1  - Is there a list of known bugs and &#x28;mis&#x29;features of IOCCC entries?](#faq6_1)
-- [6.2  - May I mirror the IOCCC web site?](#faq6_2)
+- [6.2  - May I mirror the IOCCC website?](#faq6_2)
 - [6.3  - May I use parts of the IOCCC in an article, book, newsletter, or instructional material?](#faq6_3)
 - [6.4  - Why do you sometimes use the first person plural?](#faq6_4)
 - [6.5  - What is an author handle?](#faq6_5)
@@ -467,7 +467,7 @@ For example, we [submitting to the IOCCC](faq.html#submit), we have people
 to submit remarks about entry in markdown format.  Every
 [winning IOCCC entry](years.html) uses a `README.md` markdown file
 as the basis for forming the `index.html` web page for that entry.
-All generated HTML pages on the [Official IOCCC web site](https://www.ioccc.org/index.html)
+All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
 start with some markdown content.
 
 **IMPORTANT**: Please read the [IOCCC markdown best practices](markdown.html) guide
@@ -576,15 +576,15 @@ make is much more likely for the IOCCC to be held in a yearly basis later on.
 
 
 <div id="faq1_2">
-### FAQ 1.2: What is the history of the IOCCC web site?
+### FAQ 1.2: What is the history of the IOCCC website?
 </div>
 
 #### In the beginning of www.ioccc.org
 
-The long history of the [official IOCCC web site](https://www.ioccc.org) can be
+The long history of the [official IOCCC website](https://www.ioccc.org) can be
 viewed at the [Internet Wayback Machine Wayback Machine](https://web.archive.org).
 
-One can [view several thousand snapshots showing how the IOCCC web site has
+One can [view several thousand snapshots showing how the IOCCC website has
 evolved](https://web.archive.org/web/20230000000000*/www.ioccc.org) going back
 as far as [1998 Dec 12
 www.ioccc.org](https://web.archive.org/web/19981212030016/https://www.ioccc.org/).
@@ -593,7 +593,7 @@ On 2020 Dec 31, the IOCCC source tree was moved to the [IOCCC winner
 repo](https://web.archive.org/web/20210101211346/https://www.ioccc.org/) on
 [GitHub](https://github.com).  From this point on, the [official IOCCC web
 site](https://www.ioccc.org) became a [GitHub Pages](https://pages.github.com)
-web site.
+website.
 
 #### 2020 Dec 28 bzip2 compressed tarball archive
 
@@ -631,7 +631,7 @@ c0663537cb88d39b74285a930ff1a668c6d5968b](https://github.com/ioccc-src/winner/co
 
 On 2020 Dec 30, with [commit
 c0663537cb88d39b74285a930ff1a668c6d5968b](https://github.com/ioccc-src/winner/commit/c0663537cb88d39b74285a930ff1a668c6d5968b),
-the [official IOCCC web site of 2022 Dec
+the [official IOCCC website of 2022 Dec
 29](https://web.archive.org/web/20221231001721/https://www.ioccc.org/) was
 uploaded into the [Official IOCCC winner
 repo](https://github.com/ioccc-src/winner).
@@ -686,11 +686,11 @@ and [Sat Jan 29 21:56:53 2022
 an [IOCCC judge](https://www.ioccc.org/judges.html) made edits to
 their local repository with occasional pushes to the [Official IOCCC winner
 repo](https://github.com/ioccc-src/winner) and the [Official
-www.ioccc.org web site](https://www.ioccc.org/index.html).  After
+www.ioccc.org website](https://www.ioccc.org/index.html).  After
 that time and until the **Great Fork Merge**, very few changes
 were made to the [Official IOCCC winner
 repo](https://github.com/ioccc-src/winner) and the [Official
-www.ioccc.org web site](https://www.ioccc.org/index.html) most of
+www.ioccc.org website](https://www.ioccc.org/index.html) most of
 which were news updates.
 
 While the [temp-test-ioccc
@@ -702,12 +702,12 @@ first [push into the temp-test-ioccc
 repo](https://github.com/ioccc-src/temp-test-ioccc/commit/edbc3089e1b755d85a020af7975bbc7df3737a5f)
 occurred on Sun Sep 18 11:15:49 2022 -0700.
 
-At this same time, the [temp-test-ioccc web site](https://ioccc-src.github.io/temp-test-ioccc/) went live.
+At this same time, the [temp-test-ioccc website](https://ioccc-src.github.io/temp-test-ioccc/) went live.
 
 Edits were made by an [IOCCC judge](https://www.ioccc.org/judges.html)
 to their local [git](https://git-scm.com) repository and [were pushed into the temp-test-ioccc
 repo](https://github.com/ioccc-src/temp-test-ioccc/commit/2f20ae8451ada03f4601ac727d10e1d8630861a8)
-and to the [temp-test-ioccc web site](https://ioccc-src.github.io/temp-test-ioccc/).
+and to the [temp-test-ioccc website](https://ioccc-src.github.io/temp-test-ioccc/).
 
 The [first accepted pull request](https://github.com/ioccc-src/temp-test-ioccc/pull/15)
 made directly to the [temp-test-ioccc
@@ -750,7 +750,7 @@ request](https://github.com/ioccc-src/winner/pulls).
 [gen-years.sh](%%REPO_URL%%/bin/gen-years.sh) tool.
 * Setting up to generate the top level [authors.html file](authors.html), renamed
 from `winners.html`, via the [gen-authors.sh](%%REPO_URL%%/bin/gen-authors.sh) tool.
-* Making use of a new and improved [IOCCC CSS](%%REPO_URL%%/ioccc.css) for web site consistency
+* Making use of a new and improved [IOCCC CSS](%%REPO_URL%%/ioccc.css) for website consistency
 * Etc.
 
 #### 202y mm dd The Great Fork Merge <!-- XXX - Fill in the date when Great Fork Merge happens -->
@@ -762,7 +762,7 @@ of the [IOCCC winner repo](https://github.com/ioccc-src/winner).
 
 On 202y mm dd, the temporary repo was merged back into the [IOCCC winner
 repo](https://github.com/ioccc-src/winner) resulting in many, many substantial improvements
-to the [official IOCCC web site](https://www.ioccc.org).
+to the [official IOCCC website](https://www.ioccc.org).
 
 
 <div id="faq1_3">
@@ -979,7 +979,7 @@ feed](https://fosstodon.org/@ioccc).
 
 * Upload the winning code to the [Official IOCCC winner repo](https://github.com/ioccc-src/winner)
 
-* Update the [Official IOCCC web site](index.html), and in particular
+* Update the [Official IOCCC website](index.html), and in particular
 display this year's winning IOCCC entries at the top of the [IOCCC
 winning entries page](years.html).
 
@@ -1239,7 +1239,7 @@ sharing might not work sometime, but it is the future. Fedora, also developed by
 RHEL, has switched to a Wayland session as it’s default windowing system (And it
 works flawlessly on my Laptop).
 
-See the [Wayland](https://wayland.freedesktop.org) web site for more details.
+See the [Wayland](https://wayland.freedesktop.org) website for more details.
 
 **IMPORTANT NOTE**: We do **NOT** know if IOCCC entries will run under
 **Wayland**.  Some IOCCC entries that use X11 might be OK while other IOCCC
@@ -1375,7 +1375,7 @@ See the above note for details.
 
 First, see the above note on [installing and starting Xorg](#X11_general).
 
-See the [X.org](https://x.org/wiki/) foundation web site.
+See the [X.org](https://x.org/wiki/) foundation website.
 
 **IMPORTANT NOTE**: The [X.org server has been deprecated](#Xorg_deprecated).
 See the above note for details.
@@ -2200,14 +2200,14 @@ though of course for both you may specify a rule or rules to run.
 </div>
 
 Although one can clone the entire [winner
-repo](https://github.com/ioccc-src/winner) to get the entire web site and all
+repo](https://github.com/ioccc-src/winner) to get the entire website and all
 entries, we also provide, as a convenience, a way to download individual entries
 as well as a way to download a year's winning entries.
 
 Please note that some of the links in the html files will not work! This is
 because you are not downloading the full website. If you want to view the entry
 with links intact you should clone the repo or view it on the [official IOCCC
-web site](https://www.ioccc.org) instead.
+website](https://www.ioccc.org) instead.
 
 
 #### Individual winning entry tarballs
@@ -2551,7 +2551,7 @@ cases, however, this had to be done even without `clang` objections.
 
 
 <div id="faq5">
-## Section 5: Updating or correcting IOCCC web site content
+## Section 5: Updating or correcting IOCCC website content
 </div>
 
 
@@ -2575,7 +2575,7 @@ while a (mis)feature is not considered a bug and should **not be fixed**.
 In cases where the bug is known, the entry's [known bugs](bugs.html) file
 section may offer you important fixing clues.
 
-### We welcome your help on fixing the IOCCC web site
+### We welcome your help on fixing the IOCCC website
 
 
 <div id="faq5_1">
@@ -2655,23 +2655,23 @@ have the final say in the matter.
 
 <div id="faq5_3">
 <div id="report_web_problem">
-### FAQ 5.3: How may I report an IOCCC web site problem?
+### FAQ 5.3: How may I report an IOCCC website problem?
 </div>
 </div>
 
-If you discover a problem with the IOCCC web site that is related
+If you discover a problem with the IOCCC website that is related
 to a particular IOCCC entry, please see [FAQ 5.1](#report_bug) for
 information about reporting a bug in an IOCCC entry, and see [FAQ
 5.2](#fix_an_entry) for information on how to submit a fix to an IOCCC entry.
 
-If you discover a problem with the IOCCC web site (such as a broken link, which
+If you discover a problem with the IOCCC website (such as a broken link, which
 may or may not be specific to a particular IOCCC entry) that is **not related
 to a particular IOCCC entry**, the best way you can help is to submit a fix to
-the IOCCC web site.  See [FAQ 5.4](#fix_web_site) for information on submitting fixes
-to the IOCCC web site.
+the IOCCC website.  See [FAQ 5.4](#fix_web_site) for information on submitting fixes
+to the IOCCC website.
 
-If you do not have a IOCCC web site fix, and just wish to report a
-general IOCCC web site problem, we ask that you first look at the
+If you do not have a IOCCC website fix, and just wish to report a
+general IOCCC website problem, we ask that you first look at the
 [IOCCC issues](https://github.com/ioccc-src/winner/issues) to see
 if the problem has already been reported.  If it has been reported,
 feel free to add a comment to the issue.  If you do not find an it
@@ -2681,11 +2681,11 @@ issue](https://github.com/ioccc-src/winner/issues).
 
 <div id="faq5_4">
 <div id="fix_web_site">
-### FAQ 5.4: How may I submit a fix to the IOCCC web site?
+### FAQ 5.4: How may I submit a fix to the IOCCC website?
 </div>
 </div>
 
-For IOCCC web site problems that relate to a particular IOCCC entry, please
+For IOCCC website problems that relate to a particular IOCCC entry, please
 see [FAQ 5.2](#fix_an_entry) for information on how submit a fix to an IOCCC entry.
 
 You may open a [GitHub pull request](https://github.com/ioccc-src/winner/pulls)
@@ -2700,7 +2700,7 @@ request](#ull_request) for more information about pull requests.
 
 #### Some HTML files should NOT be directly modified
 
-Nearly all HTML files on the [IOCCC web site](https://www.ioccc.org)
+Nearly all HTML files on the [IOCCC website](https://www.ioccc.org)
 are built from [markdown](https://daringfireball.net/projects/markdown/) files.
 If you see lines containing:
 
@@ -2900,7 +2900,7 @@ something like that.
 
 
 <div id="faq6_2">
-### FAQ 6.2: May I mirror the IOCCC web site?
+### FAQ 6.2: May I mirror the IOCCC website?
 </div>
 
 We are not accepting mirror requests at this time, sorry.  However you are free to fork the [IOCCC winner repo](https://github.com/ioccc-src/winner).  We do ask that your fork keep up to date with the latest changes when possible.
@@ -3049,7 +3049,7 @@ information about authors of IOCCC entries and is used to help form
 HTML files as well to contact an author.
 
 The content of these JSON files are used by tools from a [bin directory tool](bin/index.html)
-to help build HTML content for the [official IOCCC web site](https://www.ioccc.org).
+to help build HTML content for the [official IOCCC website](https://www.ioccc.org).
 For example, the `index.html` file for each IOCCC entry contains
 selected information about the authors.  Tools from the [bin directory](bin/index.html)
 use the content of these JSON files to generate the `index.html` files for each IOCCC
@@ -3157,7 +3157,7 @@ As of _Thu Nov 30 23:51:12 UTC 2023_, the _JSON value_ **MUST** be _"1.0 2023-06
 
 The _author_JSON_format_version_ would only changed when the overall format
 of the these files is modified: and then only those who maintain the
-[official IOCCC web site](https://www.ioccc.org) would be the one to do this
+[official IOCCC website](https://www.ioccc.org) would be the one to do this
 in conjunction with changes to [bin directory tools](bin/index.html).
 
 
@@ -3444,7 +3444,7 @@ be a _JSON string_ or it **MUST** be a _JSON null_.  The `github` _JSON string_ 
 start with an at sign (_@_) and **MUST** be a valid GitHub username.
 
 The IOCCC uses GitHub to hold the [official winner repo of the IOCCC](https://github.com/ioccc-src/winner),
-and hosts [official IOCCC web site](https://www.ioccc.org) on GitHub pages.
+and hosts [official IOCCC website](https://www.ioccc.org) on GitHub pages.
 
 The IOCCC GitHub handle is:
 

--- a/inc/index.html
+++ b/inc/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/inc/md2html.cfg
+++ b/inc/md2html.cfg
@@ -139,11 +139,11 @@ bin/README.md
 	-s
 	TITLE=The International Obfuscated C Code Contest
 	-s
-	DESCRIPTION=Tools used to build and maintain the IOCCC web site
+	DESCRIPTION=Tools used to build and maintain the IOCCC website
 	-s
-	KEYWORDS=IOCCC, tools, web site tools, bin
+	KEYWORDS=IOCCC, tools, website tools, bin
 	-s
-	HEADER_2=IOCCC tools used build and maintain the IOCCC web site
+	HEADER_2=IOCCC tools used build and maintain the IOCCC website
 	-D
 	../
 

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -94,7 +94,7 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -239,7 +239,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_author">

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -383,12 +383,12 @@
 <!-- BEFORE: 1st line of markdown file: index.md -->
 <!-- XXX - This entire section goes away during the final stages of the Great Fork Merge -->
 <h1 id="this-is-an-experimental-ioccc-web-site">THIS IS AN EXPERIMENTAL IOCCC WEB SITE</h1>
-<p><strong>IMPORTANT: This is NOT the official IOCCC web site!</strong></p>
+<p><strong>IMPORTANT: This is NOT the official IOCCC website!</strong></p>
 <p>Please visit <a href="https://www.ioccc.org/index.html">www.ioccc.org</a> for the official IOCCC web.</p>
-<p>Please do <strong>NOT</strong> bookmark nor link to this <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental web site</a>!</p>
+<p>Please do <strong>NOT</strong> bookmark nor link to this <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental website</a>!</p>
 <p>When this experiment is finished, this site <strong>will go away</strong>!</p>
 <p>This test web tree is part of the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a>.</p>
-<p>This web site will be undergoing major changes, so expect many broken links, typos and other problems.
+<p>This website will be undergoing major changes, so expect many broken links, typos and other problems.
 If you wish to recommend changes (understanding that things may be rapidly changing out from under your copy),
 then consider making pull requests against the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a>.</p>
 <h2 id="what-follows-is-the-actual-index.html-file">What follows is the actual index.html file</h2>

--- a/index.md
+++ b/index.md
@@ -1,17 +1,17 @@
 <!-- XXX - This entire section goes away during the final stages of the Great Fork Merge -->
 # THIS IS AN EXPERIMENTAL IOCCC WEB SITE
 
-**IMPORTANT: This is NOT the official IOCCC web site!**
+**IMPORTANT: This is NOT the official IOCCC website!**
 
 Please visit [www.ioccc.org](https://www.ioccc.org/index.html) for the official IOCCC web.
 
-Please do **NOT** bookmark nor link to this [experimental web site](https://ioccc-src.github.io/temp-test-ioccc/)!
+Please do **NOT** bookmark nor link to this [experimental website](https://ioccc-src.github.io/temp-test-ioccc/)!
 
 When this experiment is finished, this site **will go away**!
 
 This test web tree is part of the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc).
 
-This web site will be undergoing major changes, so expect many broken links, typos and other problems.
+This website will be undergoing major changes, so expect many broken links, typos and other problems.
 If you wish to recommend changes (understanding that things may be rapidly changing out from under your copy),
 then consider making pull requests against the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc).
 

--- a/judges.html
+++ b/judges.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/license.html
+++ b/license.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/location.html
+++ b/location.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/markdown.html
+++ b/markdown.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -388,7 +388,7 @@ For example, we <a href="faq.html#submit">submitting to the IOCCC</a>, we have p
 to submit remarks about entry in markdown format. Every
 <a href="years.html">winning IOCCC entry</a> uses a <code>README.md</code> markdown file
 as the basis for forming the <code>index.html</code> web page for that entry.
-All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC web site</a>
+All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>
 start with some markdown content.</p>
 <p>See the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide.
 See also <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.</p>

--- a/markdown.md
+++ b/markdown.md
@@ -5,7 +5,7 @@ For example, we [submitting to the IOCCC](faq.html#submit), we have people
 to submit remarks about entry in markdown format.  Every
 [winning IOCCC entry](years.html) uses a `README.md` markdown file
 as the basis for forming the `index.html` web page for that entry.
-All generated HTML pages on the [Official IOCCC web site](https://www.ioccc.org/index.html)
+All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
 start with some markdown content.
 
 See the [markdown syntax](https://www.markdownguide.org/basic-syntax) guide.

--- a/news.html
+++ b/news.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -390,7 +390,7 @@ major events such as the opening of a new IOCCC, or who won.</p>
 information on Mastodon.</p>
 <h2 id="section">2024-05-30</h2>
 <p>A number of issues from minor fixes have been applied to the
-<a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc web site</a>
+<a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc website</a>
 via the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc</a> repo.</p>
 <p>437 commits have been applied since 2024-04-20, bringing the total
 number to 5260 commits to date. The
@@ -424,7 +424,7 @@ This will speed up the start date of IOCCC28.</p>
 <p>It is our plan that IOCCC28 will occur in 2024, the 40th anniversary of the
 IOCCC.</p>
 <h2 id="section-1">2024-04-30</h2>
-<p>The web site now is viewing by mobile devices such as cell phones
+<p>The website now is viewing by mobile devices such as cell phones
 and tablets. Devices with a screen resolution 1024 pixels and
 narrower are given a <em>hamburger-style</em> menu icon in place of
 drop-down menus at the very top of the page (called the <em>topbar</em>).</p>
@@ -446,8 +446,8 @@ warnings, nor info** messages, changes involving fixing invalid
 links to local files have been corrected, and changes involving the
 <em>topbar</em> are now HTML 5 conforming.</p>
 <h2 id="section-2">2024-04-20</h2>
-<p>Nearly all of the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc web site</a>
-web site has undergone editorial review. Nearly all <a href="years.html">IOCCC winning entries</a>
+<p>Nearly all of the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc website</a>
+website has undergone editorial review. Nearly all <a href="years.html">IOCCC winning entries</a>
 compile on modern systems and many have <code>try.sh</code> scripts to help you run them.
 For those that cannot compile and/or do not work, we have made a
 <a href="bugs.html">Bugs and (Mis)features</a> page.</p>
@@ -455,26 +455,26 @@ For those that cannot compile and/or do not work, we have made a
 <p>All generated HTML pages are now conform to HTML 5 with the
 <a href="https://validator.w3.org/nu/">Nu Html Checker</a> reporting <strong>no error, warnings, nor info</strong> messages.</p>
 <p>The <a href="judges.html">IOCCC judges</a> have contracted with a web designer
-to improve the overall look of the web site, while <strong>maintaining
+to improve the overall look of the website, while <strong>maintaining
 the utilitarian look and feel</strong>, and without introducing any
 glaring “<em>dancing bears</em>” and other frivolous web features.</p>
 <p>We are working towards what we call the
 <strong><a href="https://github.com/ioccc-src/temp-test-ioccc/issues/2239">Great Fork Merge</a></strong>
-where the contents of the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc web site</a>
-will be merged into the <a href="https://www.ioccc.org/index.html">Official IOCCC web site</a>.</p>
+where the contents of the <a href="https://ioccc-src.github.io/temp-test-ioccc/">temp-test-ioccc website</a>
+will be merged into the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>.</p>
 <p>Stay tuned!</p>
 <h2 id="section-3">2024-02-29</h2>
-<p>We continue to make good progress on web site. In the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a> we have made nearly 4600 changes to date!</p>
+<p>We continue to make good progress on website. In the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a> we have made nearly 4600 changes to date!</p>
 <p>All web pages, including this one, are now constructed from markdown files and/or JSON data files using tools found in the <a href="bin/index.html">bin</a> directory.</p>
 <h2 id="section-4">2023-05-22</h2>
-<p>We have been busy preparing for an important / significant update to this web site. In the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a> we have made nearly 2645 changes to date.</p>
+<p>We have been busy preparing for an important / significant update to this website. In the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a> we have made nearly 2645 changes to date.</p>
 <p>While you are free to look at the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a>,
-please <strong>do not link to it</strong> as this repo and related web site will disappear once the main
+please <strong>do not link to it</strong> as this repo and related website will disappear once the main
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> has been updated.</p>
 <p>Also be aware that the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a>
 is undergoing rapid changes. There are broken links and other things in mid-change.</p>
 <p>Once we are ready to update the <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a>
-and its associated web site,
+and its associated website,
 we will post a news article warning of the pending change that is about to arrive.</p>
 <p>These 2645+ changes in the <a href="https://github.com/ioccc-src/temp-test-ioccc">temp-test-ioccc GitHub repo</a>
 include diverse things such as:</p>
@@ -537,7 +537,7 @@ of the most recent news item.</p>
 <h2 id="section-6">2022-12-18</h2>
 <p>As per the suggestion of <a href="https://fosstodon.org/@Virtaava@home.social">Toni Mikkola</a>
 (_<span class="citation" data-cites="Virtaava">@Virtaava</span><span class="citation" data-cites="home.social_">@home.social_</span>) we now maintain a
-<a href="status.json">status.json</a> page on this web site.</p>
+<a href="status.json">status.json</a> page on this website.</p>
 <p>In addition to the IOCCC-style <em>easter egg</em>, you may count on
 the JSON status page having a JSON member with name of <strong>“contest”</strong>
 that will have a value of either <strong>“closed”</strong> or <strong>“open”</strong>.
@@ -598,7 +598,7 @@ to upload the above mentioned compressed tarball: when the contest is open of co
 <p>We plan to hold in 2023, what we will call <strong>IOCCCMOCK</strong>, a trial IOCCC contest where the
 judges will go through the motions (without judging the content) of an IOCCC:
 testing the above mentioned tools and testing the submit server.</p>
-<p>We are working on complete rebuild of this web site as well.</p>
+<p>We are working on complete rebuild of this website as well.</p>
 <h2 id="section-9">2022-01-15</h2>
 <p>Source code has been released for version <strong>0.24 2022-01-15</strong> of the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry tool</a>,
@@ -624,7 +624,7 @@ we will do so by committing their code to the
 <a href="years.html">Winning entries</a>
 of the IOCCC repo, so that people will be able immediately
 view the winning source.</p>
-<p>We plan to refactor and modernize the IOCCC web site.
+<p>We plan to refactor and modernize the IOCCC website.
 We also plan to build a new and improved way to submit entries the next IOCCC.
 As a result of all this work we need to do,
 <strong>we plan to hold IOCCC28 in 2023 instead of 2021</strong>.

--- a/news.md
+++ b/news.md
@@ -12,7 +12,7 @@ information on Mastodon.
 ## 2024-05-30
 
 A number of issues from minor fixes have been applied to the
-[temp-test-ioccc web site](https://ioccc-src.github.io/temp-test-ioccc/)
+[temp-test-ioccc website](https://ioccc-src.github.io/temp-test-ioccc/)
 via the [temp-test-ioccc](https://github.com/ioccc-src/temp-test-ioccc) repo.
 
 437 commits have been applied since 2024-04-20, bringing the total
@@ -55,7 +55,7 @@ IOCCC.
 
 ## 2024-04-30
 
-The web site now is viewing by mobile devices such as cell phones
+The website now is viewing by mobile devices such as cell phones
 and tablets.  Devices with a screen resolution 1024 pixels and
 narrower are given a _hamburger-style_ menu icon in place of
 drop-down menus at the very top of the page (called the _topbar_).
@@ -85,8 +85,8 @@ _topbar_ are now HTML 5 conforming.
 
 ## 2024-04-20
 
-Nearly all of the [temp-test-ioccc web site](https://ioccc-src.github.io/temp-test-ioccc/)
-web site has undergone editorial review.  Nearly all [IOCCC winning entries](years.html)
+Nearly all of the [temp-test-ioccc website](https://ioccc-src.github.io/temp-test-ioccc/)
+website has undergone editorial review.  Nearly all [IOCCC winning entries](years.html)
 compile on modern systems and many have `try.sh` scripts to help you run them.
 For those that cannot compile and/or do not work, we have made a
 [Bugs and &#x28;Mis&#x29;features](bugs.html) page.
@@ -97,38 +97,38 @@ All generated HTML pages are now conform to HTML 5 with the
 [Nu Html Checker](https://validator.w3.org/nu/) reporting **no error, warnings, nor info** messages.
 
 The [IOCCC judges](judges.html) have contracted with a web designer
-to improve the overall look of the web site, while **maintaining
+to improve the overall look of the website, while **maintaining
 the utilitarian look and feel**, and without introducing any
 glaring "_dancing bears_" and other frivolous web features.
 
 We are working towards what we call the
 **[Great Fork Merge](https://github.com/ioccc-src/temp-test-ioccc/issues/2239)**
-where the contents of the [temp-test-ioccc web site](https://ioccc-src.github.io/temp-test-ioccc/)
-will be merged into the [Official IOCCC web site](https://www.ioccc.org/index.html).
+where the contents of the [temp-test-ioccc website](https://ioccc-src.github.io/temp-test-ioccc/)
+will be merged into the [Official IOCCC website](https://www.ioccc.org/index.html).
 
 Stay tuned!
 
 
 ## 2024-02-29
 
-We continue to make good progress on web site.  In the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc) we have made nearly 4600 changes to date!
+We continue to make good progress on website.  In the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc) we have made nearly 4600 changes to date!
 
 All web pages, including this one, are now constructed from markdown files and/or JSON data files using tools found in the [bin](bin/index.html) directory.
 
 
 ## 2023-05-22
 
-We have been busy preparing for an important / significant update to this web site.  In the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc) we have made nearly 2645 changes to date.
+We have been busy preparing for an important / significant update to this website.  In the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc) we have made nearly 2645 changes to date.
 
 While you are free to look at the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc),
-please **do not link to it** as this repo and related web site will disappear once the main
+please **do not link to it** as this repo and related website will disappear once the main
 [IOCCC winner repo](https://github.com/ioccc-src/winner) has been updated.
 
 Also be aware that the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc)
 is undergoing rapid changes.  There are broken links and other things in mid-change.
 
 Once we are ready to update the [IOCCC winner repo](https://github.com/ioccc-src/winner)
-and its associated web site,
+and its associated website,
 we will post a news article warning of the pending change that is about to arrive.
 
 These 2645+ changes in the [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc)
@@ -207,7 +207,7 @@ of the most recent news item.
 
 As per the suggestion of [Toni Mikkola](https://fosstodon.org/@Virtaava@home.social)
 (_@Virtaava@home.social_) we now maintain a
-[status.json](status.json) page on this web site.
+[status.json](status.json) page on this website.
 
 In addition to the IOCCC-style _easter egg_, you may count on
 the JSON status page having a JSON member with name of **"contest"**
@@ -294,7 +294,7 @@ We plan to hold in 2023, what we will call **IOCCCMOCK**, a trial IOCCC contest 
 judges will go through the motions (without judging the content) of an IOCCC:
 testing the above mentioned tools and testing the submit server.
 
-We are working on complete rebuild of this web site as well.
+We are working on complete rebuild of this website as well.
 
 
 ## 2022-01-15
@@ -331,7 +331,7 @@ we will do so by committing their code to the
 of the IOCCC repo, so that people will be able immediately
 view the winning source.
 
-We plan to refactor and modernize the IOCCC web site.
+We plan to refactor and modernize the IOCCC website.
 We also plan to build a new and improved way to submit entries the next IOCCC.
 As a result of all this work we need to do,
 **we plan to hold IOCCC28 in 2023 instead of 2021**.

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -432,8 +432,8 @@ at any time.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2020-Jan-15 12:21:37 UTC</strong>.</p>
 <p>Please wait to submit your entries until after that time.</p>
 <p>The official rules, guidelines and iocccsize.c tool will be available
-on the official IOCCC web site on or slightly before start of this IOCCC.
-Please check the IOCCC web site “How to enter” link:</p>
+on the official IOCCC website on or slightly before start of this IOCCC.
+Please check the IOCCC website “How to enter” link:</p>
 <pre><code>    https://www.ioccc.org/index.html#enter</code></pre>
 <p>on or after the start of this IOCCC to be sure you are using the correct
 versions of these items before using the IOCCC entry submission URL.</p>
@@ -1004,7 +1004,7 @@ This is done prior to posting the winners to the wide world.</p>
 <p>The IOCCC no longer uses twitter. IOCCC entries will be announced
 by a git commit to the IOCCC entries repo:</p>
 <pre><code>    https://github.com/ioccc-src/winner</code></pre>
-<p>that, in turn, updates the offivial IOCCC web site:</p>
+<p>that, in turn, updates the offivial IOCCC website:</p>
 <pre><code>    https://www.ioccc.org/index.html</code></pre>
 <p>In addition a note is posted to the IOCCC Mastodon account:</p>
 <pre><code>    https://fosstodon.org/@ioccc</code></pre>
@@ -1099,7 +1099,7 @@ from the <span class="citation" data-cites="IOCCC">@IOCCC</span> twitter handle.
 to be sure they are seeing the most recent tweets.</p>
 <p>The judges will then post an initial announcement of who won, the name
 of their award, and a very brief description of the winning entry
-on the IOCCC web site:</p>
+on the IOCCC website:</p>
 <pre><code>    https://www.ioccc.org/whowon.html</code></pre>
 <p>We will also attempt to submit a brief announcement story to /.:</p>
 <pre><code>    https://slashdot.org</code></pre>
@@ -1110,7 +1110,7 @@ the winning authors are given a chance to review the judges comments,
 and test our Makefile. This review process typically takes a few weeks.</p>
 <p>Sometime after the initial announcement, and once the review
 by the winners has been completed, the winning source will be
-posted to the IOCCC web site:</p>
+posted to the IOCCC website:</p>
 <pre><code>    https://www.ioccc.org/years.html
 
     NOTE: previous winners are available at that URL</code></pre>
@@ -1119,7 +1119,7 @@ posted to the IOCCC web site:</p>
 <p>The IOCCC no longer uses twitter. IOCCC entries will be announced
 by a git commit to the IOCCC entries repo:</p>
 <pre><code>    https://github.com/ioccc-src/winner</code></pre>
-<p>that, in turn, updates the official IOCCC web site:</p>
+<p>that, in turn, updates the official IOCCC website:</p>
 <pre><code>    https://www.ioccc.org/index.html</code></pre>
 <p>In addition a note is posted to the IOCCC Mastodon account:</p>
 <pre><code>    https://fosstodon.org/@ioccc</code></pre>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -84,8 +84,8 @@ The IOCCC submission URL:
 Please wait to submit your entries until after that time.
 
 The official rules, guidelines and iocccsize.c tool will be available
-on the official IOCCC web site on or slightly before start of this IOCCC.
-Please check the IOCCC web site "How to enter" link:
+on the official IOCCC website on or slightly before start of this IOCCC.
+Please check the IOCCC website "How to enter" link:
 
 ```
     https://www.ioccc.org/index.html#enter
@@ -897,7 +897,7 @@ by a git commit to the IOCCC entries repo:
     https://github.com/ioccc-src/winner
 ```
 
-that, in turn, updates the offivial IOCCC web site:
+that, in turn, updates the offivial IOCCC website:
 
 ```
     https://www.ioccc.org/index.html
@@ -1031,7 +1031,7 @@ to be sure they are seeing the most recent tweets.
 
 The judges will then post an initial announcement of who won, the name
 of their award, and a very brief description of the winning entry
-on the IOCCC web site:
+on the IOCCC website:
 
 ```
     https://www.ioccc.org/whowon.html
@@ -1052,7 +1052,7 @@ and test our Makefile.  This review process typically takes a few weeks.
 
 Sometime after the initial announcement, and once the review
 by the winners has been completed, the winning source will be
-posted to the IOCCC web site:
+posted to the IOCCC website:
 
 ```
     https://www.ioccc.org/years.html
@@ -1072,7 +1072,7 @@ by a git commit to the IOCCC entries repo:
     https://github.com/ioccc-src/winner
 ```
 
-that, in turn, updates the official IOCCC web site:
+that, in turn, updates the official IOCCC website:
 
 ```
     https://www.ioccc.org/index.html

--- a/next/index.html
+++ b/next/index.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">

--- a/next/rules.html
+++ b/next/rules.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
@@ -439,7 +439,7 @@ for <strong>important information</strong> on how to submit to the IOCCC.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2020-Jan-15 12:21:37 UTC</strong>.
 Please wait to submit your entries until after that time.</p>
 <p>The official rules, guidelines and iocccsize.c tool will be available
-on the official IOCCC web site on or slightly before start of this IOCCC.</p>
+on the official IOCCC website on or slightly before start of this IOCCC.</p>
 <p>Please recheck on or after the start of this IOCCC to be sure you
 are using the correct versions of these items before using the IOCCC
 entry submission URL.</p>
@@ -602,7 +602,7 @@ in the subject of your email message when sending email to the judges.</p>
 <p>The rules and the guidelines may (and often do) change from year to
 year. You should be sure you have the current rules and guidelines
 prior to submitting entries.</p>
-<p><strong><code>|</code></strong> See the <a href="../index.html">Official IOCCC web site</a> for additional information.</p>
+<p><strong><code>|</code></strong> See the <a href="../index.html">Official IOCCC website</a> for additional information.</p>
 <p>For the updates and breaking IOCCC news, you are encouraged to follow
 the twitter handle:</p>
 <pre><code>    @IOCCC</code></pre>

--- a/next/rules.md
+++ b/next/rules.md
@@ -86,7 +86,7 @@ for **important information** on how to submit to the IOCCC.
 Please wait to submit your entries until after that time.
 
 The official rules, guidelines and iocccsize.c tool will be available
-on the official IOCCC web site on or slightly before start of this IOCCC.
+on the official IOCCC website on or slightly before start of this IOCCC.
 
 
 Please recheck on or after the start of this IOCCC to be sure you
@@ -388,7 +388,7 @@ The rules and the guidelines may (and often do) change from year to
 year.  You should be sure you have the current rules and guidelines
 prior to submitting entries.
 
-**`|`** See the [Official IOCCC web site](../index.html) for additional information.
+**`|`** See the [Official IOCCC website](../index.html) for additional information.
 
 For the updates and breaking IOCCC news, you are encouraged to follow
 the twitter handle:

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -401,7 +401,7 @@
 <li><a href="faq.html">FAQ</a></li>
 <li><a href="faq.html#fix_an_entry">How to enter the IOCCC</a></li>
 <li><a href="faq.html#fix_an_entry">Fixing IOCCC entries</a></li>
-<li><a href="faq.html#fix_web_site">Fixing the web site</a></li>
+<li><a href="faq.html#fix_web_site">Fixing the website</a></li>
 <li><a href="faq.html#fix_author">Fixing author info</a></li>
 </ul>
 <h2 id="about">About</h2>

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -18,7 +18,7 @@
 * [FAQ](faq.html)
 * [How to enter the IOCCC](faq.html#fix_an_entry)
 * [Fixing IOCCC entries](faq.html#fix_an_entry)
-* [Fixing the web site](faq.html#fix_web_site)
+* [Fixing the website](faq.html#fix_web_site)
 * [Fixing author info](faq.html#fix_author)
 
 ## About

--- a/status.html
+++ b/status.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">
@@ -441,7 +441,7 @@ registered email address.</p></li>
 <li><p>Announce who are authors of this year’s winning IOCCC entries via the <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> mastodon
 feed</a>.</p></li>
 <li><p>Upload the winning code to the <a href="https://github.com/ioccc-src/winner">Official IOCCC winner repo</a></p></li>
-<li><p>Update the <a href="index.html">Official IOCCC web site</a>, and in particular
+<li><p>Update the <a href="index.html">Official IOCCC website</a>, and in particular
 display this year’s winning IOCCC entries at the top of the <a href="years.html">IOCCC
 winning entries page</a>.</p></li>
 <li><p>Update the <a href="news.html">IOCCC news</a> page.</p></li>

--- a/status.md
+++ b/status.md
@@ -73,7 +73,7 @@ feed](https://fosstodon.org/@ioccc).
 
 * Upload the winning code to the [Official IOCCC winner repo](https://github.com/ioccc-src/winner)
 
-* Update the [Official IOCCC web site](index.html), and in particular
+* Update the [Official IOCCC website](index.html), and in particular
 display this year's winning IOCCC entries at the top of the [IOCCC
 winning entries page](years.html).
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -1390,11 +1390,9 @@ instructional to see the differences he has provided an alternate version,
 code.</p>
 <p>He also changed the <code>argc</code> to be an <code>int</code>, not a <code>char</code>, even though it might
 often be the same (this in particular was done for <code>clang</code>).</p>
-<p>He also fixed the code to not enter an infinite loop if arg is a number not &gt; 0
-and to not crash if no arg is specified. This was done during a time it was
-deemed a problem to be fixed.</p>
-<p>NOTE: the alternate code did NOT have arg checks added as it is actually a copy of the
-original code.</p>
+<p>He also fixed the code to not enter an infinite loop if arg is a number not &gt; 0.
+To be more like the original the number of args passed to the program has not
+been fixed so that if one passes no arg it will still likely crash.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/try.sh">try.sh</a> script.</p>
 <div id="1991">
 <h1 id="the-8th-ioccc"><a href="1991/index.html">1991 - The 8th IOCCC</a></h1>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1429,12 +1429,9 @@ code.
 He also changed the `argc` to be an `int`, not a `char`, even though it might
 often be the same (this in particular was done for `clang`).
 
-He also fixed the code to not enter an infinite loop if arg is a number not > 0
-and to not crash if no arg is specified. This was done during a time it was
-deemed a problem to be fixed.
-
-NOTE: the alternate code did NOT have arg checks added as it is actually a copy of the
-original code.
+He also fixed the code to not enter an infinite loop if arg is a number not > 0.
+To be more like the original the number of args passed to the program has not
+been fixed so that if one passes no arg it will still likely crash.
 
 Cody also added the [try.sh](%%REPO_URL%%/1990/westley/try.sh) script.
 

--- a/years.html
+++ b/years.html
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_web_site" class="sub-item-link">
-                Fixing the web site
+                Fixing the website
               </a>
             </div>
 
@@ -283,7 +283,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_web_site">
-              Fixing the web site
+              Fixing the website
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#fix_author">


### PR DESCRIPTION

This is a huge update with 470 files updated. This includes the scripts
and config files that generate the html files that have (now) 'Fix the
website' (was 'Fix the web site') but mostly the html files that were
generated from scripts and markdown files. This is the only change in
the commit so although there are a lot of files to look at in the diff
it should be easy to compare.

The rationale, for those who might be curious: there was an
inconsistency where in some files it was 'web site' (most files) and
others 'website' (those by me). Since this was inconsistent I brought it
up on GitHub and it was suggested that it should all be 'website'.
