### PR TITLE
Fix missing cases of 'web site' to 'website'

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -302,7 +302,7 @@ We recommend that this tool be invoked via the top level `Makefile` by:
 ```
 
 unless the `contest_status` is to be changed, but since only the judges should
-do that that is not a problem.
+do that, that is not a problem.
 
 <div id="gen-top-html">
 ### [gen-top-html.sh](%%REPO_URL%%/bin/gen-top-html.sh)

--- a/bin/index.html
+++ b/bin/index.html
@@ -533,7 +533,7 @@ at the command line.</p>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code> by:</p>
 <pre><code>    make gen_status</code></pre>
 <p>unless the <code>contest_status</code> is to be changed, but since only the judges should
-do that that is not a problem.</p>
+do that, that is not a problem.</p>
 <div id="gen-top-html">
 <h3 id="gen-top-html.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/gen-top-html.sh">gen-top-html.sh</a></h3>
 </div>

--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
 
 <!-- BEFORE: 1st line of markdown file: index.md -->
 <!-- XXX - This entire section goes away during the final stages of the Great Fork Merge -->
-<h1 id="this-is-an-experimental-ioccc-web-site">THIS IS AN EXPERIMENTAL IOCCC WEB SITE</h1>
+<h1 id="this-is-an-experimental-ioccc-website">THIS IS AN EXPERIMENTAL IOCCC WEBSITE</h1>
 <p><strong>IMPORTANT: This is NOT the official IOCCC website!</strong></p>
 <p>Please visit <a href="https://www.ioccc.org/index.html">www.ioccc.org</a> for the official IOCCC web.</p>
 <p>Please do <strong>NOT</strong> bookmark nor link to this <a href="https://ioccc-src.github.io/temp-test-ioccc/">experimental website</a>!</p>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 <!-- XXX - This entire section goes away during the final stages of the Great Fork Merge -->
-# THIS IS AN EXPERIMENTAL IOCCC WEB SITE
+# THIS IS AN EXPERIMENTAL IOCCC WEBSITE
 
 **IMPORTANT: This is NOT the official IOCCC website!**
 

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1102,7 +1102,7 @@ you are mentioned you will not get a notification.</p>
 <p><strong><code>|</code></strong> The <strong>contest_status</strong> in the <a href="../status.json">status.json</a> file will change from <strong>judging</strong> to <strong>closed</strong> as well.</p>
 <p><strong><code>|</code></strong> When the above happens, the winning entries have been selected by the <a href="../judges.html">IOCCC judges</a>.</p>
 <p><strong><code>|</code></strong> The <a href="../judges.html">IOCCC judges</a> will begin to prepare to release the source code of the new IOCCC winners.</p>
-<p><strong><code>|</code></strong> The <a href="../judges.html">IOCCC judges</a> will post the winning source to the <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> as well as to the <a href="https://www.ioccc.org/index.html">Official IOCCC winner web site</a>.</p>
+<p><strong><code>|</code></strong> The <a href="../judges.html">IOCCC judges</a> will post the winning source to the <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> as well as to the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
 <p><strong><code>|</code></strong> The <a href="../news.html">IOCCC news</a> will also contain an announcement of the winners.</p>
 <h2 id="an-important-update-to-how-winners-are-announced-1">An important update to how winners are announced</h2>
 <p>The IOCCC no longer uses twitter. IOCCC entries will be announced
@@ -1132,7 +1132,7 @@ the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a> account. See ou
 <a href="../faq.html#try_mastodon">FAQ</a> for more information. Please be aware that
 unless you are mentioned you most likely will <strong>NOT</strong> get a notification from
 the app so you should make sure to check the page.</p>
-<p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner web site</a> in general.</p>
+<p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
 <p>Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) /\cc/\</p>
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -1010,7 +1010,7 @@ you are mentioned you will not get a notification.
 
 **`|`**   The [IOCCC judges](../judges.html) will begin to prepare to release the source code of the new IOCCC winners.
 
-**`|`**   The [IOCCC judges](../judges.html) will post the winning source to the [IOCCC winner repo](https://github.com/ioccc-src/winner) as well as to the [Official IOCCC winner web site](https://www.ioccc.org/index.html).
+**`|`**   The [IOCCC judges](../judges.html) will post the winning source to the [IOCCC winner repo](https://github.com/ioccc-src/winner) as well as to the [Official IOCCC winner website](https://www.ioccc.org/index.html).
 
 **`|`**   The [IOCCC news](../news.html) will also contain an announcement of the winners.
 
@@ -1068,7 +1068,7 @@ the [IOCCC on Mastodon](https://fosstodon.org/@ioccc) account.  See our
 unless you are mentioned you most likely will **NOT** get a notification from
 the app so you should make sure to check the page.
 
-**`|`**   Check out the [Official IOCCC winner web site](https://www.ioccc.org/index.html) in general.
+**`|`**   Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
 
 Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) /\\cc/\\

--- a/next/rules.html
+++ b/next/rules.html
@@ -631,7 +631,7 @@ the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a> account. See ou
 <a href="../faq.html#try_mastodon">FAQ</a> for more information. Please do note that unless
 you are mentioned by us you will <strong>NOT</strong> get a notification from the app so you
 should refresh the page even if you do follow us.</p>
-<p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner web site</a> in general.</p>
+<p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
 <p>Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) <code>/\cc/\</code></p>
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/rules.md
+++ b/next/rules.md
@@ -418,7 +418,7 @@ the [IOCCC on Mastodon](https://fosstodon.org/@ioccc) account.  See our
 you are mentioned by us you will **NOT** get a notification from the app so you
 should refresh the page even if you do follow us.
 
-**`|`**   Check out the [Official IOCCC winner web site](https://www.ioccc.org/index.html) in general.
+**`|`**   Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
 
 
 Leonid A. Broukhis<br>

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -3,12 +3,12 @@
 The tools under this directory are an alpha release.
 The [bin directory](bin/index.html)
 holds the formal release of tools that will
-maintain the [official IOCCC web site](https://www.ioccc.org).
+maintain the [official IOCCC website](https://www.ioccc.org).
 
-Currently these tools maintain the [experimental web site](https://ioccc-src.github.io/temp-test-ioccc/)
+Currently these tools maintain the [experimental website](https://ioccc-src.github.io/temp-test-ioccc/)
 by default, via the  [temp-test-ioccc GitHub repo](https://github.com/ioccc-src/temp-test-ioccc).
-These tools will default to using the temp-test-ioccc repo and the experimental web site
-until the [official IOCCC web site](https://www.ioccc.org), via the
+These tools will default to using the temp-test-ioccc repo and the experimental website
+until the [official IOCCC website](https://www.ioccc.org), via the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) is ready for the mass pull request/merge.
 
 **IMPORTANT**: The purpose of the `tmp` directory is to hold temporary files.
@@ -436,7 +436,7 @@ Lines printed are of the form:
 ### [src](src)
 
 This is a temporary location for potential tools that are used to
-build and maintain the www.ioccc.org web site.
+build and maintain the www.ioccc.org website.
 
 
 ### [things-todo.md](things-todo.md)


### PR DESCRIPTION
... including the index.{md,html} which was in all caps ..

The bin/README.md file (and index.html) was updated slightly with an added comma: not strictly necessary but for some it might be easier to read. This was discovered as I was going through the links (not done checking them yet but so far so good).