### PR TITLE
Restore web site to 2011/dlowe training data

### DIFF
--- a/2011/dlowe/dlowe-aux-data/english-1/Wireless_Days_2011_CFP.txt
+++ b/2011/dlowe/dlowe-aux-data/english-1/Wireless_Days_2011_CFP.txt
@@ -48,7 +48,7 @@ Papers Submission:
 Submissions should be original and limited to 5 double-column pages,
 and should follow IEEE paper templates. Paper with more pages can be
 accepted however they need to be reduced to 5 pages for publication.
-Papers are to be submitted electronically on the EDAS website of the
+Papers are to be submitted electronically on the EDAS web site of the
 conference in PDF format.
 
 http://edas.info//N10969


### PR DESCRIPTION
Since GitHub has a problem with showing really big commits it seemed like my attempts at changing 'web site' to 'website' were incomplete but they were not. Something I noticed the first time shortly before I closed that commit (as it seemed to be a problem) that I ended up changing the file:

	2011/dlowe/dlowe-aux-data/english-1/Wireless_Days_2011_CFP.txt

as well. The problem is that this was a file used to train the neural network of the entry so it should not have the change made.