### PR TITLE
Improve menu how-to for tablet devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,8 @@ then consider making pull requests against the <a href="https://github.com/ioccc
      alt="hambuger-style menu icon"
       width=24 height=24></a> in the upper right corner, click on it to display the menu.</p>
 <p>On a <strong>touchscreen mobile device</strong> browser <strong>wider than 1024 pixels</strong>,
-<strong>press and hold</strong> words in the upper right corner to activate the pull-down menu.</p>
+<strong>press and hold</strong> the menu you wish to activate (in the upper right corner) in
+order to activate the pull-down.</p>
 <h1 id="obfuscate-defined">Obfuscate defined:</h1>
 <p>tr.v. -cated, -cating, -cates.
 <BR><BR>

--- a/index.md
+++ b/index.md
@@ -31,7 +31,8 @@ If you see this icon <a href="nojs-menu.html"> <img src="png/hamburger-icon-open
       width=24 height=24></a> in the upper right corner, click on it to display the menu.
 
 On a **touchscreen mobile device** browser **wider than 1024 pixels**,
-**press and hold** words in the upper right corner to activate the pull-down menu.
+**press and hold** the menu you wish to activate (in the upper right corner) in
+order to activate the pull-down.
 
 
 # Obfuscate defined:


### PR DESCRIPTION
The words 'press and hold words in the upper right corner' is less clear than 'press and hold the menu you wish to activate'. It is obvious, perhaps, to most, but it is better to be clearer.