### PR TITLE
Fixes in contact.html and FAQ

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -391,7 +391,7 @@
 </ul>
 <p>Instead of sending us Email, <strong>Please</strong> consider using the <a href="https://github.com/ioccc-src/winner/pulls">GitHub
 pull request</a> process
-against the master <a href="https://github.com/ioccc-src/winner/branches">branch</a>
+against the <a href="https://github.com/ioccc-src/winner/branches">master branch</a>
 of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>.</p>
 <p>If you are trying to:</p>
 <ul>
@@ -399,11 +399,11 @@ of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>.<
 <li><strong>Report an IOCCC website problem</strong> - See <a href="faq.html#report_web_problem">FAQ 5.3</a></li>
 <li><strong>Report a broken or wrong web link</strong> - See <a href="faq.html#fix_link">FAQ 5.6</a></li>
 </ul>
-<p>Instead first look at the <a href="https://github.com/ioccc-src/winner/issues">IOCCC
+<p>In general, unless you have a fix, if you want to report something, you should instead first look at the <a href="https://github.com/ioccc-src/winner/issues">IOCCC
 issues</a> to see if the
 problem has already been reported. If it has been reported, feel
-free to add a comment to the issue. If you do not find an it has
-been reported, then feel free to open a <a href="https://github.com/ioccc-src/winner/issues">new IOCCC
+free to add a comment to the issue. Otherwise, if you do not see the same issue
+reported, then feel free to <a href="https://github.com/ioccc-src/winner/issues/new">open a new IOCCC
 issue</a>.</p>
 <p>If you are trying to:</p>
 <ul>

--- a/contact.md
+++ b/contact.md
@@ -8,7 +8,7 @@ If you are trying to:
 
 Instead of sending us Email, **Please** consider using the [GitHub
 pull request](https://github.com/ioccc-src/winner/pulls) process
-against the master [branch](https://github.com/ioccc-src/winner/branches)
+against the [master branch](https://github.com/ioccc-src/winner/branches)
 of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner).
 
 If you are trying to:
@@ -17,12 +17,12 @@ If you are trying to:
 * **Report an IOCCC website problem** - See [FAQ 5.3](faq.html#report_web_problem)
 * **Report a broken or wrong web link** - See [FAQ 5.6](faq.html#fix_link)
 
-Instead first look at the [IOCCC
+In general, unless you have a fix, if you want to report something, you should instead first look at the [IOCCC
 issues](https://github.com/ioccc-src/winner/issues) to see if the
 problem has already been reported.  If it has been reported, feel
-free to add a comment to the issue.  If you do not find an it has
-been reported, then feel free to open a [new IOCCC
-issue](https://github.com/ioccc-src/winner/issues).
+free to add a comment to the issue.  Otherwise, if you do not see the same issue
+reported, then feel free to [open a new IOCCC
+issue](https://github.com/ioccc-src/winner/issues/new).
 
 If you are trying to:
 

--- a/faq.html
+++ b/faq.html
@@ -414,7 +414,7 @@
 <ul>
 <li><a href="#faq3_0">3.0 - What Makefile rules are available to build or clean up IOCCC entries?</a></li>
 <li><a href="#faq3_1">3.1 - Why doesn’t an IOCCC entry compile?</a></li>
-<li><a href="#faq3_2">3.2 - Why does a IOCCC entry fail on my 64-bit system?</a></li>
+<li><a href="#faq3_2">3.2 - Why does an IOCCC entry fail on my 64-bit system?</a></li>
 <li><a href="#faq3_3">3.3 - Why do some IOCCC entries fail to compile under macOS?</a></li>
 <li><a href="#faq3_4">3.4 - Why does clang or gcc fail to compile an IOCCC entry?</a></li>
 <li><a href="#faq3_5">3.5 - What is this cb tool that is mentioned in the IOCCC?</a></li>
@@ -1210,7 +1210,7 @@ that works for modern systems but one can view the original code in the
 fixed so that they can compile in modern systems though just because an entry
 compiles does not mean it will run on your specific system.</p>
 <div id="faq3_2">
-<h3 id="faq-3.2-why-does-a-ioccc-entry-fail-on-my-64-bit-system">FAQ 3.2: Why does a IOCCC entry fail on my 64-bit system?</h3>
+<h3 id="faq-3.2-why-does-an-ioccc-entry-fail-on-my-64-bit-system">FAQ 3.2: Why does an IOCCC entry fail on my 64-bit system?</h3>
 </div>
 <p>Unfortunately some older entries are non-portable and require 32-bit support or
 32-bit binaries. A problem system here is macOS Catalina (10.15) as as of that
@@ -2218,13 +2218,12 @@ may or may not be specific to a particular IOCCC entry) that is <strong>not rela
 to a particular IOCCC entry</strong>, the best way you can help is to submit a fix to
 the IOCCC website. See <a href="#fix_web_site">FAQ 5.4</a> for information on submitting fixes
 to the IOCCC website.</p>
-<p>If you do not have a IOCCC website fix, and just wish to report a
-general IOCCC website problem, we ask that you first look at the
-<a href="https://github.com/ioccc-src/winner/issues">IOCCC issues</a> to see
-if the problem has already been reported. If it has been reported,
-feel free to add a comment to the issue. If you do not find an it
-has been reported, then fee free to open a <a href="https://github.com/ioccc-src/winner/issues">new IOCCC
-issue</a>.</p>
+<p>If you do not have an IOCCC website fix, and just wish to report a general IOCCC
+website problem, we ask that you first look at the <a href="https://github.com/ioccc-src/winner/issues">IOCCC
+issues</a> to see if the problem has
+already been reported. If it has been reported, feel free to add a comment to
+the issue. Otherwise, if you do not see the same issue reported, then feel free
+to <a href="https://github.com/ioccc-src/winner/issues/new">open a new IOCCC issue</a>.</p>
 <div id="faq5_4">
 <div id="fix_web_site">
 <h3 id="faq-5.4-how-may-i-submit-a-fix-to-the-ioccc-website">FAQ 5.4: How may I submit a fix to the IOCCC website?</h3>
@@ -2485,7 +2484,7 @@ selected information about the authors. Tools from the <a href="bin/index.html">
 use the content of these JSON files to generate the <code>index.html</code> files for each IOCCC
 winning entry.</p>
 <p>Moreover, should the <a href="judges.html">IOCCC judges</a> need to
-contact an authors of a IOCCC entry, they will consult the contents
+contact an authors of an IOCCC entry, they will consult the contents
 of the author’s JSON file for ways to contact them.</p>
 <p>Each author of an IOCCC winning entry has their own <code>author_handle.json</code> file
 of the form:</p>

--- a/faq.md
+++ b/faq.md
@@ -31,7 +31,7 @@
 ## Section  3 - [Compiling and running IOCCC entries](#faq3)
 - [3.0  - What Makefile rules are available to build or clean up IOCCC entries?](#faq3_0)
 - [3.1  - Why doesn't an IOCCC entry compile?](#faq3_1)
-- [3.2  - Why does a IOCCC entry fail on my 64-bit system?](#faq3_2)
+- [3.2  - Why does an IOCCC entry fail on my 64-bit system?](#faq3_2)
 - [3.3  - Why do some IOCCC entries fail to compile under macOS?](#faq3_3)
 - [3.4  - Why does clang or gcc fail to compile an IOCCC entry?](#faq3_4)
 - [3.5  - What is this cb tool that is mentioned in the IOCCC?](#faq3_5)
@@ -1085,7 +1085,7 @@ compiles does not mean it will run on your specific system.
 
 
 <div id="faq3_2">
-### FAQ 3.2: Why does a IOCCC entry fail on my 64-bit system?
+### FAQ 3.2: Why does an IOCCC entry fail on my 64-bit system?
 </div>
 
 Unfortunately some older entries are non-portable and require 32-bit support or
@@ -2670,13 +2670,12 @@ to a particular IOCCC entry**, the best way you can help is to submit a fix to
 the IOCCC website.  See [FAQ 5.4](#fix_web_site) for information on submitting fixes
 to the IOCCC website.
 
-If you do not have a IOCCC website fix, and just wish to report a
-general IOCCC website problem, we ask that you first look at the
-[IOCCC issues](https://github.com/ioccc-src/winner/issues) to see
-if the problem has already been reported.  If it has been reported,
-feel free to add a comment to the issue.  If you do not find an it
-has been reported, then fee free to open a [new IOCCC
-issue](https://github.com/ioccc-src/winner/issues).
+If you do not have an IOCCC website fix, and just wish to report a general IOCCC
+website problem, we ask that you first look at the [IOCCC
+issues](https://github.com/ioccc-src/winner/issues) to see if the problem has
+already been reported.  If it has been reported, feel free to add a comment to
+the issue. Otherwise, if you do not see the same issue reported, then feel free
+to [open a new IOCCC issue](https://github.com/ioccc-src/winner/issues/new).
 
 
 <div id="faq5_4">
@@ -3059,7 +3058,7 @@ use the content of these JSON files to generate the `index.html` files for each 
 winning entry.
 
 Moreover, should the [IOCCC judges](judges.html) need to
-contact an authors of a IOCCC entry, they will consult the contents
+contact an authors of an IOCCC entry, they will consult the contents
 of the author's JSON file for ways to contact them.
 
 Each author of an IOCCC winning entry has their own `author_handle.json` file


### PR DESCRIPTION
The fixes in the FAQ correspond to the fixes in the contact.html file.

With this commit the contact.html file seems okay but the FAQ is not yet looked at.