### PR TITLE
Typo fix menu item for location of authors

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1984/index.html
+++ b/1984/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1985/index.html
+++ b/1985/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/index.html
+++ b/1986/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/index.html
+++ b/1987/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/index.html
+++ b/1988/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/index.html
+++ b/1989/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/index.html
+++ b/1990/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/index.html
+++ b/1991/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/index.html
+++ b/1992/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/index.html
+++ b/1993/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/index.html
+++ b/1994/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/index.html
+++ b/1995/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/leo/spoiler1.html
+++ b/1995/leo/spoiler1.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/index.html
+++ b/1996/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/index.html
+++ b/1998/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/index.html
+++ b/2000/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/guidelines.txt
+++ b/2001/guidelines.txt
@@ -785,7 +785,7 @@ ANNOUNCEMENT OF WINNERS:
     and test our Makefile.  This review process typically takes a few weeks.   |
 									       |
     Sometime after the initial announcement, and once the review by	       |
-    the winners has been completed (perhaps Feb or Mar 2002), the winning      |
+    the winners has been completed (perhaps Feb or Mar 2002), the winning     |
     source will be posted to the IOCCC website:		               |
 									       |
 	    https://www.ioccc.org/years.html				       |

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/index.html
+++ b/2001/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/index.html
+++ b/2004/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/index.html
+++ b/2005/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/index.html
+++ b/2006/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/index.html
+++ b/2011/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/index.html
+++ b/2012/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/index.html
+++ b/2013/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/endoh1/spoilers.html
+++ b/2014/endoh1/spoilers.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/index.html
+++ b/2014/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/burton/spoilers.html
+++ b/2015/burton/spoilers.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/index.html
+++ b/2015/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/ferguson/FILES.html
+++ b/2018/ferguson/FILES.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/index.html
+++ b/2018/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/index.html
+++ b/2019/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/endoh2/spoiler/index.html
+++ b/2020/endoh2/spoiler/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/spoilers.html
+++ b/2020/ferguson1/spoilers.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/index.html
+++ b/2020/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/README.html
+++ b/README.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/authors.html
+++ b/authors.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/bin/index.html
+++ b/bin/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/bin/md2html.cfg
+++ b/bin/md2html.cfg
@@ -271,7 +271,7 @@ location.md
 	-s
 	KEYWORDS=IOCCC, IOCCC author by location, IOCCC author by country
 	-s
-	HEADER_2=Location of winning  authors
+	HEADER_2=Location of winning authors
 	-D
 	./
 

--- a/bugs.html
+++ b/bugs.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/contact.html
+++ b/contact.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/faq.html
+++ b/faq.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/inc/index.html
+++ b/inc/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -30,7 +30,7 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/judges.html
+++ b/judges.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/license.html
+++ b/license.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/location.html
+++ b/location.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 
@@ -363,7 +363,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>Location of winning  authors</h2>
+  <h2>Location of winning authors</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/markdown.html
+++ b/markdown.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/news.html
+++ b/news.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/next/index.html
+++ b/next/index.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/next/rules.html
+++ b/next/rules.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -4,7 +4,7 @@
 
 * [Winning Entries](years.html)
 * [Winning Authors](authors.html)
-* [Location of winning  authors](location.html)
+* [Location of winning authors](location.html)
 * [Bugs and &#x28;mis&#x29;features](bugs.html)
 
 ## Status

--- a/status.html
+++ b/status.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 

--- a/years.html
+++ b/years.html
@@ -74,7 +74,7 @@
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning  authors
+                Location of winning authors
               </a>
             </div>
 


### PR DESCRIPTION
It should be 'Location of winning authors' (as it is now) but by mistake there was an extra space ('Location of winning  authors'). Obviously this is a huge commit as every html file with a menu (almost all) had to be updated.