### PR TITLE
Fix 1984/decot alt build

### DIFF
--- a/1984/decot/.gitignore
+++ b/1984/decot/.gitignore
@@ -2,6 +2,7 @@
 # sort with: ../../bin/sgi.sh
 *.dSYM
 decot
+decot.alt
 decot.orig
 indent
 indent.c

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -144,9 +144,11 @@ ${PROG}: ${PROG}.c
 alt: data ${ALT_TARGET}
 	@${TRUE}
 
-
+# We CANNOT have the ${CFLAGS} here as -traditional-cpp conflicts with them,
+# causing a compilation error in at least some versions of gcc.
 ${PROG}.alt: ${PROG}.alt.c
-	${CC} ${CFLAGS} -traditional-cpp $< -o $@ ${LDFLAGS}
+	${CC} -traditional-cpp $< -o $@ ${LDFLAGS}
+
 # data files
 #
 data: ${DATA}

--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -40,6 +40,10 @@ can use this version.
     make alt
 ```
 
+Notice that one **CANNOT** have the usual `${CFLAGS}` along with the
+`-traditional-cpp` in all systems. This is why the Makefile only has the latter
+option as the others conflict with it.
+
 
 ### Alternate use:
 
@@ -71,13 +75,18 @@ to:
     for(signal=0;*k *x * __FILE__ *i;) do {
 ```
 
-To see what we mean look at the [original source file](%%REPO_URL%%/1984/decot/decot.orig.c). The
-[alternate code](%%REPO_URL%%/1984/decot/decot.alt.c) is the version that has this modification. The
+To see what we mean look at the [original source
+file](%%REPO_URL%%/1984/decot/decot.orig.c) at [line
+15](%%REPO_URL%%/1984/decot/decot.orig.c#L15) which has the way it once was. The
+[alternate code](%%REPO_URL%%/1984/decot/decot.alt.c) is the version that has
+this modification but at [line 16](%%REPO_URL%%/1984/decot/decot.alt.c#L16). The
 fixed version has instead:
 
 ``` <!---c-->
     for(signal=0;*k *= * __FILE__ *i;) do {
 ```
+
+plus a line above it that had to be added.
 
 
 ## Author's remarks:

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -418,6 +418,9 @@ The original code was fixed in 2023 to not require this.</p>
 can use this version.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
+<p>Notice that one <strong>CANNOT</strong> have the usual <code>${CFLAGS}</code> along with the
+<code>-traditional-cpp</code> in all systems. This is why the Makefile only has the latter
+option as the others conflict with it.</p>
 <h3 id="alternate-use">Alternate use:</h3>
 <pre><code>    ./decot.alt</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
@@ -430,10 +433,14 @@ changed it from:</p>
 <pre><code>    for(signal=0;*k * x * __FILE__ *i;) do {</code></pre>
 <p>to:</p>
 <pre><code>    for(signal=0;*k *x * __FILE__ *i;) do {</code></pre>
-<p>To see what we mean look at the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.orig.c">original source file</a>. The
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.alt.c">alternate code</a> is the version that has this modification. The
+<p>To see what we mean look at the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.orig.c">original source
+file</a> at <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.orig.c#L15">line
+15</a> which has the way it once was. The
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.alt.c">alternate code</a> is the version that has
+this modification but at <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.alt.c#L16">line 16</a>. The
 fixed version has instead:</p>
 <pre><code>    for(signal=0;*k *= * __FILE__ *i;) do {</code></pre>
+<p>plus a line above it that had to be added.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>No remarks were provided by the author.</p>
 <!--

--- a/bugs.html
+++ b/bugs.html
@@ -696,8 +696,8 @@ own fix or suggest that they’re fixed!</p>
 <h3 id="status-inabiaf---please-do-not-fix-1">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1984decotdecot.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.c">1984/decot/decot.c</a></h3>
 <h3 id="information-1984decotindex.html">Information: <a href="1984/decot/index.html">1984/decot/index.html</a></h3>
-<p>The purpose of this program is to print out a string of rubbish. In particular
-you should see something like:</p>
+<p>The purpose of this program is to print out what looks like a fragment of C
+code.. In particular you should see something like:</p>
 <pre><code>    $ ./decot
     &#39;&quot;,x);      /*
     \</code></pre>

--- a/bugs.md
+++ b/bugs.md
@@ -454,8 +454,8 @@ own fix or suggest that they're fixed!
 ### Source code: [1984/decot/decot.c](%%REPO_URL%%/1984/decot/decot.c)
 ### Information: [1984/decot/index.html](1984/decot/index.html)
 
-The purpose of this program is to print out a string of rubbish. In particular
-you should see something like:
+The purpose of this program is to print out what looks like a fragment of C
+code.. In particular you should see something like:
 
 ``` <!---sh-->
     $ ./decot

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -443,12 +443,11 @@ code, to see what had to be done.</p>
 <p><code>Clang</code> is also more strict about the type of args in <code>main()</code> and this was also a
 problem that Cody fixed, making it work with both <code>clang</code> and <code>gcc</code>.</p>
 <p>These fixes worked fine in macOS but it turned out that in some cases with
-<code>clang</code>
-in Linux it did not work so this had to be further fixed which Cody also did. It
-is no longer clear what the problem was as in fedora 38 with <code>clang</code> 16.0.6; the
-only difference is it causes additional warnings but it seems to work just fine.
-It seems unlikely that a fix was made just for warnings so it is presumed that
-there was another problem and thus the change is kept in place.</p>
+<code>clang</code> in Linux it did not work so this had to be further fixed which Cody also
+did. It is no longer clear what the problem was as in fedora 38 with <code>clang</code>
+16.0.6; the only difference is it causes additional warnings but it seems to
+work just fine. It seems unlikely that a fix was made just for warnings so it
+is presumed that there was another problem and thus the change is kept in place.</p>
 <p>A note about the fix is that the <code>#define</code>d macros that were used still exist
 but most are not used; they are left in just to make it look more like the
 original entry. Nevertheless those cannot be used.</p>
@@ -478,10 +477,15 @@ the others are <code>char **</code>s. This is why the arg was removed and the ca
 do not support <code>-traditional-cpp</code>.</p>
 <p>If the ANSI C committee or a new version of <code>clang</code> messes this up (both of which
 seem possible) it is easy to fix but it is hoped that this won’t happen.</p>
-<p>Originally <a href="#yusuke">Yusuke</a> supplied a patch so that this entry would compile with <code>gcc</code> -
-but not <code>clang</code> - or at least some versions.</p>
+<p>Originally <a href="#yusuke">Yusuke</a> supplied a patch so that this entry would compile
+with <code>gcc</code> - but not <code>clang</code> - or at least some versions.</p>
 <p>To see the difference from start to fixed:</p>
 <pre><code>    cd 1984/decot ; make diff_orig_prog</code></pre>
+<p>Cody later discovered that the <code>make alt</code> rule does not work as the
+<code>-traditional-cpp</code> option conflicts with some of the other options. Thus the
+<code>make alt</code> rule only uses <code>-traditional-cpp</code>.</p>
+<p>To see the diff between the original and the alternate code, try:</p>
+<pre class="&lt;!--sh--&gt;"><code>        cd 1984/decot ; make diff_orig_alt</code></pre>
 <div id="1984_laman">
 <h2 id="winning-entry-1984laman">Winning entry: <a href="1984/laman/index.html">1984/laman</a></h2>
 <h3 id="winning-entry-source-code-laman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">laman.c</a></h3>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -79,12 +79,11 @@ code, to see what had to be done.
 problem that Cody fixed, making it work with both `clang` and `gcc`.
 
 These fixes worked fine in macOS but it turned out that in some cases with
-`clang`
-in Linux it did not work so this had to be further fixed which Cody also did. It
-is no longer clear what the problem was as in fedora 38 with `clang` 16.0.6; the
-only difference is it causes additional warnings but it seems to work just fine.
-It seems unlikely that a fix was made just for warnings so it is presumed that
-there was another problem and thus the change is kept in place.
+`clang` in Linux it did not work so this had to be further fixed which Cody also
+did. It is no longer clear what the problem was as in fedora 38 with `clang`
+16.0.6; the only difference is it causes additional warnings but it seems to
+work just fine.  It seems unlikely that a fix was made just for warnings so it
+is presumed that there was another problem and thus the change is kept in place.
 
 A note about the fix is that the `#define`d macros that were used still exist
 but most are not used; they are left in just to make it look more like the
@@ -123,13 +122,23 @@ do not support `-traditional-cpp`.
 If the ANSI C committee or a new version of `clang` messes this up (both of which
 seem possible) it is easy to fix but it is hoped that this won't happen.
 
-Originally [Yusuke](#yusuke) supplied a patch so that this entry would compile with `gcc` -
-but not `clang` - or at least some versions.
+Originally [Yusuke](#yusuke) supplied a patch so that this entry would compile
+with `gcc` - but not `clang` - or at least some versions.
 
 To see the difference from start to fixed:
 
 ``` <!---sh-->
     cd 1984/decot ; make diff_orig_prog
+```
+
+Cody later discovered that the `make alt` rule does not work as the
+`-traditional-cpp` option conflicts with some of the other options. Thus the
+`make alt` rule only uses `-traditional-cpp`.
+
+To see the diff between the original and the alternate code, try:
+
+``` <!--sh-->
+	cd 1984/decot ; make diff_orig_alt
 ```
 
 

--- a/tmp/update-manifest.sh
+++ b/tmp/update-manifest.sh
@@ -303,6 +303,10 @@ read -r -n 1 -p "Press any key to continue: "
 echo 1>&2
 
 echo "$(basename "$0"): will now update index.html files." 1>&2
+echo "NOTE: quick-readme2index.sh will not create all index.html" 1>&2
+echo "files: it checks the timestamp of README.md and the respective" 1>&2
+echo "index.html files. Thus if you have not modified all the necessary" 1>&2
+echo "README.md files then you should not use the quick option!" 1>&2
 read -r -p "Do you wish to use quick-readme2index.sh (Y/N)? "
 if [[ "$REPLY" != "Y" && "$REPLY" != "y" ]]; then
     echo "$(basename "$0"): now will run: bin/all-run.sh -v $CAP_D_FLAG bin/readme2index.sh -v $CAP_D_FLAG" 1>&2
@@ -326,7 +330,6 @@ if ! bin/gen-other-html.sh -v "$CAP_D_FLAG"; then
     exit 5
 fi
 
-
 read -r -n 1 -p "Press any key to run: $GIT diff: "
 echo 1>&2
 "$GIT" diff
@@ -335,6 +338,22 @@ read -r -p "Does everything look okay (Y/N)? "
 if [[ "$REPLY" != "Y" && "$REPLY" != "y" ]]; then
     echo "$0: exiting 4 due to user telling us git diff DOES NOT LOOK OKAY." 1>&2
     exit 4
+fi
+
+echo "$(basename "$0"): now will run: make find_missing_links"
+echo "NOTE: this can take a little while." 1>&2
+if ! make find_missing_links; then
+    echo "problem running make find_missing_links, fix and try again." 1>&2
+	echo "NOTE: since everything else was updated, you can just fix the links" 1>&2
+	echo "and then run the appropriate make rules to fix just the affected html" 1>&2
+	echo "files rather than run this script all over again. If you're in doubt," 1>&2
+	echo "you can run:" 1>&2
+	echo
+	echo "		make www" 1>&2
+	echo
+	echo "to be absolutely sure that every html file is updated but this is likely" 1>&2
+	echo "not needed unless a lot of files had broken links." 1>&2
+    exit 5
 fi
 
 if [[ -n "$A_FLAG" ]]; then


### PR DESCRIPTION

In the case of this entry, it is so screwy that having the CFLAGS 
conflicts with the -traditional-cpp option in some systems. Thus the alt
rule has ONLY the -traditional-cpp option. The thanks file notes this
oddity and how to view the diff between the original and the alternate 
code.

Also the bugs file was changed to be worded like the README.md file.

The index.html file was improved for the fix to the Makefile (for the
alt build) and it also links to the specific lines in the code on GitHub
(see the index.html file how it talks about specific lines in the
judges' remarks).
