### PR TITLE
Fix links/formatting in markdown.md

### DIFF
--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,12 @@ thanks: ${GEN_TOP_HTML} thanks-for-help.md
 	@${GEN_TOP_HTML} thanks-for-help
 	@echo "... and thanks for all the fish :-)"
 
+# Bugs Bunny rule
+bugs: ${GEN_TOP_HTML} bugs.md
+	@echo "Shhh. Be vewy vewy quiet, I'm hunting wabbits .. and bugs."
+	@${GEN_TOP_HTML} bugs
+	@echo "Eh, what's up, doc?"
+
 # build entry HTML files from markdown other than README.md to index.html
 #
 gen_other_html: ${GEN_OTHER_HTML}

--- a/README.html
+++ b/README.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../news.html">

--- a/bin/index.html
+++ b/bin/index.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../news.html">

--- a/bugs.html
+++ b/bugs.html
@@ -12,8 +12,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 <title>The International Obfuscated C Code Contest</title>
 <link rel="icon" type="image/x-icon" href="./favicon.ico">
-<meta name="description" content="Bugs and (Mis)features of IOCCC entries">
-<meta name="keywords" content="IOCCC, Bugs and (Mis)features, bugs, features, misfeatures">
+<meta name="description" content="Bugs and (mis)features of IOCCC entries">
+<meta name="keywords" content="IOCCC, Bugs and (mis)features, bugs, features, misfeatures, mis-features">
 </head>
 
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
@@ -363,7 +363,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>IOCCC entry Bugs and (Mis)features</h2>
+  <h2>IOCCC entry Bugs and (mis)features</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/bugs.html
+++ b/bugs.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/contact.html
+++ b/contact.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/faq.html
+++ b/faq.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/inc/index.html
+++ b/inc/index.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../news.html">

--- a/inc/md2html.cfg
+++ b/inc/md2html.cfg
@@ -155,11 +155,11 @@ bugs.md
 	-s
 	TITLE=The International Obfuscated C Code Contest
 	-s
-	DESCRIPTION=Bugs and (Mis)features of IOCCC entries
+	DESCRIPTION=Bugs and (mis)features of IOCCC entries
 	-s
-	KEYWORDS=IOCCC, Bugs and (Mis)features, bugs, features, misfeatures
+	KEYWORDS=IOCCC, Bugs and (mis)features, bugs, features, misfeatures, mis-features
 	-s
-	HEADER_2=IOCCC entry Bugs and (Mis)features
+	HEADER_2=IOCCC entry Bugs and (mis)features
 	-D
 	./
 

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -36,7 +36,7 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -62,7 +62,7 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -192,7 +192,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -210,7 +210,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%news.html">

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/judges.html
+++ b/judges.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/license.html
+++ b/license.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/markdown.html
+++ b/markdown.html
@@ -462,17 +462,17 @@ tags</a>.</p>
 <p>The trailing slash on void HTML elements has no effect and interacts badly with
 unquoted attribute values.</p>
 <p>For example, please do NOT use:</p>
-<pre><code>    &lt;br/&gt;                                                     &lt;=== no thank you</code></pre>
+<pre><code>    &lt;br/&gt;                                                     &lt;!-- no thank you --&gt;</code></pre>
 <p>Instead use just:</p>
 <pre><code>    &lt;br&gt;</code></pre>
 <p>And for example, please do NOT use:</p>
-<pre><code>    &lt;hr/&gt;                                                     &lt;=== no thank you</code></pre>
+<pre><code>    &lt;hr/&gt;                                                     &lt;!-- no thank you --&gt;</code></pre>
 <p>Instead use just:</p>
 <pre><code>    &lt;hr&gt;</code></pre>
 <p>And for example, please do NOT use:</p>
 <pre><code>    &lt;img src=&quot;1984-anonymous-tattoo.jpg&quot;
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
-     width=600 height=401 /&gt;                                  &lt;=== no thank you</code></pre>
+     width=600 height=401 /&gt;                                  &lt;!-- no thank you --&gt;</code></pre>
 <p>Instead use just:</p>
 <pre><code>    &lt;img src=&quot;1984-anonymous-tattoo.jpg&quot;
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
@@ -483,7 +483,7 @@ unquoted attribute values.</p>
 end a markdown line with a trailing backslash (<code>\</code>). Instead use
 a trailing <code>&lt;br&gt;</code>.</p>
 <p>Instead of:</p>
-<pre><code>    In markdown,\                                             &lt;=== no thank you
+<pre><code>    In markdown,\                                             &lt;!-- no thank you --&gt;
     do NOT use trailing\
     backslashes outside of\
     a code block</code></pre>
@@ -504,14 +504,14 @@ a trailing <code>&lt;br&gt;</code>.</p>
 <h2 id="please-do-not-use-markdown-style-images">Please do NOT use markdown style images</h2>
 <p>Please do <strong>NOT</strong> use the markdown embedded image element.</p>
 <p>Instead of using this markdown element to embed an image:</p>
-<pre><code>    ![alt text](filename.png &quot;Title&quot;)                         &lt;=== no thank you</code></pre>
+<pre><code>    ![alt text](filename.png &quot;Title&quot;)                         &lt;!-- no thank you --&gt;</code></pre>
 <p>Use an <code>&lt;img ..&gt;</code> HTML element with <code>alt=</code>, <code>width=</code> and <code>length=</code>
 attributes:</p>
 <pre><code>    &lt;img src=&quot;filename.png&quot;
      alt=&quot;describe the filename.png image for someone who cannot view it&quot;
      width=PIXEL_WIDTH height=PIXEL_HEIGHT&gt;</code></pre>
 <p>For example, instead of:</p>
-<pre><code>    ![1984-anonymous-tattoo.jpg](1984-anonymous-tattoo.jpg)   &lt;=== no thank you</code></pre>
+<pre><code>    ![1984-anonymous-tattoo.jpg](1984-anonymous-tattoo.jpg)   &lt;!-- no thank you --&gt;</code></pre>
 <p>use this HTML:</p>
 <pre><code>    &lt;img src=&quot;1984-anonymous-tattoo.jpg&quot;
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
@@ -537,11 +537,11 @@ standard HTML 5 and interacts badly with unquoted attribute values.</p>
 <p>Markdown links that end in “))” complicate parsing and sometimes lead
 to incorrect URLs or file paths.</p>
 <p>Instead of:</p>
-<pre><code>    [some text](https://example.com/foo_(bar))                &lt;=== no thank you</code></pre>
+<pre><code>    [some text](https://example.com/foo_(bar))                &lt;!-- no thank you --&gt;</code></pre>
 <p>Use:</p>
 <pre><code>    [some text](https://example.com/foo_&amp;#x28;bar&amp;#x29;)</code></pre>
 <p>Instead of:</p>
-<pre><code>    This thing, ([some text](some/path)), is NOT ideal.       &lt;=== no thank you</code></pre>
+<pre><code>    This thing, ([some text](some/path)), is NOT ideal.       &lt;!-- no thank you --&gt;</code></pre>
 <p>Use:</p>
 <pre><code>    This thing, [some text](some/path), is better.</code></pre>
 <h2 id="please-do-not-place-text-on-the-next-line-after-a-markdown-code-block">Please do NOT place text on the next line after a markdown code block</h2>
@@ -557,7 +557,7 @@ NOT properly indented.</p>
         return foo;
     }
 ```
-C compilers cannot be given a -Wno-main-arg-errors flag.      &lt;=== no thank you</code></pre>
+C compilers cannot be given a -Wno-main-arg-errors flag.      &lt;!-- no thank you --&gt;</code></pre>
 <p>Use:</p>
 <pre><code>```
     int
@@ -572,11 +572,11 @@ C compilers cannot be given a -Wno-main-arg-errors flag.</code></pre>
 <h2 id="please-do-not-put-s-nor-s-in-markdown-link-titles">Please do NOT put “(”s nor “)”s in markdown link titles</h2>
 <p>Please do <strong>NOT</strong> use parenthesis inside the markdown link titles.</p>
 <p>Instead of:</p>
-<pre><code>    [some (text)](https://example.com/cyrds)                  &lt;=== no thank you</code></pre>
+<pre><code>    [some (text)](https://example.com/cyrds)                  &lt;!-- no thank you --&gt;</code></pre>
 <p>Use:</p>
 <pre><code>    [some &amp;#x28;text&amp;#x29;](https://example.com/cyrds)</code></pre>
 <p>Instead of:</p>
-<pre><code>    [ls(1)](https://example.com/ls-man-page.1)                &lt;=== no thank you</code></pre>
+<pre><code>    [ls(1)](https://example.com/ls-man-page.1)                &lt;-- no thank you --&gt;</code></pre>
 <p>Use:</p>
 <pre><code>    [ls&amp;#x28;1&amp;#x29;](https://example.com/ls-man-page.1)</code></pre>
 <!-- AFTER: last line of markdown file: markdown.md -->

--- a/markdown.html
+++ b/markdown.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">
@@ -384,22 +384,22 @@
 <!-- BEFORE: 1st line of markdown file: markdown.md -->
 <h1 id="ioccc-markdown-best-practices">IOCCC markdown best practices</h1>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
-For example, we <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
-to submit remarks about entry in markdown format. Every
+For example, when <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
+submit remarks about their entry in markdown format. Every
 <a href="years.html">winning IOCCC entry</a> uses a <code>README.md</code> markdown file
 as the basis for forming the <code>index.html</code> web page for that entry.
 All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>
 start with some markdown content.</p>
 <p>See the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide.
-See also <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.</p>
+See also the <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.</p>
 <p>Nevertheless, the IOCCC does have certain practices that we ask authors to follow.
-Some these relate to use of markdown directly, others relate to injecting HTML
+Some of these relate to use of markdown directly and others relate to injecting HTML
 into the markdown file.</p>
-<p>In particular there are things we ask people to please do <strong>NOT</strong> use in
+<p>In particular there are things we ask people to please <strong>NOT</strong> use in
 markdown files for the IOCCC:</p>
 <h2 id="please-do-not-use-name-attributes-in-html-a-..-hyperlink-elements">Please do NOT use name attributes in HTML <code>&lt;a ..&gt;</code> hyperlink elements</h2>
 <p>Please do <strong>NOT</strong> use the HTML construct:</p>
-<pre><code>    &lt;a name=&quot;string&quot;&gt;...&lt;/a&gt;                                  &lt;=== no thank you</code></pre>
+<pre><code>    &lt;a name=&quot;string&quot;&gt;...&lt;/a&gt;                                  &lt;!-- no thank you --&gt;</code></pre>
 <p>as those are <strong>NOT</strong> part of the HTML 5 standard.</p>
 <p>Instead use:</p>
 <pre><code>    &lt;div id=&quot;string&quot;&gt;...&lt;/div&gt;</code></pre>
@@ -409,26 +409,26 @@ encapsulates the HTML you want to name: i.e., the target of some
 for the given page URL.</p>
 <p>There are certain HTML Elements that cannot have internal <code>&lt;div id="string"&gt;...&lt;/div&gt;</code>.</p>
 <p>For example:</p>
-<pre><code>    # &lt;div id=&quot;string&quot;&gt;THIS WILL NOT WORK!&lt;/div&gt;              &lt;=== this will not work</code></pre>
-<p>For things like headings, you have to surround them as in:</p>
+<pre><code>    # &lt;div id=&quot;string&quot;&gt;THIS WILL NOT WORK!&lt;/div&gt;              &lt;!-- this will not work --&gt;</code></pre>
+<p>For things like headings, you have to surround them, as in:</p>
 <pre><code>    &lt;div id=&quot;string&quot;&gt;
     # This will work
     &lt;/div&gt;</code></pre>
 <p>While some browsers will still recognize the HTML construct <code>&lt;a name="string"&gt;...&lt;/a&gt;</code>, it is possible they might NOT in the future.</p>
-<h2 id="please-do-not-use-the-strike-nor-s-html-element">Please do NOT use the <code>&lt;strike&gt;</code> nor <code>&lt;s&gt;</code> HTML element</h2>
-<p>Please NOT use the obsolete <code>&lt;strike&gt;</code> nor <code>&lt;s&gt;</code> (<del> <em>strikeout</em> </del>) HTML elements:</p>
-<pre><code>    &lt;strike&gt;...&lt;/strike&gt;                                      &lt;=== no thank you
-    &lt;s&gt;...&lt;/s&gt;                                                &lt;=== no thank you</code></pre>
+<h2 id="please-do-not-use-the-strike-or-s-html-element">Please do NOT use the <code>&lt;strike&gt;</code> or <code>&lt;s&gt;</code> HTML element</h2>
+<p>Please NOT use the obsolete <code>&lt;strike&gt;</code> or <code>&lt;s&gt;</code> (<del><em>strikeout</em></del>) HTML elements:</p>
+<pre><code>    &lt;strike&gt;...&lt;/strike&gt;                                      &lt;!-- no thank you --&gt;
+    &lt;s&gt;...&lt;/s&gt;                                                &lt;!-- no thank you --&gt;</code></pre>
 <p>Use instead:</p>
 <pre><code>    &lt;del&gt;...&lt;/del&gt;</code></pre>
 <h2 id="please-do-not-use-the-u-html-element">Please do NOT use the <code>&lt;u&gt;</code> HTML element</h2>
 <p>Please NOT use the obsolete <code>&lt;u&gt;</code> (<ins><em>underline</em></ins>) HTML element:</p>
-<pre><code>    &lt;u&gt;...&lt;/u&gt;                                                &lt;=== no thank you</code></pre>
+<pre><code>    &lt;u&gt;...&lt;/u&gt;                                                &lt;!-- no thank you --&gt;</code></pre>
 <p>Use instead:</p>
 <pre><code>    &lt;ins&gt;...&lt;/ins&gt;</code></pre>
 <h2 id="please-do-not-use-the-tt-html-element">Please do NOT use the <code>&lt;tt&gt;</code> HTML element</h2>
 <p>Please do <strong>NOT</strong> use the obsolete <code>&lt;tt&gt;</code> (<span style="font-family: monospace;"><em>teletype</em></span>) HTML element:</p>
-<pre><code>    &lt;tt&gt;The obsolete tt element is obsolete&lt;/tt&gt;              &lt;=== no thank you</code></pre>
+<pre><code>    &lt;tt&gt;The obsolete tt element is obsolete&lt;/tt&gt;              &lt;!-- no thank you --&gt;</code></pre>
 <p>Instead use either a monospaced span:</p>
 <pre><code>    &lt;span style=&quot;font-family: monospace;&quot;&gt;Use of monospaced font is one option&lt;/span&gt;</code></pre>
 <p>Or better and easier still, use an inline markdown code block:</p>
@@ -436,8 +436,7 @@ for the given page URL.</p>
 <h2 id="please-do-not-use-unindented-code-blocks">Please do NOT use unindented code blocks</h2>
 <p>Please do <strong>NOT</strong> start code blocks at the left-hand edge.</p>
 <pre><code>```
-This code block                                               &lt;=== no thank you
-is NOT indented
+This code block is NOT indented                   &lt;!-- no thank you --&gt;
 ```</code></pre>
 <p>We request that you indent the code block by 4 spaces:</p>
 <pre><code>```

--- a/markdown.md
+++ b/markdown.md
@@ -1,21 +1,21 @@
 # IOCCC markdown best practices
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
-For example, we [submitting to the IOCCC](faq.html#submit), we have people
-to submit remarks about entry in markdown format.  Every
+For example, when [submitting to the IOCCC](faq.html#submit), we have people
+submit remarks about their entry in markdown format.  Every
 [winning IOCCC entry](years.html) uses a `README.md` markdown file
 as the basis for forming the `index.html` web page for that entry.
 All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
 start with some markdown content.
 
 See the [markdown syntax](https://www.markdownguide.org/basic-syntax) guide.
-See also [CommonMark Spec](https://spec.commonmark.org/current/).
+See also the [CommonMark Spec](https://spec.commonmark.org/current/).
 
 Nevertheless, the IOCCC does have certain practices that we ask authors to follow.
-Some these relate to use of markdown directly, others relate to injecting HTML
+Some of these relate to use of markdown directly and others relate to injecting HTML
 into the markdown file.
 
-In particular there are things we ask people to please do **NOT** use in
+In particular there are things we ask people to please **NOT** use in
 markdown files for the IOCCC:
 
 
@@ -24,7 +24,7 @@ markdown files for the IOCCC:
 Please do **NOT** use the HTML construct:
 
 ```
-    <a name="string">...</a>                                  <=== no thank you
+    <a name="string">...</a>                                  <!-- no thank you -->
 ```
 
 as those are **NOT** part of the HTML 5 standard.
@@ -46,10 +46,10 @@ id="string">...</div>`.
 For example:
 
 ```
-    # <div id="string">THIS WILL NOT WORK!</div>              <=== this will not work
+    # <div id="string">THIS WILL NOT WORK!</div>              <!-- this will not work -->
 ```
 
-For things like headings, you have to surround them as in:
+For things like headings, you have to surround them, as in:
 
 ```
     <div id="string">
@@ -61,13 +61,13 @@ While some browsers will still recognize the HTML construct `<a
 name="string">...</a>`, it is possible they might NOT in the future.
 
 
-## Please do NOT use the `<strike>` nor `<s>` HTML element
+## Please do NOT use the `<strike>` or `<s>` HTML element
 
-Please NOT use the obsolete `<strike>` nor `<s>` (<del> _strikeout_ </del>) HTML elements:
+Please NOT use the obsolete `<strike>` or `<s>` (<del>_strikeout_</del>) HTML elements:
 
 ```
-    <strike>...</strike>                                      <=== no thank you
-    <s>...</s>                                                <=== no thank you
+    <strike>...</strike>                                      <!-- no thank you -->
+    <s>...</s>                                                <!-- no thank you -->
 ```
 
 Use instead:
@@ -82,7 +82,7 @@ Use instead:
 Please NOT use the obsolete `<u>` (<ins>_underline_</ins>) HTML element:
 
 ```
-    <u>...</u>                                                <=== no thank you
+    <u>...</u>                                                <!-- no thank you -->
 ```
 
 Use instead:
@@ -97,7 +97,7 @@ Use instead:
 Please do **NOT** use the obsolete `<tt>` (<span style="font-family: monospace;">_teletype_</span>) HTML element:
 
 ```
-    <tt>The obsolete tt element is obsolete</tt>              <=== no thank you
+    <tt>The obsolete tt element is obsolete</tt>              <!-- no thank you -->
 ```
 
 Instead use either a monospaced span:
@@ -119,8 +119,7 @@ Please do **NOT** start code blocks at the left-hand edge.
 
 ````
 ```
-This code block                                               <=== no thank you
-is NOT indented
+This code block is NOT indented                   <!-- no thank you -->
 ```
 ````
 

--- a/markdown.md
+++ b/markdown.md
@@ -165,7 +165,7 @@ unquoted attribute values.
 For example, please do NOT use:
 
 ```
-    <br/>                                                     <=== no thank you
+    <br/>                                                     <!-- no thank you -->
 ```
 
 Instead use just:
@@ -177,7 +177,7 @@ Instead use just:
 And for example, please do NOT use:
 
 ```
-    <hr/>                                                     <=== no thank you
+    <hr/>                                                     <!-- no thank you -->
 ```
 
 Instead use just:
@@ -191,7 +191,7 @@ And for example, please do NOT use:
 ```
     <img src="1984-anonymous-tattoo.jpg"
      alt="image of a tattoo of the 1984 anonymous C code"
-     width=600 height=401 />                                  <=== no thank you
+     width=600 height=401 />                                  <!-- no thank you -->
 ```
 
 Instead use just:
@@ -214,7 +214,7 @@ a trailing `<br>`.
 Instead of:
 
 ```
-    In markdown,\                                             <=== no thank you
+    In markdown,\                                             <!-- no thank you -->
     do NOT use trailing\
     backslashes outside of\
     a code block
@@ -251,7 +251,7 @@ Please do **NOT** use the markdown embedded image element.
 Instead of using this markdown element to embed an image:
 
 ```
-    ![alt text](filename.png "Title")                         <=== no thank you
+    ![alt text](filename.png "Title")                         <!-- no thank you -->
 ```
 
 Use an `<img ..>` HTML element with `alt=`, `width=` and `length=`
@@ -266,7 +266,7 @@ attributes:
 For example, instead of:
 
 ```
-    ![1984-anonymous-tattoo.jpg](1984-anonymous-tattoo.jpg)   <=== no thank you
+    ![1984-anonymous-tattoo.jpg](1984-anonymous-tattoo.jpg)   <!-- no thank you -->
 ```
 
 use this HTML:
@@ -318,7 +318,7 @@ to incorrect URLs or file paths.
 Instead of:
 
 ```
-    [some text](https://example.com/foo_(bar))                <=== no thank you
+    [some text](https://example.com/foo_(bar))                <!-- no thank you -->
 ```
 
 Use:
@@ -330,7 +330,7 @@ Use:
 Instead of:
 
 ```
-    This thing, ([some text](some/path)), is NOT ideal.       <=== no thank you
+    This thing, ([some text](some/path)), is NOT ideal.       <!-- no thank you -->
 ```
 
 Use:
@@ -357,7 +357,7 @@ Instead of:
         return foo;
     }
 ```
-C compilers cannot be given a -Wno-main-arg-errors flag.      <=== no thank you
+C compilers cannot be given a -Wno-main-arg-errors flag.      <!-- no thank you -->
 ````
 
 Use:
@@ -384,7 +384,7 @@ Please do **NOT** use parenthesis inside the markdown link titles.
 Instead of:
 
 ```
-    [some (text)](https://example.com/cyrds)                  <=== no thank you
+    [some (text)](https://example.com/cyrds)                  <!-- no thank you -->
 ```
 
 Use:
@@ -396,7 +396,7 @@ Use:
 Instead of:
 
 ```
-    [ls(1)](https://example.com/ls-man-page.1)                <=== no thank you
+    [ls(1)](https://example.com/ls-man-page.1)                <-- no thank you -->
 ```
 
 Use:

--- a/news.html
+++ b/news.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../news.html">

--- a/next/index.html
+++ b/next/index.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../news.html">

--- a/next/rules.html
+++ b/next/rules.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../news.html">

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">
@@ -388,18 +388,18 @@
 <li><a href="years.html">Winning Entries</a></li>
 <li><a href="authors.html">People who have won</a></li>
 <li><a href="location.html">Location of authors</a></li>
-<li><a href="bugs.html">Bugs &amp; Misfeatures</a></li>
+<li><a href="bugs.html">Bugs and (mis)features</a></li>
 </ul>
 <h2 id="status">Status</h2>
 <ul>
 <li><a href="news.html">IOCCC News</a></li>
 <li><a href="status.html">Contest status</a></li>
-<li><a href="next/index.html">Rules &amp; Guidelines</a></li>
+<li><a href="next/index.html">Rules and Guidelines</a></li>
 </ul>
 <h2 id="faq">FAQ</h2>
 <ul>
 <li><a href="faq.html">FAQ</a></li>
-<li><a href="faq.html#fix_an_entry">How to enter the IOCCC</a></li>
+<li><a href="faq.html#submit">How to enter the IOCCC</a></li>
 <li><a href="faq.html#fix_an_entry">Fixing IOCCC entries</a></li>
 <li><a href="faq.html#fix_web_site">Fixing the website</a></li>
 <li><a href="faq.html#fix_author">Fixing author info</a></li>

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -5,18 +5,18 @@
 * [Winning Entries](years.html)
 * [People who have won](authors.html)
 * [Location of authors](location.html)
-* [Bugs &amp; Misfeatures](bugs.html)
+* [Bugs and (mis)features](bugs.html)
 
 ## Status
 
 * [IOCCC News](news.html)
 * [Contest status](status.html)
-* [Rules &amp; Guidelines](next/index.html)
+* [Rules and Guidelines](next/index.html)
 
 ## FAQ
 
 * [FAQ](faq.html)
-* [How to enter the IOCCC](faq.html#fix_an_entry)
+* [How to enter the IOCCC](faq.html#submit)
 * [Fixing IOCCC entries](faq.html#fix_an_entry)
 * [Fixing the website](faq.html#fix_web_site)
 * [Fixing author info](faq.html#fix_author)

--- a/status.html
+++ b/status.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -80,7 +80,7 @@
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
-                Bugs &amp; (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
           </div>
@@ -106,7 +106,7 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules &amp; Guidelines
+                Rules and Guidelines
               </a>
             </div>
           </div>
@@ -236,7 +236,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./bugs.html">
-              Bugs &amp; (Mis)features
+              Bugs and (mis)features
             </a>
 
           </div>
@@ -254,7 +254,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules &amp; Guidelines
+              Rules and Guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./news.html">


### PR DESCRIPTION

Something that was not noted in the other commit that touched this file
is that because this is markdown which renders to html I changed the
comments in the form of:

        <=== no thank you

to

        <!-- no thank you -->

This was not strictly necessary but and for non html it might not even
make sense except that it is still rendered to html and in most cases
(if not all) it is html. This was done for the rest of the file now too.
