### PR TITLE
Check links/formatting in remaining next/ files

### DIFF
--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -384,7 +384,7 @@
 <!-- BEFORE: 1st line of markdown file: next/guidelines.md -->
 <!-- START: this line starts content from: inc/guidelines.closed.hdr -->
 <h1 id="warning-these-guidelines-are-out-of-date">WARNING: These guidelines are OUT OF DATE</h1>
-<p>They are a <strong>very tentative proposal</strong> for the next IOCCC
+<p>These guidelines are a <strong>very tentative proposal</strong> for the next IOCCC
 that is <strong>VERY LIKELY</strong> to be updated before the next IOCCC.
 They are are provided as a <strong>very tentative</strong> hint at what
 might be used in a future IOCCC.</p>
@@ -396,46 +396,48 @@ might be used in a future IOCCC.</p>
 <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> mastodon feed</a> for information about future IOCCC openings.</p>
 <!-- END: the next line ends content from: inc/guidelines.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
-<h1 id="th-international-obfuscated-c-code-contest-official-guidelines">27th International Obfuscated C Code Contest Official Guidelines</h1>
+<h1 id="th-international-obfuscated-c-code-contest-official-guidelines">28th International Obfuscated C Code Contest Official Guidelines</h1>
 <p>Copyright © 2024 Leonid A. Broukhis, Landon Curt Noll.</p>
 <p>All Rights Reserved. Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered. All other uses must receive prior permission in
-writing from the contest judges.</p>
+writing by <a href="../contact.html">contacting the judges</a>.</p>
 <h2 id="guidelines-version">Guidelines version</h2>
 <p><strong><code>|</code></strong> This guidelines file is version <strong>2023-04-04-v28</strong>.</p>
-<p><strong>IMPORTANT</strong>: Be sure to read the <a href="rules.html">IOCCC rules</a>.</p>
+<p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <h3 id="change-marks">Change marks</h3>
 <p><strong><code>|</code></strong> <strong>← Lines that start with this symbol indicate a change from the previous IOCCC</strong></p>
-<p>Most lines (we sometimes make mistakes) that were modified start the <strong><code>|</code></strong> symbol.</p>
+<p>Most lines (we sometimes make mistakes) that were modified since the previous
+IOCCC start with the <strong><code>|</code></strong> symbol.</p>
 <h1 id="about-this-file">ABOUT THIS FILE:</h1>
-<p>This file contains guidelines intended to help people who wish to
-submit entries to the International Obfuscated C Code Contest (IOCCC).</p>
-<p>This is not the IOCCC rules, though it does contain comments about
-them. The guidelines should be viewed as hints and suggestions.
+<p>This file contains <em>guidelines</em> intended to help people who wish to
+submit entries to the <a href="https://www.ioccc.org">International Obfuscated C Code Contest
+(IOCCC)</a>.</p>
+<p>These are not the IOCCC rules, though it does contain comments about
+them. The guidelines should be viewed as <em>hints</em> and <em>suggestions</em>.
 Entries that violate the guidelines but remain within the rules are
 allowed. Even so, you are safer if you remain within the guidelines.</p>
-<p>You should read the current IOCCC rules, prior to submitting entries.
+<p>You should read the current <a href="rules.html">IOCCC rules</a>, prior to submitting entries.
 The rules are typically sent out with these guidelines.</p>
 <h1 id="whats-new-in-20192020">WHAT’S NEW IN 2019/2020</h1>
 <p><strong><code>|</code></strong> This IOCCC runs from <strong>2019-Dec-26 06:01:41 UTC</strong> to <strong>2020-Mar-15 06:26:49 UTC</strong>.</p>
 <p><strong><code>|</code></strong> The reason for the times of day are so that key IOCCC events occur during UTC
 <strong><code>|</code></strong> “prime time”. Do you understand why we factored this into the rules and
 <strong><code>|</code></strong> guidelines? :-)</p>
-<p>Until the start of this IOCCC, these rules, guidelines and iocccsize.c tool
-should be considered provisional BETA versions and may be adjusted
-at any time.</p>
+<p>Until the start of this IOCCC, these rules, guidelines and iocccsize.c
+(contained in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+toolkit</a>)
+tool should be considered provisional <strong>BETA</strong> versions and may be
+adjusted <strong>AT ANY TIME</strong>.</p>
 <p><strong><code>|</code></strong> Even though the contest will start in 2019, because the contest will close
 <strong><code>|</code></strong> in 2020, URLs, subject lines, and contest related email addresses use 2019.</p>
-<p>The IOCCC submission URL:</p>
-<pre><code>    https://submit.ioccc.org/</code></pre>
+<p>The IOCCC submission URL is <a href="https://submit.ioccc.org/" class="uri">https://submit.ioccc.org/</a>.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2020-Jan-15 12:21:37 UTC</strong>.</p>
 <p>Please wait to submit your entries until after that time.</p>
-<p>The official rules, guidelines and iocccsize.c tool will be available
+<p>The official rules, guidelines and iocccsize.c (invoked by the mkiocccentry) tool will be available
 on the official IOCCC website on or slightly before start of this IOCCC.
-Please check the IOCCC website “How to enter” link:</p>
-<pre><code>    https://www.ioccc.org/index.html#enter</code></pre>
-<p>on or after the start of this IOCCC to be sure you are using the correct
+Please check the IOCCC FAQ <a href="../faq#submit">How to submit</a>.
+on or after the start of this IOCCC to be sure you are using the correct
 versions of these items before using the IOCCC entry submission URL.</p>
 <h1 id="hints-and-suggestions">HINTS AND SUGGESTIONS:</h1>
 <p>You are encouraged to examine the winners of previous contests. See
@@ -568,9 +570,11 @@ and enjoy your entry.</p>
 So try to ensure that your entry compiles warning free. If possible,
 to compile compile your code using:</p>
 <pre><code>    -Wall -Wextra -pedantic</code></pre>
-<p>For compilers, such as clang, that have the -Weverything option, try
+<p>For compilers, such as clang, that have the <code>-Weverything</code> option, try
 to make your code compile warning free using:</p>
 <pre><code>    -Wall -Wextra -Weverything -pedantic</code></pre>
+<p>.. though see <a href="../faq.html#faq3_11">Why do Makefiles use -Weverything with
+clang?</a> in the <a href="../faq.html">FAQ</a>.</p>
 <p>If you must turn off various warnings on the compile line such as:</p>
 <pre><code>    ... -Wno-empty-body -Wno-return-type ...</code></pre>
 <p>be sure to clearly state so in your remarks AS WELL AS in
@@ -588,7 +592,7 @@ except in one small part (ISO/IEC 9899:2011) where they might not truly
 understand the implications of such words.</p>
 <pre><code>    http://hitchhikers.wikia.com/wiki/Belgium
     http://www.bezem.de/pdf/ReservedWordsInC.pdf</code></pre>
-<p>DO NOT assume that we will use gcc to compile your program.
+<p><strong>DO NOT</strong> assume that we will use gcc to compile your program.
 We will first try to compile your program using Clang.</p>
 <p>It is much better to not use any obscure compiler flags if
 you can help it. We want to discourage the use of obscure compiler
@@ -602,7 +606,7 @@ of nested functions such as:</p>
 |       please_do_not_submit_this();
     }</code></pre>
 <p>This is because such nested functions often requires one to compile with
-a flag such as -fnested-functions that is not found on some compilers.</p>
+a flag such as <code>-fnested-functions</code> that is not found on some compilers.</p>
 <p>On 2012 July 20, the judges rescinded the encouragement of
 nested functions. Such constructions, while interesting and sometimes
 amusing, will have to wait until they required by a C standard that are
@@ -610,23 +614,23 @@ actually implemented in commonly used C compilers. Sorry!</p>
 <p><strong><code>|</code></strong> We prefer programs that do not require a fish license: crayons and
 <strong><code>|</code></strong> cat detector vans not withstanding.</p>
 <p>If your entry uses functions that have a variable number of
-arguments, be careful. Systems implement va_list as a wide variety
-of ways. Because of this, a number of operations using va_list are
+arguments, be careful. Systems implement <code>va_list</code> as a wide variety
+of ways. Because of this, a number of operations using <code>va_list</code> are
 not portable and must not be used:</p>
 <ul>
-<li>assigning a non-va_list variable to/from a va_list variable</li>
-<li>casting a non-va_list variable into/from a va_list variable</li>
-<li>passing a va_list variable to a function expecting a non-va_list arg</li>
-<li>passing a non-va_list variable to a function expecting a va_list arg</li>
-<li>performing arithmetic on va_list variables</li>
-<li>using va_list as a structure or union</li>
+<li>assigning a non-<code>va_list</code> variable to/from a <code>va_list</code> variable</li>
+<li>casting a non-<code>va_list</code> variable into/from a <code>va_list</code> variable</li>
+<li>passing a <code>va_list</code> variable to a function expecting a non-<code>va_list</code> arg</li>
+<li>passing a non-<code>va_list</code> variable to a function expecting a <code>va_list</code> arg</li>
+<li>performing arithmetic on <code>va_list</code> variables</li>
+<li>using <code>va_list</code> as a structure or union</li>
 </ul>
-<p>In particular, do not treat va_list variables as if they were a char **’s.</p>
-<p>Avoid using &lt;varargs.h&gt;. Use &lt;stdarg.h&gt; instead.</p>
+<p>In particular, do not treat <code>va_list</code> variables as if they were a <code>char **</code>s.</p>
+<p>Avoid using <code>varargs.h</code>. Use <code>stdarg.h</code> instead.</p>
 <p>On 28 January 2007, the Judges rescinded the requirement that the
-’#” in a C preprocessor directive must be the 1st non-whitespace octet.</p>
-<p>The exit() function returns void. Some broken systems have exit()
-return int, your entry should assume that exit() returns a void.</p>
+<code>#</code> in a C preprocessor directive must be the 1st non-whitespace octet.</p>
+<p>The <code>exit(3)</code> function returns void. Some broken systems have <code>exit(3)</code>
+return <code>int</code>, your entry should assume that <code>exit(3)</code> returns a <code>void</code>.</p>
 <p><strong><code>|</code></strong> This guideline has a change mark at the very start of this line.</p>
 <p>Small programs are best when they are short, obscure and concise.
 While such programs are not as complex as other winners, they do
@@ -697,13 +701,13 @@ operating systems (i.e., Linux, GNU Hurd, BSD, Unix, etc.).</p>
 <p>There are at least zero judges who think that Fideism has little
 or nothing to do with the IOCCC judging process.</p>
 <p>Don’t forget that the building of your program should be done
-<strong><em>without human intervention</em></strong>. So don’t do things such as:</p>
+<strong><em>WITHOUT human intervention</em></strong>. So don’t do things such as:</p>
 <pre><code>    prog: prog.c
         #echo this next line requires data from standard input
         cat &gt; prog.c
         ${CC} prog.c -o prog</code></pre>
 <p>However, you can do something cute such as making your program
-do something dumb (or cute) when it is built ‘automatically’. And
+do something dumb (or cute) when it is built ‘automatically’, and
 when it is run with a human involved, do something more clever.
 For example, one could use the build instructions:</p>
 <pre><code>    prog: prog.c
@@ -713,14 +717,14 @@ For example, one could use the build instructions:</p>
 alternate / human intervention based building.</p>
 <p>We want to get away from source that is simply a compact blob of
 octets. Really try to be more creative than blob coding. <em>HINT!</em></p>
-<p>Please do not use things like gzip to get around the size limit.
+<p>Please do not use things like <code>gzip(1)</code> to get around the size limit.
 Please try to be much more creative.</p>
 <p>We really dislike entries that make blatant use of including
 large data files to get around the source code size limit.</p>
-<p>We do not recommend submitting systemd source code to the IOCCC,
+<p>We do not recommend submitting <a href="https://systemd.io">systemd</a> source code to the IOCCC,
 if nothing else because that code is likely to exceed the source code
 size limit. This isn’t to say that another highly compact and obfuscated
-replacement of init would not be an interesting submission.</p>
+replacement of <code>init</code> would not be an interesting submission.</p>
 <p>Did we remember to indicate that programs that blatantly use
 some complex state machine to do something simple are boring?
 We think we did. :-)</p>
@@ -732,7 +736,7 @@ version of the same program that is formatted in an interesting
 and/or obfuscated way, would definitely win over the first two!
 Remember, you can submit more than one entry. See the rules for details.</p>
 <p>We suggest that you avoid trying for the ‘smallest self-replicating’
-source. The smallest, a zero byte entry, won in 1994.</p>
+source. The smallest, a zero byte entry, <a href="../1994/smr/index.html">won in 1994</a>.</p>
 <p>Programs that claim to be the smallest C source that does something, really
 better be the smallest such program or they risk being rejected because
 they do not work as documented.</p>
@@ -813,7 +817,7 @@ read so many twisted entries, you too would enjoy a good laugh or two.
 We think the readers of the contest winners do as well. We do read
 the program “remarks” during the judging process, so it is worth your
 while to write remarkable program “remarks”.</p>
-<p>We dislike C code with trailing control-M’s (r \015) that results
+<p>We dislike C code with trailing control-M’s (<code>\r</code> or <code>\015</code>) that results
 in compilation failures. Some non-Unix/non-Linux tools such as
 MS Visual C and MS Visual C++ leave trailing control-M’s on lines.
 Users of such tools should strip off such control-M’s before submitting
@@ -832,7 +836,7 @@ Instead of unescaped octets, you should use or escapes:</p>
 <p>It is a very good idea to, in your remarks file, tell us why you
 think your entry is obfuscated. This is particularly true if
 your entry is has some very subtle obfuscations that we might
-otherwise overlook. &lt;&lt;– Hint!</p>
+otherwise overlook. <strong>&lt;&lt;– Hint!</strong></p>
 <p>Anyone can format their code into a dense blob. A really clever
 author will try format their entry using a “normal” formatting style
 such that at first glance (if you squint and don’t look at the details)
@@ -941,11 +945,11 @@ sales, product management an even from customers themselves on a
 all too regular basis. This is one of the reasons why the rules and
 guidelines are written in obfuscated form.</p>
 <h1 id="judging-process">JUDGING PROCESS:</h1>
-<p>Entries are judged by Leonid A. Broukhis, Simon Cooper, Landon Curt Noll.</p>
+<p>Entries are judged by Leonid A. Broukhis and Landon Curt Noll.</p>
 <p>Each entry submitted is given a random id number and subdirectory. The
 entry files including, but not limited to prog.c, Makefile (that we
 form from around your “how to build” information), as well as any
-data files that you submit are all placed under their own directory.
+data files that you submit are all placed under their own directory
 stored and judged from this directory.</p>
 <p>Any information about the authors is not read by the judges until
 the judging process is complete, and then only from entries that have
@@ -959,7 +963,7 @@ about the others. However we consider this to be simply circumstantial
 and outside the scope of the above paragraph.</p>
 <p>Some people, in the past, have attempted to obfuscate their identity by
 including comments of famous Internet personalities such as Peter Honeyman
-(http://www.citi.umich.edu/u/honey/). The judges are on to this
+(<a href="http://www.citi.umich.edu/u/honey/" class="uri">http://www.citi.umich.edu/u/honey/</a>). The judges are on to this
 trick and therefore consider any obfuscated source or data file
 claiming to be from Honeyman to not be form Honeyman. This of course
 creates an interesting paradox known as the “obfuscated Peter Honeyman
@@ -972,7 +976,7 @@ won an award. So it is theoretically possible that Peter Honeyman
 did submit an entry in the past. In the past, Peter had denied
 submitting anything to the IOCCC. Perhaps those entries were
 submitted by one of his students?</p>
-<p>Hopefully we are very CLEAR on this point! The rules now strongly state:
+<p>Hopefully we are <strong>VERY CLEAR</strong> on this point! The rules now strongly state:
 PLEASE DO NOT put a name of an author, in an obvious way, into your
 source code, remarks, data files, etc. The above “Peter Honeyman is
 exempt” not withstanding.</p>
@@ -985,7 +989,7 @@ Because the main ‘prize’ of winning is being announced, we make all
 attempts to send non-winners into oblivion. We remove all non-winning
 files, and shred all related paper. By tradition, we do not even
 reveal the number of entries that we received.</p>
-<p>During the judging process. a process that spans multiple sessions
+<p>During the judging process, a process that spans multiple sessions
 over a few weeks, post general updates from our <span class="citation" data-cites="IOCCC">@IOCCC</span> twitter account.</p>
 <p>Once we have selected the winners, for each category we will tweet:</p>
 <ul>
@@ -1002,12 +1006,12 @@ often accept their suggestions/comments about our remarks as well.
 This is done prior to posting the winners to the wide world.</p>
 <h2 id="an-important-2023-update-to-how-winners-are-announced">An important 2023 update to how winners are announced</h2>
 <p>The IOCCC no longer uses twitter. IOCCC entries will be announced
-by a git commit to the IOCCC entries repo:</p>
-<pre><code>    https://github.com/ioccc-src/winner</code></pre>
-<p>that, in turn, updates the offivial IOCCC website:</p>
-<pre><code>    https://www.ioccc.org/index.html</code></pre>
-<p>In addition a note is posted to the IOCCC Mastodon account:</p>
-<pre><code>    https://fosstodon.org/@ioccc</code></pre>
+by a git commit to the <a href="https://github.com/ioccc-src/winner">IOCCC entries
+repo</a>.</p>
+<p>that, in turn, updates the <a href="https://www.ioccc.org/index.html">official IOCCC
+website</a>.</p>
+<p>In addition a note is posted to the IOCCC Mastodon account
+(<a href="https://fosstodon.org/@ioccc" class="uri">https://fosstodon.org/@ioccc</a>).</p>
 <h2 id="back-to-the-judging-process">Back to the Judging process</h2>
 <p>Judging consists of a number of elimination rounds. During a round,
 the collection of entries are divided into two roughly equal piles;
@@ -1123,7 +1127,7 @@ by a git commit to the IOCCC entries repo:</p>
 <pre><code>    https://www.ioccc.org/index.html</code></pre>
 <p>In addition a note is posted to the IOCCC Mastodon account:</p>
 <pre><code>    https://fosstodon.org/@ioccc</code></pre>
-<h2 id="back-to-annoucement-of-winners">Back to annoucement of winners</h2>
+<h2 id="back-to-announcement-of-winners">Back to announcement of winners</h2>
 <p>It is pointless to ask the IOCCC judges how many entries we receive.
 Other government TLA or FLA snooping organizations are prohibited from
 either confirming, denying or revealing any knowledge of this data point.</p>
@@ -1133,8 +1137,8 @@ and on T-Shirts. More than one winner has been turned in a tattoo!</p>
 <p>Last, but not least, winners receive international fame and flames! :-)</p>
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 <p>You may contact the judges by sending email to the following address:</p>
-<pre><code>|   q.2020@ioccc.org        (do not submit entries to this address)</code></pre>
-<p><strong><code>|</code></strong> You must include the words ‘ioccc 2020 question’ in the subject of your
+<pre><code>|   q.2024@ioccc.org        (do not submit entries to this address)</code></pre>
+<p><strong><code>|</code></strong> You must include the words ‘ioccc 2024 question’ in the subject of your
 email message when sending email to the judges.</p>
 <p>Questions and comments about the contest are welcome. Comments about
 confusing rules and guidelines are also welcome.</p>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -2,7 +2,7 @@
 
 # WARNING: These guidelines are OUT OF DATE
 
-They are a **very tentative proposal** for the next IOCCC
+These guidelines are a **very tentative proposal** for the next IOCCC
 that is **VERY LIKELY** to be updated before the next IOCCC.
 They are are provided as a **very tentative** hint at what
 might be used in a future IOCCC.
@@ -20,41 +20,43 @@ Watch both [the IOCCC status page](../status.html) and the
 
 <!-- END: the next line ends content from: inc/guidelines.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
-# 27th International Obfuscated C Code Contest Official Guidelines
+# 28th International Obfuscated C Code Contest Official Guidelines
 
 Copyright &copy; 2024 Leonid A. Broukhis, Landon Curt Noll.
 
 All Rights Reserved.  Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered.  All other uses must receive prior permission in
-writing from the contest judges.
+writing by [contacting the judges](../contact.html).
 
 
 ## Guidelines version
 
 **`|`** This guidelines file is version **2023-04-04-v28**.
 
-**IMPORTANT**: Be sure to read the [IOCCC rules](rules.html).
+**IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
 
 
 ### Change marks
 
 **`|`** **&larr; Lines that start with this symbol indicate a change from the previous IOCCC**
 
-Most lines (we sometimes make mistakes) that were modified start the **`|`** symbol.
+Most lines (we sometimes make mistakes) that were modified since the previous
+IOCCC start with the **`|`** symbol.
 
 
 # ABOUT THIS FILE:
 
-This file contains guidelines intended to help people who wish to
-submit entries to the International Obfuscated C Code Contest (IOCCC).
+This file contains _guidelines_ intended to help people who wish to
+submit entries to the [International Obfuscated C Code Contest
+&#x28;IOCCC&#x29;](https://www.ioccc.org).
 
-This is not the IOCCC rules, though it does contain comments about
-them.  The guidelines should be viewed as hints and suggestions.
+These are not the IOCCC rules, though it does contain comments about
+them.  The guidelines should be viewed as _hints_ and _suggestions_.
 Entries that violate the guidelines but remain within the rules are
 allowed.  Even so, you are safer if you remain within the guidelines.
 
-You should read the current IOCCC rules, prior to submitting entries.
+You should read the current [IOCCC rules](rules.html), prior to submitting entries.
 The rules are typically sent out with these guidelines.
 
 
@@ -66,31 +68,24 @@ The rules are typically sent out with these guidelines.
 **`|`**   "prime time".  Do you understand why we factored this into the rules and
 **`|`**   guidelines?  :-)
 
-Until the start of this IOCCC, these rules, guidelines and iocccsize.c tool
-should be considered provisional BETA versions and may be adjusted
-at any time.
+Until the start of this IOCCC, these rules, guidelines and iocccsize.c
+(contained in the [mkiocccentry
+toolkit](https://github.com/ioccc-src/mkiocccentry))
+tool should be considered provisional **BETA** versions and may be
+adjusted **AT ANY TIME**.
 
 **`|`**   Even though the contest will start in 2019, because the contest will close
 **`|`**   in 2020, URLs, subject lines, and contest related email addresses use 2019.
 
-The IOCCC submission URL:
-
-```
-    https://submit.ioccc.org/
-```
+The IOCCC submission URL is <https://submit.ioccc.org/>.
 
 **`|`**   The submit URL should be active on or slightly before **2020-Jan-15 12:21:37 UTC**.
 
 Please wait to submit your entries until after that time.
 
-The official rules, guidelines and iocccsize.c tool will be available
+The official rules, guidelines and iocccsize.c (invoked by the mkiocccentry) tool will be available
 on the official IOCCC website on or slightly before start of this IOCCC.
-Please check the IOCCC website "How to enter" link:
-
-```
-    https://www.ioccc.org/index.html#enter
-```
-
+Please check the IOCCC FAQ [How to submit](../faq#submit).
 on or after the start of this IOCCC to be sure you are using the correct
 versions of these items before using the IOCCC entry submission URL.
 
@@ -280,12 +275,16 @@ to compile compile your code using:
     -Wall -Wextra -pedantic
 ```
 
-For compilers, such as clang, that have the -Weverything option, try
+For compilers, such as clang, that have the `-Weverything` option, try
 to make your code compile warning free using:
 
 ```
     -Wall -Wextra -Weverything -pedantic
 ```
+
+.. though see [Why do Makefiles use -Weverything with
+clang?](../faq.html#faq3_11) in the [FAQ](../faq.html).
+
 
 If you must turn off various warnings on the compile line such as:
 
@@ -318,7 +317,7 @@ understand the implications of such words.
     http://www.bezem.de/pdf/ReservedWordsInC.pdf
 ```
 
-DO NOT assume that we will use gcc to compile your program.
+**DO NOT** assume that we will use gcc to compile your program.
 We will first try to compile your program using Clang.
 
 It is much better to not use any obscure compiler flags if
@@ -338,7 +337,7 @@ of nested functions such as:
 ```
 
 This is because such nested functions often requires one to compile with
-a flag such as -fnested-functions that is not found on some compilers.
+a flag such as `-fnested-functions` that is not found on some compilers.
 
 On 2012 July 20, the judges rescinded the encouragement of
 nested functions.  Such constructions, while interesting and sometimes
@@ -349,26 +348,26 @@ actually implemented in commonly used C compilers.  Sorry!
 **`|`**   cat detector vans not withstanding.
 
 If your entry uses functions that have a variable number of
-arguments, be careful. Systems implement va_list as a wide variety
-of ways.  Because of this, a number of operations using va_list are
+arguments, be careful. Systems implement `va_list` as a wide variety
+of ways.  Because of this, a number of operations using `va_list` are
 not portable and must not be used:
 
-* assigning a non-va_list variable to/from a va_list variable
-* casting a non-va_list variable into/from a va_list variable
-* passing a va_list variable to a function expecting a non-va_list arg
-* passing a non-va_list variable to a function expecting a va_list arg
-* performing arithmetic on va_list variables
-* using va_list as a structure or union
+* assigning a non-`va_list` variable to/from a `va_list` variable
+* casting a non-`va_list` variable into/from a `va_list` variable
+* passing a `va_list` variable to a function expecting a non-`va_list` arg
+* passing a non-`va_list` variable to a function expecting a `va_list` arg
+* performing arithmetic on `va_list` variables
+* using `va_list` as a structure or union
 
-In particular, do not treat va_list variables as if they were a char **'s.
+In particular, do not treat `va_list` variables as if they were a `char **`s.
 
-Avoid using <varargs.h>.  Use <stdarg.h> instead.
+Avoid using `varargs.h`.  Use `stdarg.h` instead.
 
 On 28 January 2007, the Judges rescinded the requirement that the
-'#" in a C preprocessor directive must be the 1st non-whitespace octet.
+`#` in a C preprocessor directive must be the 1st non-whitespace octet.
 
-The exit() function returns void.  Some broken systems have exit()
-return int, your entry should assume that exit() returns a void.
+The `exit(3)` function returns void.  Some broken systems have `exit(3)`
+return `int`, your entry should assume that `exit(3)` returns a `void`.
 
 **`|`**   This guideline has a change mark at the very start of this line.
 
@@ -458,7 +457,7 @@ There are at least zero judges who think that Fideism has little
 or nothing to do with the IOCCC judging process.
 
 Don't forget that the building of your program should be done
-***without human intervention***.  So don't do things such as:
+***WITHOUT human intervention***.  So don't do things such as:
 
 ```
     prog: prog.c
@@ -468,7 +467,7 @@ Don't forget that the building of your program should be done
 ```
 
 However, you can do something cute such as making your program
-do something dumb (or cute) when it is built 'automatically'.  And
+do something dumb (or cute) when it is built 'automatically', and
 when it is run with a human involved, do something more clever.
 For example, one could use the build instructions:
 
@@ -484,16 +483,16 @@ alternate / human intervention based building.
 We want to get away from source that is simply a compact blob of
 octets.   Really try to be more creative than blob coding. *HINT!*
 
-Please do not use things like gzip to get around the size limit.
+Please do not use things like `gzip(1)` to get around the size limit.
 Please try to be much more creative.
 
 We really dislike entries that make blatant use of including
 large data files to get around the source code size limit.
 
-We do not recommend submitting systemd source code to the IOCCC,
+We do not recommend submitting [systemd](https://systemd.io) source code to the IOCCC,
 if nothing else because that code is likely to exceed the source code
 size limit.  This isn't to say that another highly compact and obfuscated
-replacement of init would not be an interesting submission.
+replacement of `init` would not be an interesting submission.
 
 Did we remember to indicate that programs that blatantly use
 some complex state machine to do something simple are boring?
@@ -509,7 +508,7 @@ and/or obfuscated way, would definitely win over the first two!
 Remember, you can submit more than one entry.  See the rules for details.
 
 We suggest that you avoid trying for the 'smallest self-replicating'
-source.  The smallest, a zero byte entry, won in 1994.
+source.  The smallest, a zero byte entry, [won in 1994](../1994/smr/index.html).
 
 Programs that claim to be the smallest C source that does something, really
 better be the smallest such program or they risk being rejected because
@@ -620,7 +619,7 @@ We think the readers of the contest winners do as well.  We do read
 the program "remarks" during the judging process, so it is worth your
 while to write remarkable program "remarks".
 
-We dislike C code with trailing control-M's (\r or \015) that results
+We dislike C code with trailing control-M's (`\r` or `\015`) that results
 in compilation failures.  Some non-Unix/non-Linux tools such as
 MS Visual C and MS Visual C++ leave trailing control-M's on lines.
 Users of such tools should strip off such control-M's before submitting
@@ -645,7 +644,7 @@ Instead of unescaped octets, you should use \octal or \hex escapes:
 It is a very good idea to, in your remarks file, tell us why you
 think your entry is obfuscated.  This is particularly true if
 your entry is has some very subtle obfuscations that we might
-otherwise overlook.  <<-- Hint!
+otherwise overlook.  **<<-- Hint!**
 
 Anyone can format their code into a dense blob.  A really clever
 author will try format their entry using a "normal" formatting style
@@ -815,12 +814,12 @@ guidelines are written in obfuscated form.
 
 # JUDGING PROCESS:
 
-Entries are judged by Leonid A. Broukhis, Simon Cooper, Landon Curt Noll.
+Entries are judged by Leonid A. Broukhis and Landon Curt Noll.
 
 Each entry submitted is given a random id number and subdirectory.  The
 entry files including, but not limited to prog.c, Makefile (that we
 form from around your "how to build" information), as well as any
-data files that you submit are all placed under their own directory.
+data files that you submit are all placed under their own directory
 stored and judged from this directory.
 
 Any information about the authors is not read by the judges until
@@ -838,7 +837,7 @@ and outside the scope of the above paragraph.
 
 Some people, in the past, have attempted to obfuscate their identity by
 including comments of famous Internet personalities such as Peter Honeyman
-(http://www.citi.umich.edu/u/honey/).  The judges are on to this
+(<http://www.citi.umich.edu/u/honey/>).  The judges are on to this
 trick and therefore consider any obfuscated source or data file
 claiming to be from Honeyman to not be form Honeyman.  This of course
 creates an interesting paradox known as the "obfuscated Peter Honeyman
@@ -853,7 +852,7 @@ did submit an entry in the past.  In the past, Peter had denied
 submitting anything to the IOCCC.  Perhaps those entries were
 submitted by one of his students?
 
-Hopefully we are very CLEAR on this point!  The rules now strongly state:
+Hopefully we are **VERY CLEAR** on this point!  The rules now strongly state:
 PLEASE DO NOT put a name of an author, in an obvious way, into your
 source code, remarks, data files, etc.  The above "Peter Honeyman is
 exempt" not withstanding.
@@ -870,7 +869,7 @@ attempts to send non-winners into oblivion.  We remove all non-winning
 files, and shred all related paper.  By tradition, we do not even
 reveal the number of entries that we received.
 
-During the judging process. a process that spans multiple sessions
+During the judging process, a process that spans multiple sessions
 over a few weeks, post general updates from our @IOCCC twitter account.
 
 Once we have selected the winners, for each category we will tweet:
@@ -891,23 +890,14 @@ This is done prior to posting the winners to the wide world.
 ## An important 2023 update to how winners are announced
 
 The IOCCC no longer uses twitter.  IOCCC entries will be announced
-by a git commit to the IOCCC entries repo:
+by a git commit to the [IOCCC entries
+repo](https://github.com/ioccc-src/winner).
 
-```
-    https://github.com/ioccc-src/winner
-```
+that, in turn, updates the [official IOCCC
+website](https://www.ioccc.org/index.html).
 
-that, in turn, updates the offivial IOCCC website:
-
-```
-    https://www.ioccc.org/index.html
-```
-
-In addition a note is posted to the IOCCC Mastodon account:
-
-```
-    https://fosstodon.org/@ioccc
-```
+In addition a note is posted to the IOCCC Mastodon account
+(<https://fosstodon.org/@ioccc>).
 
 
 ## Back to the Judging process
@@ -1085,7 +1075,7 @@ In addition a note is posted to the IOCCC Mastodon account:
 ```
 
 
-## Back to annoucement of winners
+## Back to announcement of winners
 
 It is pointless to ask the IOCCC judges how many entries we receive.
 Other government TLA or FLA snooping organizations are prohibited from
@@ -1103,10 +1093,10 @@ Last, but not least, winners receive international fame and flames!  :-)
 You may contact the judges by sending email to the following address:
 
 ```
-|   q.2020@ioccc.org        (do not submit entries to this address)
+|   q.2024@ioccc.org        (do not submit entries to this address)
 ```
 
-**`|`**   You must include the words 'ioccc 2020 question' in the subject of your
+**`|`**   You must include the words 'ioccc 2024 question' in the subject of your
 email message when sending email to the judges.
 
 Questions and comments about the contest are welcome.  Comments about

--- a/next/rules.html
+++ b/next/rules.html
@@ -384,7 +384,7 @@
 <!-- BEFORE: 1st line of markdown file: next/rules.md -->
 <!-- START: this line starts content from: inc/rules.closed.hdr -->
 <h1 id="warning-these-rules-are-out-of-date">WARNING: These rules are OUT OF DATE</h1>
-<p>They are a <strong>very tentative proposal</strong> for the next IOCCC
+<p>These rules are a <strong>very tentative proposal</strong> for the next IOCCC
 that is <strong>VERY LIKELY</strong> to be updated before the next IOCCC.
 They are are provided as a <strong>very tentative</strong> hint at what
 might be used in a future IOCCC.</p>
@@ -396,18 +396,19 @@ might be used in a future IOCCC.</p>
 <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> mastodon feed</a> for information about future IOCCC openings.</p>
 <!-- END: the next line ends content from: inc/rules.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
-<h1 id="th-international-obfuscated-c-code-contest-official-rules">27th International Obfuscated C Code Contest Official Rules</h1>
+<h1 id="th-international-obfuscated-c-code-contest-official-rules">28th International Obfuscated C Code Contest Official Rules</h1>
 <p><strong><code>|</code></strong> Copyright © 2024 Leonid A. Broukhis, Landon Curt Noll.</p>
 <p>All Rights Reserved. Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered. All other uses must receive prior permission in
-writing from the <a href="../contact.html">contest judges</a>.</p>
+writing by <a href="../contact.html">contacting the judges</a>.</p>
 <h2 id="rules-version">Rules version</h2>
 <p><strong><code>|</code></strong> These rules are version <strong>2024-04-04-v28</strong>.</p>
 <p><strong>IMPORTANT</strong>: Be sure to read the <a href="guidelines.html">IOCCC guidelines</a>.</p>
 <h3 id="change-marks">Change marks</h3>
 <p><strong><code>|</code></strong> <strong>← Lines that start with this symbol indicate a change from the previous IOCCC</strong></p>
-<p>Most lines (we sometimes make mistakes) that were modified start the <strong><code>|</code></strong> symbol.</p>
+<p>Most lines (we sometimes make mistakes) that were modified since the previous
+IOCCC start the <strong><code>|</code></strong> symbol.</p>
 <h1 id="obfuscate-defined">Obfuscate defined:</h1>
 <p>tr.v. -cated, -cating, -cates.
 <BR><BR>
@@ -429,8 +430,11 @@ writing from the <a href="../contact.html">contest judges</a>.</p>
 <h1 id="important-ioccc-dates">Important IOCCC dates</h1>
 <p><strong><code>|</code></strong> This IOCCC runs from <strong>2019-Dec-26 06:01:41 UTC</strong> to <strong>2020-Mar-15 06:26:49 UTC</strong>.</p>
 <p>Until the start of this IOCCC, these rules, guidelines and iocccsize.c
-tool should be considered provisional BETA versions and may be
-adjusted at any time.</p>
+(contained in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+toolkit</a> and invoked by the
+<code>mkiocccentry</code> tool)
+should be considered provisional <strong>BETA</strong> versions and may be
+adjusted <strong>AT ANY TIME</strong>.</p>
 <p>When the IOCCC is open, the submission URL is:
 <a href="https://submit.ioccc.org/">https://submit.ioccc.org/</a>, at all other
 times that link is likely to be unresponsive.</p>
@@ -438,8 +442,10 @@ times that link is likely to be unresponsive.</p>
 for <strong>important information</strong> on how to submit to the IOCCC.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2020-Jan-15 12:21:37 UTC</strong>.
 Please wait to submit your entries until after that time.</p>
-<p>The official rules, guidelines and iocccsize.c tool will be available
-on the official IOCCC website on or slightly before start of this IOCCC.</p>
+<p>The official rules, guidelines will be available on the <a href="../index.html">official IOCCC
+website</a> on or slightly before start of this IOCCC. The
+<code>mkiocccentry</code> toolkit may be obtained at any time at the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry toolkit repo</a>.</p>
 <p>Please recheck on or after the start of this IOCCC to be sure you
 are using the correct versions of these items before using the IOCCC
 entry submission URL.</p>
@@ -450,19 +456,21 @@ entry submission URL.</p>
 <h2 id="rule-1">Rule 1</h2>
 <p>Your entry must be a complete program.</p>
 <h2 id="rule-2">Rule 2</h2>
-<p><strong><code>|</code></strong> The size rule requires your entry to satisfy BOTH rule 2a and rule 2b:</p>
+<p><strong><code>|</code></strong> The size rule requires your entry to satisfy <strong>BOTH</strong> rule 2a and rule 2b:</p>
 <h2 id="rule-2a">Rule 2a</h2>
-<p>The size of your program source <strong>must be &lt;= 4096 bytes</strong>in length.</p>
+<p>The size of your program source <strong>MUST BE &lt;= 4096 bytes</strong>in length.</p>
 <h2 id="rule-2b">Rule 2b</h2>
 <p>When your program source is fed as input to the current IOCCC size
 tool, and the IOCCC size tool -i command line option is used, the
 value printed <strong>shall not exceed 2053</strong>.</p>
 <p><strong><code>|</code></strong> The source to the current IOCCC size tool is found in the
-<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry tool repo</a>.</p>
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry tool repo</a>. If you use
+the <code>mkiocccentry</code> tool (which we <strong>STRONGLY recommend you do</strong>) will invoke
+this tool before packaging your entry for submission.</p>
 <h2 id="rule-3">Rule 3</h2>
 <p>Submissions should be performed using the instructions outlined at:
 the <a href="../faq.html#submit">How to enter link</a> link.</p>
-<p>To submit to an open IOCCC, you must the <a href="https://submit.ioccc.org/">IOCCC submit server</a>.</p>
+<p>To submit to an open IOCCC, you must use the <a href="https://submit.ioccc.org/">IOCCC submit server</a>.</p>
 <p>When the IOCCC is not open, that link will likely be unresponsive.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2020-Jan-15 12:21:37 UTC</strong>.
 Please wait to submit your entries until after that time.</p>
@@ -472,52 +480,53 @@ Please wait to submit your entries until after that time.</p>
 <p>Your source code will be the file <strong>prog.c</strong>. The compiled binary
 will be called <strong>prog</strong>.</p>
 <h2 id="rule-5">Rule 5</h2>
-<p>Your entry must not modify the content or filename of any part of your
-original entry including, but not limited to prog.c, the Makefile
-(we create from your how to build instructions), as well as any data
+<p>Your entry <strong>MUST</strong> not modify the content or filename of any part of your
+original entry including, but not limited to <strong>prog.c</strong>, the <strong>Makefile</strong>
+(that we create from your how to build instructions), as well as any data
 files you submit.</p>
-<p>If you entry wishes to modify such content, it must first copy the
+<p>If you entry wishes to modify such content, it <strong>MUST</strong> first copy the
 file to a new filename and then modify that copy.</p>
 <h2 id="rule-6">Rule 6</h2>
-<p><strong><code>|</code></strong> I am not a rule, I am a free(void *man)!</p>
+<p><strong><code>|</code></strong> I am not a rule, I am a <code>free(void \*man)</code>!</p>
 <pre><code>        while (!understand(ioccc(rule(you(are(number(6))))))) { ha_ha_ha(); }</code></pre>
 <h2 id="rule-7">Rule 7</h2>
 <p>The obfuscated C program must be an original work that you own.</p>
-<p>You (the authors) must own the contents of your submission OR
-you must have permission from the owners to submit their content
+<p>You (the author(s)) must own the contents of your submission OR
+you must have permission from the owner(s) to submit their content
 under the following license:</p>
 <p><strong><code>|</code></strong> <strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
 <p>See also Rule 18.</p>
-<p>If you submit any content that is owned by others, you MUST
+<p>If you submit any content that is owned by others, you <strong>MUST</strong>
 detail that ownership (i.e., who owns what) and document the
 permission you obtained.</p>
-<p>Please note that the IOCCC size tool is not an original work.</p>
+<p>Please note that the IOCCC size tool is <strong>NOT</strong> an original work.</p>
 <h2 id="rule-8">Rule 8</h2>
 <p><strong><code>|</code></strong> Entries must be received prior to the end of this IOCCC which is:</p>
 <pre><code>    2020-Mar-15 06:26:49 UTC</code></pre>
-<p>A confirmation of submission will be sent to the submitter email address before the close of the contest.</p>
+<p>A confirmation of submission will be sent to the submitting email address
+before the close of the contest.</p>
 <h2 id="rule-9">Rule 9</h2>
 <p><strong><code>|</code></strong> Each person may submit up to and including 8.000000 entries per contest.</p>
 <p>Each entry must be submitted separately.</p>
 <h2 id="rule-10">Rule 10</h2>
 <p>Entries requiring human interaction to be initially compiled are not permitted.</p>
 <h2 id="rule-11">Rule 11</h2>
-<p>Programs that require special privileges (setuid, setgid, super-user,
+<p>Programs that require special privileges (<code>setuid(2)</code>, <code>setgid(2)</code>, super-user,
 special owner, special group, etc.) are still highly discouraged. We
 do not guarantee these functions will behave as you expect on our test
-platforms. If your program needs special permissions please document
+platforms. If your program needs special permissions <strong>please</strong> document
 them in the remarks file.</p>
 <h2 id="rule-12">Rule 12</h2>
 <p>Legal abuse of the rules is somewhat encouraged. An entry that, in
 the opinion of the judges, violates the rules will be disqualified.
-Entries that attempt to abuse the rules must try to justify why
-their rule abuse is legal in the remarks file.</p>
+Entries that attempt to abuse the rules <strong>MUST</strong> try to justify why
+their rule abuse is legal, in the remarks file.</p>
 <h2 id="rule-13">Rule 13</h2>
 <p>Any C source that fails to compile because of unescaped octets with
 the high bit set (octet value &gt;= 128) will be rejected.</p>
 <h2 id="rule-14">Rule 14</h2>
 <p>Any C source that fails to compile because of lines with trailing
-control-M’s (i.e., lines with a tailing octet 015) will be rejected.</p>
+control-M’s (i.e., lines with a tailing octet <code>015</code>) will be rejected.</p>
 <p>Please do not put trailing control-M’s on remarks file lines.
 Please check to be sure, before submitting, that you have removed
 any control-M at the end of remark file lines.</p>
@@ -535,55 +544,67 @@ submission.</p>
 <p>After your email address has been confirmed, the submission code will
 be valid for submitting and editing the entry for the lifetime of the
 competition.</p>
+<p>See also <a href="../faq.html#submit">How may I submit to the IOCCC?</a> in the
+<a href="../faq.html">FAQ</a>.</p>
 <h2 id="rule-16">Rule 16</h2>
-<p>You are STRONGLY encouraged to submit a previously unpublished and
+<p>You are <strong>STRONGLY</strong> encouraged to submit a previously unpublished and
 original entry. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.</p>
 <h2 id="rule-17">Rule 17</h2>
 <p>The total size of your submission: the sum of the size of the program,
-hints, comments, build and info files MUST be less than or equal
-to 1048576 octets in size.</p>
+hints, comments, build and info files <strong>MUST</strong> be less than or equal
+to 1048576 octets in size. The
+[mkiocccentry toolkit]((https://github.com/ioccc-src/mkiocccentry) will verify
+that your entry is not too big.</p>
 <h2 id="rule-18">Rule 18</h2>
 <p>The entirety of your entry must be submitted under the following license:</p>
 <p><strong><code>|</code></strong> <strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
-<p>You (the authors) must own the contents of your submission OR
-you must have permission from the owners to submit their content</p>
+<p>You (the author(s)) <strong>MUST</strong> own the contents of your submission <strong>OR</strong>
+you <strong>MUST</strong> have permission from the owner(s) to submit their content.</p>
 <p>You must not submit anything that cannot be submitted under that license.</p>
 <h2 id="rule-19">Rule 19</h2>
 <p>The remarks file must be written in markdown format. See
-the Daring Fireball {Markdown: Basics](http://daringfireball.net/projects/markdown/basics)
+the Daring Fireball <a href="http://daringfireball.net/projects/markdown/basics">Markdown: Basics</a>
 for more information.</p>
 <p><strong><code>|</code></strong> We currently use <a href="https://pandoc.org">pandoc</a> to convert markdown to HTML.</p>
 <h2 id="rule-20">Rule 20</h2>
-<p>The how to build instructions must be in make form.</p>
-<p>The target of the make file must be called prog. The original
-C source file must be called prog.c.</p>
+<p>The how to build instructions must be in Makefile format. See <a href="../faq.html#make_compatibility">What kind of
+make(1) compatibility does the IOCCC support and will it support other
+kinds?</a> for more details on what we support.</p>
+<p>The target of the Makefile must be called <code>prog</code>. The original
+C source file must be called <code>prog.c</code>.</p>
 <p>To invoke the C compiler, use <code>${CC}</code>.
 To invoke the C preprocessor use <code>${CPP}</code>.</p>
-<p>Do not assume that . (the current directory) is in the <code>$PATH</code>.</p>
+<p>Do not assume that <code>.</code> (the current directory) is in the <code>$PATH</code>.</p>
 <p>Use a shell command syntax that is compatible with bash.</p>
 <p>Assume that commands commonly found in POSIX-like / Linux-like systems
 are available in the search path.</p>
 <p>Do not assume any particular given value of <code>${CFLAGS}</code> or other
-commonly used make variables.</p>
+commonly used make variables. In other words you <strong>MUST</strong> specify the <code>CFLAGS</code>
+to use.</p>
+<p>See also the
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">Makefile.example</a>
+for help in constructing your Makefile. The <code>mkiocccentry</code>, which can be found
+at the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>, tries to
+detect if required rules exist in your Makefile.</p>
 <h2 id="rule-21">Rule 21</h2>
-<p>Your entry must not create nor modify files above the current directory
+<p>Your entry must not create or modify files above the current directory
 with the exception of the <code>/tmp</code> and the <code>/var/tmp</code> directories. Your entry
-may create subdirectories below the current directory, or in /tmp,
-or in <code>/var/tmp</code> provided that “<strong>.</strong>” is <strong>not</strong> the first octet in any
-directory name.</p>
+<strong>MAY</strong> create subdirectories below the current directory, or in <code>/tmp</code>,
+or in <code>/var/tmp</code> provided that “<strong>.</strong>” is <strong>NOT</strong> the first octet in any
+directory name or filename you submit.</p>
 <h2 id="rule-22">Rule 22</h2>
 <p>Catch 22:</p>
 <p>Your source code, data files, remarks and program output must <strong>NOT</strong>
 identify the authors of your code. The judges <strong>STRONGLY prefer</strong> to
-not know who is submitting entries to the IOCCC.</p>
+NOT know who is submitting entries to the IOCCC.</p>
 <p>Even if you are a previous IOCCC winner, catch 22 still applies.</p>
-<p>Identifying the authors of your entry in an obvious way anywhere
-within in your code, data, remarks or program output (unless you are
+<p>Identifying the author(s) of your entry in an obvious way anywhere
+within your code, data, remarks or program output (unless you are
 <em>Peter Honeyman</em> or pretending to be <em>Peter Honeyman</em>) will be grounds
 for disqualification of your entry.</p>
-<p>Yes, Virginia, <strong>we really mean it</strong>!</p>
+<p>Yes, Virginia, <strong>we REALLY mean it</strong>!</p>
 <h2 id="rule-23">Rule 23</h2>
 <p>This prime rule number is reserved for future use.</p>
 <h2 id="rule-24">Rule 24</h2>
@@ -593,11 +614,11 @@ for disqualification of your entry.</p>
 <h2 id="rule-26">Rule 26</h2>
 <p><strong><code>|</code></strong> Rule 26 is also a rule.</p>
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
-<p>The judging will be done by Leonid A. Broukhis, Simon Cooper,
+<p>The judging will be done by Leonid A. Broukhis and
 Landon Curt Noll.</p>
 <p><strong><code>|</code></strong> Please send questions or comments about the contest, to:</p>
-<pre><code>    q.2020@ioccc.org</code></pre>
-<p><strong><code>|</code></strong> <strong>IMPORANT</strong>: You must include the words <strong>ioccc 2020 question</strong>
+<pre><code>    q.2024@ioccc.org</code></pre>
+<p><strong><code>|</code></strong> <strong>IMPORTANT</strong>: You must include the words <strong>ioccc 2024 question</strong>
 in the subject of your email message when sending email to the judges.</p>
 <p>The rules and the guidelines may (and often do) change from year to
 year. You should be sure you have the current rules and guidelines
@@ -613,12 +634,11 @@ to be sure they are seeing the most recent tweets.</p>
 <h2 id="an-important-update-to-this-historic-note">An important update to this historic note</h2>
 <p><strong>-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-</strong></p>
 <p><strong><code>|</code></strong> <strong>The IOCCC no longer uses twitter</strong>.</p>
-<p><strong><code>|</code></strong> Today the <a href="../contact.html#mastodon">IOCCC uses Mastodon</a>.</p>
+<p><strong><code>|</code></strong> Today the <a href="../contact.html#try_mastodon">IOCCC uses Mastodon</a>.</p>
 <p><strong><code>|</code></strong> For more information and to see our IOCCC Mastodon posts, see:</p>
 <pre><code>    https://fosstodon.org/@ioccc</code></pre>
 <p><strong>-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-</strong></p>
 <p>Leonid A. Broukhis<br>
-Simon Cooper<br>
 chongo (Landon Curt Noll) <code>/\cc/\</code></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a>

--- a/next/rules.md
+++ b/next/rules.md
@@ -2,7 +2,7 @@
 
 # WARNING: These rules are OUT OF DATE
 
-They are a **very tentative proposal** for the next IOCCC
+These rules are a **very tentative proposal** for the next IOCCC
 that is **VERY LIKELY** to be updated before the next IOCCC.
 They are are provided as a **very tentative** hint at what
 might be used in a future IOCCC.
@@ -20,14 +20,14 @@ Watch both [the IOCCC status page](../status.html) and the
 
 <!-- END: the next line ends content from: inc/rules.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
-# 27th International Obfuscated C Code Contest Official Rules
+# 28th International Obfuscated C Code Contest Official Rules
 
 **`|`** Copyright &copy; 2024 Leonid A. Broukhis, Landon Curt Noll.
 
 All Rights Reserved.  Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered.  All other uses must receive prior permission in
-writing from the [contest judges](../contact.html).
+writing by [contacting the judges](../contact.html).
 
 
 ## Rules version
@@ -41,7 +41,8 @@ writing from the [contest judges](../contact.html).
 
 **`|`** **&larr; Lines that start with this symbol indicate a change from the previous IOCCC**
 
-Most lines (we sometimes make mistakes) that were modified start the **`|`** symbol.
+Most lines (we sometimes make mistakes) that were modified since the previous
+IOCCC start the **`|`** symbol.
 
 
 # Obfuscate defined:
@@ -72,8 +73,11 @@ The goals of the IOCCC:
 **`|`** This IOCCC runs from **2019-Dec-26 06:01:41 UTC** to **2020-Mar-15 06:26:49 UTC**.
 
 Until the start of this IOCCC, these rules, guidelines and iocccsize.c
-tool should be considered provisional BETA versions and may be
-adjusted at any time.
+(contained in the [mkiocccentry
+toolkit](https://github.com/ioccc-src/mkiocccentry) and invoked by the
+`mkiocccentry` tool)
+should be considered provisional **BETA** versions and may be
+adjusted **AT ANY TIME**.
 
 When the IOCCC is open, the submission URL is:
 [https://submit.ioccc.org/](https://submit.ioccc.org/), at all other
@@ -85,9 +89,10 @@ for **important information** on how to submit to the IOCCC.
 **`|`** The submit URL should be active on or slightly before **2020-Jan-15 12:21:37 UTC**.
 Please wait to submit your entries until after that time.
 
-The official rules, guidelines and iocccsize.c tool will be available
-on the official IOCCC website on or slightly before start of this IOCCC.
-
+The official rules, guidelines will be available on the [official IOCCC
+website](../index.html) on or slightly before start of this IOCCC. The
+`mkiocccentry` toolkit may be obtained at any time at the
+[mkiocccentry toolkit repo](https://github.com/ioccc-src/mkiocccentry).
 
 Please recheck on or after the start of this IOCCC to be sure you
 are using the correct versions of these items before using the IOCCC
@@ -111,12 +116,12 @@ Your entry must be a complete program.
 
 ## Rule 2
 
-**`|`** The size rule requires your entry to satisfy BOTH rule 2a and rule 2b:
+**`|`** The size rule requires your entry to satisfy **BOTH** rule 2a and rule 2b:
 
 
 ## Rule 2a
 
-The size of your program source **must be <= 4096 bytes**in length.
+The size of your program source **MUST BE <= 4096 bytes**in length.
 
 ## Rule 2b
 
@@ -125,7 +130,9 @@ tool, and the IOCCC size tool -i command line option is used, the
 value printed **shall not exceed 2053**.
 
 **`|`** The source to the current IOCCC size tool is found in the
-[mkiocccentry tool repo](https://github.com/ioccc-src/mkiocccentry).
+[mkiocccentry tool repo](https://github.com/ioccc-src/mkiocccentry). If you use
+the `mkiocccentry` tool (which we **STRONGLY recommend you do**) will invoke
+this tool before packaging your entry for submission.
 
 
 ## Rule 3
@@ -133,7 +140,7 @@ value printed **shall not exceed 2053**.
 Submissions should be performed using the instructions outlined at:
 the [How to enter link](../faq.html#submit) link.
 
-To submit to an open IOCCC, you must the [IOCCC submit server](https://submit.ioccc.org/).
+To submit to an open IOCCC, you must use the [IOCCC submit server](https://submit.ioccc.org/).
 
 When the IOCCC is not open, that link will likely be unresponsive.
 
@@ -153,18 +160,18 @@ will be called **prog**.
 
 ## Rule 5
 
-Your entry must not modify the content or filename of any part of your
-original entry including, but not limited to prog.c, the Makefile
-(we create from your how to build instructions), as well as any data
+Your entry **MUST** not modify the content or filename of any part of your
+original entry including, but not limited to **prog.c**, the **Makefile**
+(that we create from your how to build instructions), as well as any data
 files you submit.
 
-If you entry wishes to modify such content, it must first copy the
+If you entry wishes to modify such content, it **MUST** first copy the
 file to a new filename and then modify that copy.
 
 
 ## Rule 6
 
-**`|`** I am not a rule, I am a free(void \*man)!
+**`|`** I am not a rule, I am a `free(void \*man)`!
 
 ``` <!---c-->
         while (!understand(ioccc(rule(you(are(number(6))))))) { ha_ha_ha(); }
@@ -175,19 +182,19 @@ file to a new filename and then modify that copy.
 
 The obfuscated C program must be an original work that you own.
 
-You (the authors) must own the contents of your submission OR
-you must have permission from the owners to submit their content
+You (the author(s)) must own the contents of your submission OR
+you must have permission from the owner(s) to submit their content
 under the following license:
 
 **`|`** **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
 
 See also Rule 18.
 
-If you submit any content that is owned by others, you MUST
+If you submit any content that is owned by others, you **MUST**
 detail that ownership (i.e., who owns what) and document the
 permission you obtained.
 
-Please note that the IOCCC size tool is not an original work.
+Please note that the IOCCC size tool is **NOT** an original work.
 
 
 ## Rule 8
@@ -198,7 +205,8 @@ Please note that the IOCCC size tool is not an original work.
     2020-Mar-15 06:26:49 UTC
 ```
 
-A confirmation of submission will be sent to the submitter email address before the close of the contest.
+A confirmation of submission will be sent to the submitting email address
+before the close of the contest.
 
 
 ## Rule 9
@@ -215,10 +223,10 @@ Entries requiring human interaction to be initially compiled are not permitted.
 
 ## Rule 11
 
-Programs that require special privileges (setuid, setgid, super-user,
+Programs that require special privileges (`setuid(2)`, `setgid(2)`, super-user,
 special owner, special group, etc.) are still highly discouraged. We
 do not guarantee these functions will behave as you expect on our test
-platforms. If your program needs special permissions please document
+platforms. If your program needs special permissions **please** document
 them in the remarks file.
 
 
@@ -226,8 +234,8 @@ them in the remarks file.
 
 Legal abuse of the rules is somewhat encouraged.  An entry that, in
 the opinion of the judges, violates the rules will be disqualified.
-Entries that attempt to abuse the rules must try to justify why
-their rule abuse is legal in the remarks file.
+Entries that attempt to abuse the rules **MUST** try to justify why
+their rule abuse is legal, in the remarks file.
 
 
 ## Rule 13
@@ -239,7 +247,7 @@ the high bit set (octet value >= 128) will be rejected.
 ## Rule 14
 
 Any C source that fails to compile because of lines with trailing
-control-M's (i.e., lines with a tailing octet 015) will be rejected.
+control-M's (i.e., lines with a tailing octet `015`) will be rejected.
 
 Please do not put trailing control-M's on remarks file lines.
 Please check to be sure, before submitting, that you have removed
@@ -265,10 +273,13 @@ After your email address has been confirmed, the submission code will
 be valid for submitting and editing the entry for the lifetime of the
 competition.
 
+See also [How may I submit to the IOCCC?](../faq.html#submit) in the
+[FAQ](../faq.html).
+
 
 ## Rule 16
 
-You are STRONGLY encouraged to submit a previously unpublished and
+You are **STRONGLY** encouraged to submit a previously unpublished and
 original entry. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.
@@ -277,8 +288,10 @@ been published may be disqualified.
 ## Rule 17
 
 The total size of your submission: the sum of the size of the program,
-hints, comments, build and info files MUST be less than or equal
-to 1048576 octets in size.
+hints, comments, build and info files **MUST** be less than or equal
+to 1048576 octets in size. The
+[mkiocccentry toolkit]((https://github.com/ioccc-src/mkiocccentry) will verify
+that your entry is not too big.
 
 
 ## Rule 18
@@ -287,8 +300,8 @@ The entirety of your entry must be submitted under the following license:
 
 **`|`** **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
 
-You (the authors) must own the contents of your submission OR
-you must have permission from the owners to submit their content
+You (the author(s)) **MUST** own the contents of your submission **OR**
+you **MUST** have permission from the owner(s) to submit their content.
 
 You must not submit anything that cannot be submitted under that license.
 
@@ -296,7 +309,7 @@ You must not submit anything that cannot be submitted under that license.
 ## Rule 19
 
 The remarks file must be written in markdown format. See
-the Daring Fireball {Markdown: Basics](http://daringfireball.net/projects/markdown/basics)
+the Daring Fireball [Markdown: Basics](http://daringfireball.net/projects/markdown/basics)
 for more information.
 
 **`|`** We currently use [pandoc](https://pandoc.org) to convert markdown to HTML.
@@ -304,15 +317,17 @@ for more information.
 
 ## Rule 20
 
-The how to build instructions must be in make form.
+The how to build instructions must be in Makefile format. See [What kind of
+make&#x28;1&#x29; compatibility does the IOCCC support and will it support other
+kinds?](../faq.html#make_compatibility) for more details on what we support.
 
-The target of the make file must be called prog.  The original
-C source file must be called prog.c.
+The target of the Makefile must be called `prog`.  The original
+C source file must be called `prog.c`.
 
 To invoke the C compiler, use `${CC}`.
 To invoke the C preprocessor use `${CPP}`.
 
-Do not assume that . (the current directory) is in the `$PATH`.
+Do not assume that `.` (the current directory) is in the `$PATH`.
 
 Use a shell command syntax that is compatible with bash.
 
@@ -320,16 +335,23 @@ Assume that commands commonly found in POSIX-like / Linux-like systems
 are available in the search path.
 
 Do not assume any particular given value of `${CFLAGS}` or other
-commonly used make variables.
+commonly used make variables. In other words you **MUST** specify the `CFLAGS`
+to use.
+
+See also the
+[Makefile.example](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
+for help in constructing your Makefile. The `mkiocccentry`, which can be found
+at the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry), tries to
+detect if required rules exist in your Makefile.
 
 
 ## Rule 21
 
-Your entry must not create nor modify files above the current directory
+Your entry must not create or modify files above the current directory
 with the exception of the `/tmp` and the `/var/tmp` directories.  Your entry
-may create subdirectories below the current directory, or in /tmp,
-or in `/var/tmp` provided that "**.**" is **not** the first octet in any
-directory name.
+**MAY** create subdirectories below the current directory, or in `/tmp`,
+or in `/var/tmp` provided that "**.**" is **NOT** the first octet in any
+directory name or filename you submit.
 
 
 ## Rule 22
@@ -338,16 +360,16 @@ Catch 22:
 
 Your source code, data files, remarks and program output must **NOT**
 identify the authors of your code.  The judges **STRONGLY prefer** to
-not know who is submitting entries to the IOCCC.
+NOT know who is submitting entries to the IOCCC.
 
 Even if you are a previous IOCCC winner, catch 22 still applies.
 
-Identifying the authors of your entry in an obvious way anywhere
-within in your code, data, remarks or program output (unless you are
+Identifying the author(s) of your entry in an obvious way anywhere
+within your code, data, remarks or program output (unless you are
 _Peter Honeyman_ or pretending to be _Peter Honeyman_) will be grounds
 for disqualification of your entry.
 
-Yes, Virginia, **we really mean it**!
+Yes, Virginia, **we REALLY mean it**!
 
 
 ## Rule 23
@@ -372,16 +394,16 @@ Even though 24 is not prime, you should still see rule #23.
 
 # FOR MORE INFORMATION:
 
-The judging will be done by Leonid A. Broukhis, Simon Cooper,
+The judging will be done by Leonid A. Broukhis and
 Landon Curt Noll.
 
 **`|`** Please send questions or comments about the contest, to:
 
 ```
-    q.2020@ioccc.org
+    q.2024@ioccc.org
 ```
 
-**`|`** **IMPORANT**: You must include the words **ioccc 2020 question**
+**`|`** **IMPORTANT**: You must include the words **ioccc 2024 question**
 in the subject of your email message when sending email to the judges.
 
 The rules and the guidelines may (and often do) change from year to
@@ -413,7 +435,7 @@ to be sure they are seeing the most recent tweets.
 
 **`|`** **The IOCCC no longer uses twitter**.
 
-**`|`** Today the [IOCCC uses Mastodon](../contact.html#mastodon).
+**`|`** Today the [IOCCC uses Mastodon](../contact.html#try_mastodon).
 
 **`|`** For more information and to see our IOCCC Mastodon posts, see:
 
@@ -424,7 +446,6 @@ to be sure they are seeing the most recent tweets.
 **-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-**
 
 Leonid A. Broukhis<br>
-Simon Cooper<br>
 chongo (Landon Curt Noll) `/\cc/\`
 
 


### PR DESCRIPTION
Some links were fixed. For instance instead of index.html#enter it's now the relevant FAQ. A markdown link was broken so that it did not create a link at all.

Some formatting was updated mostly to make points bold or in code block (if it's going to be html it might as well especially as they are important).

And although there were some typo fixes there still are some typos in there. If you don't know why that is see the FAQ 1.0: How did the IOCCC get started?. :-) Besides much will be changed in these files by the judges and the purpose of this commit was to make sure links were valid and that the files are rendered okay, not to try and change the rules (although I did update the IOCCC email and make it the 28th IOCCC and fix the judges [list] .. to make a reference to something recent :-) ).

This commit means that the files under next/ have all been checked. As usual we all anticipate things to change but some things that were outdated were corrected (or they were at least partially corrected like referring to the mkiocccentry repo) to help out a bit.