### PR TITLE
Improve menu and link title and consistency

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1984/index.html
+++ b/1984/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1985/index.html
+++ b/1985/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/index.html
+++ b/1986/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/index.html
+++ b/1987/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/index.html
+++ b/1988/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/index.html
+++ b/1989/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/index.html
+++ b/1990/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/index.html
+++ b/1991/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/index.html
+++ b/1992/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/index.html
+++ b/1993/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/index.html
+++ b/1994/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/index.html
+++ b/1995/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/leo/spoiler1.html
+++ b/1995/leo/spoiler1.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/index.html
+++ b/1996/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/index.html
+++ b/1998/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/index.html
+++ b/2000/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/index.html
+++ b/2001/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/index.html
+++ b/2004/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/index.html
+++ b/2005/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/index.html
+++ b/2006/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/index.html
+++ b/2011/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/index.html
+++ b/2012/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../../location.html">

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/index.html
+++ b/2013/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/endoh1/spoilers.html
+++ b/2014/endoh1/spoilers.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/index.html
+++ b/2014/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/burton/spoilers.html
+++ b/2015/burton/spoilers.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/index.html
+++ b/2015/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/ferguson/FILES.html
+++ b/2018/ferguson/FILES.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/index.html
+++ b/2018/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/index.html
+++ b/2019/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/endoh2/spoiler/index.html
+++ b/2020/endoh2/spoiler/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../../location.html">

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/spoilers.html
+++ b/2020/ferguson1/spoilers.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/index.html
+++ b/2020/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/README.html
+++ b/README.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">

--- a/authors.html
+++ b/authors.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/bin/README.md
+++ b/bin/README.md
@@ -379,6 +379,31 @@ We recommend that this tool be invoked via the top level `Makefile` by:
 ```
 
 
+<div id="md2html_cfg">
+### [md2html.cfg](%%REPO_URL%%/bin/md2html.cfg)
+</div>
+
+This is a configuration file for the [md2html](index.html#md2html) tool.
+Although a configuration file it is also something of a script file.
+
+To not down descend into the depths of `pandoc(1)` and to have to explain how
+this file can change all the HTML files, we advise you to let
+[Smaug](https://www.glyphweb.com/arda/s/smaug.html) (the dragon of
+[Erebor](https://www.glyphweb.com/arda/e/erebor.html)), famously visited by a
+[Hobbit](https://www.glyphweb.com/arda/h/hobbits.html) and 13
+[Dwarves](https://www.glyphweb.com/arda/d/dwarves.html) in the
+[T.A.](https://www.glyphweb.com/arda/t/thirdage.html) 2941 or 1341
+in the [Shire-reckoning](https://www.glyphweb.com/arda/s/shirereckoning.html), slumber as
+"here be dragons". If you still need convincing, we wish to remind you of [Bilbo
+Baggins](https://www.glyphweb.com/arda/b/bilbobaggins.html)' famous words:
+
+
+```
+	"Never laugh at live dragons, Bilbo you fool!" he said to himself, and it
+	became a favourite saying of his later, and passed into a proverb.
+```
+
+
 <div id="md2html">
 ### [md2html.sh](%%REPO_URL%%/bin/md2html.sh)
 </div>
@@ -387,7 +412,7 @@ This is the primary tool that forms IOCCC generated HTML content from
 markdown files (permanent markdown files or temporarily generated
 markdown files) and HTML fragments from the [inc directory](../inc/index.html).
 
-The [bin/md2html.cfg](%%REPO_URL%%/bin/md2html.cfg) configuration file is
+The [md2html.cfg](index.html#md2html_cfg) configuration file is
 used by [md2html.sh](%%REPO_URL%%/bin/md2html.sh) to drive the generation process.
 
 

--- a/bin/index.html
+++ b/bin/index.html
@@ -575,13 +575,30 @@ do that, that is not a problem.</p>
 <pre><code>    bin/gen-years.sh -v 1</code></pre>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code> by:</p>
 <pre><code>    make gen_years</code></pre>
+<div id="md2html_cfg">
+<h3 id="md2html.cfg"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/md2html.cfg">md2html.cfg</a></h3>
+</div>
+<p>This is a configuration file for the <a href="index.html#md2html">md2html</a> tool.
+Although a configuration file it is also something of a script file.</p>
+<p>To not down descend into the depths of <code>pandoc(1)</code> and to have to explain how
+this file can change all the HTML files, we advise you to let
+<a href="https://www.glyphweb.com/arda/s/smaug.html">Smaug</a> (the dragon of
+<a href="https://www.glyphweb.com/arda/e/erebor.html">Erebor</a>), famously visited by a
+<a href="https://www.glyphweb.com/arda/h/hobbits.html">Hobbit</a> and 13
+<a href="https://www.glyphweb.com/arda/d/dwarves.html">Dwarves</a> in the
+<a href="https://www.glyphweb.com/arda/t/thirdage.html">T.A.</a> 2941 or 1341
+in the <a href="https://www.glyphweb.com/arda/s/shirereckoning.html">Shire-reckoning</a>, slumber as
+“here be dragons”. If you still need convincing, we wish to remind you of <a href="https://www.glyphweb.com/arda/b/bilbobaggins.html">Bilbo
+Baggins</a>’ famous words:</p>
+<pre><code>        &quot;Never laugh at live dragons, Bilbo you fool!&quot; he said to himself, and it
+        became a favourite saying of his later, and passed into a proverb.</code></pre>
 <div id="md2html">
 <h3 id="md2html.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/md2html.sh">md2html.sh</a></h3>
 </div>
 <p>This is the primary tool that forms IOCCC generated HTML content from
 markdown files (permanent markdown files or temporarily generated
 markdown files) and HTML fragments from the <a href="../inc/index.html">inc directory</a>.</p>
-<p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/md2html.cfg">bin/md2html.cfg</a> configuration file is
+<p>The <a href="index.html#md2html_cfg">md2html.cfg</a> configuration file is
 used by <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/md2html.sh">md2html.sh</a> to drive the generation process.</p>
 <div id="output-index-author">
 <h3 id="output-index-author.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/output-index-author.sh">output-index-author.sh</a></h3>

--- a/bin/index.html
+++ b/bin/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/bin/md2html.cfg
+++ b/bin/md2html.cfg
@@ -267,11 +267,11 @@ location.md
 	-s
 	TITLE=The International Obfuscated C Code Contest
 	-s
-	DESCRIPTION=Locations and/or countries of IOCCC Authors
+	DESCRIPTION=Location of winning authors
 	-s
 	KEYWORDS=IOCCC, IOCCC author by location, IOCCC author by country
 	-s
-	HEADER_2=IOCCC author by location and/or country
+	HEADER_2=Location of winning  authors
 	-D
 	./
 
@@ -283,11 +283,11 @@ markdown.md
 	-s
 	TITLE=The International Obfuscated C Code Contest
 	-s
-	DESCRIPTION=IOCCC markdown
+	DESCRIPTION=IOCCC markdown guidelines
 	-s
 	KEYWORDS=IOCCC, markdown
 	-s
-	HEADER_2=IOCCC markdown best practices
+	HEADER_2=IOCCC markdown guidelines
 	-D
 	./
 

--- a/bugs.html
+++ b/bugs.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/contact.html
+++ b/contact.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/faq.html
+++ b/faq.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -385,7 +385,7 @@
 <h1 id="faq-table-of-contents">FAQ Table of Contents</h1>
 <h2 id="section-0---submitting-entries-to-a-new-ioccc">Section 0 - <a href="#faq0">Submitting entries to a new IOCCC</a></h2>
 <ul>
-<li><a href="#faq0_0">0.0 - How may I submit to the IOCCC?</a></li>
+<li><a href="#faq0_0">0.0 - How may I enter the IOCCC?</a></li>
 <li><a href="#faq0_1">0.1 - What types of entries have been frequently submitted to the IOCCC?</a></li>
 <li><a href="#faq0_2">0.2 - What should I put in my entry’s Makefile?</a></li>
 <li><a href="#faq0_3">0.3 - May I use a different source or compiled filename than prog.c or prog?</a></li>
@@ -480,7 +480,7 @@ other inconsistencies with the original entry?</a></li>
 </div>
 <div id="faq0_0">
 <div id="submit">
-<h3 id="faq-0.0-how-may-i-submit-to-the-ioccc">FAQ 0.0: How may I submit to the IOCCC?</h3>
+<h3 id="faq-0.0-how-may-i-enter-the-ioccc">FAQ 0.0: How may I enter the IOCCC?</h3>
 </div>
 </div>
 <p>To submit your code to the IOCCC, you <strong>MUST</strong> follow these steps:</p>
@@ -2259,7 +2259,10 @@ For example, in <a href="contact.html">contact.html</a>, one may read:</p>
     &lt;!-- !!! Do not modify this web page, instead modify the file: contact.md --&gt;
     &lt;!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! --&gt;</code></pre>
 <p>This means that you could consider editing the referenced markdown file
-in your <a href="#pull_request">IOCCC pull request</a>.</p>
+AND then run <code>make www</code> from the top level directory in your <a href="#pull_request">IOCCC pull
+request</a>. There are quicker ways but to be sure you get
+everything built you should do this. If you modified a markdown and you do not
+see the same file as a html file then you did not complete the fix.</p>
 <p>Please see <a href="#fix_an_entry">FAQ 5.2 How may I submit a fix to an IOCCC
 entry</a>. See also the <a href="#ull_request">FAQ 6.10 How does someone
 make a change to a file and submit that change as a GitHub pull

--- a/faq.html
+++ b/faq.html
@@ -2324,7 +2324,7 @@ location</strong>, without the permission of the original author.</p>
 If wish to fix such links, you may open a GitHub pull request as described in
 <a href="#fix_web_site">FAQ 5.4</a>. In the case of dead links or invalid links it doesn’t matter
 if it’s a specific winner or not; the procedure is the same: open a pull request
-to fix the problem. See also the <a href="#ull_request">FAQ 6.10 How does someone
+to fix the problem. See also the <a href="#pull_request">FAQ 6.10 How does someone
 make a change to a file and submit that change as a GitHub pull
 request</a> for more information about pull requests.</p>
 <p>As far as how to find the updated link you can try using the <a href="https://web.archive.org">Internet Wayback

--- a/faq.md
+++ b/faq.md
@@ -2,7 +2,7 @@
 
 
 ## Section  0 - [Submitting entries to a new IOCCC](#faq0)
-- [0.0  - How may I submit to the IOCCC?](#faq0_0)
+- [0.0  - How may I enter the IOCCC?](#faq0_0)
 - [0.1  - What types of entries have been frequently submitted to the IOCCC?](#faq0_1)
 - [0.2  - What should I put in my entry's Makefile?](#faq0_2)
 - [0.3  - May I use a different source or compiled filename than prog.c or prog?](#faq0_3)
@@ -102,7 +102,7 @@ other inconsistencies with the original entry?](#faq4_3)
 
 <div id="faq0_0">
 <div id="submit">
-### FAQ 0.0: How may I submit to the IOCCC?
+### FAQ 0.0: How may I enter the IOCCC?
 </div>
 </div>
 
@@ -2727,7 +2727,10 @@ For example, in [contact.html](contact.html), one may read:
 ```
 
 This means that you could consider editing the referenced markdown file
-in your [IOCCC pull request](#pull_request).
+AND then run `make www` from the top level directory in your [IOCCC pull
+request](#pull_request). There are quicker ways but to be sure you get
+everything built you should do this. If you modified a markdown and you do not
+see the same file as a html file then you did not complete the fix.
 
 Please see [FAQ 5.2 How may I submit a fix to an IOCCC
 entry](#fix_an_entry).  See also the [FAQ 6.10 How does someone

--- a/faq.md
+++ b/faq.md
@@ -2824,7 +2824,7 @@ If wish to fix such links, you may open a GitHub pull request as described in
 if it's a specific winner or not; the procedure is the same: open a pull request
 to fix the problem.  See also the [FAQ 6.10 How does someone
 make a change to a file and submit that change as a GitHub pull
-request](#ull_request) for more information about pull requests.
+request](#pull_request) for more information about pull requests.
 
 As far as how to find the updated link you can try using the [Internet Wayback
 Machine](https://web.archive.org) and see if you can find the last non 4xx non

--- a/inc/index.html
+++ b/inc/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -24,13 +24,13 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -100,7 +100,7 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -138,7 +138,7 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -184,7 +184,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%location.html">

--- a/index.html
+++ b/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/judges.html
+++ b/judges.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -382,7 +382,7 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: judges.md -->
-<h1 id="the-judges">The Judges</h1>
+<h1 id="the-ioccc-judges">The IOCCC Judges</h1>
 <ul>
 <li><a href="http://www.mailcom.com/main.shtml">Leonid A. Broukhis</a></li>
 <li><a href="http://www.isthe.com/chongo/">Landon Curt Noll</a></li>

--- a/judges.md
+++ b/judges.md
@@ -1,4 +1,4 @@
-# The Judges
+# The IOCCC Judges
 
 * [Leonid A. Broukhis](http://www.mailcom.com/main.shtml)
 * [Landon Curt Noll](http://www.isthe.com/chongo/)

--- a/license.html
+++ b/license.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/location.html
+++ b/location.html
@@ -12,7 +12,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 <title>The International Obfuscated C Code Contest</title>
 <link rel="icon" type="image/x-icon" href="./favicon.ico">
-<meta name="description" content="Locations and/or countries of IOCCC Authors">
+<meta name="description" content="Location of winning authors">
 <meta name="keywords" content="IOCCC, IOCCC author by location, IOCCC author by country">
 </head>
 
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -363,7 +363,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>IOCCC author by location and/or country</h2>
+  <h2>Location of winning  authors</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/markdown.html
+++ b/markdown.html
@@ -12,7 +12,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 <title>The International Obfuscated C Code Contest</title>
 <link rel="icon" type="image/x-icon" href="./favicon.ico">
-<meta name="description" content="IOCCC markdown">
+<meta name="description" content="IOCCC markdown guidelines">
 <meta name="keywords" content="IOCCC, markdown">
 </head>
 
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -363,7 +363,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>IOCCC markdown best practices</h2>
+  <h2>IOCCC markdown guidelines</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->
@@ -382,7 +382,7 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: markdown.md -->
-<h1 id="ioccc-markdown-best-practices">IOCCC markdown best practices</h1>
+<h1 id="ioccc-markdown-guidelines">IOCCC markdown guidelines</h1>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
 For example, when <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
 submit remarks about their entry in markdown format. Every

--- a/markdown.md
+++ b/markdown.md
@@ -1,4 +1,4 @@
-# IOCCC markdown best practices
+# IOCCC markdown guidelines
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
 For example, when [submitting to the IOCCC](faq.html#submit), we have people

--- a/news.html
+++ b/news.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/next/README.md
+++ b/next/README.md
@@ -1,4 +1,4 @@
-# IOCCC Rules and Guidelines
+# Rules and Guidelines
 
 **IMPORTANT**: Did you read the **Important disclaimers about scope**
 and did you check the current **[IOCCC status](../status.html)**?

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/next/index.html
+++ b/next/index.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -382,7 +382,7 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: next/README.md -->
-<h1 id="ioccc-rules-and-guidelines">IOCCC Rules and Guidelines</h1>
+<h1 id="rules-and-guidelines">Rules and Guidelines</h1>
 <p><strong>IMPORTANT</strong>: Did you read the <strong>Important disclaimers about scope</strong>
 and did you check the current <strong><a href="../status.html">IOCCC status</a></strong>?</p>
 <ul>

--- a/next/rules.html
+++ b/next/rules.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="../faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -386,8 +386,8 @@
 <h2 id="entries">Entries</h2>
 <ul>
 <li><a href="years.html">Winning Entries</a></li>
-<li><a href="authors.html">People who have won</a></li>
-<li><a href="location.html">Location of authors</a></li>
+<li><a href="authors.html">Winning Authors</a></li>
+<li><a href="location.html">Location of winning authors</a></li>
 <li><a href="bugs.html">Bugs and (mis)features</a></li>
 </ul>
 <h2 id="status">Status</h2>
@@ -402,7 +402,7 @@
 <li><a href="faq.html#submit">How to enter the IOCCC</a></li>
 <li><a href="faq.html#fix_an_entry">Fixing IOCCC entries</a></li>
 <li><a href="faq.html#fix_web_site">Fixing the website</a></li>
-<li><a href="faq.html#fix_author">Fixing author info</a></li>
+<li><a href="faq.html#fix_author">Updating author info</a></li>
 </ul>
 <h2 id="about">About</h2>
 <ul>

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -3,8 +3,8 @@
 ## Entries
 
 * [Winning Entries](years.html)
-* [People who have won](authors.html)
-* [Location of authors](location.html)
+* [Winning Authors](authors.html)
+* [Location of winning  authors](location.html)
 * [Bugs and &#x28;mis&#x29;features](bugs.html)
 
 ## Status
@@ -19,7 +19,7 @@
 * [How to enter the IOCCC](faq.html#submit)
 * [Fixing IOCCC entries](faq.html#fix_an_entry)
 * [Fixing the website](faq.html#fix_web_site)
-* [Fixing author info](faq.html#fix_author)
+* [Updating author info](faq.html#fix_author)
 
 ## About
 

--- a/status.html
+++ b/status.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">

--- a/years.html
+++ b/years.html
@@ -68,13 +68,13 @@
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                People who have won
+                Winning Authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of authors
+                Location of winning  authors
               </a>
             </div>
 
@@ -144,7 +144,7 @@
 
             <div class="outfit-font">
               <a href="./faq.html#fix_author" class="sub-item-link">
-                Fixing author info
+                Updating author info
               </a>
             </div>
           </div>
@@ -182,7 +182,7 @@
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown
+                IOCCC markdown guidelines
               </a>
             </div>
           </div>
@@ -228,7 +228,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              People who have won
+              Authors of winning IOCCC entries
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">


### PR DESCRIPTION

A few page names were changed and menu link (titles) were changed too.
By page names it means either DESCRIPTION or HEADER_2 in 
bin/md2html.cfg. Although it looks better and is more consistent, there
might be one or two that can be further improved.

Naturally every html file that is markdown based was updated.