### PR TITLE
Fix typos in next/README.md, run make gen_top_html

### DIFF
--- a/next/README.md
+++ b/next/README.md
@@ -65,10 +65,10 @@ about any **changes**.
 When the IOCCC status is **_judging_**, the [rules](rules.html) and [guidelines](guidelines.html) are
 for the current IOCCC **that is _no longer open_ for new submissions**.
 
-See the [IOCCC news](../news.html) and well as the [IOCCC
+See the [IOCCC news](../news.html) as well as the [IOCCC
 Mastodon](https://fosstodon.org/@ioccc) feed for updates
 on the IOCCC judging process as well as for the announcement
-for [who won the IOCCC](../years.html).
+of [who won the IOCCC](../years.html).
 
 
 <!--

--- a/next/index.html
+++ b/next/index.html
@@ -427,10 +427,10 @@ about any <strong>changes</strong>.</p>
 <h3 id="when-the-ioccc-status-is-judging">When the IOCCC status is <em>judging</em></h3>
 <p>When the IOCCC status is <strong><em>judging</em></strong>, the <a href="rules.html">rules</a> and <a href="guidelines.html">guidelines</a> are
 for the current IOCCC <strong>that is <em>no longer open</em> for new submissions</strong>.</p>
-<p>See the <a href="../news.html">IOCCC news</a> and well as the <a href="https://fosstodon.org/@ioccc">IOCCC
+<p>See the <a href="../news.html">IOCCC news</a> as well as the <a href="https://fosstodon.org/@ioccc">IOCCC
 Mastodon</a> feed for updates
 on the IOCCC judging process as well as for the announcement
-for <a href="../years.html">who won the IOCCC</a>.</p>
+of <a href="../years.html">who won the IOCCC</a>.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.


### PR DESCRIPTION
One typo was fixed and wording was slightly changed in one thing which is not really a typo but might be clearer now (if only slightly).

The links seem okay though I did not go through them in the browser as each section has the same links and it is easier to check them in vim than going back and forth in the browser between pages. It should all be good.

Thus next/README.md and next/index.html have been updated and can be considered completely reviewed at this time.