### PR TITLE
Format fix bugs.md

### DIFF
--- a/bugs.md
+++ b/bugs.md
@@ -1063,7 +1063,7 @@ looked at later but you're welcome to try and fix this too! A tip on how
 Previously it had a buffer size of 256 which could easily overflow. In this
 entry `gets(3)` is used in a more complicated way: first `m` is set to `*++p` in
 a for loop where `p` is argv. Later `m` is set to point to `h` which was of size
-256. `gets(3)` is called as `m = gets(m)`) but trying to change it to use
+256\. `gets(3)` is called as `m = gets(m)`) but trying to change it to use
 `fgets(3)` proved more a problem. Since the input must come from the command
 line Cody changed the buffer size to `ARG_MAX+1` which should be enough (again
 theoretically) especially since the command expects redirecting a dictionary

--- a/faq.html
+++ b/faq.html
@@ -1661,7 +1661,7 @@ known and we are looking for someone to attempt to fix it.</p>
 <p>In some cases there is an alternate version of the IOCCC entry
 that you may wish to try.</p>
 <p>It also possible that you may have discovered a bug in an winning IOCCC
-entry. If so, you are invited to try an fix the IOCCC entry and
+entry. If so, you are invited to try and fix the IOCCC entry and
 submit that fix by way of a <a href="https://github.com/ioccc-src/winner/pulls">GitHub pull
 request</a>.
 Please see <a href="#fix_an_entry">FAQ 5.2</a> for how to submit a fix to an IOCCC entry.</p>

--- a/faq.md
+++ b/faq.md
@@ -1808,7 +1808,7 @@ In some cases there is an alternate version of the IOCCC entry
 that you may wish to try.
 
 It also possible that you may have discovered a bug in an winning IOCCC
-entry.  If so, you are invited to try an fix the IOCCC entry and
+entry.  If so, you are invited to try and fix the IOCCC entry and
 submit that fix by way of a [GitHub pull
 request](https://github.com/ioccc-src/winner/pulls).
 Please see [FAQ 5.2](#fix_an_entry) for how to submit a fix to an IOCCC entry.


### PR DESCRIPTION

It seems pandoc actually handles it okay but the markdown was fixed 
anyway (in other words it does not change the html file). A line that 
was part of a sentence (the end of) started with '256.' This was changed
to '256\.' (another option would be to move the '256.' to the end of the
previous line). With pandoc the html file does not change but this very
issue has caused me problems before so I fixed it.
