### PR TITLE
Improve bin/output-year-index.sh

### DIFF
--- a/1984/index.html
+++ b/1984/index.html
@@ -429,10 +429,10 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1984.tar.bz2"><strong>Download all winning entries from 1984</strong></a></p>
 <ul>
-<li><a href="anonymous/index.html">1984/anonymous</a> - Dishonorable Mention</li>
-<li><a href="decot/index.html">1984/decot</a> - Second Place</li>
-<li><a href="laman/index.html">1984/laman</a> - Third Place</li>
-<li><a href="mullender/index.html">1984/mullender</a> - Grand Prize</li>
+<li><a href="anonymous/index.html"><strong>1984/anonymous</strong></a> - <strong>Dishonorable Mention</strong></li>
+<li><a href="decot/index.html"><strong>1984/decot</strong></a> - <strong>Second Place</strong></li>
+<li><a href="laman/index.html"><strong>1984/laman</strong></a> - <strong>Third Place</strong></li>
+<li><a href="mullender/index.html"><strong>1984/mullender</strong></a> - <strong>Grand Prize</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1985/index.html
+++ b/1985/index.html
@@ -428,11 +428,11 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1985.tar.bz2"><strong>Download all winning entries from 1985</strong></a></p>
 <ul>
-<li><a href="applin/index.html">1985/applin</a> - Best one liner</li>
-<li><a href="august/index.html">1985/august</a> - Most obscure program</li>
-<li><a href="lycklama/index.html">1985/lycklama</a> - Strangest appearing program</li>
-<li><a href="shapiro/index.html">1985/shapiro</a> - Grand Prize - Most well rounded in confusion</li>
-<li><a href="sicherman/index.html">1985/sicherman</a> - Worst abuse of the C preprocessor</li>
+<li><a href="applin/index.html"><strong>1985/applin</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="august/index.html"><strong>1985/august</strong></a> - <strong>Most obscure program</strong></li>
+<li><a href="lycklama/index.html"><strong>1985/lycklama</strong></a> - <strong>Strangest appearing program</strong></li>
+<li><a href="shapiro/index.html"><strong>1985/shapiro</strong></a> - <strong>Grand Prize - Most well rounded in confusion</strong></li>
+<li><a href="sicherman/index.html"><strong>1985/sicherman</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1986/index.html
+++ b/1986/index.html
@@ -437,15 +437,15 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1986.tar.bz2"><strong>Download all winning entries from 1986</strong></a></p>
 <ul>
-<li><a href="applin/index.html">1986/applin</a> - Most adaptable program</li>
-<li><a href="august/index.html">1986/august</a> - Best complex task done in a complex way</li>
-<li><a href="bright/index.html">1986/bright</a> - Most useful obfuscation</li>
-<li><a href="hague/index.html">1986/hague</a> - Worst abuse of the C preprocessor</li>
-<li><a href="holloway/index.html">1986/holloway</a> - Best simple task performed in a complex way</li>
-<li><a href="marshall/index.html">1986/marshall</a> - Best layout</li>
-<li><a href="pawka/index.html">1986/pawka</a> - Most illegible code</li>
-<li><a href="stein/index.html">1986/stein</a> - Best one liner</li>
-<li><a href="wall/index.html">1986/wall</a> - Grand Prize - Most well rounded in confusion</li>
+<li><a href="applin/index.html"><strong>1986/applin</strong></a> - <strong>Most adaptable program</strong></li>
+<li><a href="august/index.html"><strong>1986/august</strong></a> - <strong>Best complex task done in a complex way</strong></li>
+<li><a href="bright/index.html"><strong>1986/bright</strong></a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="hague/index.html"><strong>1986/hague</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><a href="holloway/index.html"><strong>1986/holloway</strong></a> - <strong>Best simple task performed in a complex way</strong></li>
+<li><a href="marshall/index.html"><strong>1986/marshall</strong></a> - <strong>Best layout</strong></li>
+<li><a href="pawka/index.html"><strong>1986/pawka</strong></a> - <strong>Most illegible code</strong></li>
+<li><a href="stein/index.html"><strong>1986/stein</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="wall/index.html"><strong>1986/wall</strong></a> - <strong>Grand Prize - Most well rounded in confusion</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1987/index.html
+++ b/1987/index.html
@@ -442,13 +442,13 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1987.tar.bz2"><strong>Download all winning entries from 1987</strong></a></p>
 <ul>
-<li><a href="biggar/index.html">1987/biggar</a> - Best abuse of the rules</li>
-<li><a href="heckbert/index.html">1987/heckbert</a> - Best obfuscator of programs</li>
-<li><a href="hines/index.html">1987/hines</a> - Worst style</li>
-<li><a href="korn/index.html">1987/korn</a> - Best one liner</li>
-<li><a href="lievaart/index.html">1987/lievaart</a> - Grand Prize</li>
-<li><a href="wall/index.html">1987/wall</a> - Most useful obfuscation</li>
-<li><a href="westley/index.html">1987/westley</a> - Best layout</li>
+<li><a href="biggar/index.html"><strong>1987/biggar</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="heckbert/index.html"><strong>1987/heckbert</strong></a> - <strong>Best obfuscator of programs</strong></li>
+<li><a href="hines/index.html"><strong>1987/hines</strong></a> - <strong>Worst style</strong></li>
+<li><a href="korn/index.html"><strong>1987/korn</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="lievaart/index.html"><strong>1987/lievaart</strong></a> - <strong>Grand Prize</strong></li>
+<li><a href="wall/index.html"><strong>1987/wall</strong></a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="westley/index.html"><strong>1987/westley</strong></a> - <strong>Best layout</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1988/index.html
+++ b/1988/index.html
@@ -394,15 +394,16 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>The maximum size of entries was raised from 1024 to 1536 bytes, however smaller
 entries were encouraged. Due to the <a href="../1987/biggar/index.html">“Best Abuse of the Rules” entry of
 1987</a>, a limit of 160 chars in the compile line was introduced.</p>
-<p>This year, the Grand Prize was given to the most unusual entry and best
-abuse of the C Preprocessor rather than the most well rounded entry.</p>
-<p><a href="rules.txt">Rules</a> and <a href="../years.html#1988">results</a> were posted to comp.lang.c,
-comp.sources.unix and alt.sources. The 1988 winning entries will be published
+<p>This year, the <a href="applin/index.html">Best of Show</a> was given to the most unusual
+entry and <code>best abuse of the C Preprocessor</code> rather than the most well rounded
+entry.</p>
+<p><a href="rules.txt">Rules</a> and <a href="../years.html#1988">results</a> were posted to <em>comp.lang.c</em>,
+<em>comp.sources.unix</em> and <em>alt.sources</em>. The 1988 winning entries will be published
 in the <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
 Journal</a>.</p>
 <p>Winning entries for previous years were repackaged with each year
 being in its own directory. Makefiles and hints were also provided.
-The package was posted to the comp.sources.unix newsgroup. They are
+The package was posted to the <em>comp.sources.unix</em> newsgroup. They are
 also available on a wide number of USENET archive sites.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
@@ -435,15 +436,15 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1988.tar.bz2"><strong>Download all winning entries from 1988</strong></a></p>
 <ul>
-<li><a href="applin/index.html">1988/applin</a> - Best of Show</li>
-<li><a href="dale/index.html">1988/dale</a> - Best abuse of system calls</li>
-<li><a href="isaak/index.html">1988/isaak</a> - Best visuals</li>
-<li><a href="litmaath/index.html">1988/litmaath</a> - Best small program</li>
-<li><a href="phillipps/index.html">1988/phillipps</a> - Least likely to compile successfully</li>
-<li><a href="reddy/index.html">1988/reddy</a> - Most useful obfuscated C program</li>
-<li><a href="robison/index.html">1988/robison</a> - Best abuse of C constructs</li>
-<li><a href="spinellis/index.html">1988/spinellis</a> - Best abuse of the rules</li>
-<li><a href="westley/index.html">1988/westley</a> - Best layout</li>
+<li><a href="applin/index.html"><strong>1988/applin</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="dale/index.html"><strong>1988/dale</strong></a> - <strong>Best abuse of system calls</strong></li>
+<li><a href="isaak/index.html"><strong>1988/isaak</strong></a> - <strong>Best visuals</strong></li>
+<li><a href="litmaath/index.html"><strong>1988/litmaath</strong></a> - <strong>Best small program</strong></li>
+<li><a href="phillipps/index.html"><strong>1988/phillipps</strong></a> - <strong>Least likely to compile successfully</strong></li>
+<li><a href="reddy/index.html"><strong>1988/reddy</strong></a> - <strong>Most useful obfuscated C program</strong></li>
+<li><a href="robison/index.html"><strong>1988/robison</strong></a> - <strong>Best abuse of C constructs</strong></li>
+<li><a href="spinellis/index.html"><strong>1988/spinellis</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="westley/index.html"><strong>1988/westley</strong></a> - <strong>Best layout</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1989/index.html
+++ b/1989/index.html
@@ -439,16 +439,16 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1989.tar.bz2"><strong>Download all winning entries from 1989</strong></a></p>
 <ul>
-<li><a href="fubar/index.html">1989/fubar</a> - Best self-modifying program</li>
-<li><a href="jar.1/index.html">1989/jar.1</a> - Strangest abuse of the rules</li>
-<li><a href="jar.2/index.html">1989/jar.2</a> - Best of Show</li>
-<li><a href="ovdluhe/index.html">1989/ovdluhe</a> - Most humorous output</li>
-<li><a href="paul/index.html">1989/paul</a> - Most complex algorithm</li>
-<li><a href="robison/index.html">1989/robison</a> - Best minimal use of C</li>
-<li><a href="roemer/index.html">1989/roemer</a> - Best layout</li>
-<li><a href="tromp/index.html">1989/tromp</a> - Best game</li>
-<li><a href="vanb/index.html">1989/vanb</a> - Best one liner</li>
-<li><a href="westley/index.html">1989/westley</a> - Most algorithms in one program</li>
+<li><a href="fubar/index.html"><strong>1989/fubar</strong></a> - <strong>Best self-modifying program</strong></li>
+<li><a href="jar.1/index.html"><strong>1989/jar.1</strong></a> - <strong>Strangest abuse of the rules</strong></li>
+<li><a href="jar.2/index.html"><strong>1989/jar.2</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="ovdluhe/index.html"><strong>1989/ovdluhe</strong></a> - <strong>Most humorous output</strong></li>
+<li><a href="paul/index.html"><strong>1989/paul</strong></a> - <strong>Most complex algorithm</strong></li>
+<li><a href="robison/index.html"><strong>1989/robison</strong></a> - <strong>Best minimal use of C</strong></li>
+<li><a href="roemer/index.html"><strong>1989/roemer</strong></a> - <strong>Best layout</strong></li>
+<li><a href="tromp/index.html"><strong>1989/tromp</strong></a> - <strong>Best game</strong></li>
+<li><a href="vanb/index.html"><strong>1989/vanb</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="westley/index.html"><strong>1989/westley</strong></a> - <strong>Most algorithms in one program</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1990/index.html
+++ b/1990/index.html
@@ -435,17 +435,17 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1990.tar.bz2"><strong>Download all winning entries from 1990</strong></a></p>
 <ul>
-<li><a href="baruch/index.html">1990/baruch</a> - Best small program</li>
-<li><a href="cmills/index.html">1990/cmills</a> - Best game</li>
-<li><a href="dds/index.html">1990/dds</a> - Best language tool</li>
-<li><a href="dg/index.html">1990/dg</a> - Best abuse of the C preprocessor</li>
-<li><a href="jaw/index.html">1990/jaw</a> - Best entropy-reducer</li>
-<li><a href="pjr/index.html">1990/pjr</a> - Most unusual data structure</li>
-<li><a href="scjones/index.html">1990/scjones</a> - ANSI Committee’s worst abuse of C</li>
-<li><a href="stig/index.html">1990/stig</a> - Strangest abuse of the rules</li>
-<li><a href="tbr/index.html">1990/tbr</a> - Best utility</li>
-<li><a href="theorem/index.html">1990/theorem</a> - Best of Show</li>
-<li><a href="westley/index.html">1990/westley</a> - Best layout</li>
+<li><a href="baruch/index.html"><strong>1990/baruch</strong></a> - <strong>Best small program</strong></li>
+<li><a href="cmills/index.html"><strong>1990/cmills</strong></a> - <strong>Best game</strong></li>
+<li><a href="dds/index.html"><strong>1990/dds</strong></a> - <strong>Best language tool</strong></li>
+<li><a href="dg/index.html"><strong>1990/dg</strong></a> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><a href="jaw/index.html"><strong>1990/jaw</strong></a> - <strong>Best entropy-reducer</strong></li>
+<li><a href="pjr/index.html"><strong>1990/pjr</strong></a> - <strong>Most unusual data structure</strong></li>
+<li><a href="scjones/index.html"><strong>1990/scjones</strong></a> - <strong>ANSI Committee’s worst abuse of C</strong></li>
+<li><a href="stig/index.html"><strong>1990/stig</strong></a> - <strong>Strangest abuse of the rules</strong></li>
+<li><a href="tbr/index.html"><strong>1990/tbr</strong></a> - <strong>Best utility</strong></li>
+<li><a href="theorem/index.html"><strong>1990/theorem</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="westley/index.html"><strong>1990/westley</strong></a> - <strong>Best layout</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1991/index.html
+++ b/1991/index.html
@@ -486,15 +486,15 @@ as assistant pizza chef. Larry Bassel was official taste tester. Yummo!</p>
 </div>
 <p><a href="1991.tar.bz2"><strong>Download all winning entries from 1991</strong></a></p>
 <ul>
-<li><a href="ant/index.html">1991/ant</a> - Best utility</li>
-<li><a href="brnstnd/index.html">1991/brnstnd</a> - Best of Show</li>
-<li><a href="buzzard/index.html">1991/buzzard</a> - Best output</li>
-<li><a href="cdupont/index.html">1991/cdupont</a> - Most useful label</li>
-<li><a href="davidguy/index.html">1991/davidguy</a> - Best X11 graphics</li>
-<li><a href="dds/index.html">1991/dds</a> - Most well rounded</li>
-<li><a href="fine/index.html">1991/fine</a> - Best one liner</li>
-<li><a href="rince/index.html">1991/rince</a> - Best game</li>
-<li><a href="westley/index.html">1991/westley</a> - Grand Prize</li>
+<li><a href="ant/index.html"><strong>1991/ant</strong></a> - <strong>Best utility</strong></li>
+<li><a href="brnstnd/index.html"><strong>1991/brnstnd</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="buzzard/index.html"><strong>1991/buzzard</strong></a> - <strong>Best output</strong></li>
+<li><a href="cdupont/index.html"><strong>1991/cdupont</strong></a> - <strong>Most useful label</strong></li>
+<li><a href="davidguy/index.html"><strong>1991/davidguy</strong></a> - <strong>Best X11 graphics</strong></li>
+<li><a href="dds/index.html"><strong>1991/dds</strong></a> - <strong>Most well rounded</strong></li>
+<li><a href="fine/index.html"><strong>1991/fine</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="rince/index.html"><strong>1991/rince</strong></a> - <strong>Best game</strong></li>
+<li><a href="westley/index.html"><strong>1991/westley</strong></a> - <strong>Grand Prize</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1992/index.html
+++ b/1992/index.html
@@ -481,19 +481,19 @@ to serve as official taste testers. Yummo!</p>
 </div>
 <p><a href="1992.tar.bz2"><strong>Download all winning entries from 1992</strong></a></p>
 <ul>
-<li><a href="adrian/index.html">1992/adrian</a> - Most educational</li>
-<li><a href="albert/index.html">1992/albert</a> - Most useful program</li>
-<li><a href="ant/index.html">1992/ant</a> - Best utility</li>
-<li><a href="buzzard.1/index.html">1992/buzzard.1</a> - Most obfuscated algorithm</li>
-<li><a href="buzzard.2/index.html">1992/buzzard.2</a> - Best language tool</li>
-<li><a href="gson/index.html">1992/gson</a> - Most humorous output</li>
-<li><a href="imc/index.html">1992/imc</a> - Best output</li>
-<li><a href="kivinen/index.html">1992/kivinen</a> - Best X program</li>
-<li><a href="lush/index.html">1992/lush</a> - Worst abuse of the C preprocessor</li>
-<li><a href="marangon/index.html">1992/marangon</a> - Best game</li>
-<li><a href="nathan/index.html">1992/nathan</a> - Worst abuse of the rules</li>
-<li><a href="vern/index.html">1992/vern</a> - Best of Show</li>
-<li><a href="westley/index.html">1992/westley</a> - Best small program</li>
+<li><a href="adrian/index.html"><strong>1992/adrian</strong></a> - <strong>Most educational</strong></li>
+<li><a href="albert/index.html"><strong>1992/albert</strong></a> - <strong>Most useful program</strong></li>
+<li><a href="ant/index.html"><strong>1992/ant</strong></a> - <strong>Best utility</strong></li>
+<li><a href="buzzard.1/index.html"><strong>1992/buzzard.1</strong></a> - <strong>Most obfuscated algorithm</strong></li>
+<li><a href="buzzard.2/index.html"><strong>1992/buzzard.2</strong></a> - <strong>Best language tool</strong></li>
+<li><a href="gson/index.html"><strong>1992/gson</strong></a> - <strong>Most humorous output</strong></li>
+<li><a href="imc/index.html"><strong>1992/imc</strong></a> - <strong>Best output</strong></li>
+<li><a href="kivinen/index.html"><strong>1992/kivinen</strong></a> - <strong>Best X program</strong></li>
+<li><a href="lush/index.html"><strong>1992/lush</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><a href="marangon/index.html"><strong>1992/marangon</strong></a> - <strong>Best game</strong></li>
+<li><a href="nathan/index.html"><strong>1992/nathan</strong></a> - <strong>Worst abuse of the rules</strong></li>
+<li><a href="vern/index.html"><strong>1992/vern</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="westley/index.html"><strong>1992/westley</strong></a> - <strong>Best small program</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1993/index.html
+++ b/1993/index.html
@@ -457,17 +457,17 @@ to serve as official taste testers. And as usual, the food was excellent.</p>
 </div>
 <p><a href="1993.tar.bz2"><strong>Download all winning entries from 1993</strong></a></p>
 <ul>
-<li><a href="ant/index.html">1993/ant</a> - Best utility</li>
-<li><a href="cmills/index.html">1993/cmills</a> - Bill Gates Award</li>
-<li><a href="dgibson/index.html">1993/dgibson</a> - Best abuse of the C preprocessor</li>
-<li><a href="ejb/index.html">1993/ejb</a> - Best obfuscated algorithm</li>
-<li><a href="jonth/index.html">1993/jonth</a> - Most obfuscated X program</li>
-<li><a href="leo/index.html">1993/leo</a> - Best game</li>
-<li><a href="lmfjyh/index.html">1993/lmfjyh</a> - Most versatile source</li>
-<li><a href="plummer/index.html">1993/plummer</a> - Best one liner</li>
-<li><a href="rince/index.html">1993/rince</a> - Most well rounded</li>
-<li><a href="schnitzi/index.html">1993/schnitzi</a> - Obfuscated Intelligence Award</li>
-<li><a href="vanb/index.html">1993/vanb</a> - Most irregular expression</li>
+<li><a href="ant/index.html"><strong>1993/ant</strong></a> - <strong>Best utility</strong></li>
+<li><a href="cmills/index.html"><strong>1993/cmills</strong></a> - <strong>Bill Gates Award</strong></li>
+<li><a href="dgibson/index.html"><strong>1993/dgibson</strong></a> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><a href="ejb/index.html"><strong>1993/ejb</strong></a> - <strong>Best obfuscated algorithm</strong></li>
+<li><a href="jonth/index.html"><strong>1993/jonth</strong></a> - <strong>Most obfuscated X program</strong></li>
+<li><a href="leo/index.html"><strong>1993/leo</strong></a> - <strong>Best game</strong></li>
+<li><a href="lmfjyh/index.html"><strong>1993/lmfjyh</strong></a> - <strong>Most versatile source</strong></li>
+<li><a href="plummer/index.html"><strong>1993/plummer</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="rince/index.html"><strong>1993/rince</strong></a> - <strong>Most well rounded</strong></li>
+<li><a href="schnitzi/index.html"><strong>1993/schnitzi</strong></a> - <strong>Obfuscated Intelligence Award</strong></li>
+<li><a href="vanb/index.html"><strong>1993/vanb</strong></a> - <strong>Most irregular expression</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1994/index.html
+++ b/1994/index.html
@@ -516,17 +516,17 @@ Dessert: Homemade chocolate/pecan brownies, fruit</p>
 </div>
 <p><a href="1994.tar.bz2"><strong>Download all winning entries from 1994</strong></a></p>
 <ul>
-<li><a href="dodsond1/index.html">1994/dodsond1</a> - Best game</li>
-<li><a href="dodsond2/index.html">1994/dodsond2</a> - Most obfuscated packaging</li>
-<li><a href="horton/index.html">1994/horton</a> - Best utility</li>
-<li><a href="imc/index.html">1994/imc</a> - Most obfuscated algorithm</li>
-<li><a href="ldb/index.html">1994/ldb</a> - Best one liner</li>
-<li><a href="schnitzi/index.html">1994/schnitzi</a> - Best layout</li>
-<li><a href="shapiro/index.html">1994/shapiro</a> - Most well rounded obfuscation</li>
-<li><a href="smr/index.html">1994/smr</a> - Worst abuse of the rules</li>
-<li><a href="tvr/index.html">1994/tvr</a> - Best X11 program</li>
-<li><a href="weisberg/index.html">1994/weisberg</a> - Best short program</li>
-<li><a href="westley/index.html">1994/westley</a> - Worst abuse of the C preprocessor</li>
+<li><a href="dodsond1/index.html"><strong>1994/dodsond1</strong></a> - <strong>Best game</strong></li>
+<li><a href="dodsond2/index.html"><strong>1994/dodsond2</strong></a> - <strong>Most obfuscated packaging</strong></li>
+<li><a href="horton/index.html"><strong>1994/horton</strong></a> - <strong>Best utility</strong></li>
+<li><a href="imc/index.html"><strong>1994/imc</strong></a> - <strong>Most obfuscated algorithm</strong></li>
+<li><a href="ldb/index.html"><strong>1994/ldb</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="schnitzi/index.html"><strong>1994/schnitzi</strong></a> - <strong>Best layout</strong></li>
+<li><a href="shapiro/index.html"><strong>1994/shapiro</strong></a> - <strong>Most well rounded obfuscation</strong></li>
+<li><a href="smr/index.html"><strong>1994/smr</strong></a> - <strong>Worst abuse of the rules</strong></li>
+<li><a href="tvr/index.html"><strong>1994/tvr</strong></a> - <strong>Best X11 program</strong></li>
+<li><a href="weisberg/index.html"><strong>1994/weisberg</strong></a> - <strong>Best short program</strong></li>
+<li><a href="westley/index.html"><strong>1994/westley</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1995/index.html
+++ b/1995/index.html
@@ -518,18 +518,18 @@ Dessert: Key lime pie</p>
 </div>
 <p><a href="1995.tar.bz2"><strong>Download all winning entries from 1995</strong></a></p>
 <ul>
-<li><a href="cdua/index.html">1995/cdua</a> - Best output</li>
-<li><a href="dodsond1/index.html">1995/dodsond1</a> - Most humorous</li>
-<li><a href="dodsond2/index.html">1995/dodsond2</a> - Best game</li>
-<li><a href="esde/index.html">1995/esde</a> - Interesting algorithm</li>
-<li><a href="garry/index.html">1995/garry</a> - Best utility</li>
-<li><a href="heathbar/index.html">1995/heathbar</a> - Best layout</li>
-<li><a href="leo/index.html">1995/leo</a> - Best use of obfuscation</li>
-<li><a href="makarios/index.html">1995/makarios</a> - Best short program</li>
-<li><a href="savastio/index.html">1995/savastio</a> - Most obfuscated syntax</li>
-<li><a href="schnitzi/index.html">1995/schnitzi</a> - Best one liner</li>
-<li><a href="spinellis/index.html">1995/spinellis</a> - Abusing the rules</li>
-<li><a href="vanschnitz/index.html">1995/vanschnitz</a> - Worst abuse of the C preprocessor and most likely to amaze</li>
+<li><a href="cdua/index.html"><strong>1995/cdua</strong></a> - <strong>Best output</strong></li>
+<li><a href="dodsond1/index.html"><strong>1995/dodsond1</strong></a> - <strong>Most humorous</strong></li>
+<li><a href="dodsond2/index.html"><strong>1995/dodsond2</strong></a> - <strong>Best game</strong></li>
+<li><a href="esde/index.html"><strong>1995/esde</strong></a> - <strong>Interesting algorithm</strong></li>
+<li><a href="garry/index.html"><strong>1995/garry</strong></a> - <strong>Best utility</strong></li>
+<li><a href="heathbar/index.html"><strong>1995/heathbar</strong></a> - <strong>Best layout</strong></li>
+<li><a href="leo/index.html"><strong>1995/leo</strong></a> - <strong>Best use of obfuscation</strong></li>
+<li><a href="makarios/index.html"><strong>1995/makarios</strong></a> - <strong>Best short program</strong></li>
+<li><a href="savastio/index.html"><strong>1995/savastio</strong></a> - <strong>Most obfuscated syntax</strong></li>
+<li><a href="schnitzi/index.html"><strong>1995/schnitzi</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="spinellis/index.html"><strong>1995/spinellis</strong></a> - <strong>Abusing the rules</strong></li>
+<li><a href="vanschnitz/index.html"><strong>1995/vanschnitz</strong></a> - <strong>Worst abuse of the C preprocessor and most likely to amaze</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1996/index.html
+++ b/1996/index.html
@@ -477,17 +477,17 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1996.tar.bz2"><strong>Download all winning entries from 1996</strong></a></p>
 <ul>
-<li><a href="august/index.html">1996/august</a> - Best of Show</li>
-<li><a href="dalbec/index.html">1996/dalbec</a> - Best numerical obfuscation</li>
-<li><a href="eldby/index.html">1996/eldby</a> - Best output</li>
-<li><a href="gandalf/index.html">1996/gandalf</a> - Best layout</li>
-<li><a href="huffman/index.html">1996/huffman</a> - Best obfuscated character set utility</li>
-<li><a href="jonth/index.html">1996/jonth</a> - Best X11 entry</li>
-<li><a href="rcm/index.html">1996/rcm</a> - Best RFC obfuscation</li>
-<li><a href="schweikh1/index.html">1996/schweikh1</a> - Worst abuse of the C preprocessor</li>
-<li><a href="schweikh2/index.html">1996/schweikh2</a> - Best algorithm</li>
-<li><a href="schweikh3/index.html">1996/schweikh3</a> - Best utility</li>
-<li><a href="westley/index.html">1996/westley</a> - Best one liner</li>
+<li><a href="august/index.html"><strong>1996/august</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="dalbec/index.html"><strong>1996/dalbec</strong></a> - <strong>Best numerical obfuscation</strong></li>
+<li><a href="eldby/index.html"><strong>1996/eldby</strong></a> - <strong>Best output</strong></li>
+<li><a href="gandalf/index.html"><strong>1996/gandalf</strong></a> - <strong>Best layout</strong></li>
+<li><a href="huffman/index.html"><strong>1996/huffman</strong></a> - <strong>Best obfuscated character set utility</strong></li>
+<li><a href="jonth/index.html"><strong>1996/jonth</strong></a> - <strong>Best X11 entry</strong></li>
+<li><a href="rcm/index.html"><strong>1996/rcm</strong></a> - <strong>Best RFC obfuscation</strong></li>
+<li><a href="schweikh1/index.html"><strong>1996/schweikh1</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><a href="schweikh2/index.html"><strong>1996/schweikh2</strong></a> - <strong>Best algorithm</strong></li>
+<li><a href="schweikh3/index.html"><strong>1996/schweikh3</strong></a> - <strong>Best utility</strong></li>
+<li><a href="westley/index.html"><strong>1996/westley</strong></a> - <strong>Best one liner</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1998/index.html
+++ b/1998/index.html
@@ -507,20 +507,20 @@ message when sending email to the judges.</p>
 </div>
 <p><a href="1998.tar.bz2"><strong>Download all winning entries from 1998</strong></a></p>
 <ul>
-<li><a href="banks/index.html">1998/banks</a> - Best of Show</li>
-<li><a href="bas1/index.html">1998/bas1</a> - Best encapsulation</li>
-<li><a href="bas2/index.html">1998/bas2</a> - Best small program</li>
-<li><a href="chaos/index.html">1998/chaos</a> - Best object orientation</li>
-<li><a href="df/index.html">1998/df</a> - Best data hiding</li>
-<li><a href="dlowe/index.html">1998/dlowe</a> - Best utility</li>
-<li><a href="dloweneil/index.html">1998/dloweneil</a> - Most fun</li>
-<li><a href="dorssel/index.html">1998/dorssel</a> - Obsolescent feature</li>
-<li><a href="fanf/index.html">1998/fanf</a> - Most obfuscated translator</li>
-<li><a href="schnitzi/index.html">1998/schnitzi</a> - Best flow control</li>
-<li><a href="schweikh1/index.html">1998/schweikh1</a> - CPP abuse</li>
-<li><a href="schweikh2/index.html">1998/schweikh2</a> - Most erratic behavior</li>
-<li><a href="schweikh3/index.html">1998/schweikh3</a> - Most space efficient</li>
-<li><a href="tomtorfs/index.html">1998/tomtorfs</a> - Best self-documenting</li>
+<li><a href="banks/index.html"><strong>1998/banks</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="bas1/index.html"><strong>1998/bas1</strong></a> - <strong>Best encapsulation</strong></li>
+<li><a href="bas2/index.html"><strong>1998/bas2</strong></a> - <strong>Best small program</strong></li>
+<li><a href="chaos/index.html"><strong>1998/chaos</strong></a> - <strong>Best object orientation</strong></li>
+<li><a href="df/index.html"><strong>1998/df</strong></a> - <strong>Best data hiding</strong></li>
+<li><a href="dlowe/index.html"><strong>1998/dlowe</strong></a> - <strong>Best utility</strong></li>
+<li><a href="dloweneil/index.html"><strong>1998/dloweneil</strong></a> - <strong>Most fun</strong></li>
+<li><a href="dorssel/index.html"><strong>1998/dorssel</strong></a> - <strong>Obsolescent feature</strong></li>
+<li><a href="fanf/index.html"><strong>1998/fanf</strong></a> - <strong>Most obfuscated translator</strong></li>
+<li><a href="schnitzi/index.html"><strong>1998/schnitzi</strong></a> - <strong>Best flow control</strong></li>
+<li><a href="schweikh1/index.html"><strong>1998/schweikh1</strong></a> - <strong>CPP abuse</strong></li>
+<li><a href="schweikh2/index.html"><strong>1998/schweikh2</strong></a> - <strong>Most erratic behavior</strong></li>
+<li><a href="schweikh3/index.html"><strong>1998/schweikh3</strong></a> - <strong>Most space efficient</strong></li>
+<li><a href="tomtorfs/index.html"><strong>1998/tomtorfs</strong></a> - <strong>Best self-documenting</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2000/index.html
+++ b/2000/index.html
@@ -478,20 +478,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2000.tar.bz2"><strong>Download all winning entries from 2000</strong></a></p>
 <ul>
-<li><a href="anderson/index.html">2000/anderson</a> - Best use of flags</li>
-<li><a href="bellard/index.html">2000/bellard</a> - Most specific output</li>
-<li><a href="bmeyer/index.html">2000/bmeyer</a> - Best utility</li>
-<li><a href="briddlebane/index.html">2000/briddlebane</a> - Best abuse of user</li>
-<li><a href="dhyang/index.html">2000/dhyang</a> - Best layout</li>
-<li><a href="dlowe/index.html">2000/dlowe</a> - Worst abuse of the rules</li>
-<li><a href="jarijyrki/index.html">2000/jarijyrki</a> - Best of Show</li>
-<li><a href="natori/index.html">2000/natori</a> - Best small program</li>
-<li><a href="primenum/index.html">2000/primenum</a> - Best abuse of CPP</li>
-<li><a href="rince/index.html">2000/rince</a> - Astronomically obfuscated</li>
-<li><a href="robison/index.html">2000/robison</a> - Best game</li>
-<li><a href="schneiderwent/index.html">2000/schneiderwent</a> - Most timely output</li>
-<li><a href="thadgavin/index.html">2000/thadgavin</a> - Most portable output</li>
-<li><a href="tomx/index.html">2000/tomx</a> - Most complete program</li>
+<li><a href="anderson/index.html"><strong>2000/anderson</strong></a> - <strong>Best use of flags</strong></li>
+<li><a href="bellard/index.html"><strong>2000/bellard</strong></a> - <strong>Most specific output</strong></li>
+<li><a href="bmeyer/index.html"><strong>2000/bmeyer</strong></a> - <strong>Best utility</strong></li>
+<li><a href="briddlebane/index.html"><strong>2000/briddlebane</strong></a> - <strong>Best abuse of user</strong></li>
+<li><a href="dhyang/index.html"><strong>2000/dhyang</strong></a> - <strong>Best layout</strong></li>
+<li><a href="dlowe/index.html"><strong>2000/dlowe</strong></a> - <strong>Worst abuse of the rules</strong></li>
+<li><a href="jarijyrki/index.html"><strong>2000/jarijyrki</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="natori/index.html"><strong>2000/natori</strong></a> - <strong>Best small program</strong></li>
+<li><a href="primenum/index.html"><strong>2000/primenum</strong></a> - <strong>Best abuse of CPP</strong></li>
+<li><a href="rince/index.html"><strong>2000/rince</strong></a> - <strong>Astronomically obfuscated</strong></li>
+<li><a href="robison/index.html"><strong>2000/robison</strong></a> - <strong>Best game</strong></li>
+<li><a href="schneiderwent/index.html"><strong>2000/schneiderwent</strong></a> - <strong>Most timely output</strong></li>
+<li><a href="thadgavin/index.html"><strong>2000/thadgavin</strong></a> - <strong>Most portable output</strong></li>
+<li><a href="tomx/index.html"><strong>2000/tomx</strong></a> - <strong>Most complete program</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2001/index.html
+++ b/2001/index.html
@@ -466,21 +466,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2001.tar.bz2"><strong>Download all winning entries from 2001</strong></a></p>
 <ul>
-<li><a href="anonymous/index.html">2001/anonymous</a> - Dishonorable mention</li>
-<li><a href="bellard/index.html">2001/bellard</a> - Best abuse of the rules</li>
-<li><a href="cheong/index.html">2001/cheong</a> - Best short program</li>
-<li><a href="coupard/index.html">2001/coupard</a> - Most obfuscated sound</li>
-<li><a href="ctk/index.html">2001/ctk</a> - Worst driver</li>
-<li><a href="dgbeards/index.html">2001/dgbeards</a> - Best AI</li>
-<li><a href="herrmann1/index.html">2001/herrmann1</a> - Best abuse of the C preprocessor</li>
-<li><a href="herrmann2/index.html">2001/herrmann2</a> - Most eye-crossing</li>
-<li><a href="jason/index.html">2001/jason</a> - Best of Show</li>
-<li><a href="kev/index.html">2001/kev</a> - Best curses game</li>
-<li><a href="ollinger/index.html">2001/ollinger</a> - Best of Show</li>
-<li><a href="rosten/index.html">2001/rosten</a> - Best abuse of the user</li>
-<li><a href="schweikh/index.html">2001/schweikh</a> - Best one liner</li>
-<li><a href="westley/index.html">2001/westley</a> - Best position-independent code</li>
-<li><a href="williams/index.html">2001/williams</a> - Best graphic game</li>
+<li><a href="anonymous/index.html"><strong>2001/anonymous</strong></a> - <strong>Dishonorable mention</strong></li>
+<li><a href="bellard/index.html"><strong>2001/bellard</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="cheong/index.html"><strong>2001/cheong</strong></a> - <strong>Best short program</strong></li>
+<li><a href="coupard/index.html"><strong>2001/coupard</strong></a> - <strong>Most obfuscated sound</strong></li>
+<li><a href="ctk/index.html"><strong>2001/ctk</strong></a> - <strong>Worst driver</strong></li>
+<li><a href="dgbeards/index.html"><strong>2001/dgbeards</strong></a> - <strong>Best AI</strong></li>
+<li><a href="herrmann1/index.html"><strong>2001/herrmann1</strong></a> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><a href="herrmann2/index.html"><strong>2001/herrmann2</strong></a> - <strong>Most eye-crossing</strong></li>
+<li><a href="jason/index.html"><strong>2001/jason</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="kev/index.html"><strong>2001/kev</strong></a> - <strong>Best curses game</strong></li>
+<li><a href="ollinger/index.html"><strong>2001/ollinger</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="rosten/index.html"><strong>2001/rosten</strong></a> - <strong>Best abuse of the user</strong></li>
+<li><a href="schweikh/index.html"><strong>2001/schweikh</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="westley/index.html"><strong>2001/westley</strong></a> - <strong>Best position-independent code</strong></li>
+<li><a href="williams/index.html"><strong>2001/williams</strong></a> - <strong>Best graphic game</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2004/index.html
+++ b/2004/index.html
@@ -457,21 +457,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2004.tar.bz2"><strong>Download all winning entries from 2004</strong></a></p>
 <ul>
-<li><a href="anonymous/index.html">2004/anonymous</a> - Best use of ‘Precious’ Lines</li>
-<li><a href="arachnid/index.html">2004/arachnid</a> - Best use of vision</li>
-<li><a href="burley/index.html">2004/burley</a> - Best calculated risk</li>
-<li><a href="gavare/index.html">2004/gavare</a> - Best use of light and spheres</li>
-<li><a href="gavin/index.html">2004/gavin</a> - Best of Show</li>
-<li><a href="hibachi/index.html">2004/hibachi</a> - Best abuse of the guidelines</li>
-<li><a href="hoyle/index.html">2004/hoyle</a> - Most functional output</li>
-<li><a href="jdalbec/index.html">2004/jdalbec</a> - Best abuse of the periodic table</li>
-<li><a href="kopczynski/index.html">2004/kopczynski</a> - Best one liner</li>
-<li><a href="newbern/index.html">2004/newbern</a> - Best font engine</li>
-<li><a href="omoikane/index.html">2004/omoikane</a> - Best utility</li>
-<li><a href="schnitzi/index.html">2004/schnitzi</a> - Best non-use of curses</li>
-<li><a href="sds/index.html">2004/sds</a> - Best abuse of indentation</li>
-<li><a href="vik1/index.html">2004/vik1</a> - Best X11 game</li>
-<li><a href="vik2/index.html">2004/vik2</a> - Best abuse of CPP</li>
+<li><a href="anonymous/index.html"><strong>2004/anonymous</strong></a> - <strong>Best use of ‘Precious’ Lines</strong></li>
+<li><a href="arachnid/index.html"><strong>2004/arachnid</strong></a> - <strong>Best use of vision</strong></li>
+<li><a href="burley/index.html"><strong>2004/burley</strong></a> - <strong>Best calculated risk</strong></li>
+<li><a href="gavare/index.html"><strong>2004/gavare</strong></a> - <strong>Best use of light and spheres</strong></li>
+<li><a href="gavin/index.html"><strong>2004/gavin</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="hibachi/index.html"><strong>2004/hibachi</strong></a> - <strong>Best abuse of the guidelines</strong></li>
+<li><a href="hoyle/index.html"><strong>2004/hoyle</strong></a> - <strong>Most functional output</strong></li>
+<li><a href="jdalbec/index.html"><strong>2004/jdalbec</strong></a> - <strong>Best abuse of the periodic table</strong></li>
+<li><a href="kopczynski/index.html"><strong>2004/kopczynski</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="newbern/index.html"><strong>2004/newbern</strong></a> - <strong>Best font engine</strong></li>
+<li><a href="omoikane/index.html"><strong>2004/omoikane</strong></a> - <strong>Best utility</strong></li>
+<li><a href="schnitzi/index.html"><strong>2004/schnitzi</strong></a> - <strong>Best non-use of curses</strong></li>
+<li><a href="sds/index.html"><strong>2004/sds</strong></a> - <strong>Best abuse of indentation</strong></li>
+<li><a href="vik1/index.html"><strong>2004/vik1</strong></a> - <strong>Best X11 game</strong></li>
+<li><a href="vik2/index.html"><strong>2004/vik2</strong></a> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2005/index.html
+++ b/2005/index.html
@@ -473,21 +473,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2005.tar.bz2"><strong>Download all winning entries from 2005</strong></a></p>
 <ul>
-<li><a href="aidan/index.html">2005/aidan</a> - Most ingenious puzzle solution</li>
-<li><a href="anon/index.html">2005/anon</a> - Best 3D puzzle</li>
-<li><a href="boutines/index.html">2005/boutines</a> - Most superfluous output</li>
-<li><a href="chia/index.html">2005/chia</a> - Most ambiguous language</li>
-<li><a href="giljade/index.html">2005/giljade</a> - Best 2D puzzle</li>
-<li><a href="jetro/index.html">2005/jetro</a> - Most sonorous output</li>
-<li><a href="klausler/index.html">2005/klausler</a> - Abuse of the rules</li>
-<li><a href="mikeash/index.html">2005/mikeash</a> - Best use of parenthesis</li>
-<li><a href="mynx/index.html">2005/mynx</a> - Best use of the WWW</li>
-<li><a href="persano/index.html">2005/persano</a> - Best of Show</li>
-<li><a href="sykes/index.html">2005/sykes</a> - Best emulator</li>
-<li><a href="timwi/index.html">2005/timwi</a> - Most discourteous interpreter</li>
-<li><a href="toledo/index.html">2005/toledo</a> - Best game</li>
-<li><a href="vik/index.html">2005/vik</a> - Most circuitous walk</li>
-<li><a href="vince/index.html">2005/vince</a> - Most beauteous visuals</li>
+<li><a href="aidan/index.html"><strong>2005/aidan</strong></a> - <strong>Most ingenious puzzle solution</strong></li>
+<li><a href="anon/index.html"><strong>2005/anon</strong></a> - <strong>Best 3D puzzle</strong></li>
+<li><a href="boutines/index.html"><strong>2005/boutines</strong></a> - <strong>Most superfluous output</strong></li>
+<li><a href="chia/index.html"><strong>2005/chia</strong></a> - <strong>Most ambiguous language</strong></li>
+<li><a href="giljade/index.html"><strong>2005/giljade</strong></a> - <strong>Best 2D puzzle</strong></li>
+<li><a href="jetro/index.html"><strong>2005/jetro</strong></a> - <strong>Most sonorous output</strong></li>
+<li><a href="klausler/index.html"><strong>2005/klausler</strong></a> - <strong>Abuse of the rules</strong></li>
+<li><a href="mikeash/index.html"><strong>2005/mikeash</strong></a> - <strong>Best use of parenthesis</strong></li>
+<li><a href="mynx/index.html"><strong>2005/mynx</strong></a> - <strong>Best use of the WWW</strong></li>
+<li><a href="persano/index.html"><strong>2005/persano</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="sykes/index.html"><strong>2005/sykes</strong></a> - <strong>Best emulator</strong></li>
+<li><a href="timwi/index.html"><strong>2005/timwi</strong></a> - <strong>Most discourteous interpreter</strong></li>
+<li><a href="toledo/index.html"><strong>2005/toledo</strong></a> - <strong>Best game</strong></li>
+<li><a href="vik/index.html"><strong>2005/vik</strong></a> - <strong>Most circuitous walk</strong></li>
+<li><a href="vince/index.html"><strong>2005/vince</strong></a> - <strong>Most beauteous visuals</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2006/index.html
+++ b/2006/index.html
@@ -453,20 +453,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2006.tar.bz2"><strong>Download all winning entries from 2006</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2006/birken</a> - EDAMAME Award</li>
-<li><a href="borsanyi/index.html">2006/borsanyi</a> - Most useful</li>
-<li><a href="grothe/index.html">2006/grothe</a> - Most obfuscated audio</li>
-<li><a href="hamre/index.html">2006/hamre</a> - Most irrational</li>
-<li><a href="meyer/index.html">2006/meyer</a> - Best game</li>
-<li><a href="monge/index.html">2006/monge</a> - Best compiled graphics</li>
-<li><a href="night/index.html">2006/night</a> - Best abuse of computation</li>
-<li><a href="sloane/index.html">2006/sloane</a> - Homer’s favorite</li>
-<li><a href="stewart/index.html">2006/stewart</a> - Best computed graphics</li>
-<li><a href="sykes1/index.html">2006/sykes1</a> - Best assembler</li>
-<li><a href="sykes2/index.html">2006/sykes2</a> - Best one liner</li>
-<li><a href="toledo1/index.html">2006/toledo1</a> - Best small program</li>
-<li><a href="toledo2/index.html">2006/toledo2</a> - Best of Show</li>
-<li><a href="toledo3/index.html">2006/toledo3</a> - Most portable chess set</li>
+<li><a href="birken/index.html"><strong>2006/birken</strong></a> - <strong>EDAMAME Award</strong></li>
+<li><a href="borsanyi/index.html"><strong>2006/borsanyi</strong></a> - <strong>Most useful</strong></li>
+<li><a href="grothe/index.html"><strong>2006/grothe</strong></a> - <strong>Most obfuscated audio</strong></li>
+<li><a href="hamre/index.html"><strong>2006/hamre</strong></a> - <strong>Most irrational</strong></li>
+<li><a href="meyer/index.html"><strong>2006/meyer</strong></a> - <strong>Best game</strong></li>
+<li><a href="monge/index.html"><strong>2006/monge</strong></a> - <strong>Best compiled graphics</strong></li>
+<li><a href="night/index.html"><strong>2006/night</strong></a> - <strong>Best abuse of computation</strong></li>
+<li><a href="sloane/index.html"><strong>2006/sloane</strong></a> - <strong>Homer’s favorite</strong></li>
+<li><a href="stewart/index.html"><strong>2006/stewart</strong></a> - <strong>Best computed graphics</strong></li>
+<li><a href="sykes1/index.html"><strong>2006/sykes1</strong></a> - <strong>Best assembler</strong></li>
+<li><a href="sykes2/index.html"><strong>2006/sykes2</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="toledo1/index.html"><strong>2006/toledo1</strong></a> - <strong>Best small program</strong></li>
+<li><a href="toledo2/index.html"><strong>2006/toledo2</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="toledo3/index.html"><strong>2006/toledo3</strong></a> - <strong>Most portable chess set</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2011/index.html
+++ b/2011/index.html
@@ -452,20 +452,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2011.tar.bz2"><strong>Download all winning entries from 2011</strong></a></p>
 <ul>
-<li><a href="akari/index.html">2011/akari</a> - Best of Show - Most Shrinkable</li>
-<li><a href="blakely/index.html">2011/blakely</a> - Most devolving</li>
-<li><a href="borsanyi/index.html">2011/borsanyi</a> - Best data utility</li>
-<li><a href="dlowe/index.html">2011/dlowe</a> - Most self deprecating</li>
-<li><a href="eastman/index.html">2011/eastman</a> - Best ball</li>
-<li><a href="fredriksson/index.html">2011/fredriksson</a> - Most useful</li>
-<li><a href="goren/index.html">2011/goren</a> - Most artistic</li>
-<li><a href="hamaji/index.html">2011/hamaji</a> - Best solved puzzle</li>
-<li><a href="hou/index.html">2011/hou</a> - Best self documenting program</li>
-<li><a href="konno/index.html">2011/konno</a> - Best one liner</li>
-<li><a href="richards/index.html">2011/richards</a> - Most surprisingly portable</li>
-<li><a href="toledo/index.html">2011/toledo</a> - Best non-chess game</li>
-<li><a href="vik/index.html">2011/vik</a> - Most sound</li>
-<li><a href="zucker/index.html">2011/zucker</a> - Most shiny</li>
+<li><a href="akari/index.html">2011/akari</a> - <strong>Best of Show - Most Shrinkable</strong></li>
+<li><a href="blakely/index.html">2011/blakely</a> - <strong>Most devolving</strong></li>
+<li><a href="borsanyi/index.html">2011/borsanyi</a> - <strong>Best data utility</strong></li>
+<li><a href="dlowe/index.html">2011/dlowe</a> - <strong>Most self deprecating</strong></li>
+<li><a href="eastman/index.html">2011/eastman</a> - <strong>Best ball</strong></li>
+<li><a href="fredriksson/index.html">2011/fredriksson</a> - <strong>Most useful</strong></li>
+<li><a href="goren/index.html">2011/goren</a> - <strong>Most artistic</strong></li>
+<li><a href="hamaji/index.html">2011/hamaji</a> - <strong>Best solved puzzle</strong></li>
+<li><a href="hou/index.html">2011/hou</a> - <strong>Best self documenting program</strong></li>
+<li><a href="konno/index.html">2011/konno</a> - <strong>Best one liner</strong></li>
+<li><a href="richards/index.html">2011/richards</a> - <strong>Most surprisingly portable</strong></li>
+<li><a href="toledo/index.html">2011/toledo</a> - <strong>Best non-chess game</strong></li>
+<li><a href="vik/index.html">2011/vik</a> - <strong>Most sound</strong></li>
+<li><a href="zucker/index.html">2011/zucker</a> - <strong>Most shiny</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2011/index.html
+++ b/2011/index.html
@@ -452,20 +452,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2011.tar.bz2"><strong>Download all winning entries from 2011</strong></a></p>
 <ul>
-<li><a href="akari/index.html">2011/akari</a> - <strong>Best of Show - Most Shrinkable</strong></li>
-<li><a href="blakely/index.html">2011/blakely</a> - <strong>Most devolving</strong></li>
-<li><a href="borsanyi/index.html">2011/borsanyi</a> - <strong>Best data utility</strong></li>
-<li><a href="dlowe/index.html">2011/dlowe</a> - <strong>Most self deprecating</strong></li>
-<li><a href="eastman/index.html">2011/eastman</a> - <strong>Best ball</strong></li>
-<li><a href="fredriksson/index.html">2011/fredriksson</a> - <strong>Most useful</strong></li>
-<li><a href="goren/index.html">2011/goren</a> - <strong>Most artistic</strong></li>
-<li><a href="hamaji/index.html">2011/hamaji</a> - <strong>Best solved puzzle</strong></li>
-<li><a href="hou/index.html">2011/hou</a> - <strong>Best self documenting program</strong></li>
-<li><a href="konno/index.html">2011/konno</a> - <strong>Best one liner</strong></li>
-<li><a href="richards/index.html">2011/richards</a> - <strong>Most surprisingly portable</strong></li>
-<li><a href="toledo/index.html">2011/toledo</a> - <strong>Best non-chess game</strong></li>
-<li><a href="vik/index.html">2011/vik</a> - <strong>Most sound</strong></li>
-<li><a href="zucker/index.html">2011/zucker</a> - <strong>Most shiny</strong></li>
+<li><a href="akari/index.html"><strong>2011/akari</strong></a> - <strong>Best of Show - Most Shrinkable</strong></li>
+<li><a href="blakely/index.html"><strong>2011/blakely</strong></a> - <strong>Most devolving</strong></li>
+<li><a href="borsanyi/index.html"><strong>2011/borsanyi</strong></a> - <strong>Best data utility</strong></li>
+<li><a href="dlowe/index.html"><strong>2011/dlowe</strong></a> - <strong>Most self deprecating</strong></li>
+<li><a href="eastman/index.html"><strong>2011/eastman</strong></a> - <strong>Best ball</strong></li>
+<li><a href="fredriksson/index.html"><strong>2011/fredriksson</strong></a> - <strong>Most useful</strong></li>
+<li><a href="goren/index.html"><strong>2011/goren</strong></a> - <strong>Most artistic</strong></li>
+<li><a href="hamaji/index.html"><strong>2011/hamaji</strong></a> - <strong>Best solved puzzle</strong></li>
+<li><a href="hou/index.html"><strong>2011/hou</strong></a> - <strong>Best self documenting program</strong></li>
+<li><a href="konno/index.html"><strong>2011/konno</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="richards/index.html"><strong>2011/richards</strong></a> - <strong>Most surprisingly portable</strong></li>
+<li><a href="toledo/index.html"><strong>2011/toledo</strong></a> - <strong>Best non-chess game</strong></li>
+<li><a href="vik/index.html"><strong>2011/vik</strong></a> - <strong>Most sound</strong></li>
+<li><a href="zucker/index.html"><strong>2011/zucker</strong></a> - <strong>Most shiny</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2012/index.html
+++ b/2012/index.html
@@ -488,20 +488,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2012.tar.bz2"><strong>Download all winning entries from 2012</strong></a></p>
 <ul>
-<li><a href="blakely/index.html">2012/blakely</a> - Most GIFted expressions</li>
-<li><a href="deckmyn/index.html">2012/deckmyn</a> - Most notable and best tool</li>
-<li><a href="dlowe/index.html">2012/dlowe</a> - Best way to lose a life</li>
-<li><a href="endoh1/index.html">2012/endoh1</a> - Most complex ASCII fluid - Honorable mention</li>
-<li><a href="endoh2/index.html">2012/endoh2</a> - PiE in the sky award</li>
-<li><a href="grothe/index.html">2012/grothe</a> - Most conspiratorial</li>
-<li><a href="hamano/index.html">2012/hamano</a> - Most elementary use of C - Silver Award</li>
-<li><a href="hou/index.html">2012/hou</a> - Most useful obfuscation</li>
-<li><a href="kang/index.html">2012/kang</a> - Best short program</li>
-<li><a href="konno/index.html">2012/konno</a> - Best one liner</li>
-<li><a href="omoikane/index.html">2012/omoikane</a> - Most surreptitious</li>
-<li><a href="tromp/index.html">2012/tromp</a> - Most functional</li>
-<li><a href="vik/index.html">2012/vik</a> - Best use of cocoa - Bronze Award</li>
-<li><a href="zeitak/index.html">2012/zeitak</a> - Balanced use of obfuscation - Gold Award</li>
+<li><a href="blakely/index.html">2012/blakely</a> - <strong>Most GIFted expressions</strong></li>
+<li><a href="deckmyn/index.html">2012/deckmyn</a> - <strong>Most notable and best tool</strong></li>
+<li><a href="dlowe/index.html">2012/dlowe</a> - <strong>Best way to lose a life</strong></li>
+<li><a href="endoh1/index.html">2012/endoh1</a> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
+<li><a href="endoh2/index.html">2012/endoh2</a> - <strong>PiE in the sky award</strong></li>
+<li><a href="grothe/index.html">2012/grothe</a> - <strong>Most conspiratorial</strong></li>
+<li><a href="hamano/index.html">2012/hamano</a> - <strong>Most elementary use of C - Silver Award</strong></li>
+<li><a href="hou/index.html">2012/hou</a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="kang/index.html">2012/kang</a> - <strong>Best short program</strong></li>
+<li><a href="konno/index.html">2012/konno</a> - <strong>Best one liner</strong></li>
+<li><a href="omoikane/index.html">2012/omoikane</a> - <strong>Most surreptitious</strong></li>
+<li><a href="tromp/index.html">2012/tromp</a> - <strong>Most functional</strong></li>
+<li><a href="vik/index.html">2012/vik</a> - <strong>Best use of cocoa - Bronze Award</strong></li>
+<li><a href="zeitak/index.html">2012/zeitak</a> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2012/index.html
+++ b/2012/index.html
@@ -488,20 +488,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2012.tar.bz2"><strong>Download all winning entries from 2012</strong></a></p>
 <ul>
-<li><a href="blakely/index.html">2012/blakely</a> - <strong>Most GIFted expressions</strong></li>
-<li><a href="deckmyn/index.html">2012/deckmyn</a> - <strong>Most notable and best tool</strong></li>
-<li><a href="dlowe/index.html">2012/dlowe</a> - <strong>Best way to lose a life</strong></li>
-<li><a href="endoh1/index.html">2012/endoh1</a> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
-<li><a href="endoh2/index.html">2012/endoh2</a> - <strong>PiE in the sky award</strong></li>
-<li><a href="grothe/index.html">2012/grothe</a> - <strong>Most conspiratorial</strong></li>
-<li><a href="hamano/index.html">2012/hamano</a> - <strong>Most elementary use of C - Silver Award</strong></li>
-<li><a href="hou/index.html">2012/hou</a> - <strong>Most useful obfuscation</strong></li>
-<li><a href="kang/index.html">2012/kang</a> - <strong>Best short program</strong></li>
-<li><a href="konno/index.html">2012/konno</a> - <strong>Best one liner</strong></li>
-<li><a href="omoikane/index.html">2012/omoikane</a> - <strong>Most surreptitious</strong></li>
-<li><a href="tromp/index.html">2012/tromp</a> - <strong>Most functional</strong></li>
-<li><a href="vik/index.html">2012/vik</a> - <strong>Best use of cocoa - Bronze Award</strong></li>
-<li><a href="zeitak/index.html">2012/zeitak</a> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
+<li><a href="blakely/index.html"><strong>2012/blakely</strong></a> - <strong>Most GIFted expressions</strong></li>
+<li><a href="deckmyn/index.html"><strong>2012/deckmyn</strong></a> - <strong>Most notable and best tool</strong></li>
+<li><a href="dlowe/index.html"><strong>2012/dlowe</strong></a> - <strong>Best way to lose a life</strong></li>
+<li><a href="endoh1/index.html"><strong>2012/endoh1</strong></a> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
+<li><a href="endoh2/index.html"><strong>2012/endoh2</strong></a> - <strong>PiE in the sky award</strong></li>
+<li><a href="grothe/index.html"><strong>2012/grothe</strong></a> - <strong>Most conspiratorial</strong></li>
+<li><a href="hamano/index.html"><strong>2012/hamano</strong></a> - <strong>Most elementary use of C - Silver Award</strong></li>
+<li><a href="hou/index.html"><strong>2012/hou</strong></a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="kang/index.html"><strong>2012/kang</strong></a> - <strong>Best short program</strong></li>
+<li><a href="konno/index.html"><strong>2012/konno</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="omoikane/index.html"><strong>2012/omoikane</strong></a> - <strong>Most surreptitious</strong></li>
+<li><a href="tromp/index.html"><strong>2012/tromp</strong></a> - <strong>Most functional</strong></li>
+<li><a href="vik/index.html"><strong>2012/vik</strong></a> - <strong>Best use of cocoa - Bronze Award</strong></li>
+<li><a href="zeitak/index.html"><strong>2012/zeitak</strong></a> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2013/index.html
+++ b/2013/index.html
@@ -474,21 +474,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2013.tar.bz2"><strong>Download all winning entries from 2013</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2013/birken</a> - <strong>Best painting tool</strong></li>
-<li><a href="cable1/index.html">2013/cable1</a> - <strong>Most partisan one liner</strong></li>
-<li><a href="cable2/index.html">2013/cable2</a> - <strong>Best of Show</strong></li>
-<li><a href="cable3/index.html">2013/cable3</a> - <strong>Largest small system emulator</strong></li>
-<li><a href="dlowe/index.html">2013/dlowe</a> - <strong>Best sparkling utility</strong></li>
-<li><a href="endoh1/index.html">2013/endoh1</a> - <strong>Most lazy SKIer</strong></li>
-<li><a href="endoh2/index.html">2013/endoh2</a> - <strong>Most recyclable</strong></li>
-<li><a href="endoh3/index.html">2013/endoh3</a> - <strong>Most tweetable one liner</strong></li>
-<li><a href="endoh4/index.html">2013/endoh4</a> - <strong>Most solid</strong></li>
-<li><a href="hou/index.html">2013/hou</a> - <strong>Best use of one infinite loop</strong></li>
-<li><a href="mills/index.html">2013/mills</a> - <strong>Most timely rendered</strong></li>
-<li><a href="misaka/index.html">2013/misaka</a> - <strong>Most catty</strong></li>
-<li><a href="morgan1/index.html">2013/morgan1</a> - <strong>Smallest large system simulator</strong></li>
-<li><a href="morgan2/index.html">2013/morgan2</a> - <strong>Most playfully versatile</strong></li>
-<li><a href="robison/index.html">2013/robison</a> - <strong>Most poetic use of strings</strong></li>
+<li><a href="birken/index.html"><strong>2013/birken</strong></a> - <strong>Best painting tool</strong></li>
+<li><a href="cable1/index.html"><strong>2013/cable1</strong></a> - <strong>Most partisan one liner</strong></li>
+<li><a href="cable2/index.html"><strong>2013/cable2</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="cable3/index.html"><strong>2013/cable3</strong></a> - <strong>Largest small system emulator</strong></li>
+<li><a href="dlowe/index.html"><strong>2013/dlowe</strong></a> - <strong>Best sparkling utility</strong></li>
+<li><a href="endoh1/index.html"><strong>2013/endoh1</strong></a> - <strong>Most lazy SKIer</strong></li>
+<li><a href="endoh2/index.html"><strong>2013/endoh2</strong></a> - <strong>Most recyclable</strong></li>
+<li><a href="endoh3/index.html"><strong>2013/endoh3</strong></a> - <strong>Most tweetable one liner</strong></li>
+<li><a href="endoh4/index.html"><strong>2013/endoh4</strong></a> - <strong>Most solid</strong></li>
+<li><a href="hou/index.html"><strong>2013/hou</strong></a> - <strong>Best use of one infinite loop</strong></li>
+<li><a href="mills/index.html"><strong>2013/mills</strong></a> - <strong>Most timely rendered</strong></li>
+<li><a href="misaka/index.html"><strong>2013/misaka</strong></a> - <strong>Most catty</strong></li>
+<li><a href="morgan1/index.html"><strong>2013/morgan1</strong></a> - <strong>Smallest large system simulator</strong></li>
+<li><a href="morgan2/index.html"><strong>2013/morgan2</strong></a> - <strong>Most playfully versatile</strong></li>
+<li><a href="robison/index.html"><strong>2013/robison</strong></a> - <strong>Most poetic use of strings</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2013/index.html
+++ b/2013/index.html
@@ -474,21 +474,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2013.tar.bz2"><strong>Download all winning entries from 2013</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2013/birken</a> - Best painting tool</li>
-<li><a href="cable1/index.html">2013/cable1</a> - Most partisan one liner</li>
-<li><a href="cable2/index.html">2013/cable2</a> - Best of Show</li>
-<li><a href="cable3/index.html">2013/cable3</a> - Largest small system emulator</li>
-<li><a href="dlowe/index.html">2013/dlowe</a> - Best sparkling utility</li>
-<li><a href="endoh1/index.html">2013/endoh1</a> - Most lazy SKIer</li>
-<li><a href="endoh2/index.html">2013/endoh2</a> - Most recyclable</li>
-<li><a href="endoh3/index.html">2013/endoh3</a> - Most tweetable one liner</li>
-<li><a href="endoh4/index.html">2013/endoh4</a> - Most solid</li>
-<li><a href="hou/index.html">2013/hou</a> - Best use of one infinite loop</li>
-<li><a href="mills/index.html">2013/mills</a> - Most timely rendered</li>
-<li><a href="misaka/index.html">2013/misaka</a> - Most catty</li>
-<li><a href="morgan1/index.html">2013/morgan1</a> - Smallest large system simulator</li>
-<li><a href="morgan2/index.html">2013/morgan2</a> - Most playfully versatile</li>
-<li><a href="robison/index.html">2013/robison</a> - Most poetic use of strings</li>
+<li><a href="birken/index.html">2013/birken</a> - <strong>Best painting tool</strong></li>
+<li><a href="cable1/index.html">2013/cable1</a> - <strong>Most partisan one liner</strong></li>
+<li><a href="cable2/index.html">2013/cable2</a> - <strong>Best of Show</strong></li>
+<li><a href="cable3/index.html">2013/cable3</a> - <strong>Largest small system emulator</strong></li>
+<li><a href="dlowe/index.html">2013/dlowe</a> - <strong>Best sparkling utility</strong></li>
+<li><a href="endoh1/index.html">2013/endoh1</a> - <strong>Most lazy SKIer</strong></li>
+<li><a href="endoh2/index.html">2013/endoh2</a> - <strong>Most recyclable</strong></li>
+<li><a href="endoh3/index.html">2013/endoh3</a> - <strong>Most tweetable one liner</strong></li>
+<li><a href="endoh4/index.html">2013/endoh4</a> - <strong>Most solid</strong></li>
+<li><a href="hou/index.html">2013/hou</a> - <strong>Best use of one infinite loop</strong></li>
+<li><a href="mills/index.html">2013/mills</a> - <strong>Most timely rendered</strong></li>
+<li><a href="misaka/index.html">2013/misaka</a> - <strong>Most catty</strong></li>
+<li><a href="morgan1/index.html">2013/morgan1</a> - <strong>Smallest large system simulator</strong></li>
+<li><a href="morgan2/index.html">2013/morgan2</a> - <strong>Most playfully versatile</strong></li>
+<li><a href="robison/index.html">2013/robison</a> - <strong>Most poetic use of strings</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2014/index.html
+++ b/2014/index.html
@@ -489,17 +489,17 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2014.tar.bz2"><strong>Download all winning entries from 2014</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2014/birken</a> - Best use of port 1701</li>
-<li><a href="deak/index.html">2014/deak</a> - Most underscored argument</li>
-<li><a href="endoh1/index.html">2014/endoh1</a> - Most square (YODA Award)</li>
-<li><a href="endoh2/index.html">2014/endoh2</a> - Best use of bioinformatics</li>
-<li><a href="maffiodo1/index.html">2014/maffiodo1</a> - Homage to a classic game</li>
-<li><a href="maffiodo2/index.html">2014/maffiodo2</a> - Most tweetable entry</li>
-<li><a href="morgan/index.html">2014/morgan</a> - Most likely to succeed</li>
-<li><a href="sinon/index.html">2014/sinon</a> - Best choice of optimization</li>
-<li><a href="skeggs/index.html">2014/skeggs</a> - Most dynamic</li>
-<li><a href="vik/index.html">2014/vik</a> - Best handling of beeps</li>
-<li><a href="wiedijk/index.html">2014/wiedijk</a> - Most functional</li>
+<li><a href="birken/index.html">2014/birken</a> - <strong>Best use of port 1701</strong></li>
+<li><a href="deak/index.html">2014/deak</a> - <strong>Most underscored argument</strong></li>
+<li><a href="endoh1/index.html">2014/endoh1</a> - <strong>Most square (YODA Award)</strong></li>
+<li><a href="endoh2/index.html">2014/endoh2</a> - <strong>Best use of bioinformatics</strong></li>
+<li><a href="maffiodo1/index.html">2014/maffiodo1</a> - <strong>Homage to a classic game</strong></li>
+<li><a href="maffiodo2/index.html">2014/maffiodo2</a> - <strong>Most tweetable entry</strong></li>
+<li><a href="morgan/index.html">2014/morgan</a> - <strong>Most likely to succeed</strong></li>
+<li><a href="sinon/index.html">2014/sinon</a> - <strong>Best choice of optimization</strong></li>
+<li><a href="skeggs/index.html">2014/skeggs</a> - <strong>Most dynamic</strong></li>
+<li><a href="vik/index.html">2014/vik</a> - <strong>Best handling of beeps</strong></li>
+<li><a href="wiedijk/index.html">2014/wiedijk</a> - <strong>Most functional</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2014/index.html
+++ b/2014/index.html
@@ -489,17 +489,17 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2014.tar.bz2"><strong>Download all winning entries from 2014</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2014/birken</a> - <strong>Best use of port 1701</strong></li>
-<li><a href="deak/index.html">2014/deak</a> - <strong>Most underscored argument</strong></li>
-<li><a href="endoh1/index.html">2014/endoh1</a> - <strong>Most square (YODA Award)</strong></li>
-<li><a href="endoh2/index.html">2014/endoh2</a> - <strong>Best use of bioinformatics</strong></li>
-<li><a href="maffiodo1/index.html">2014/maffiodo1</a> - <strong>Homage to a classic game</strong></li>
-<li><a href="maffiodo2/index.html">2014/maffiodo2</a> - <strong>Most tweetable entry</strong></li>
-<li><a href="morgan/index.html">2014/morgan</a> - <strong>Most likely to succeed</strong></li>
-<li><a href="sinon/index.html">2014/sinon</a> - <strong>Best choice of optimization</strong></li>
-<li><a href="skeggs/index.html">2014/skeggs</a> - <strong>Most dynamic</strong></li>
-<li><a href="vik/index.html">2014/vik</a> - <strong>Best handling of beeps</strong></li>
-<li><a href="wiedijk/index.html">2014/wiedijk</a> - <strong>Most functional</strong></li>
+<li><a href="birken/index.html"><strong>2014/birken</strong></a> - <strong>Best use of port 1701</strong></li>
+<li><a href="deak/index.html"><strong>2014/deak</strong></a> - <strong>Most underscored argument</strong></li>
+<li><a href="endoh1/index.html"><strong>2014/endoh1</strong></a> - <strong>Most square (YODA Award)</strong></li>
+<li><a href="endoh2/index.html"><strong>2014/endoh2</strong></a> - <strong>Best use of bioinformatics</strong></li>
+<li><a href="maffiodo1/index.html"><strong>2014/maffiodo1</strong></a> - <strong>Homage to a classic game</strong></li>
+<li><a href="maffiodo2/index.html"><strong>2014/maffiodo2</strong></a> - <strong>Most tweetable entry</strong></li>
+<li><a href="morgan/index.html"><strong>2014/morgan</strong></a> - <strong>Most likely to succeed</strong></li>
+<li><a href="sinon/index.html"><strong>2014/sinon</strong></a> - <strong>Best choice of optimization</strong></li>
+<li><a href="skeggs/index.html"><strong>2014/skeggs</strong></a> - <strong>Most dynamic</strong></li>
+<li><a href="vik/index.html"><strong>2014/vik</strong></a> - <strong>Best handling of beeps</strong></li>
+<li><a href="wiedijk/index.html"><strong>2014/wiedijk</strong></a> - <strong>Most functional</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2015/index.html
+++ b/2015/index.html
@@ -489,20 +489,20 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2015.tar.bz2"><strong>Download all winning entries from 2015</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2015/burton</a> - Most useful</li>
-<li><a href="dogon/index.html">2015/dogon</a> - Most crafty</li>
-<li><a href="duble/index.html">2015/duble</a> - Best handwriting</li>
-<li><a href="endoh1/index.html">2015/endoh1</a> - Most diffused reaction</li>
-<li><a href="endoh2/index.html">2015/endoh2</a> - Most overlooked obfuscation</li>
-<li><a href="endoh3/index.html">2015/endoh3</a> - Back to the Future Award</li>
-<li><a href="endoh4/index.html">2015/endoh4</a> - Best one liner</li>
-<li><a href="hou/index.html">2015/hou</a> - Most well rounded hash</li>
-<li><a href="howe/index.html">2015/howe</a> - Most different</li>
-<li><a href="mills1/index.html">2015/mills1</a> - For the Birds! Award</li>
-<li><a href="mills2/index.html">2015/mills2</a> - Most compact</li>
-<li><a href="muth/index.html">2015/muth</a> - Most complete use of CPP</li>
-<li><a href="schweikhardt/index.html">2015/schweikhardt</a> - Best documented</li>
-<li><a href="yang/index.html">2015/yang</a> - Most pointed reaction</li>
+<li><a href="burton/index.html">2015/burton</a> - <strong>Most useful</strong></li>
+<li><a href="dogon/index.html">2015/dogon</a> - <strong>Most crafty</strong></li>
+<li><a href="duble/index.html">2015/duble</a> - <strong>Best handwriting</strong></li>
+<li><a href="endoh1/index.html">2015/endoh1</a> - <strong>Most diffused reaction</strong></li>
+<li><a href="endoh2/index.html">2015/endoh2</a> - <strong>Most overlooked obfuscation</strong></li>
+<li><a href="endoh3/index.html">2015/endoh3</a> - <strong>Back to the Future Award</strong></li>
+<li><a href="endoh4/index.html">2015/endoh4</a> - <strong>Best one liner</strong></li>
+<li><a href="hou/index.html">2015/hou</a> - <strong>Most well rounded hash</strong></li>
+<li><a href="howe/index.html">2015/howe</a> - <strong>Most different</strong></li>
+<li><a href="mills1/index.html">2015/mills1</a> - <strong>For the Birds! Award</strong></li>
+<li><a href="mills2/index.html">2015/mills2</a> - <strong>Most compact</strong></li>
+<li><a href="muth/index.html">2015/muth</a> - <strong>Most complete use of CPP</strong></li>
+<li><a href="schweikhardt/index.html">2015/schweikhardt</a> - <strong>Best documented</strong></li>
+<li><a href="yang/index.html">2015/yang</a> - <strong>Most pointed reaction</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2015/index.html
+++ b/2015/index.html
@@ -489,20 +489,20 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2015.tar.bz2"><strong>Download all winning entries from 2015</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2015/burton</a> - <strong>Most useful</strong></li>
-<li><a href="dogon/index.html">2015/dogon</a> - <strong>Most crafty</strong></li>
-<li><a href="duble/index.html">2015/duble</a> - <strong>Best handwriting</strong></li>
-<li><a href="endoh1/index.html">2015/endoh1</a> - <strong>Most diffused reaction</strong></li>
-<li><a href="endoh2/index.html">2015/endoh2</a> - <strong>Most overlooked obfuscation</strong></li>
-<li><a href="endoh3/index.html">2015/endoh3</a> - <strong>Back to the Future Award</strong></li>
-<li><a href="endoh4/index.html">2015/endoh4</a> - <strong>Best one liner</strong></li>
-<li><a href="hou/index.html">2015/hou</a> - <strong>Most well rounded hash</strong></li>
-<li><a href="howe/index.html">2015/howe</a> - <strong>Most different</strong></li>
-<li><a href="mills1/index.html">2015/mills1</a> - <strong>For the Birds! Award</strong></li>
-<li><a href="mills2/index.html">2015/mills2</a> - <strong>Most compact</strong></li>
-<li><a href="muth/index.html">2015/muth</a> - <strong>Most complete use of CPP</strong></li>
-<li><a href="schweikhardt/index.html">2015/schweikhardt</a> - <strong>Best documented</strong></li>
-<li><a href="yang/index.html">2015/yang</a> - <strong>Most pointed reaction</strong></li>
+<li><a href="burton/index.html"><strong>2015/burton</strong></a> - <strong>Most useful</strong></li>
+<li><a href="dogon/index.html"><strong>2015/dogon</strong></a> - <strong>Most crafty</strong></li>
+<li><a href="duble/index.html"><strong>2015/duble</strong></a> - <strong>Best handwriting</strong></li>
+<li><a href="endoh1/index.html"><strong>2015/endoh1</strong></a> - <strong>Most diffused reaction</strong></li>
+<li><a href="endoh2/index.html"><strong>2015/endoh2</strong></a> - <strong>Most overlooked obfuscation</strong></li>
+<li><a href="endoh3/index.html"><strong>2015/endoh3</strong></a> - <strong>Back to the Future Award</strong></li>
+<li><a href="endoh4/index.html"><strong>2015/endoh4</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="hou/index.html"><strong>2015/hou</strong></a> - <strong>Most well rounded hash</strong></li>
+<li><a href="howe/index.html"><strong>2015/howe</strong></a> - <strong>Most different</strong></li>
+<li><a href="mills1/index.html"><strong>2015/mills1</strong></a> - <strong>For the Birds! Award</strong></li>
+<li><a href="mills2/index.html"><strong>2015/mills2</strong></a> - <strong>Most compact</strong></li>
+<li><a href="muth/index.html"><strong>2015/muth</strong></a> - <strong>Most complete use of CPP</strong></li>
+<li><a href="schweikhardt/index.html"><strong>2015/schweikhardt</strong></a> - <strong>Best documented</strong></li>
+<li><a href="yang/index.html"><strong>2015/yang</strong></a> - <strong>Most pointed reaction</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2018/index.html
+++ b/2018/index.html
@@ -476,21 +476,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2018.tar.bz2"><strong>Download all winning entries from 2018</strong></a></p>
 <ul>
-<li><a href="algmyr/index.html">2018/algmyr</a> - Most cacophonic</li>
-<li><a href="anderson/index.html">2018/anderson</a> - Most able to divine code gaps</li>
-<li><a href="bellard/index.html">2018/bellard</a> - Most inflationary</li>
-<li><a href="burton1/index.html">2018/burton1</a> - Best one liner</li>
-<li><a href="burton2/index.html">2018/burton2</a> - Best abuse of the rules</li>
-<li><a href="ciura/index.html">2018/ciura</a> - Most likely to be awarded</li>
-<li><a href="endoh1/index.html">2018/endoh1</a> - Best tool to reveal holes</li>
-<li><a href="endoh2/index.html">2018/endoh2</a> - Best use of python</li>
-<li><a href="ferguson/index.html">2018/ferguson</a> - Best use of weasel words</li>
-<li><a href="giles/index.html">2018/giles</a> - Most unstable</li>
-<li><a href="hou/index.html">2018/hou</a> - Most likely to top the charts</li>
-<li><a href="mills/index.html">2018/mills</a> - Best of Show</li>
-<li><a href="poikola/index.html">2018/poikola</a> - Most stellar</li>
-<li><a href="vokes/index.html">2018/vokes</a> - Most connected</li>
-<li><a href="yang/index.html">2018/yang</a> - Most shifty</li>
+<li><a href="algmyr/index.html">2018/algmyr</a> - <strong>Most cacophonic</strong></li>
+<li><a href="anderson/index.html">2018/anderson</a> - <strong>Most able to divine code gaps</strong></li>
+<li><a href="bellard/index.html">2018/bellard</a> - <strong>Most inflationary</strong></li>
+<li><a href="burton1/index.html">2018/burton1</a> - <strong>Best one liner</strong></li>
+<li><a href="burton2/index.html">2018/burton2</a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="ciura/index.html">2018/ciura</a> - <strong>Most likely to be awarded</strong></li>
+<li><a href="endoh1/index.html">2018/endoh1</a> - <strong>Best tool to reveal holes</strong></li>
+<li><a href="endoh2/index.html">2018/endoh2</a> - <strong>Best use of python</strong></li>
+<li><a href="ferguson/index.html">2018/ferguson</a> - <strong>Best use of weasel words</strong></li>
+<li><a href="giles/index.html">2018/giles</a> - <strong>Most unstable</strong></li>
+<li><a href="hou/index.html">2018/hou</a> - <strong>Most likely to top the charts</strong></li>
+<li><a href="mills/index.html">2018/mills</a> - <strong>Best of Show</strong></li>
+<li><a href="poikola/index.html">2018/poikola</a> - <strong>Most stellar</strong></li>
+<li><a href="vokes/index.html">2018/vokes</a> - <strong>Most connected</strong></li>
+<li><a href="yang/index.html">2018/yang</a> - <strong>Most shifty</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2018/index.html
+++ b/2018/index.html
@@ -476,21 +476,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2018.tar.bz2"><strong>Download all winning entries from 2018</strong></a></p>
 <ul>
-<li><a href="algmyr/index.html">2018/algmyr</a> - <strong>Most cacophonic</strong></li>
-<li><a href="anderson/index.html">2018/anderson</a> - <strong>Most able to divine code gaps</strong></li>
-<li><a href="bellard/index.html">2018/bellard</a> - <strong>Most inflationary</strong></li>
-<li><a href="burton1/index.html">2018/burton1</a> - <strong>Best one liner</strong></li>
-<li><a href="burton2/index.html">2018/burton2</a> - <strong>Best abuse of the rules</strong></li>
-<li><a href="ciura/index.html">2018/ciura</a> - <strong>Most likely to be awarded</strong></li>
-<li><a href="endoh1/index.html">2018/endoh1</a> - <strong>Best tool to reveal holes</strong></li>
-<li><a href="endoh2/index.html">2018/endoh2</a> - <strong>Best use of python</strong></li>
-<li><a href="ferguson/index.html">2018/ferguson</a> - <strong>Best use of weasel words</strong></li>
-<li><a href="giles/index.html">2018/giles</a> - <strong>Most unstable</strong></li>
-<li><a href="hou/index.html">2018/hou</a> - <strong>Most likely to top the charts</strong></li>
-<li><a href="mills/index.html">2018/mills</a> - <strong>Best of Show</strong></li>
-<li><a href="poikola/index.html">2018/poikola</a> - <strong>Most stellar</strong></li>
-<li><a href="vokes/index.html">2018/vokes</a> - <strong>Most connected</strong></li>
-<li><a href="yang/index.html">2018/yang</a> - <strong>Most shifty</strong></li>
+<li><a href="algmyr/index.html"><strong>2018/algmyr</strong></a> - <strong>Most cacophonic</strong></li>
+<li><a href="anderson/index.html"><strong>2018/anderson</strong></a> - <strong>Most able to divine code gaps</strong></li>
+<li><a href="bellard/index.html"><strong>2018/bellard</strong></a> - <strong>Most inflationary</strong></li>
+<li><a href="burton1/index.html"><strong>2018/burton1</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="burton2/index.html"><strong>2018/burton2</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="ciura/index.html"><strong>2018/ciura</strong></a> - <strong>Most likely to be awarded</strong></li>
+<li><a href="endoh1/index.html"><strong>2018/endoh1</strong></a> - <strong>Best tool to reveal holes</strong></li>
+<li><a href="endoh2/index.html"><strong>2018/endoh2</strong></a> - <strong>Best use of python</strong></li>
+<li><a href="ferguson/index.html"><strong>2018/ferguson</strong></a> - <strong>Best use of weasel words</strong></li>
+<li><a href="giles/index.html"><strong>2018/giles</strong></a> - <strong>Most unstable</strong></li>
+<li><a href="hou/index.html"><strong>2018/hou</strong></a> - <strong>Most likely to top the charts</strong></li>
+<li><a href="mills/index.html"><strong>2018/mills</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="poikola/index.html"><strong>2018/poikola</strong></a> - <strong>Most stellar</strong></li>
+<li><a href="vokes/index.html"><strong>2018/vokes</strong></a> - <strong>Most connected</strong></li>
+<li><a href="yang/index.html"><strong>2018/yang</strong></a> - <strong>Most shifty</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2019/index.html
+++ b/2019/index.html
@@ -463,20 +463,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2019.tar.bz2"><strong>Download all winning entries from 2019</strong></a></p>
 <ul>
-<li><a href="adamovsky/index.html">2019/adamovsky</a> - <strong>Most functional interpreter</strong></li>
-<li><a href="burton/index.html">2019/burton</a> - <strong>Best one liner</strong></li>
-<li><a href="ciura/index.html">2019/ciura</a> - <strong>Most alphabetic</strong></li>
-<li><a href="diels-grabsch1/index.html">2019/diels-grabsch1</a> - <strong>Best small program</strong></li>
-<li><a href="diels-grabsch2/index.html">2019/diels-grabsch2</a> - <strong>Most self-aware</strong></li>
-<li><a href="dogon/index.html">2019/dogon</a> - <strong>Best use of space and time</strong></li>
-<li><a href="duble/index.html">2019/duble</a> - <strong>Best collaborative graphics</strong></li>
-<li><a href="endoh/index.html">2019/endoh</a> - <strong>Most in need of debugging</strong></li>
-<li><a href="giles/index.html">2019/giles</a> - <strong>Most in need of wide space</strong></li>
-<li><a href="karns/index.html">2019/karns</a> - <strong>Most in need of whitespace</strong></li>
-<li><a href="lynn/index.html">2019/lynn</a> - <strong>Most functional compiler</strong></li>
-<li><a href="mills/index.html">2019/mills</a> - <strong>Most in need to be tweeted</strong></li>
-<li><a href="poikola/index.html">2019/poikola</a> - <strong>Most calendrical</strong></li>
-<li><a href="yang/index.html">2019/yang</a> - <strong>Most in need of transparency</strong></li>
+<li><a href="adamovsky/index.html"><strong>2019/adamovsky</strong></a> - <strong>Most functional interpreter</strong></li>
+<li><a href="burton/index.html"><strong>2019/burton</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="ciura/index.html"><strong>2019/ciura</strong></a> - <strong>Most alphabetic</strong></li>
+<li><a href="diels-grabsch1/index.html"><strong>2019/diels-grabsch1</strong></a> - <strong>Best small program</strong></li>
+<li><a href="diels-grabsch2/index.html"><strong>2019/diels-grabsch2</strong></a> - <strong>Most self-aware</strong></li>
+<li><a href="dogon/index.html"><strong>2019/dogon</strong></a> - <strong>Best use of space and time</strong></li>
+<li><a href="duble/index.html"><strong>2019/duble</strong></a> - <strong>Best collaborative graphics</strong></li>
+<li><a href="endoh/index.html"><strong>2019/endoh</strong></a> - <strong>Most in need of debugging</strong></li>
+<li><a href="giles/index.html"><strong>2019/giles</strong></a> - <strong>Most in need of wide space</strong></li>
+<li><a href="karns/index.html"><strong>2019/karns</strong></a> - <strong>Most in need of whitespace</strong></li>
+<li><a href="lynn/index.html"><strong>2019/lynn</strong></a> - <strong>Most functional compiler</strong></li>
+<li><a href="mills/index.html"><strong>2019/mills</strong></a> - <strong>Most in need to be tweeted</strong></li>
+<li><a href="poikola/index.html"><strong>2019/poikola</strong></a> - <strong>Most calendrical</strong></li>
+<li><a href="yang/index.html"><strong>2019/yang</strong></a> - <strong>Most in need of transparency</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2019/index.html
+++ b/2019/index.html
@@ -463,20 +463,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2019.tar.bz2"><strong>Download all winning entries from 2019</strong></a></p>
 <ul>
-<li><a href="adamovsky/index.html">2019/adamovsky</a> - Most functional interpreter</li>
-<li><a href="burton/index.html">2019/burton</a> - Best one liner</li>
-<li><a href="ciura/index.html">2019/ciura</a> - Most alphabetic</li>
-<li><a href="diels-grabsch1/index.html">2019/diels-grabsch1</a> - Best small program</li>
-<li><a href="diels-grabsch2/index.html">2019/diels-grabsch2</a> - Most self-aware</li>
-<li><a href="dogon/index.html">2019/dogon</a> - Best use of space and time</li>
-<li><a href="duble/index.html">2019/duble</a> - Best collaborative graphics</li>
-<li><a href="endoh/index.html">2019/endoh</a> - Most in need of debugging</li>
-<li><a href="giles/index.html">2019/giles</a> - Most in need of wide space</li>
-<li><a href="karns/index.html">2019/karns</a> - Most in need of whitespace</li>
-<li><a href="lynn/index.html">2019/lynn</a> - Most functional compiler</li>
-<li><a href="mills/index.html">2019/mills</a> - Most in need to be tweeted</li>
-<li><a href="poikola/index.html">2019/poikola</a> - Most calendrical</li>
-<li><a href="yang/index.html">2019/yang</a> - Most in need of transparency</li>
+<li><a href="adamovsky/index.html">2019/adamovsky</a> - <strong>Most functional interpreter</strong></li>
+<li><a href="burton/index.html">2019/burton</a> - <strong>Best one liner</strong></li>
+<li><a href="ciura/index.html">2019/ciura</a> - <strong>Most alphabetic</strong></li>
+<li><a href="diels-grabsch1/index.html">2019/diels-grabsch1</a> - <strong>Best small program</strong></li>
+<li><a href="diels-grabsch2/index.html">2019/diels-grabsch2</a> - <strong>Most self-aware</strong></li>
+<li><a href="dogon/index.html">2019/dogon</a> - <strong>Best use of space and time</strong></li>
+<li><a href="duble/index.html">2019/duble</a> - <strong>Best collaborative graphics</strong></li>
+<li><a href="endoh/index.html">2019/endoh</a> - <strong>Most in need of debugging</strong></li>
+<li><a href="giles/index.html">2019/giles</a> - <strong>Most in need of wide space</strong></li>
+<li><a href="karns/index.html">2019/karns</a> - <strong>Most in need of whitespace</strong></li>
+<li><a href="lynn/index.html">2019/lynn</a> - <strong>Most functional compiler</strong></li>
+<li><a href="mills/index.html">2019/mills</a> - <strong>Most in need to be tweeted</strong></li>
+<li><a href="poikola/index.html">2019/poikola</a> - <strong>Most calendrical</strong></li>
+<li><a href="yang/index.html">2019/yang</a> - <strong>Most in need of transparency</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2020/index.html
+++ b/2020/index.html
@@ -462,21 +462,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2020.tar.bz2"><strong>Download all winning entries from 2020</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2020/burton</a> - Best one liner</li>
-<li><a href="carlini/index.html">2020/carlini</a> - Best of Show - abuse of libc</li>
-<li><a href="endoh1/index.html">2020/endoh1</a> - Most explosive</li>
-<li><a href="endoh2/index.html">2020/endoh2</a> - Best perspective</li>
-<li><a href="endoh3/index.html">2020/endoh3</a> - Most head-turning</li>
-<li><a href="ferguson1/index.html">2020/ferguson1</a> - Don’t tread on me award</li>
-<li><a href="ferguson2/index.html">2020/ferguson2</a> - Most enigmatic</li>
-<li><a href="giles/index.html">2020/giles</a> - Most phony</li>
-<li><a href="kurdyukov1/index.html">2020/kurdyukov1</a> - Best utility</li>
-<li><a href="kurdyukov2/index.html">2020/kurdyukov2</a> - Least detailed</li>
-<li><a href="kurdyukov3/index.html">2020/kurdyukov3</a> - Bset slaml prragom</li>
-<li><a href="kurdyukov4/index.html">2020/kurdyukov4</a> - Best abuse of lámatyávë</li>
-<li><a href="otterness/index.html">2020/otterness</a> - Most percussive</li>
-<li><a href="tsoj/index.html">2020/tsoj</a> - Most misleading indentation</li>
-<li><a href="yang/index.html">2020/yang</a> - Best abuse of CPP</li>
+<li><a href="burton/index.html">2020/burton</a> - <strong>Best one liner</strong></li>
+<li><a href="carlini/index.html">2020/carlini</a> - <strong>Best of Show - abuse of libc</strong></li>
+<li><a href="endoh1/index.html">2020/endoh1</a> - <strong>Most explosive</strong></li>
+<li><a href="endoh2/index.html">2020/endoh2</a> - <strong>Best perspective</strong></li>
+<li><a href="endoh3/index.html">2020/endoh3</a> - <strong>Most head-turning</strong></li>
+<li><a href="ferguson1/index.html">2020/ferguson1</a> - <strong>Don’t tread on me award</strong></li>
+<li><a href="ferguson2/index.html">2020/ferguson2</a> - <strong>Most enigmatic</strong></li>
+<li><a href="giles/index.html">2020/giles</a> - <strong>Most phony</strong></li>
+<li><a href="kurdyukov1/index.html">2020/kurdyukov1</a> - <strong>Best utility</strong></li>
+<li><a href="kurdyukov2/index.html">2020/kurdyukov2</a> - <strong>Least detailed</strong></li>
+<li><a href="kurdyukov3/index.html">2020/kurdyukov3</a> - <strong>Bset slaml prragom</strong></li>
+<li><a href="kurdyukov4/index.html">2020/kurdyukov4</a> - <strong>Best abuse of lámatyávë</strong></li>
+<li><a href="otterness/index.html">2020/otterness</a> - <strong>Most percussive</strong></li>
+<li><a href="tsoj/index.html">2020/tsoj</a> - <strong>Most misleading indentation</strong></li>
+<li><a href="yang/index.html">2020/yang</a> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2020/index.html
+++ b/2020/index.html
@@ -462,21 +462,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2020.tar.bz2"><strong>Download all winning entries from 2020</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2020/burton</a> - <strong>Best one liner</strong></li>
-<li><a href="carlini/index.html">2020/carlini</a> - <strong>Best of Show - abuse of libc</strong></li>
-<li><a href="endoh1/index.html">2020/endoh1</a> - <strong>Most explosive</strong></li>
-<li><a href="endoh2/index.html">2020/endoh2</a> - <strong>Best perspective</strong></li>
-<li><a href="endoh3/index.html">2020/endoh3</a> - <strong>Most head-turning</strong></li>
-<li><a href="ferguson1/index.html">2020/ferguson1</a> - <strong>Don’t tread on me award</strong></li>
-<li><a href="ferguson2/index.html">2020/ferguson2</a> - <strong>Most enigmatic</strong></li>
-<li><a href="giles/index.html">2020/giles</a> - <strong>Most phony</strong></li>
-<li><a href="kurdyukov1/index.html">2020/kurdyukov1</a> - <strong>Best utility</strong></li>
-<li><a href="kurdyukov2/index.html">2020/kurdyukov2</a> - <strong>Least detailed</strong></li>
-<li><a href="kurdyukov3/index.html">2020/kurdyukov3</a> - <strong>Bset slaml prragom</strong></li>
-<li><a href="kurdyukov4/index.html">2020/kurdyukov4</a> - <strong>Best abuse of lámatyávë</strong></li>
-<li><a href="otterness/index.html">2020/otterness</a> - <strong>Most percussive</strong></li>
-<li><a href="tsoj/index.html">2020/tsoj</a> - <strong>Most misleading indentation</strong></li>
-<li><a href="yang/index.html">2020/yang</a> - <strong>Best abuse of CPP</strong></li>
+<li><a href="burton/index.html"><strong>2020/burton</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="carlini/index.html"><strong>2020/carlini</strong></a> - <strong>Best of Show - abuse of libc</strong></li>
+<li><a href="endoh1/index.html"><strong>2020/endoh1</strong></a> - <strong>Most explosive</strong></li>
+<li><a href="endoh2/index.html"><strong>2020/endoh2</strong></a> - <strong>Best perspective</strong></li>
+<li><a href="endoh3/index.html"><strong>2020/endoh3</strong></a> - <strong>Most head-turning</strong></li>
+<li><a href="ferguson1/index.html"><strong>2020/ferguson1</strong></a> - <strong>Don’t tread on me award</strong></li>
+<li><a href="ferguson2/index.html"><strong>2020/ferguson2</strong></a> - <strong>Most enigmatic</strong></li>
+<li><a href="giles/index.html"><strong>2020/giles</strong></a> - <strong>Most phony</strong></li>
+<li><a href="kurdyukov1/index.html"><strong>2020/kurdyukov1</strong></a> - <strong>Best utility</strong></li>
+<li><a href="kurdyukov2/index.html"><strong>2020/kurdyukov2</strong></a> - <strong>Least detailed</strong></li>
+<li><a href="kurdyukov3/index.html"><strong>2020/kurdyukov3</strong></a> - <strong>Bset slaml prragom</strong></li>
+<li><a href="kurdyukov4/index.html"><strong>2020/kurdyukov4</strong></a> - <strong>Best abuse of lámatyávë</strong></li>
+<li><a href="otterness/index.html"><strong>2020/otterness</strong></a> - <strong>Most percussive</strong></li>
+<li><a href="tsoj/index.html"><strong>2020/tsoj</strong></a> - <strong>Most misleading indentation</strong></li>
+<li><a href="yang/index.html"><strong>2020/yang</strong></a> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/bin/output-year-index.sh
+++ b/bin/output-year-index.sh
@@ -29,6 +29,8 @@
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
+# .. with very minor improvements in June 2024 by Cody Boone Ferguson.
+#
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
 # provided that the above copyright, this permission notice and text
@@ -220,7 +222,7 @@ function output_award
 	echo "$0: ERROR: in output_award: no award found in .entry.json file: $ENTRY_JSON_PATH" 1>&2
 	return 5
     fi
-    echo "$AWARD_STRING"
+    echo "**$AWARD_STRING**"
     return 0
 }
 
@@ -429,7 +431,7 @@ if [[ ! -x $PANDOC_WRAPPER ]]; then
     exit 5
 fi
 
-# verify that YYYY is a entry directory
+# verify that YYYY is an entry directory
 #
 if [[ ! -d $YYYY ]]; then
     echo "$0: ERROR: arg is not a directory: $YYYY" 1>&2
@@ -646,7 +648,7 @@ for YYYY_DIR in $(< "$YEAR_FILE"); do
     #
     ENTRY_NAME=$(basename "$YYYY_DIR")
     export ENTRY_NAME
-    echo "* [$YYYY_DIR]($ENTRY_NAME/index.html) - $AWARD"
+    echo "* [**$YYYY_DIR**]($ENTRY_NAME/index.html) - $AWARD"
 done | if [[ -z $NOOP ]]; then
     cat >> "$TMP_FILE"
 else


### PR DESCRIPTION
Make it consistent with my improvement to bin/gen-years.sh: the entry awards in the links (to each entry) are now in bold and so are the link names. This helps them stand out a bit more.