### PR TITLE
Slight improvement to authors.html

### DIFF
--- a/1984/index.html
+++ b/1984/index.html
@@ -429,10 +429,10 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1984.tar.bz2"><strong>Download all winning entries from 1984</strong></a></p>
 <ul>
-<li><a href="anonymous/index.html">1984/anonymous</a> - Dishonorable Mention</li>
-<li><a href="decot/index.html">1984/decot</a> - Second Place</li>
-<li><a href="laman/index.html">1984/laman</a> - Third Place</li>
-<li><a href="mullender/index.html">1984/mullender</a> - Grand Prize</li>
+<li><a href="anonymous/index.html"><strong>1984/anonymous</strong></a> - <strong>Dishonorable Mention</strong></li>
+<li><a href="decot/index.html"><strong>1984/decot</strong></a> - <strong>Second Place</strong></li>
+<li><a href="laman/index.html"><strong>1984/laman</strong></a> - <strong>Third Place</strong></li>
+<li><a href="mullender/index.html"><strong>1984/mullender</strong></a> - <strong>Grand Prize</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1985/index.html
+++ b/1985/index.html
@@ -428,11 +428,11 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1985.tar.bz2"><strong>Download all winning entries from 1985</strong></a></p>
 <ul>
-<li><a href="applin/index.html">1985/applin</a> - Best one liner</li>
-<li><a href="august/index.html">1985/august</a> - Most obscure program</li>
-<li><a href="lycklama/index.html">1985/lycklama</a> - Strangest appearing program</li>
-<li><a href="shapiro/index.html">1985/shapiro</a> - Grand Prize - Most well rounded in confusion</li>
-<li><a href="sicherman/index.html">1985/sicherman</a> - Worst abuse of the C preprocessor</li>
+<li><a href="applin/index.html"><strong>1985/applin</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="august/index.html"><strong>1985/august</strong></a> - <strong>Most obscure program</strong></li>
+<li><a href="lycklama/index.html"><strong>1985/lycklama</strong></a> - <strong>Strangest appearing program</strong></li>
+<li><a href="shapiro/index.html"><strong>1985/shapiro</strong></a> - <strong>Grand Prize - Most well rounded in confusion</strong></li>
+<li><a href="sicherman/index.html"><strong>1985/sicherman</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1986/index.html
+++ b/1986/index.html
@@ -437,15 +437,15 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1986.tar.bz2"><strong>Download all winning entries from 1986</strong></a></p>
 <ul>
-<li><a href="applin/index.html">1986/applin</a> - Most adaptable program</li>
-<li><a href="august/index.html">1986/august</a> - Best complex task done in a complex way</li>
-<li><a href="bright/index.html">1986/bright</a> - Most useful obfuscation</li>
-<li><a href="hague/index.html">1986/hague</a> - Worst abuse of the C preprocessor</li>
-<li><a href="holloway/index.html">1986/holloway</a> - Best simple task performed in a complex way</li>
-<li><a href="marshall/index.html">1986/marshall</a> - Best layout</li>
-<li><a href="pawka/index.html">1986/pawka</a> - Most illegible code</li>
-<li><a href="stein/index.html">1986/stein</a> - Best one liner</li>
-<li><a href="wall/index.html">1986/wall</a> - Grand Prize - Most well rounded in confusion</li>
+<li><a href="applin/index.html"><strong>1986/applin</strong></a> - <strong>Most adaptable program</strong></li>
+<li><a href="august/index.html"><strong>1986/august</strong></a> - <strong>Best complex task done in a complex way</strong></li>
+<li><a href="bright/index.html"><strong>1986/bright</strong></a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="hague/index.html"><strong>1986/hague</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><a href="holloway/index.html"><strong>1986/holloway</strong></a> - <strong>Best simple task performed in a complex way</strong></li>
+<li><a href="marshall/index.html"><strong>1986/marshall</strong></a> - <strong>Best layout</strong></li>
+<li><a href="pawka/index.html"><strong>1986/pawka</strong></a> - <strong>Most illegible code</strong></li>
+<li><a href="stein/index.html"><strong>1986/stein</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="wall/index.html"><strong>1986/wall</strong></a> - <strong>Grand Prize - Most well rounded in confusion</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1987/index.html
+++ b/1987/index.html
@@ -442,13 +442,13 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1987.tar.bz2"><strong>Download all winning entries from 1987</strong></a></p>
 <ul>
-<li><a href="biggar/index.html">1987/biggar</a> - Best abuse of the rules</li>
-<li><a href="heckbert/index.html">1987/heckbert</a> - Best obfuscator of programs</li>
-<li><a href="hines/index.html">1987/hines</a> - Worst style</li>
-<li><a href="korn/index.html">1987/korn</a> - Best one liner</li>
-<li><a href="lievaart/index.html">1987/lievaart</a> - Grand Prize</li>
-<li><a href="wall/index.html">1987/wall</a> - Most useful obfuscation</li>
-<li><a href="westley/index.html">1987/westley</a> - Best layout</li>
+<li><a href="biggar/index.html"><strong>1987/biggar</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="heckbert/index.html"><strong>1987/heckbert</strong></a> - <strong>Best obfuscator of programs</strong></li>
+<li><a href="hines/index.html"><strong>1987/hines</strong></a> - <strong>Worst style</strong></li>
+<li><a href="korn/index.html"><strong>1987/korn</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="lievaart/index.html"><strong>1987/lievaart</strong></a> - <strong>Grand Prize</strong></li>
+<li><a href="wall/index.html"><strong>1987/wall</strong></a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="westley/index.html"><strong>1987/westley</strong></a> - <strong>Best layout</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1988/index.html
+++ b/1988/index.html
@@ -394,15 +394,16 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>The maximum size of entries was raised from 1024 to 1536 bytes, however smaller
 entries were encouraged. Due to the <a href="../1987/biggar/index.html">“Best Abuse of the Rules” entry of
 1987</a>, a limit of 160 chars in the compile line was introduced.</p>
-<p>This year, the Grand Prize was given to the most unusual entry and best
-abuse of the C Preprocessor rather than the most well rounded entry.</p>
-<p><a href="rules.txt">Rules</a> and <a href="../years.html#1988">results</a> were posted to comp.lang.c,
-comp.sources.unix and alt.sources. The 1988 winning entries will be published
+<p>This year, the <a href="applin/index.html">Best of Show</a> was given to the most unusual
+entry and <code>best abuse of the C Preprocessor</code> rather than the most well rounded
+entry.</p>
+<p><a href="rules.txt">Rules</a> and <a href="../years.html#1988">results</a> were posted to <em>comp.lang.c</em>,
+<em>comp.sources.unix</em> and <em>alt.sources</em>. The 1988 winning entries will be published
 in the <a href="https://www.vintage-computer.com/publications.php?microsystemsjournal">Micro/Systems
 Journal</a>.</p>
 <p>Winning entries for previous years were repackaged with each year
 being in its own directory. Makefiles and hints were also provided.
-The package was posted to the comp.sources.unix newsgroup. They are
+The package was posted to the <em>comp.sources.unix</em> newsgroup. They are
 also available on a wide number of USENET archive sites.</p>
 <h2 id="final-comments">Final Comments</h2>
 <p><strong>IMPORTANT NOTE</strong>: See <a href="../contact.html">contact.html</a> for up to date contact details
@@ -435,15 +436,15 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1988.tar.bz2"><strong>Download all winning entries from 1988</strong></a></p>
 <ul>
-<li><a href="applin/index.html">1988/applin</a> - Best of Show</li>
-<li><a href="dale/index.html">1988/dale</a> - Best abuse of system calls</li>
-<li><a href="isaak/index.html">1988/isaak</a> - Best visuals</li>
-<li><a href="litmaath/index.html">1988/litmaath</a> - Best small program</li>
-<li><a href="phillipps/index.html">1988/phillipps</a> - Least likely to compile successfully</li>
-<li><a href="reddy/index.html">1988/reddy</a> - Most useful obfuscated C program</li>
-<li><a href="robison/index.html">1988/robison</a> - Best abuse of C constructs</li>
-<li><a href="spinellis/index.html">1988/spinellis</a> - Best abuse of the rules</li>
-<li><a href="westley/index.html">1988/westley</a> - Best layout</li>
+<li><a href="applin/index.html"><strong>1988/applin</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="dale/index.html"><strong>1988/dale</strong></a> - <strong>Best abuse of system calls</strong></li>
+<li><a href="isaak/index.html"><strong>1988/isaak</strong></a> - <strong>Best visuals</strong></li>
+<li><a href="litmaath/index.html"><strong>1988/litmaath</strong></a> - <strong>Best small program</strong></li>
+<li><a href="phillipps/index.html"><strong>1988/phillipps</strong></a> - <strong>Least likely to compile successfully</strong></li>
+<li><a href="reddy/index.html"><strong>1988/reddy</strong></a> - <strong>Most useful obfuscated C program</strong></li>
+<li><a href="robison/index.html"><strong>1988/robison</strong></a> - <strong>Best abuse of C constructs</strong></li>
+<li><a href="spinellis/index.html"><strong>1988/spinellis</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="westley/index.html"><strong>1988/westley</strong></a> - <strong>Best layout</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1989/index.html
+++ b/1989/index.html
@@ -439,16 +439,16 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1989.tar.bz2"><strong>Download all winning entries from 1989</strong></a></p>
 <ul>
-<li><a href="fubar/index.html">1989/fubar</a> - Best self-modifying program</li>
-<li><a href="jar.1/index.html">1989/jar.1</a> - Strangest abuse of the rules</li>
-<li><a href="jar.2/index.html">1989/jar.2</a> - Best of Show</li>
-<li><a href="ovdluhe/index.html">1989/ovdluhe</a> - Most humorous output</li>
-<li><a href="paul/index.html">1989/paul</a> - Most complex algorithm</li>
-<li><a href="robison/index.html">1989/robison</a> - Best minimal use of C</li>
-<li><a href="roemer/index.html">1989/roemer</a> - Best layout</li>
-<li><a href="tromp/index.html">1989/tromp</a> - Best game</li>
-<li><a href="vanb/index.html">1989/vanb</a> - Best one liner</li>
-<li><a href="westley/index.html">1989/westley</a> - Most algorithms in one program</li>
+<li><a href="fubar/index.html"><strong>1989/fubar</strong></a> - <strong>Best self-modifying program</strong></li>
+<li><a href="jar.1/index.html"><strong>1989/jar.1</strong></a> - <strong>Strangest abuse of the rules</strong></li>
+<li><a href="jar.2/index.html"><strong>1989/jar.2</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="ovdluhe/index.html"><strong>1989/ovdluhe</strong></a> - <strong>Most humorous output</strong></li>
+<li><a href="paul/index.html"><strong>1989/paul</strong></a> - <strong>Most complex algorithm</strong></li>
+<li><a href="robison/index.html"><strong>1989/robison</strong></a> - <strong>Best minimal use of C</strong></li>
+<li><a href="roemer/index.html"><strong>1989/roemer</strong></a> - <strong>Best layout</strong></li>
+<li><a href="tromp/index.html"><strong>1989/tromp</strong></a> - <strong>Best game</strong></li>
+<li><a href="vanb/index.html"><strong>1989/vanb</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="westley/index.html"><strong>1989/westley</strong></a> - <strong>Most algorithms in one program</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1990/index.html
+++ b/1990/index.html
@@ -435,17 +435,17 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1990.tar.bz2"><strong>Download all winning entries from 1990</strong></a></p>
 <ul>
-<li><a href="baruch/index.html">1990/baruch</a> - Best small program</li>
-<li><a href="cmills/index.html">1990/cmills</a> - Best game</li>
-<li><a href="dds/index.html">1990/dds</a> - Best language tool</li>
-<li><a href="dg/index.html">1990/dg</a> - Best abuse of the C preprocessor</li>
-<li><a href="jaw/index.html">1990/jaw</a> - Best entropy-reducer</li>
-<li><a href="pjr/index.html">1990/pjr</a> - Most unusual data structure</li>
-<li><a href="scjones/index.html">1990/scjones</a> - ANSI Committee’s worst abuse of C</li>
-<li><a href="stig/index.html">1990/stig</a> - Strangest abuse of the rules</li>
-<li><a href="tbr/index.html">1990/tbr</a> - Best utility</li>
-<li><a href="theorem/index.html">1990/theorem</a> - Best of Show</li>
-<li><a href="westley/index.html">1990/westley</a> - Best layout</li>
+<li><a href="baruch/index.html"><strong>1990/baruch</strong></a> - <strong>Best small program</strong></li>
+<li><a href="cmills/index.html"><strong>1990/cmills</strong></a> - <strong>Best game</strong></li>
+<li><a href="dds/index.html"><strong>1990/dds</strong></a> - <strong>Best language tool</strong></li>
+<li><a href="dg/index.html"><strong>1990/dg</strong></a> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><a href="jaw/index.html"><strong>1990/jaw</strong></a> - <strong>Best entropy-reducer</strong></li>
+<li><a href="pjr/index.html"><strong>1990/pjr</strong></a> - <strong>Most unusual data structure</strong></li>
+<li><a href="scjones/index.html"><strong>1990/scjones</strong></a> - <strong>ANSI Committee’s worst abuse of C</strong></li>
+<li><a href="stig/index.html"><strong>1990/stig</strong></a> - <strong>Strangest abuse of the rules</strong></li>
+<li><a href="tbr/index.html"><strong>1990/tbr</strong></a> - <strong>Best utility</strong></li>
+<li><a href="theorem/index.html"><strong>1990/theorem</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="westley/index.html"><strong>1990/westley</strong></a> - <strong>Best layout</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1991/index.html
+++ b/1991/index.html
@@ -486,15 +486,15 @@ as assistant pizza chef. Larry Bassel was official taste tester. Yummo!</p>
 </div>
 <p><a href="1991.tar.bz2"><strong>Download all winning entries from 1991</strong></a></p>
 <ul>
-<li><a href="ant/index.html">1991/ant</a> - Best utility</li>
-<li><a href="brnstnd/index.html">1991/brnstnd</a> - Best of Show</li>
-<li><a href="buzzard/index.html">1991/buzzard</a> - Best output</li>
-<li><a href="cdupont/index.html">1991/cdupont</a> - Most useful label</li>
-<li><a href="davidguy/index.html">1991/davidguy</a> - Best X11 graphics</li>
-<li><a href="dds/index.html">1991/dds</a> - Most well rounded</li>
-<li><a href="fine/index.html">1991/fine</a> - Best one liner</li>
-<li><a href="rince/index.html">1991/rince</a> - Best game</li>
-<li><a href="westley/index.html">1991/westley</a> - Grand Prize</li>
+<li><a href="ant/index.html"><strong>1991/ant</strong></a> - <strong>Best utility</strong></li>
+<li><a href="brnstnd/index.html"><strong>1991/brnstnd</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="buzzard/index.html"><strong>1991/buzzard</strong></a> - <strong>Best output</strong></li>
+<li><a href="cdupont/index.html"><strong>1991/cdupont</strong></a> - <strong>Most useful label</strong></li>
+<li><a href="davidguy/index.html"><strong>1991/davidguy</strong></a> - <strong>Best X11 graphics</strong></li>
+<li><a href="dds/index.html"><strong>1991/dds</strong></a> - <strong>Most well rounded</strong></li>
+<li><a href="fine/index.html"><strong>1991/fine</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="rince/index.html"><strong>1991/rince</strong></a> - <strong>Best game</strong></li>
+<li><a href="westley/index.html"><strong>1991/westley</strong></a> - <strong>Grand Prize</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1992/index.html
+++ b/1992/index.html
@@ -481,19 +481,19 @@ to serve as official taste testers. Yummo!</p>
 </div>
 <p><a href="1992.tar.bz2"><strong>Download all winning entries from 1992</strong></a></p>
 <ul>
-<li><a href="adrian/index.html">1992/adrian</a> - Most educational</li>
-<li><a href="albert/index.html">1992/albert</a> - Most useful program</li>
-<li><a href="ant/index.html">1992/ant</a> - Best utility</li>
-<li><a href="buzzard.1/index.html">1992/buzzard.1</a> - Most obfuscated algorithm</li>
-<li><a href="buzzard.2/index.html">1992/buzzard.2</a> - Best language tool</li>
-<li><a href="gson/index.html">1992/gson</a> - Most humorous output</li>
-<li><a href="imc/index.html">1992/imc</a> - Best output</li>
-<li><a href="kivinen/index.html">1992/kivinen</a> - Best X program</li>
-<li><a href="lush/index.html">1992/lush</a> - Worst abuse of the C preprocessor</li>
-<li><a href="marangon/index.html">1992/marangon</a> - Best game</li>
-<li><a href="nathan/index.html">1992/nathan</a> - Worst abuse of the rules</li>
-<li><a href="vern/index.html">1992/vern</a> - Best of Show</li>
-<li><a href="westley/index.html">1992/westley</a> - Best small program</li>
+<li><a href="adrian/index.html"><strong>1992/adrian</strong></a> - <strong>Most educational</strong></li>
+<li><a href="albert/index.html"><strong>1992/albert</strong></a> - <strong>Most useful program</strong></li>
+<li><a href="ant/index.html"><strong>1992/ant</strong></a> - <strong>Best utility</strong></li>
+<li><a href="buzzard.1/index.html"><strong>1992/buzzard.1</strong></a> - <strong>Most obfuscated algorithm</strong></li>
+<li><a href="buzzard.2/index.html"><strong>1992/buzzard.2</strong></a> - <strong>Best language tool</strong></li>
+<li><a href="gson/index.html"><strong>1992/gson</strong></a> - <strong>Most humorous output</strong></li>
+<li><a href="imc/index.html"><strong>1992/imc</strong></a> - <strong>Best output</strong></li>
+<li><a href="kivinen/index.html"><strong>1992/kivinen</strong></a> - <strong>Best X program</strong></li>
+<li><a href="lush/index.html"><strong>1992/lush</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><a href="marangon/index.html"><strong>1992/marangon</strong></a> - <strong>Best game</strong></li>
+<li><a href="nathan/index.html"><strong>1992/nathan</strong></a> - <strong>Worst abuse of the rules</strong></li>
+<li><a href="vern/index.html"><strong>1992/vern</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="westley/index.html"><strong>1992/westley</strong></a> - <strong>Best small program</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1993/index.html
+++ b/1993/index.html
@@ -457,17 +457,17 @@ to serve as official taste testers. And as usual, the food was excellent.</p>
 </div>
 <p><a href="1993.tar.bz2"><strong>Download all winning entries from 1993</strong></a></p>
 <ul>
-<li><a href="ant/index.html">1993/ant</a> - Best utility</li>
-<li><a href="cmills/index.html">1993/cmills</a> - Bill Gates Award</li>
-<li><a href="dgibson/index.html">1993/dgibson</a> - Best abuse of the C preprocessor</li>
-<li><a href="ejb/index.html">1993/ejb</a> - Best obfuscated algorithm</li>
-<li><a href="jonth/index.html">1993/jonth</a> - Most obfuscated X program</li>
-<li><a href="leo/index.html">1993/leo</a> - Best game</li>
-<li><a href="lmfjyh/index.html">1993/lmfjyh</a> - Most versatile source</li>
-<li><a href="plummer/index.html">1993/plummer</a> - Best one liner</li>
-<li><a href="rince/index.html">1993/rince</a> - Most well rounded</li>
-<li><a href="schnitzi/index.html">1993/schnitzi</a> - Obfuscated Intelligence Award</li>
-<li><a href="vanb/index.html">1993/vanb</a> - Most irregular expression</li>
+<li><a href="ant/index.html"><strong>1993/ant</strong></a> - <strong>Best utility</strong></li>
+<li><a href="cmills/index.html"><strong>1993/cmills</strong></a> - <strong>Bill Gates Award</strong></li>
+<li><a href="dgibson/index.html"><strong>1993/dgibson</strong></a> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><a href="ejb/index.html"><strong>1993/ejb</strong></a> - <strong>Best obfuscated algorithm</strong></li>
+<li><a href="jonth/index.html"><strong>1993/jonth</strong></a> - <strong>Most obfuscated X program</strong></li>
+<li><a href="leo/index.html"><strong>1993/leo</strong></a> - <strong>Best game</strong></li>
+<li><a href="lmfjyh/index.html"><strong>1993/lmfjyh</strong></a> - <strong>Most versatile source</strong></li>
+<li><a href="plummer/index.html"><strong>1993/plummer</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="rince/index.html"><strong>1993/rince</strong></a> - <strong>Most well rounded</strong></li>
+<li><a href="schnitzi/index.html"><strong>1993/schnitzi</strong></a> - <strong>Obfuscated Intelligence Award</strong></li>
+<li><a href="vanb/index.html"><strong>1993/vanb</strong></a> - <strong>Most irregular expression</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1994/index.html
+++ b/1994/index.html
@@ -516,17 +516,17 @@ Dessert: Homemade chocolate/pecan brownies, fruit</p>
 </div>
 <p><a href="1994.tar.bz2"><strong>Download all winning entries from 1994</strong></a></p>
 <ul>
-<li><a href="dodsond1/index.html">1994/dodsond1</a> - Best game</li>
-<li><a href="dodsond2/index.html">1994/dodsond2</a> - Most obfuscated packaging</li>
-<li><a href="horton/index.html">1994/horton</a> - Best utility</li>
-<li><a href="imc/index.html">1994/imc</a> - Most obfuscated algorithm</li>
-<li><a href="ldb/index.html">1994/ldb</a> - Best one liner</li>
-<li><a href="schnitzi/index.html">1994/schnitzi</a> - Best layout</li>
-<li><a href="shapiro/index.html">1994/shapiro</a> - Most well rounded obfuscation</li>
-<li><a href="smr/index.html">1994/smr</a> - Worst abuse of the rules</li>
-<li><a href="tvr/index.html">1994/tvr</a> - Best X11 program</li>
-<li><a href="weisberg/index.html">1994/weisberg</a> - Best short program</li>
-<li><a href="westley/index.html">1994/westley</a> - Worst abuse of the C preprocessor</li>
+<li><a href="dodsond1/index.html"><strong>1994/dodsond1</strong></a> - <strong>Best game</strong></li>
+<li><a href="dodsond2/index.html"><strong>1994/dodsond2</strong></a> - <strong>Most obfuscated packaging</strong></li>
+<li><a href="horton/index.html"><strong>1994/horton</strong></a> - <strong>Best utility</strong></li>
+<li><a href="imc/index.html"><strong>1994/imc</strong></a> - <strong>Most obfuscated algorithm</strong></li>
+<li><a href="ldb/index.html"><strong>1994/ldb</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="schnitzi/index.html"><strong>1994/schnitzi</strong></a> - <strong>Best layout</strong></li>
+<li><a href="shapiro/index.html"><strong>1994/shapiro</strong></a> - <strong>Most well rounded obfuscation</strong></li>
+<li><a href="smr/index.html"><strong>1994/smr</strong></a> - <strong>Worst abuse of the rules</strong></li>
+<li><a href="tvr/index.html"><strong>1994/tvr</strong></a> - <strong>Best X11 program</strong></li>
+<li><a href="weisberg/index.html"><strong>1994/weisberg</strong></a> - <strong>Best short program</strong></li>
+<li><a href="westley/index.html"><strong>1994/westley</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1995/index.html
+++ b/1995/index.html
@@ -518,18 +518,18 @@ Dessert: Key lime pie</p>
 </div>
 <p><a href="1995.tar.bz2"><strong>Download all winning entries from 1995</strong></a></p>
 <ul>
-<li><a href="cdua/index.html">1995/cdua</a> - Best output</li>
-<li><a href="dodsond1/index.html">1995/dodsond1</a> - Most humorous</li>
-<li><a href="dodsond2/index.html">1995/dodsond2</a> - Best game</li>
-<li><a href="esde/index.html">1995/esde</a> - Interesting algorithm</li>
-<li><a href="garry/index.html">1995/garry</a> - Best utility</li>
-<li><a href="heathbar/index.html">1995/heathbar</a> - Best layout</li>
-<li><a href="leo/index.html">1995/leo</a> - Best use of obfuscation</li>
-<li><a href="makarios/index.html">1995/makarios</a> - Best short program</li>
-<li><a href="savastio/index.html">1995/savastio</a> - Most obfuscated syntax</li>
-<li><a href="schnitzi/index.html">1995/schnitzi</a> - Best one liner</li>
-<li><a href="spinellis/index.html">1995/spinellis</a> - Abusing the rules</li>
-<li><a href="vanschnitz/index.html">1995/vanschnitz</a> - Worst abuse of the C preprocessor and most likely to amaze</li>
+<li><a href="cdua/index.html"><strong>1995/cdua</strong></a> - <strong>Best output</strong></li>
+<li><a href="dodsond1/index.html"><strong>1995/dodsond1</strong></a> - <strong>Most humorous</strong></li>
+<li><a href="dodsond2/index.html"><strong>1995/dodsond2</strong></a> - <strong>Best game</strong></li>
+<li><a href="esde/index.html"><strong>1995/esde</strong></a> - <strong>Interesting algorithm</strong></li>
+<li><a href="garry/index.html"><strong>1995/garry</strong></a> - <strong>Best utility</strong></li>
+<li><a href="heathbar/index.html"><strong>1995/heathbar</strong></a> - <strong>Best layout</strong></li>
+<li><a href="leo/index.html"><strong>1995/leo</strong></a> - <strong>Best use of obfuscation</strong></li>
+<li><a href="makarios/index.html"><strong>1995/makarios</strong></a> - <strong>Best short program</strong></li>
+<li><a href="savastio/index.html"><strong>1995/savastio</strong></a> - <strong>Most obfuscated syntax</strong></li>
+<li><a href="schnitzi/index.html"><strong>1995/schnitzi</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="spinellis/index.html"><strong>1995/spinellis</strong></a> - <strong>Abusing the rules</strong></li>
+<li><a href="vanschnitz/index.html"><strong>1995/vanschnitz</strong></a> - <strong>Worst abuse of the C preprocessor and most likely to amaze</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1996/index.html
+++ b/1996/index.html
@@ -477,17 +477,17 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="1996.tar.bz2"><strong>Download all winning entries from 1996</strong></a></p>
 <ul>
-<li><a href="august/index.html">1996/august</a> - Best of Show</li>
-<li><a href="dalbec/index.html">1996/dalbec</a> - Best numerical obfuscation</li>
-<li><a href="eldby/index.html">1996/eldby</a> - Best output</li>
-<li><a href="gandalf/index.html">1996/gandalf</a> - Best layout</li>
-<li><a href="huffman/index.html">1996/huffman</a> - Best obfuscated character set utility</li>
-<li><a href="jonth/index.html">1996/jonth</a> - Best X11 entry</li>
-<li><a href="rcm/index.html">1996/rcm</a> - Best RFC obfuscation</li>
-<li><a href="schweikh1/index.html">1996/schweikh1</a> - Worst abuse of the C preprocessor</li>
-<li><a href="schweikh2/index.html">1996/schweikh2</a> - Best algorithm</li>
-<li><a href="schweikh3/index.html">1996/schweikh3</a> - Best utility</li>
-<li><a href="westley/index.html">1996/westley</a> - Best one liner</li>
+<li><a href="august/index.html"><strong>1996/august</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="dalbec/index.html"><strong>1996/dalbec</strong></a> - <strong>Best numerical obfuscation</strong></li>
+<li><a href="eldby/index.html"><strong>1996/eldby</strong></a> - <strong>Best output</strong></li>
+<li><a href="gandalf/index.html"><strong>1996/gandalf</strong></a> - <strong>Best layout</strong></li>
+<li><a href="huffman/index.html"><strong>1996/huffman</strong></a> - <strong>Best obfuscated character set utility</strong></li>
+<li><a href="jonth/index.html"><strong>1996/jonth</strong></a> - <strong>Best X11 entry</strong></li>
+<li><a href="rcm/index.html"><strong>1996/rcm</strong></a> - <strong>Best RFC obfuscation</strong></li>
+<li><a href="schweikh1/index.html"><strong>1996/schweikh1</strong></a> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><a href="schweikh2/index.html"><strong>1996/schweikh2</strong></a> - <strong>Best algorithm</strong></li>
+<li><a href="schweikh3/index.html"><strong>1996/schweikh3</strong></a> - <strong>Best utility</strong></li>
+<li><a href="westley/index.html"><strong>1996/westley</strong></a> - <strong>Best one liner</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/1998/index.html
+++ b/1998/index.html
@@ -507,20 +507,20 @@ message when sending email to the judges.</p>
 </div>
 <p><a href="1998.tar.bz2"><strong>Download all winning entries from 1998</strong></a></p>
 <ul>
-<li><a href="banks/index.html">1998/banks</a> - Best of Show</li>
-<li><a href="bas1/index.html">1998/bas1</a> - Best encapsulation</li>
-<li><a href="bas2/index.html">1998/bas2</a> - Best small program</li>
-<li><a href="chaos/index.html">1998/chaos</a> - Best object orientation</li>
-<li><a href="df/index.html">1998/df</a> - Best data hiding</li>
-<li><a href="dlowe/index.html">1998/dlowe</a> - Best utility</li>
-<li><a href="dloweneil/index.html">1998/dloweneil</a> - Most fun</li>
-<li><a href="dorssel/index.html">1998/dorssel</a> - Obsolescent feature</li>
-<li><a href="fanf/index.html">1998/fanf</a> - Most obfuscated translator</li>
-<li><a href="schnitzi/index.html">1998/schnitzi</a> - Best flow control</li>
-<li><a href="schweikh1/index.html">1998/schweikh1</a> - CPP abuse</li>
-<li><a href="schweikh2/index.html">1998/schweikh2</a> - Most erratic behavior</li>
-<li><a href="schweikh3/index.html">1998/schweikh3</a> - Most space efficient</li>
-<li><a href="tomtorfs/index.html">1998/tomtorfs</a> - Best self-documenting</li>
+<li><a href="banks/index.html"><strong>1998/banks</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="bas1/index.html"><strong>1998/bas1</strong></a> - <strong>Best encapsulation</strong></li>
+<li><a href="bas2/index.html"><strong>1998/bas2</strong></a> - <strong>Best small program</strong></li>
+<li><a href="chaos/index.html"><strong>1998/chaos</strong></a> - <strong>Best object orientation</strong></li>
+<li><a href="df/index.html"><strong>1998/df</strong></a> - <strong>Best data hiding</strong></li>
+<li><a href="dlowe/index.html"><strong>1998/dlowe</strong></a> - <strong>Best utility</strong></li>
+<li><a href="dloweneil/index.html"><strong>1998/dloweneil</strong></a> - <strong>Most fun</strong></li>
+<li><a href="dorssel/index.html"><strong>1998/dorssel</strong></a> - <strong>Obsolescent feature</strong></li>
+<li><a href="fanf/index.html"><strong>1998/fanf</strong></a> - <strong>Most obfuscated translator</strong></li>
+<li><a href="schnitzi/index.html"><strong>1998/schnitzi</strong></a> - <strong>Best flow control</strong></li>
+<li><a href="schweikh1/index.html"><strong>1998/schweikh1</strong></a> - <strong>CPP abuse</strong></li>
+<li><a href="schweikh2/index.html"><strong>1998/schweikh2</strong></a> - <strong>Most erratic behavior</strong></li>
+<li><a href="schweikh3/index.html"><strong>1998/schweikh3</strong></a> - <strong>Most space efficient</strong></li>
+<li><a href="tomtorfs/index.html"><strong>1998/tomtorfs</strong></a> - <strong>Best self-documenting</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2000/index.html
+++ b/2000/index.html
@@ -478,20 +478,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2000.tar.bz2"><strong>Download all winning entries from 2000</strong></a></p>
 <ul>
-<li><a href="anderson/index.html">2000/anderson</a> - Best use of flags</li>
-<li><a href="bellard/index.html">2000/bellard</a> - Most specific output</li>
-<li><a href="bmeyer/index.html">2000/bmeyer</a> - Best utility</li>
-<li><a href="briddlebane/index.html">2000/briddlebane</a> - Best abuse of user</li>
-<li><a href="dhyang/index.html">2000/dhyang</a> - Best layout</li>
-<li><a href="dlowe/index.html">2000/dlowe</a> - Worst abuse of the rules</li>
-<li><a href="jarijyrki/index.html">2000/jarijyrki</a> - Best of Show</li>
-<li><a href="natori/index.html">2000/natori</a> - Best small program</li>
-<li><a href="primenum/index.html">2000/primenum</a> - Best abuse of CPP</li>
-<li><a href="rince/index.html">2000/rince</a> - Astronomically obfuscated</li>
-<li><a href="robison/index.html">2000/robison</a> - Best game</li>
-<li><a href="schneiderwent/index.html">2000/schneiderwent</a> - Most timely output</li>
-<li><a href="thadgavin/index.html">2000/thadgavin</a> - Most portable output</li>
-<li><a href="tomx/index.html">2000/tomx</a> - Most complete program</li>
+<li><a href="anderson/index.html"><strong>2000/anderson</strong></a> - <strong>Best use of flags</strong></li>
+<li><a href="bellard/index.html"><strong>2000/bellard</strong></a> - <strong>Most specific output</strong></li>
+<li><a href="bmeyer/index.html"><strong>2000/bmeyer</strong></a> - <strong>Best utility</strong></li>
+<li><a href="briddlebane/index.html"><strong>2000/briddlebane</strong></a> - <strong>Best abuse of user</strong></li>
+<li><a href="dhyang/index.html"><strong>2000/dhyang</strong></a> - <strong>Best layout</strong></li>
+<li><a href="dlowe/index.html"><strong>2000/dlowe</strong></a> - <strong>Worst abuse of the rules</strong></li>
+<li><a href="jarijyrki/index.html"><strong>2000/jarijyrki</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="natori/index.html"><strong>2000/natori</strong></a> - <strong>Best small program</strong></li>
+<li><a href="primenum/index.html"><strong>2000/primenum</strong></a> - <strong>Best abuse of CPP</strong></li>
+<li><a href="rince/index.html"><strong>2000/rince</strong></a> - <strong>Astronomically obfuscated</strong></li>
+<li><a href="robison/index.html"><strong>2000/robison</strong></a> - <strong>Best game</strong></li>
+<li><a href="schneiderwent/index.html"><strong>2000/schneiderwent</strong></a> - <strong>Most timely output</strong></li>
+<li><a href="thadgavin/index.html"><strong>2000/thadgavin</strong></a> - <strong>Most portable output</strong></li>
+<li><a href="tomx/index.html"><strong>2000/tomx</strong></a> - <strong>Most complete program</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2001/index.html
+++ b/2001/index.html
@@ -466,21 +466,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2001.tar.bz2"><strong>Download all winning entries from 2001</strong></a></p>
 <ul>
-<li><a href="anonymous/index.html">2001/anonymous</a> - Dishonorable mention</li>
-<li><a href="bellard/index.html">2001/bellard</a> - Best abuse of the rules</li>
-<li><a href="cheong/index.html">2001/cheong</a> - Best short program</li>
-<li><a href="coupard/index.html">2001/coupard</a> - Most obfuscated sound</li>
-<li><a href="ctk/index.html">2001/ctk</a> - Worst driver</li>
-<li><a href="dgbeards/index.html">2001/dgbeards</a> - Best AI</li>
-<li><a href="herrmann1/index.html">2001/herrmann1</a> - Best abuse of the C preprocessor</li>
-<li><a href="herrmann2/index.html">2001/herrmann2</a> - Most eye-crossing</li>
-<li><a href="jason/index.html">2001/jason</a> - Best of Show</li>
-<li><a href="kev/index.html">2001/kev</a> - Best curses game</li>
-<li><a href="ollinger/index.html">2001/ollinger</a> - Best of Show</li>
-<li><a href="rosten/index.html">2001/rosten</a> - Best abuse of the user</li>
-<li><a href="schweikh/index.html">2001/schweikh</a> - Best one liner</li>
-<li><a href="westley/index.html">2001/westley</a> - Best position-independent code</li>
-<li><a href="williams/index.html">2001/williams</a> - Best graphic game</li>
+<li><a href="anonymous/index.html"><strong>2001/anonymous</strong></a> - <strong>Dishonorable mention</strong></li>
+<li><a href="bellard/index.html"><strong>2001/bellard</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="cheong/index.html"><strong>2001/cheong</strong></a> - <strong>Best short program</strong></li>
+<li><a href="coupard/index.html"><strong>2001/coupard</strong></a> - <strong>Most obfuscated sound</strong></li>
+<li><a href="ctk/index.html"><strong>2001/ctk</strong></a> - <strong>Worst driver</strong></li>
+<li><a href="dgbeards/index.html"><strong>2001/dgbeards</strong></a> - <strong>Best AI</strong></li>
+<li><a href="herrmann1/index.html"><strong>2001/herrmann1</strong></a> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><a href="herrmann2/index.html"><strong>2001/herrmann2</strong></a> - <strong>Most eye-crossing</strong></li>
+<li><a href="jason/index.html"><strong>2001/jason</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="kev/index.html"><strong>2001/kev</strong></a> - <strong>Best curses game</strong></li>
+<li><a href="ollinger/index.html"><strong>2001/ollinger</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="rosten/index.html"><strong>2001/rosten</strong></a> - <strong>Best abuse of the user</strong></li>
+<li><a href="schweikh/index.html"><strong>2001/schweikh</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="westley/index.html"><strong>2001/westley</strong></a> - <strong>Best position-independent code</strong></li>
+<li><a href="williams/index.html"><strong>2001/williams</strong></a> - <strong>Best graphic game</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2004/index.html
+++ b/2004/index.html
@@ -457,21 +457,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2004.tar.bz2"><strong>Download all winning entries from 2004</strong></a></p>
 <ul>
-<li><a href="anonymous/index.html">2004/anonymous</a> - Best use of ‘Precious’ Lines</li>
-<li><a href="arachnid/index.html">2004/arachnid</a> - Best use of vision</li>
-<li><a href="burley/index.html">2004/burley</a> - Best calculated risk</li>
-<li><a href="gavare/index.html">2004/gavare</a> - Best use of light and spheres</li>
-<li><a href="gavin/index.html">2004/gavin</a> - Best of Show</li>
-<li><a href="hibachi/index.html">2004/hibachi</a> - Best abuse of the guidelines</li>
-<li><a href="hoyle/index.html">2004/hoyle</a> - Most functional output</li>
-<li><a href="jdalbec/index.html">2004/jdalbec</a> - Best abuse of the periodic table</li>
-<li><a href="kopczynski/index.html">2004/kopczynski</a> - Best one liner</li>
-<li><a href="newbern/index.html">2004/newbern</a> - Best font engine</li>
-<li><a href="omoikane/index.html">2004/omoikane</a> - Best utility</li>
-<li><a href="schnitzi/index.html">2004/schnitzi</a> - Best non-use of curses</li>
-<li><a href="sds/index.html">2004/sds</a> - Best abuse of indentation</li>
-<li><a href="vik1/index.html">2004/vik1</a> - Best X11 game</li>
-<li><a href="vik2/index.html">2004/vik2</a> - Best abuse of CPP</li>
+<li><a href="anonymous/index.html"><strong>2004/anonymous</strong></a> - <strong>Best use of ‘Precious’ Lines</strong></li>
+<li><a href="arachnid/index.html"><strong>2004/arachnid</strong></a> - <strong>Best use of vision</strong></li>
+<li><a href="burley/index.html"><strong>2004/burley</strong></a> - <strong>Best calculated risk</strong></li>
+<li><a href="gavare/index.html"><strong>2004/gavare</strong></a> - <strong>Best use of light and spheres</strong></li>
+<li><a href="gavin/index.html"><strong>2004/gavin</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="hibachi/index.html"><strong>2004/hibachi</strong></a> - <strong>Best abuse of the guidelines</strong></li>
+<li><a href="hoyle/index.html"><strong>2004/hoyle</strong></a> - <strong>Most functional output</strong></li>
+<li><a href="jdalbec/index.html"><strong>2004/jdalbec</strong></a> - <strong>Best abuse of the periodic table</strong></li>
+<li><a href="kopczynski/index.html"><strong>2004/kopczynski</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="newbern/index.html"><strong>2004/newbern</strong></a> - <strong>Best font engine</strong></li>
+<li><a href="omoikane/index.html"><strong>2004/omoikane</strong></a> - <strong>Best utility</strong></li>
+<li><a href="schnitzi/index.html"><strong>2004/schnitzi</strong></a> - <strong>Best non-use of curses</strong></li>
+<li><a href="sds/index.html"><strong>2004/sds</strong></a> - <strong>Best abuse of indentation</strong></li>
+<li><a href="vik1/index.html"><strong>2004/vik1</strong></a> - <strong>Best X11 game</strong></li>
+<li><a href="vik2/index.html"><strong>2004/vik2</strong></a> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2005/index.html
+++ b/2005/index.html
@@ -473,21 +473,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2005.tar.bz2"><strong>Download all winning entries from 2005</strong></a></p>
 <ul>
-<li><a href="aidan/index.html">2005/aidan</a> - Most ingenious puzzle solution</li>
-<li><a href="anon/index.html">2005/anon</a> - Best 3D puzzle</li>
-<li><a href="boutines/index.html">2005/boutines</a> - Most superfluous output</li>
-<li><a href="chia/index.html">2005/chia</a> - Most ambiguous language</li>
-<li><a href="giljade/index.html">2005/giljade</a> - Best 2D puzzle</li>
-<li><a href="jetro/index.html">2005/jetro</a> - Most sonorous output</li>
-<li><a href="klausler/index.html">2005/klausler</a> - Abuse of the rules</li>
-<li><a href="mikeash/index.html">2005/mikeash</a> - Best use of parenthesis</li>
-<li><a href="mynx/index.html">2005/mynx</a> - Best use of the WWW</li>
-<li><a href="persano/index.html">2005/persano</a> - Best of Show</li>
-<li><a href="sykes/index.html">2005/sykes</a> - Best emulator</li>
-<li><a href="timwi/index.html">2005/timwi</a> - Most discourteous interpreter</li>
-<li><a href="toledo/index.html">2005/toledo</a> - Best game</li>
-<li><a href="vik/index.html">2005/vik</a> - Most circuitous walk</li>
-<li><a href="vince/index.html">2005/vince</a> - Most beauteous visuals</li>
+<li><a href="aidan/index.html"><strong>2005/aidan</strong></a> - <strong>Most ingenious puzzle solution</strong></li>
+<li><a href="anon/index.html"><strong>2005/anon</strong></a> - <strong>Best 3D puzzle</strong></li>
+<li><a href="boutines/index.html"><strong>2005/boutines</strong></a> - <strong>Most superfluous output</strong></li>
+<li><a href="chia/index.html"><strong>2005/chia</strong></a> - <strong>Most ambiguous language</strong></li>
+<li><a href="giljade/index.html"><strong>2005/giljade</strong></a> - <strong>Best 2D puzzle</strong></li>
+<li><a href="jetro/index.html"><strong>2005/jetro</strong></a> - <strong>Most sonorous output</strong></li>
+<li><a href="klausler/index.html"><strong>2005/klausler</strong></a> - <strong>Abuse of the rules</strong></li>
+<li><a href="mikeash/index.html"><strong>2005/mikeash</strong></a> - <strong>Best use of parenthesis</strong></li>
+<li><a href="mynx/index.html"><strong>2005/mynx</strong></a> - <strong>Best use of the WWW</strong></li>
+<li><a href="persano/index.html"><strong>2005/persano</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="sykes/index.html"><strong>2005/sykes</strong></a> - <strong>Best emulator</strong></li>
+<li><a href="timwi/index.html"><strong>2005/timwi</strong></a> - <strong>Most discourteous interpreter</strong></li>
+<li><a href="toledo/index.html"><strong>2005/toledo</strong></a> - <strong>Best game</strong></li>
+<li><a href="vik/index.html"><strong>2005/vik</strong></a> - <strong>Most circuitous walk</strong></li>
+<li><a href="vince/index.html"><strong>2005/vince</strong></a> - <strong>Most beauteous visuals</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2006/index.html
+++ b/2006/index.html
@@ -453,20 +453,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2006.tar.bz2"><strong>Download all winning entries from 2006</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2006/birken</a> - EDAMAME Award</li>
-<li><a href="borsanyi/index.html">2006/borsanyi</a> - Most useful</li>
-<li><a href="grothe/index.html">2006/grothe</a> - Most obfuscated audio</li>
-<li><a href="hamre/index.html">2006/hamre</a> - Most irrational</li>
-<li><a href="meyer/index.html">2006/meyer</a> - Best game</li>
-<li><a href="monge/index.html">2006/monge</a> - Best compiled graphics</li>
-<li><a href="night/index.html">2006/night</a> - Best abuse of computation</li>
-<li><a href="sloane/index.html">2006/sloane</a> - Homer’s favorite</li>
-<li><a href="stewart/index.html">2006/stewart</a> - Best computed graphics</li>
-<li><a href="sykes1/index.html">2006/sykes1</a> - Best assembler</li>
-<li><a href="sykes2/index.html">2006/sykes2</a> - Best one liner</li>
-<li><a href="toledo1/index.html">2006/toledo1</a> - Best small program</li>
-<li><a href="toledo2/index.html">2006/toledo2</a> - Best of Show</li>
-<li><a href="toledo3/index.html">2006/toledo3</a> - Most portable chess set</li>
+<li><a href="birken/index.html"><strong>2006/birken</strong></a> - <strong>EDAMAME Award</strong></li>
+<li><a href="borsanyi/index.html"><strong>2006/borsanyi</strong></a> - <strong>Most useful</strong></li>
+<li><a href="grothe/index.html"><strong>2006/grothe</strong></a> - <strong>Most obfuscated audio</strong></li>
+<li><a href="hamre/index.html"><strong>2006/hamre</strong></a> - <strong>Most irrational</strong></li>
+<li><a href="meyer/index.html"><strong>2006/meyer</strong></a> - <strong>Best game</strong></li>
+<li><a href="monge/index.html"><strong>2006/monge</strong></a> - <strong>Best compiled graphics</strong></li>
+<li><a href="night/index.html"><strong>2006/night</strong></a> - <strong>Best abuse of computation</strong></li>
+<li><a href="sloane/index.html"><strong>2006/sloane</strong></a> - <strong>Homer’s favorite</strong></li>
+<li><a href="stewart/index.html"><strong>2006/stewart</strong></a> - <strong>Best computed graphics</strong></li>
+<li><a href="sykes1/index.html"><strong>2006/sykes1</strong></a> - <strong>Best assembler</strong></li>
+<li><a href="sykes2/index.html"><strong>2006/sykes2</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="toledo1/index.html"><strong>2006/toledo1</strong></a> - <strong>Best small program</strong></li>
+<li><a href="toledo2/index.html"><strong>2006/toledo2</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="toledo3/index.html"><strong>2006/toledo3</strong></a> - <strong>Most portable chess set</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2011/index.html
+++ b/2011/index.html
@@ -452,20 +452,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2011.tar.bz2"><strong>Download all winning entries from 2011</strong></a></p>
 <ul>
-<li><a href="akari/index.html">2011/akari</a> - Best of Show - Most Shrinkable</li>
-<li><a href="blakely/index.html">2011/blakely</a> - Most devolving</li>
-<li><a href="borsanyi/index.html">2011/borsanyi</a> - Best data utility</li>
-<li><a href="dlowe/index.html">2011/dlowe</a> - Most self deprecating</li>
-<li><a href="eastman/index.html">2011/eastman</a> - Best ball</li>
-<li><a href="fredriksson/index.html">2011/fredriksson</a> - Most useful</li>
-<li><a href="goren/index.html">2011/goren</a> - Most artistic</li>
-<li><a href="hamaji/index.html">2011/hamaji</a> - Best solved puzzle</li>
-<li><a href="hou/index.html">2011/hou</a> - Best self documenting program</li>
-<li><a href="konno/index.html">2011/konno</a> - Best one liner</li>
-<li><a href="richards/index.html">2011/richards</a> - Most surprisingly portable</li>
-<li><a href="toledo/index.html">2011/toledo</a> - Best non-chess game</li>
-<li><a href="vik/index.html">2011/vik</a> - Most sound</li>
-<li><a href="zucker/index.html">2011/zucker</a> - Most shiny</li>
+<li><a href="akari/index.html">2011/akari</a> - <strong>Best of Show - Most Shrinkable</strong></li>
+<li><a href="blakely/index.html">2011/blakely</a> - <strong>Most devolving</strong></li>
+<li><a href="borsanyi/index.html">2011/borsanyi</a> - <strong>Best data utility</strong></li>
+<li><a href="dlowe/index.html">2011/dlowe</a> - <strong>Most self deprecating</strong></li>
+<li><a href="eastman/index.html">2011/eastman</a> - <strong>Best ball</strong></li>
+<li><a href="fredriksson/index.html">2011/fredriksson</a> - <strong>Most useful</strong></li>
+<li><a href="goren/index.html">2011/goren</a> - <strong>Most artistic</strong></li>
+<li><a href="hamaji/index.html">2011/hamaji</a> - <strong>Best solved puzzle</strong></li>
+<li><a href="hou/index.html">2011/hou</a> - <strong>Best self documenting program</strong></li>
+<li><a href="konno/index.html">2011/konno</a> - <strong>Best one liner</strong></li>
+<li><a href="richards/index.html">2011/richards</a> - <strong>Most surprisingly portable</strong></li>
+<li><a href="toledo/index.html">2011/toledo</a> - <strong>Best non-chess game</strong></li>
+<li><a href="vik/index.html">2011/vik</a> - <strong>Most sound</strong></li>
+<li><a href="zucker/index.html">2011/zucker</a> - <strong>Most shiny</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2011/index.html
+++ b/2011/index.html
@@ -452,20 +452,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2011.tar.bz2"><strong>Download all winning entries from 2011</strong></a></p>
 <ul>
-<li><a href="akari/index.html">2011/akari</a> - <strong>Best of Show - Most Shrinkable</strong></li>
-<li><a href="blakely/index.html">2011/blakely</a> - <strong>Most devolving</strong></li>
-<li><a href="borsanyi/index.html">2011/borsanyi</a> - <strong>Best data utility</strong></li>
-<li><a href="dlowe/index.html">2011/dlowe</a> - <strong>Most self deprecating</strong></li>
-<li><a href="eastman/index.html">2011/eastman</a> - <strong>Best ball</strong></li>
-<li><a href="fredriksson/index.html">2011/fredriksson</a> - <strong>Most useful</strong></li>
-<li><a href="goren/index.html">2011/goren</a> - <strong>Most artistic</strong></li>
-<li><a href="hamaji/index.html">2011/hamaji</a> - <strong>Best solved puzzle</strong></li>
-<li><a href="hou/index.html">2011/hou</a> - <strong>Best self documenting program</strong></li>
-<li><a href="konno/index.html">2011/konno</a> - <strong>Best one liner</strong></li>
-<li><a href="richards/index.html">2011/richards</a> - <strong>Most surprisingly portable</strong></li>
-<li><a href="toledo/index.html">2011/toledo</a> - <strong>Best non-chess game</strong></li>
-<li><a href="vik/index.html">2011/vik</a> - <strong>Most sound</strong></li>
-<li><a href="zucker/index.html">2011/zucker</a> - <strong>Most shiny</strong></li>
+<li><a href="akari/index.html"><strong>2011/akari</strong></a> - <strong>Best of Show - Most Shrinkable</strong></li>
+<li><a href="blakely/index.html"><strong>2011/blakely</strong></a> - <strong>Most devolving</strong></li>
+<li><a href="borsanyi/index.html"><strong>2011/borsanyi</strong></a> - <strong>Best data utility</strong></li>
+<li><a href="dlowe/index.html"><strong>2011/dlowe</strong></a> - <strong>Most self deprecating</strong></li>
+<li><a href="eastman/index.html"><strong>2011/eastman</strong></a> - <strong>Best ball</strong></li>
+<li><a href="fredriksson/index.html"><strong>2011/fredriksson</strong></a> - <strong>Most useful</strong></li>
+<li><a href="goren/index.html"><strong>2011/goren</strong></a> - <strong>Most artistic</strong></li>
+<li><a href="hamaji/index.html"><strong>2011/hamaji</strong></a> - <strong>Best solved puzzle</strong></li>
+<li><a href="hou/index.html"><strong>2011/hou</strong></a> - <strong>Best self documenting program</strong></li>
+<li><a href="konno/index.html"><strong>2011/konno</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="richards/index.html"><strong>2011/richards</strong></a> - <strong>Most surprisingly portable</strong></li>
+<li><a href="toledo/index.html"><strong>2011/toledo</strong></a> - <strong>Best non-chess game</strong></li>
+<li><a href="vik/index.html"><strong>2011/vik</strong></a> - <strong>Most sound</strong></li>
+<li><a href="zucker/index.html"><strong>2011/zucker</strong></a> - <strong>Most shiny</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2012/index.html
+++ b/2012/index.html
@@ -488,20 +488,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2012.tar.bz2"><strong>Download all winning entries from 2012</strong></a></p>
 <ul>
-<li><a href="blakely/index.html">2012/blakely</a> - Most GIFted expressions</li>
-<li><a href="deckmyn/index.html">2012/deckmyn</a> - Most notable and best tool</li>
-<li><a href="dlowe/index.html">2012/dlowe</a> - Best way to lose a life</li>
-<li><a href="endoh1/index.html">2012/endoh1</a> - Most complex ASCII fluid - Honorable mention</li>
-<li><a href="endoh2/index.html">2012/endoh2</a> - PiE in the sky award</li>
-<li><a href="grothe/index.html">2012/grothe</a> - Most conspiratorial</li>
-<li><a href="hamano/index.html">2012/hamano</a> - Most elementary use of C - Silver Award</li>
-<li><a href="hou/index.html">2012/hou</a> - Most useful obfuscation</li>
-<li><a href="kang/index.html">2012/kang</a> - Best short program</li>
-<li><a href="konno/index.html">2012/konno</a> - Best one liner</li>
-<li><a href="omoikane/index.html">2012/omoikane</a> - Most surreptitious</li>
-<li><a href="tromp/index.html">2012/tromp</a> - Most functional</li>
-<li><a href="vik/index.html">2012/vik</a> - Best use of cocoa - Bronze Award</li>
-<li><a href="zeitak/index.html">2012/zeitak</a> - Balanced use of obfuscation - Gold Award</li>
+<li><a href="blakely/index.html">2012/blakely</a> - <strong>Most GIFted expressions</strong></li>
+<li><a href="deckmyn/index.html">2012/deckmyn</a> - <strong>Most notable and best tool</strong></li>
+<li><a href="dlowe/index.html">2012/dlowe</a> - <strong>Best way to lose a life</strong></li>
+<li><a href="endoh1/index.html">2012/endoh1</a> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
+<li><a href="endoh2/index.html">2012/endoh2</a> - <strong>PiE in the sky award</strong></li>
+<li><a href="grothe/index.html">2012/grothe</a> - <strong>Most conspiratorial</strong></li>
+<li><a href="hamano/index.html">2012/hamano</a> - <strong>Most elementary use of C - Silver Award</strong></li>
+<li><a href="hou/index.html">2012/hou</a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="kang/index.html">2012/kang</a> - <strong>Best short program</strong></li>
+<li><a href="konno/index.html">2012/konno</a> - <strong>Best one liner</strong></li>
+<li><a href="omoikane/index.html">2012/omoikane</a> - <strong>Most surreptitious</strong></li>
+<li><a href="tromp/index.html">2012/tromp</a> - <strong>Most functional</strong></li>
+<li><a href="vik/index.html">2012/vik</a> - <strong>Best use of cocoa - Bronze Award</strong></li>
+<li><a href="zeitak/index.html">2012/zeitak</a> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2012/index.html
+++ b/2012/index.html
@@ -488,20 +488,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2012.tar.bz2"><strong>Download all winning entries from 2012</strong></a></p>
 <ul>
-<li><a href="blakely/index.html">2012/blakely</a> - <strong>Most GIFted expressions</strong></li>
-<li><a href="deckmyn/index.html">2012/deckmyn</a> - <strong>Most notable and best tool</strong></li>
-<li><a href="dlowe/index.html">2012/dlowe</a> - <strong>Best way to lose a life</strong></li>
-<li><a href="endoh1/index.html">2012/endoh1</a> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
-<li><a href="endoh2/index.html">2012/endoh2</a> - <strong>PiE in the sky award</strong></li>
-<li><a href="grothe/index.html">2012/grothe</a> - <strong>Most conspiratorial</strong></li>
-<li><a href="hamano/index.html">2012/hamano</a> - <strong>Most elementary use of C - Silver Award</strong></li>
-<li><a href="hou/index.html">2012/hou</a> - <strong>Most useful obfuscation</strong></li>
-<li><a href="kang/index.html">2012/kang</a> - <strong>Best short program</strong></li>
-<li><a href="konno/index.html">2012/konno</a> - <strong>Best one liner</strong></li>
-<li><a href="omoikane/index.html">2012/omoikane</a> - <strong>Most surreptitious</strong></li>
-<li><a href="tromp/index.html">2012/tromp</a> - <strong>Most functional</strong></li>
-<li><a href="vik/index.html">2012/vik</a> - <strong>Best use of cocoa - Bronze Award</strong></li>
-<li><a href="zeitak/index.html">2012/zeitak</a> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
+<li><a href="blakely/index.html"><strong>2012/blakely</strong></a> - <strong>Most GIFted expressions</strong></li>
+<li><a href="deckmyn/index.html"><strong>2012/deckmyn</strong></a> - <strong>Most notable and best tool</strong></li>
+<li><a href="dlowe/index.html"><strong>2012/dlowe</strong></a> - <strong>Best way to lose a life</strong></li>
+<li><a href="endoh1/index.html"><strong>2012/endoh1</strong></a> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
+<li><a href="endoh2/index.html"><strong>2012/endoh2</strong></a> - <strong>PiE in the sky award</strong></li>
+<li><a href="grothe/index.html"><strong>2012/grothe</strong></a> - <strong>Most conspiratorial</strong></li>
+<li><a href="hamano/index.html"><strong>2012/hamano</strong></a> - <strong>Most elementary use of C - Silver Award</strong></li>
+<li><a href="hou/index.html"><strong>2012/hou</strong></a> - <strong>Most useful obfuscation</strong></li>
+<li><a href="kang/index.html"><strong>2012/kang</strong></a> - <strong>Best short program</strong></li>
+<li><a href="konno/index.html"><strong>2012/konno</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="omoikane/index.html"><strong>2012/omoikane</strong></a> - <strong>Most surreptitious</strong></li>
+<li><a href="tromp/index.html"><strong>2012/tromp</strong></a> - <strong>Most functional</strong></li>
+<li><a href="vik/index.html"><strong>2012/vik</strong></a> - <strong>Best use of cocoa - Bronze Award</strong></li>
+<li><a href="zeitak/index.html"><strong>2012/zeitak</strong></a> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2013/index.html
+++ b/2013/index.html
@@ -474,21 +474,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2013.tar.bz2"><strong>Download all winning entries from 2013</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2013/birken</a> - <strong>Best painting tool</strong></li>
-<li><a href="cable1/index.html">2013/cable1</a> - <strong>Most partisan one liner</strong></li>
-<li><a href="cable2/index.html">2013/cable2</a> - <strong>Best of Show</strong></li>
-<li><a href="cable3/index.html">2013/cable3</a> - <strong>Largest small system emulator</strong></li>
-<li><a href="dlowe/index.html">2013/dlowe</a> - <strong>Best sparkling utility</strong></li>
-<li><a href="endoh1/index.html">2013/endoh1</a> - <strong>Most lazy SKIer</strong></li>
-<li><a href="endoh2/index.html">2013/endoh2</a> - <strong>Most recyclable</strong></li>
-<li><a href="endoh3/index.html">2013/endoh3</a> - <strong>Most tweetable one liner</strong></li>
-<li><a href="endoh4/index.html">2013/endoh4</a> - <strong>Most solid</strong></li>
-<li><a href="hou/index.html">2013/hou</a> - <strong>Best use of one infinite loop</strong></li>
-<li><a href="mills/index.html">2013/mills</a> - <strong>Most timely rendered</strong></li>
-<li><a href="misaka/index.html">2013/misaka</a> - <strong>Most catty</strong></li>
-<li><a href="morgan1/index.html">2013/morgan1</a> - <strong>Smallest large system simulator</strong></li>
-<li><a href="morgan2/index.html">2013/morgan2</a> - <strong>Most playfully versatile</strong></li>
-<li><a href="robison/index.html">2013/robison</a> - <strong>Most poetic use of strings</strong></li>
+<li><a href="birken/index.html"><strong>2013/birken</strong></a> - <strong>Best painting tool</strong></li>
+<li><a href="cable1/index.html"><strong>2013/cable1</strong></a> - <strong>Most partisan one liner</strong></li>
+<li><a href="cable2/index.html"><strong>2013/cable2</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="cable3/index.html"><strong>2013/cable3</strong></a> - <strong>Largest small system emulator</strong></li>
+<li><a href="dlowe/index.html"><strong>2013/dlowe</strong></a> - <strong>Best sparkling utility</strong></li>
+<li><a href="endoh1/index.html"><strong>2013/endoh1</strong></a> - <strong>Most lazy SKIer</strong></li>
+<li><a href="endoh2/index.html"><strong>2013/endoh2</strong></a> - <strong>Most recyclable</strong></li>
+<li><a href="endoh3/index.html"><strong>2013/endoh3</strong></a> - <strong>Most tweetable one liner</strong></li>
+<li><a href="endoh4/index.html"><strong>2013/endoh4</strong></a> - <strong>Most solid</strong></li>
+<li><a href="hou/index.html"><strong>2013/hou</strong></a> - <strong>Best use of one infinite loop</strong></li>
+<li><a href="mills/index.html"><strong>2013/mills</strong></a> - <strong>Most timely rendered</strong></li>
+<li><a href="misaka/index.html"><strong>2013/misaka</strong></a> - <strong>Most catty</strong></li>
+<li><a href="morgan1/index.html"><strong>2013/morgan1</strong></a> - <strong>Smallest large system simulator</strong></li>
+<li><a href="morgan2/index.html"><strong>2013/morgan2</strong></a> - <strong>Most playfully versatile</strong></li>
+<li><a href="robison/index.html"><strong>2013/robison</strong></a> - <strong>Most poetic use of strings</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2013/index.html
+++ b/2013/index.html
@@ -474,21 +474,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2013.tar.bz2"><strong>Download all winning entries from 2013</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2013/birken</a> - Best painting tool</li>
-<li><a href="cable1/index.html">2013/cable1</a> - Most partisan one liner</li>
-<li><a href="cable2/index.html">2013/cable2</a> - Best of Show</li>
-<li><a href="cable3/index.html">2013/cable3</a> - Largest small system emulator</li>
-<li><a href="dlowe/index.html">2013/dlowe</a> - Best sparkling utility</li>
-<li><a href="endoh1/index.html">2013/endoh1</a> - Most lazy SKIer</li>
-<li><a href="endoh2/index.html">2013/endoh2</a> - Most recyclable</li>
-<li><a href="endoh3/index.html">2013/endoh3</a> - Most tweetable one liner</li>
-<li><a href="endoh4/index.html">2013/endoh4</a> - Most solid</li>
-<li><a href="hou/index.html">2013/hou</a> - Best use of one infinite loop</li>
-<li><a href="mills/index.html">2013/mills</a> - Most timely rendered</li>
-<li><a href="misaka/index.html">2013/misaka</a> - Most catty</li>
-<li><a href="morgan1/index.html">2013/morgan1</a> - Smallest large system simulator</li>
-<li><a href="morgan2/index.html">2013/morgan2</a> - Most playfully versatile</li>
-<li><a href="robison/index.html">2013/robison</a> - Most poetic use of strings</li>
+<li><a href="birken/index.html">2013/birken</a> - <strong>Best painting tool</strong></li>
+<li><a href="cable1/index.html">2013/cable1</a> - <strong>Most partisan one liner</strong></li>
+<li><a href="cable2/index.html">2013/cable2</a> - <strong>Best of Show</strong></li>
+<li><a href="cable3/index.html">2013/cable3</a> - <strong>Largest small system emulator</strong></li>
+<li><a href="dlowe/index.html">2013/dlowe</a> - <strong>Best sparkling utility</strong></li>
+<li><a href="endoh1/index.html">2013/endoh1</a> - <strong>Most lazy SKIer</strong></li>
+<li><a href="endoh2/index.html">2013/endoh2</a> - <strong>Most recyclable</strong></li>
+<li><a href="endoh3/index.html">2013/endoh3</a> - <strong>Most tweetable one liner</strong></li>
+<li><a href="endoh4/index.html">2013/endoh4</a> - <strong>Most solid</strong></li>
+<li><a href="hou/index.html">2013/hou</a> - <strong>Best use of one infinite loop</strong></li>
+<li><a href="mills/index.html">2013/mills</a> - <strong>Most timely rendered</strong></li>
+<li><a href="misaka/index.html">2013/misaka</a> - <strong>Most catty</strong></li>
+<li><a href="morgan1/index.html">2013/morgan1</a> - <strong>Smallest large system simulator</strong></li>
+<li><a href="morgan2/index.html">2013/morgan2</a> - <strong>Most playfully versatile</strong></li>
+<li><a href="robison/index.html">2013/robison</a> - <strong>Most poetic use of strings</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2014/index.html
+++ b/2014/index.html
@@ -489,17 +489,17 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2014.tar.bz2"><strong>Download all winning entries from 2014</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2014/birken</a> - Best use of port 1701</li>
-<li><a href="deak/index.html">2014/deak</a> - Most underscored argument</li>
-<li><a href="endoh1/index.html">2014/endoh1</a> - Most square (YODA Award)</li>
-<li><a href="endoh2/index.html">2014/endoh2</a> - Best use of bioinformatics</li>
-<li><a href="maffiodo1/index.html">2014/maffiodo1</a> - Homage to a classic game</li>
-<li><a href="maffiodo2/index.html">2014/maffiodo2</a> - Most tweetable entry</li>
-<li><a href="morgan/index.html">2014/morgan</a> - Most likely to succeed</li>
-<li><a href="sinon/index.html">2014/sinon</a> - Best choice of optimization</li>
-<li><a href="skeggs/index.html">2014/skeggs</a> - Most dynamic</li>
-<li><a href="vik/index.html">2014/vik</a> - Best handling of beeps</li>
-<li><a href="wiedijk/index.html">2014/wiedijk</a> - Most functional</li>
+<li><a href="birken/index.html">2014/birken</a> - <strong>Best use of port 1701</strong></li>
+<li><a href="deak/index.html">2014/deak</a> - <strong>Most underscored argument</strong></li>
+<li><a href="endoh1/index.html">2014/endoh1</a> - <strong>Most square (YODA Award)</strong></li>
+<li><a href="endoh2/index.html">2014/endoh2</a> - <strong>Best use of bioinformatics</strong></li>
+<li><a href="maffiodo1/index.html">2014/maffiodo1</a> - <strong>Homage to a classic game</strong></li>
+<li><a href="maffiodo2/index.html">2014/maffiodo2</a> - <strong>Most tweetable entry</strong></li>
+<li><a href="morgan/index.html">2014/morgan</a> - <strong>Most likely to succeed</strong></li>
+<li><a href="sinon/index.html">2014/sinon</a> - <strong>Best choice of optimization</strong></li>
+<li><a href="skeggs/index.html">2014/skeggs</a> - <strong>Most dynamic</strong></li>
+<li><a href="vik/index.html">2014/vik</a> - <strong>Best handling of beeps</strong></li>
+<li><a href="wiedijk/index.html">2014/wiedijk</a> - <strong>Most functional</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2014/index.html
+++ b/2014/index.html
@@ -489,17 +489,17 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2014.tar.bz2"><strong>Download all winning entries from 2014</strong></a></p>
 <ul>
-<li><a href="birken/index.html">2014/birken</a> - <strong>Best use of port 1701</strong></li>
-<li><a href="deak/index.html">2014/deak</a> - <strong>Most underscored argument</strong></li>
-<li><a href="endoh1/index.html">2014/endoh1</a> - <strong>Most square (YODA Award)</strong></li>
-<li><a href="endoh2/index.html">2014/endoh2</a> - <strong>Best use of bioinformatics</strong></li>
-<li><a href="maffiodo1/index.html">2014/maffiodo1</a> - <strong>Homage to a classic game</strong></li>
-<li><a href="maffiodo2/index.html">2014/maffiodo2</a> - <strong>Most tweetable entry</strong></li>
-<li><a href="morgan/index.html">2014/morgan</a> - <strong>Most likely to succeed</strong></li>
-<li><a href="sinon/index.html">2014/sinon</a> - <strong>Best choice of optimization</strong></li>
-<li><a href="skeggs/index.html">2014/skeggs</a> - <strong>Most dynamic</strong></li>
-<li><a href="vik/index.html">2014/vik</a> - <strong>Best handling of beeps</strong></li>
-<li><a href="wiedijk/index.html">2014/wiedijk</a> - <strong>Most functional</strong></li>
+<li><a href="birken/index.html"><strong>2014/birken</strong></a> - <strong>Best use of port 1701</strong></li>
+<li><a href="deak/index.html"><strong>2014/deak</strong></a> - <strong>Most underscored argument</strong></li>
+<li><a href="endoh1/index.html"><strong>2014/endoh1</strong></a> - <strong>Most square (YODA Award)</strong></li>
+<li><a href="endoh2/index.html"><strong>2014/endoh2</strong></a> - <strong>Best use of bioinformatics</strong></li>
+<li><a href="maffiodo1/index.html"><strong>2014/maffiodo1</strong></a> - <strong>Homage to a classic game</strong></li>
+<li><a href="maffiodo2/index.html"><strong>2014/maffiodo2</strong></a> - <strong>Most tweetable entry</strong></li>
+<li><a href="morgan/index.html"><strong>2014/morgan</strong></a> - <strong>Most likely to succeed</strong></li>
+<li><a href="sinon/index.html"><strong>2014/sinon</strong></a> - <strong>Best choice of optimization</strong></li>
+<li><a href="skeggs/index.html"><strong>2014/skeggs</strong></a> - <strong>Most dynamic</strong></li>
+<li><a href="vik/index.html"><strong>2014/vik</strong></a> - <strong>Best handling of beeps</strong></li>
+<li><a href="wiedijk/index.html"><strong>2014/wiedijk</strong></a> - <strong>Most functional</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2015/index.html
+++ b/2015/index.html
@@ -489,20 +489,20 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2015.tar.bz2"><strong>Download all winning entries from 2015</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2015/burton</a> - Most useful</li>
-<li><a href="dogon/index.html">2015/dogon</a> - Most crafty</li>
-<li><a href="duble/index.html">2015/duble</a> - Best handwriting</li>
-<li><a href="endoh1/index.html">2015/endoh1</a> - Most diffused reaction</li>
-<li><a href="endoh2/index.html">2015/endoh2</a> - Most overlooked obfuscation</li>
-<li><a href="endoh3/index.html">2015/endoh3</a> - Back to the Future Award</li>
-<li><a href="endoh4/index.html">2015/endoh4</a> - Best one liner</li>
-<li><a href="hou/index.html">2015/hou</a> - Most well rounded hash</li>
-<li><a href="howe/index.html">2015/howe</a> - Most different</li>
-<li><a href="mills1/index.html">2015/mills1</a> - For the Birds! Award</li>
-<li><a href="mills2/index.html">2015/mills2</a> - Most compact</li>
-<li><a href="muth/index.html">2015/muth</a> - Most complete use of CPP</li>
-<li><a href="schweikhardt/index.html">2015/schweikhardt</a> - Best documented</li>
-<li><a href="yang/index.html">2015/yang</a> - Most pointed reaction</li>
+<li><a href="burton/index.html">2015/burton</a> - <strong>Most useful</strong></li>
+<li><a href="dogon/index.html">2015/dogon</a> - <strong>Most crafty</strong></li>
+<li><a href="duble/index.html">2015/duble</a> - <strong>Best handwriting</strong></li>
+<li><a href="endoh1/index.html">2015/endoh1</a> - <strong>Most diffused reaction</strong></li>
+<li><a href="endoh2/index.html">2015/endoh2</a> - <strong>Most overlooked obfuscation</strong></li>
+<li><a href="endoh3/index.html">2015/endoh3</a> - <strong>Back to the Future Award</strong></li>
+<li><a href="endoh4/index.html">2015/endoh4</a> - <strong>Best one liner</strong></li>
+<li><a href="hou/index.html">2015/hou</a> - <strong>Most well rounded hash</strong></li>
+<li><a href="howe/index.html">2015/howe</a> - <strong>Most different</strong></li>
+<li><a href="mills1/index.html">2015/mills1</a> - <strong>For the Birds! Award</strong></li>
+<li><a href="mills2/index.html">2015/mills2</a> - <strong>Most compact</strong></li>
+<li><a href="muth/index.html">2015/muth</a> - <strong>Most complete use of CPP</strong></li>
+<li><a href="schweikhardt/index.html">2015/schweikhardt</a> - <strong>Best documented</strong></li>
+<li><a href="yang/index.html">2015/yang</a> - <strong>Most pointed reaction</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2015/index.html
+++ b/2015/index.html
@@ -489,20 +489,20 @@ send us the fix (patch file or the entire changed file).</p>
 </div>
 <p><a href="2015.tar.bz2"><strong>Download all winning entries from 2015</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2015/burton</a> - <strong>Most useful</strong></li>
-<li><a href="dogon/index.html">2015/dogon</a> - <strong>Most crafty</strong></li>
-<li><a href="duble/index.html">2015/duble</a> - <strong>Best handwriting</strong></li>
-<li><a href="endoh1/index.html">2015/endoh1</a> - <strong>Most diffused reaction</strong></li>
-<li><a href="endoh2/index.html">2015/endoh2</a> - <strong>Most overlooked obfuscation</strong></li>
-<li><a href="endoh3/index.html">2015/endoh3</a> - <strong>Back to the Future Award</strong></li>
-<li><a href="endoh4/index.html">2015/endoh4</a> - <strong>Best one liner</strong></li>
-<li><a href="hou/index.html">2015/hou</a> - <strong>Most well rounded hash</strong></li>
-<li><a href="howe/index.html">2015/howe</a> - <strong>Most different</strong></li>
-<li><a href="mills1/index.html">2015/mills1</a> - <strong>For the Birds! Award</strong></li>
-<li><a href="mills2/index.html">2015/mills2</a> - <strong>Most compact</strong></li>
-<li><a href="muth/index.html">2015/muth</a> - <strong>Most complete use of CPP</strong></li>
-<li><a href="schweikhardt/index.html">2015/schweikhardt</a> - <strong>Best documented</strong></li>
-<li><a href="yang/index.html">2015/yang</a> - <strong>Most pointed reaction</strong></li>
+<li><a href="burton/index.html"><strong>2015/burton</strong></a> - <strong>Most useful</strong></li>
+<li><a href="dogon/index.html"><strong>2015/dogon</strong></a> - <strong>Most crafty</strong></li>
+<li><a href="duble/index.html"><strong>2015/duble</strong></a> - <strong>Best handwriting</strong></li>
+<li><a href="endoh1/index.html"><strong>2015/endoh1</strong></a> - <strong>Most diffused reaction</strong></li>
+<li><a href="endoh2/index.html"><strong>2015/endoh2</strong></a> - <strong>Most overlooked obfuscation</strong></li>
+<li><a href="endoh3/index.html"><strong>2015/endoh3</strong></a> - <strong>Back to the Future Award</strong></li>
+<li><a href="endoh4/index.html"><strong>2015/endoh4</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="hou/index.html"><strong>2015/hou</strong></a> - <strong>Most well rounded hash</strong></li>
+<li><a href="howe/index.html"><strong>2015/howe</strong></a> - <strong>Most different</strong></li>
+<li><a href="mills1/index.html"><strong>2015/mills1</strong></a> - <strong>For the Birds! Award</strong></li>
+<li><a href="mills2/index.html"><strong>2015/mills2</strong></a> - <strong>Most compact</strong></li>
+<li><a href="muth/index.html"><strong>2015/muth</strong></a> - <strong>Most complete use of CPP</strong></li>
+<li><a href="schweikhardt/index.html"><strong>2015/schweikhardt</strong></a> - <strong>Best documented</strong></li>
+<li><a href="yang/index.html"><strong>2015/yang</strong></a> - <strong>Most pointed reaction</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2018/index.html
+++ b/2018/index.html
@@ -476,21 +476,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2018.tar.bz2"><strong>Download all winning entries from 2018</strong></a></p>
 <ul>
-<li><a href="algmyr/index.html">2018/algmyr</a> - Most cacophonic</li>
-<li><a href="anderson/index.html">2018/anderson</a> - Most able to divine code gaps</li>
-<li><a href="bellard/index.html">2018/bellard</a> - Most inflationary</li>
-<li><a href="burton1/index.html">2018/burton1</a> - Best one liner</li>
-<li><a href="burton2/index.html">2018/burton2</a> - Best abuse of the rules</li>
-<li><a href="ciura/index.html">2018/ciura</a> - Most likely to be awarded</li>
-<li><a href="endoh1/index.html">2018/endoh1</a> - Best tool to reveal holes</li>
-<li><a href="endoh2/index.html">2018/endoh2</a> - Best use of python</li>
-<li><a href="ferguson/index.html">2018/ferguson</a> - Best use of weasel words</li>
-<li><a href="giles/index.html">2018/giles</a> - Most unstable</li>
-<li><a href="hou/index.html">2018/hou</a> - Most likely to top the charts</li>
-<li><a href="mills/index.html">2018/mills</a> - Best of Show</li>
-<li><a href="poikola/index.html">2018/poikola</a> - Most stellar</li>
-<li><a href="vokes/index.html">2018/vokes</a> - Most connected</li>
-<li><a href="yang/index.html">2018/yang</a> - Most shifty</li>
+<li><a href="algmyr/index.html">2018/algmyr</a> - <strong>Most cacophonic</strong></li>
+<li><a href="anderson/index.html">2018/anderson</a> - <strong>Most able to divine code gaps</strong></li>
+<li><a href="bellard/index.html">2018/bellard</a> - <strong>Most inflationary</strong></li>
+<li><a href="burton1/index.html">2018/burton1</a> - <strong>Best one liner</strong></li>
+<li><a href="burton2/index.html">2018/burton2</a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="ciura/index.html">2018/ciura</a> - <strong>Most likely to be awarded</strong></li>
+<li><a href="endoh1/index.html">2018/endoh1</a> - <strong>Best tool to reveal holes</strong></li>
+<li><a href="endoh2/index.html">2018/endoh2</a> - <strong>Best use of python</strong></li>
+<li><a href="ferguson/index.html">2018/ferguson</a> - <strong>Best use of weasel words</strong></li>
+<li><a href="giles/index.html">2018/giles</a> - <strong>Most unstable</strong></li>
+<li><a href="hou/index.html">2018/hou</a> - <strong>Most likely to top the charts</strong></li>
+<li><a href="mills/index.html">2018/mills</a> - <strong>Best of Show</strong></li>
+<li><a href="poikola/index.html">2018/poikola</a> - <strong>Most stellar</strong></li>
+<li><a href="vokes/index.html">2018/vokes</a> - <strong>Most connected</strong></li>
+<li><a href="yang/index.html">2018/yang</a> - <strong>Most shifty</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2018/index.html
+++ b/2018/index.html
@@ -476,21 +476,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2018.tar.bz2"><strong>Download all winning entries from 2018</strong></a></p>
 <ul>
-<li><a href="algmyr/index.html">2018/algmyr</a> - <strong>Most cacophonic</strong></li>
-<li><a href="anderson/index.html">2018/anderson</a> - <strong>Most able to divine code gaps</strong></li>
-<li><a href="bellard/index.html">2018/bellard</a> - <strong>Most inflationary</strong></li>
-<li><a href="burton1/index.html">2018/burton1</a> - <strong>Best one liner</strong></li>
-<li><a href="burton2/index.html">2018/burton2</a> - <strong>Best abuse of the rules</strong></li>
-<li><a href="ciura/index.html">2018/ciura</a> - <strong>Most likely to be awarded</strong></li>
-<li><a href="endoh1/index.html">2018/endoh1</a> - <strong>Best tool to reveal holes</strong></li>
-<li><a href="endoh2/index.html">2018/endoh2</a> - <strong>Best use of python</strong></li>
-<li><a href="ferguson/index.html">2018/ferguson</a> - <strong>Best use of weasel words</strong></li>
-<li><a href="giles/index.html">2018/giles</a> - <strong>Most unstable</strong></li>
-<li><a href="hou/index.html">2018/hou</a> - <strong>Most likely to top the charts</strong></li>
-<li><a href="mills/index.html">2018/mills</a> - <strong>Best of Show</strong></li>
-<li><a href="poikola/index.html">2018/poikola</a> - <strong>Most stellar</strong></li>
-<li><a href="vokes/index.html">2018/vokes</a> - <strong>Most connected</strong></li>
-<li><a href="yang/index.html">2018/yang</a> - <strong>Most shifty</strong></li>
+<li><a href="algmyr/index.html"><strong>2018/algmyr</strong></a> - <strong>Most cacophonic</strong></li>
+<li><a href="anderson/index.html"><strong>2018/anderson</strong></a> - <strong>Most able to divine code gaps</strong></li>
+<li><a href="bellard/index.html"><strong>2018/bellard</strong></a> - <strong>Most inflationary</strong></li>
+<li><a href="burton1/index.html"><strong>2018/burton1</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="burton2/index.html"><strong>2018/burton2</strong></a> - <strong>Best abuse of the rules</strong></li>
+<li><a href="ciura/index.html"><strong>2018/ciura</strong></a> - <strong>Most likely to be awarded</strong></li>
+<li><a href="endoh1/index.html"><strong>2018/endoh1</strong></a> - <strong>Best tool to reveal holes</strong></li>
+<li><a href="endoh2/index.html"><strong>2018/endoh2</strong></a> - <strong>Best use of python</strong></li>
+<li><a href="ferguson/index.html"><strong>2018/ferguson</strong></a> - <strong>Best use of weasel words</strong></li>
+<li><a href="giles/index.html"><strong>2018/giles</strong></a> - <strong>Most unstable</strong></li>
+<li><a href="hou/index.html"><strong>2018/hou</strong></a> - <strong>Most likely to top the charts</strong></li>
+<li><a href="mills/index.html"><strong>2018/mills</strong></a> - <strong>Best of Show</strong></li>
+<li><a href="poikola/index.html"><strong>2018/poikola</strong></a> - <strong>Most stellar</strong></li>
+<li><a href="vokes/index.html"><strong>2018/vokes</strong></a> - <strong>Most connected</strong></li>
+<li><a href="yang/index.html"><strong>2018/yang</strong></a> - <strong>Most shifty</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2019/index.html
+++ b/2019/index.html
@@ -463,20 +463,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2019.tar.bz2"><strong>Download all winning entries from 2019</strong></a></p>
 <ul>
-<li><a href="adamovsky/index.html">2019/adamovsky</a> - <strong>Most functional interpreter</strong></li>
-<li><a href="burton/index.html">2019/burton</a> - <strong>Best one liner</strong></li>
-<li><a href="ciura/index.html">2019/ciura</a> - <strong>Most alphabetic</strong></li>
-<li><a href="diels-grabsch1/index.html">2019/diels-grabsch1</a> - <strong>Best small program</strong></li>
-<li><a href="diels-grabsch2/index.html">2019/diels-grabsch2</a> - <strong>Most self-aware</strong></li>
-<li><a href="dogon/index.html">2019/dogon</a> - <strong>Best use of space and time</strong></li>
-<li><a href="duble/index.html">2019/duble</a> - <strong>Best collaborative graphics</strong></li>
-<li><a href="endoh/index.html">2019/endoh</a> - <strong>Most in need of debugging</strong></li>
-<li><a href="giles/index.html">2019/giles</a> - <strong>Most in need of wide space</strong></li>
-<li><a href="karns/index.html">2019/karns</a> - <strong>Most in need of whitespace</strong></li>
-<li><a href="lynn/index.html">2019/lynn</a> - <strong>Most functional compiler</strong></li>
-<li><a href="mills/index.html">2019/mills</a> - <strong>Most in need to be tweeted</strong></li>
-<li><a href="poikola/index.html">2019/poikola</a> - <strong>Most calendrical</strong></li>
-<li><a href="yang/index.html">2019/yang</a> - <strong>Most in need of transparency</strong></li>
+<li><a href="adamovsky/index.html"><strong>2019/adamovsky</strong></a> - <strong>Most functional interpreter</strong></li>
+<li><a href="burton/index.html"><strong>2019/burton</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="ciura/index.html"><strong>2019/ciura</strong></a> - <strong>Most alphabetic</strong></li>
+<li><a href="diels-grabsch1/index.html"><strong>2019/diels-grabsch1</strong></a> - <strong>Best small program</strong></li>
+<li><a href="diels-grabsch2/index.html"><strong>2019/diels-grabsch2</strong></a> - <strong>Most self-aware</strong></li>
+<li><a href="dogon/index.html"><strong>2019/dogon</strong></a> - <strong>Best use of space and time</strong></li>
+<li><a href="duble/index.html"><strong>2019/duble</strong></a> - <strong>Best collaborative graphics</strong></li>
+<li><a href="endoh/index.html"><strong>2019/endoh</strong></a> - <strong>Most in need of debugging</strong></li>
+<li><a href="giles/index.html"><strong>2019/giles</strong></a> - <strong>Most in need of wide space</strong></li>
+<li><a href="karns/index.html"><strong>2019/karns</strong></a> - <strong>Most in need of whitespace</strong></li>
+<li><a href="lynn/index.html"><strong>2019/lynn</strong></a> - <strong>Most functional compiler</strong></li>
+<li><a href="mills/index.html"><strong>2019/mills</strong></a> - <strong>Most in need to be tweeted</strong></li>
+<li><a href="poikola/index.html"><strong>2019/poikola</strong></a> - <strong>Most calendrical</strong></li>
+<li><a href="yang/index.html"><strong>2019/yang</strong></a> - <strong>Most in need of transparency</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2019/index.html
+++ b/2019/index.html
@@ -463,20 +463,20 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2019.tar.bz2"><strong>Download all winning entries from 2019</strong></a></p>
 <ul>
-<li><a href="adamovsky/index.html">2019/adamovsky</a> - Most functional interpreter</li>
-<li><a href="burton/index.html">2019/burton</a> - Best one liner</li>
-<li><a href="ciura/index.html">2019/ciura</a> - Most alphabetic</li>
-<li><a href="diels-grabsch1/index.html">2019/diels-grabsch1</a> - Best small program</li>
-<li><a href="diels-grabsch2/index.html">2019/diels-grabsch2</a> - Most self-aware</li>
-<li><a href="dogon/index.html">2019/dogon</a> - Best use of space and time</li>
-<li><a href="duble/index.html">2019/duble</a> - Best collaborative graphics</li>
-<li><a href="endoh/index.html">2019/endoh</a> - Most in need of debugging</li>
-<li><a href="giles/index.html">2019/giles</a> - Most in need of wide space</li>
-<li><a href="karns/index.html">2019/karns</a> - Most in need of whitespace</li>
-<li><a href="lynn/index.html">2019/lynn</a> - Most functional compiler</li>
-<li><a href="mills/index.html">2019/mills</a> - Most in need to be tweeted</li>
-<li><a href="poikola/index.html">2019/poikola</a> - Most calendrical</li>
-<li><a href="yang/index.html">2019/yang</a> - Most in need of transparency</li>
+<li><a href="adamovsky/index.html">2019/adamovsky</a> - <strong>Most functional interpreter</strong></li>
+<li><a href="burton/index.html">2019/burton</a> - <strong>Best one liner</strong></li>
+<li><a href="ciura/index.html">2019/ciura</a> - <strong>Most alphabetic</strong></li>
+<li><a href="diels-grabsch1/index.html">2019/diels-grabsch1</a> - <strong>Best small program</strong></li>
+<li><a href="diels-grabsch2/index.html">2019/diels-grabsch2</a> - <strong>Most self-aware</strong></li>
+<li><a href="dogon/index.html">2019/dogon</a> - <strong>Best use of space and time</strong></li>
+<li><a href="duble/index.html">2019/duble</a> - <strong>Best collaborative graphics</strong></li>
+<li><a href="endoh/index.html">2019/endoh</a> - <strong>Most in need of debugging</strong></li>
+<li><a href="giles/index.html">2019/giles</a> - <strong>Most in need of wide space</strong></li>
+<li><a href="karns/index.html">2019/karns</a> - <strong>Most in need of whitespace</strong></li>
+<li><a href="lynn/index.html">2019/lynn</a> - <strong>Most functional compiler</strong></li>
+<li><a href="mills/index.html">2019/mills</a> - <strong>Most in need to be tweeted</strong></li>
+<li><a href="poikola/index.html">2019/poikola</a> - <strong>Most calendrical</strong></li>
+<li><a href="yang/index.html">2019/yang</a> - <strong>Most in need of transparency</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2020/index.html
+++ b/2020/index.html
@@ -462,21 +462,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2020.tar.bz2"><strong>Download all winning entries from 2020</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2020/burton</a> - Best one liner</li>
-<li><a href="carlini/index.html">2020/carlini</a> - Best of Show - abuse of libc</li>
-<li><a href="endoh1/index.html">2020/endoh1</a> - Most explosive</li>
-<li><a href="endoh2/index.html">2020/endoh2</a> - Best perspective</li>
-<li><a href="endoh3/index.html">2020/endoh3</a> - Most head-turning</li>
-<li><a href="ferguson1/index.html">2020/ferguson1</a> - Don’t tread on me award</li>
-<li><a href="ferguson2/index.html">2020/ferguson2</a> - Most enigmatic</li>
-<li><a href="giles/index.html">2020/giles</a> - Most phony</li>
-<li><a href="kurdyukov1/index.html">2020/kurdyukov1</a> - Best utility</li>
-<li><a href="kurdyukov2/index.html">2020/kurdyukov2</a> - Least detailed</li>
-<li><a href="kurdyukov3/index.html">2020/kurdyukov3</a> - Bset slaml prragom</li>
-<li><a href="kurdyukov4/index.html">2020/kurdyukov4</a> - Best abuse of lámatyávë</li>
-<li><a href="otterness/index.html">2020/otterness</a> - Most percussive</li>
-<li><a href="tsoj/index.html">2020/tsoj</a> - Most misleading indentation</li>
-<li><a href="yang/index.html">2020/yang</a> - Best abuse of CPP</li>
+<li><a href="burton/index.html">2020/burton</a> - <strong>Best one liner</strong></li>
+<li><a href="carlini/index.html">2020/carlini</a> - <strong>Best of Show - abuse of libc</strong></li>
+<li><a href="endoh1/index.html">2020/endoh1</a> - <strong>Most explosive</strong></li>
+<li><a href="endoh2/index.html">2020/endoh2</a> - <strong>Best perspective</strong></li>
+<li><a href="endoh3/index.html">2020/endoh3</a> - <strong>Most head-turning</strong></li>
+<li><a href="ferguson1/index.html">2020/ferguson1</a> - <strong>Don’t tread on me award</strong></li>
+<li><a href="ferguson2/index.html">2020/ferguson2</a> - <strong>Most enigmatic</strong></li>
+<li><a href="giles/index.html">2020/giles</a> - <strong>Most phony</strong></li>
+<li><a href="kurdyukov1/index.html">2020/kurdyukov1</a> - <strong>Best utility</strong></li>
+<li><a href="kurdyukov2/index.html">2020/kurdyukov2</a> - <strong>Least detailed</strong></li>
+<li><a href="kurdyukov3/index.html">2020/kurdyukov3</a> - <strong>Bset slaml prragom</strong></li>
+<li><a href="kurdyukov4/index.html">2020/kurdyukov4</a> - <strong>Best abuse of lámatyávë</strong></li>
+<li><a href="otterness/index.html">2020/otterness</a> - <strong>Most percussive</strong></li>
+<li><a href="tsoj/index.html">2020/tsoj</a> - <strong>Most misleading indentation</strong></li>
+<li><a href="yang/index.html">2020/yang</a> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/2020/index.html
+++ b/2020/index.html
@@ -462,21 +462,21 @@ See also <a href="../faq.html">the IOCCC FAQ</a> for additional information on t
 </div>
 <p><a href="2020.tar.bz2"><strong>Download all winning entries from 2020</strong></a></p>
 <ul>
-<li><a href="burton/index.html">2020/burton</a> - <strong>Best one liner</strong></li>
-<li><a href="carlini/index.html">2020/carlini</a> - <strong>Best of Show - abuse of libc</strong></li>
-<li><a href="endoh1/index.html">2020/endoh1</a> - <strong>Most explosive</strong></li>
-<li><a href="endoh2/index.html">2020/endoh2</a> - <strong>Best perspective</strong></li>
-<li><a href="endoh3/index.html">2020/endoh3</a> - <strong>Most head-turning</strong></li>
-<li><a href="ferguson1/index.html">2020/ferguson1</a> - <strong>Don’t tread on me award</strong></li>
-<li><a href="ferguson2/index.html">2020/ferguson2</a> - <strong>Most enigmatic</strong></li>
-<li><a href="giles/index.html">2020/giles</a> - <strong>Most phony</strong></li>
-<li><a href="kurdyukov1/index.html">2020/kurdyukov1</a> - <strong>Best utility</strong></li>
-<li><a href="kurdyukov2/index.html">2020/kurdyukov2</a> - <strong>Least detailed</strong></li>
-<li><a href="kurdyukov3/index.html">2020/kurdyukov3</a> - <strong>Bset slaml prragom</strong></li>
-<li><a href="kurdyukov4/index.html">2020/kurdyukov4</a> - <strong>Best abuse of lámatyávë</strong></li>
-<li><a href="otterness/index.html">2020/otterness</a> - <strong>Most percussive</strong></li>
-<li><a href="tsoj/index.html">2020/tsoj</a> - <strong>Most misleading indentation</strong></li>
-<li><a href="yang/index.html">2020/yang</a> - <strong>Best abuse of CPP</strong></li>
+<li><a href="burton/index.html"><strong>2020/burton</strong></a> - <strong>Best one liner</strong></li>
+<li><a href="carlini/index.html"><strong>2020/carlini</strong></a> - <strong>Best of Show - abuse of libc</strong></li>
+<li><a href="endoh1/index.html"><strong>2020/endoh1</strong></a> - <strong>Most explosive</strong></li>
+<li><a href="endoh2/index.html"><strong>2020/endoh2</strong></a> - <strong>Best perspective</strong></li>
+<li><a href="endoh3/index.html"><strong>2020/endoh3</strong></a> - <strong>Most head-turning</strong></li>
+<li><a href="ferguson1/index.html"><strong>2020/ferguson1</strong></a> - <strong>Don’t tread on me award</strong></li>
+<li><a href="ferguson2/index.html"><strong>2020/ferguson2</strong></a> - <strong>Most enigmatic</strong></li>
+<li><a href="giles/index.html"><strong>2020/giles</strong></a> - <strong>Most phony</strong></li>
+<li><a href="kurdyukov1/index.html"><strong>2020/kurdyukov1</strong></a> - <strong>Best utility</strong></li>
+<li><a href="kurdyukov2/index.html"><strong>2020/kurdyukov2</strong></a> - <strong>Least detailed</strong></li>
+<li><a href="kurdyukov3/index.html"><strong>2020/kurdyukov3</strong></a> - <strong>Bset slaml prragom</strong></li>
+<li><a href="kurdyukov4/index.html"><strong>2020/kurdyukov4</strong></a> - <strong>Best abuse of lámatyávë</strong></li>
+<li><a href="otterness/index.html"><strong>2020/otterness</strong></a> - <strong>Most percussive</strong></li>
+<li><a href="tsoj/index.html"><strong>2020/tsoj</strong></a> - <strong>Most misleading indentation</strong></li>
+<li><a href="yang/index.html"><strong>2020/yang</strong></a> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/authors.html
+++ b/authors.html
@@ -431,7 +431,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2019/adamovsky/index.html">2019/adamovsky</a> - Most functional interpreter</li>
+<li><strong><a href="2019/adamovsky/index.html">2019/adamovsky</a></strong> - <strong>Most functional interpreter</strong></li>
 </ul>
 <p>
 </p>
@@ -446,7 +446,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/algmyr/index.html">2018/algmyr</a> - Most cacophonic</li>
+<li><strong><a href="2018/algmyr/index.html">2018/algmyr</a></strong> - <strong>Most cacophonic</strong></li>
 </ul>
 <p>
 </p>
@@ -461,7 +461,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/anderson/index.html">2018/anderson</a> - Most able to divine code gaps</li>
+<li><strong><a href="2018/anderson/index.html">2018/anderson</a></strong> - <strong>Most able to divine code gaps</strong></li>
 </ul>
 <p>
 </p>
@@ -476,7 +476,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/anderson/index.html">2000/anderson</a> - Best use of flags</li>
+<li><strong><a href="2000/anderson/index.html">2000/anderson</a></strong> - <strong>Best use of flags</strong></li>
 </ul>
 <p>
 </p>
@@ -491,7 +491,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1984/anonymous/index.html">1984/anonymous</a> - Dishonorable Mention</li>
+<li><strong><a href="1984/anonymous/index.html">1984/anonymous</a></strong> - <strong>Dishonorable Mention</strong></li>
 </ul>
 <p>
 </p>
@@ -506,7 +506,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/anonymous/index.html">2001/anonymous</a> - Dishonorable mention</li>
+<li><strong><a href="2001/anonymous/index.html">2001/anonymous</a></strong> - <strong>Dishonorable mention</strong></li>
 </ul>
 <p>
 </p>
@@ -523,7 +523,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/anonymous/index.html">2004/anonymous</a> - Best use of ‘Precious’ Lines</li>
+<li><strong><a href="2004/anonymous/index.html">2004/anonymous</a></strong> - <strong>Best use of ‘Precious’ Lines</strong></li>
 </ul>
 <p>
 </p>
@@ -538,7 +538,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/anon/index.html">2005/anon</a> - Best 3D puzzle</li>
+<li><strong><a href="2005/anon/index.html">2005/anon</a></strong> - <strong>Best 3D puzzle</strong></li>
 </ul>
 <p>
 </p>
@@ -553,7 +553,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2015/endoh1/index.html">2015/endoh1</a> - Most diffused reaction</li>
+<li><strong><a href="2015/endoh1/index.html">2015/endoh1</a></strong> - <strong>Most diffused reaction</strong></li>
 </ul>
 <p>
 </p>
@@ -570,7 +570,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/davidguy/index.html">1991/davidguy</a> - Best X11 graphics</li>
+<li><strong><a href="1991/davidguy/index.html">1991/davidguy</a></strong> - <strong>Best X11 graphics</strong></li>
 </ul>
 <p>
 </p>
@@ -587,9 +587,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1985/applin/index.html">1985/applin</a> - Best one liner</li>
-<li><a href="1986/applin/index.html">1986/applin</a> - Most adaptable program</li>
-<li><a href="1988/applin/index.html">1988/applin</a> - Best of Show</li>
+<li><strong><a href="1985/applin/index.html">1985/applin</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="1986/applin/index.html">1986/applin</a></strong> - <strong>Most adaptable program</strong></li>
+<li><strong><a href="1988/applin/index.html">1988/applin</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -606,9 +606,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/jar.1/index.html">1989/jar.1</a> - Strangest abuse of the rules</li>
-<li><a href="1989/jar.2/index.html">1989/jar.2</a> - Best of Show</li>
-<li><a href="2000/jarijyrki/index.html">2000/jarijyrki</a> - Best of Show</li>
+<li><strong><a href="1989/jar.1/index.html">1989/jar.1</a></strong> - <strong>Strangest abuse of the rules</strong></li>
+<li><strong><a href="1989/jar.2/index.html">1989/jar.2</a></strong> - <strong>Best of Show</strong></li>
+<li><strong><a href="2000/jarijyrki/index.html">2000/jarijyrki</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -623,7 +623,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/mikeash/index.html">2005/mikeash</a> - Best use of parenthesis</li>
+<li><strong><a href="2005/mikeash/index.html">2005/mikeash</a></strong> - <strong>Best use of parenthesis</strong></li>
 </ul>
 <p>
 </p>
@@ -640,9 +640,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1985/august/index.html">1985/august</a> - Most obscure program</li>
-<li><a href="1986/august/index.html">1986/august</a> - Best complex task done in a complex way</li>
-<li><a href="1996/august/index.html">1996/august</a> - Best of Show</li>
+<li><strong><a href="1985/august/index.html">1985/august</a></strong> - <strong>Most obscure program</strong></li>
+<li><strong><a href="1986/august/index.html">1986/august</a></strong> - <strong>Best complex task done in a complex way</strong></li>
+<li><strong><a href="1996/august/index.html">1996/august</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <!-- b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  b  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -664,8 +664,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/bas1/index.html">1998/bas1</a> - Best encapsulation</li>
-<li><a href="1998/bas2/index.html">1998/bas2</a> - Best small program</li>
+<li><strong><a href="1998/bas1/index.html">1998/bas1</a></strong> - <strong>Best encapsulation</strong></li>
+<li><strong><a href="1998/bas2/index.html">1998/bas2</a></strong> - <strong>Best small program</strong></li>
 </ul>
 <p>
 </p>
@@ -684,7 +684,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/banks/index.html">1998/banks</a> - Best of Show</li>
+<li><strong><a href="1998/banks/index.html">1998/banks</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -699,7 +699,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/gavin/index.html">2004/gavin</a> - Best of Show</li>
+<li><strong><a href="2004/gavin/index.html">2004/gavin</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -716,9 +716,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/buzzard/index.html">1991/buzzard</a> - Best output</li>
-<li><a href="1992/buzzard.1/index.html">1992/buzzard.1</a> - Most obfuscated algorithm</li>
-<li><a href="1992/buzzard.2/index.html">1992/buzzard.2</a> - Best language tool</li>
+<li><strong><a href="1991/buzzard/index.html">1991/buzzard</a></strong> - <strong>Best output</strong></li>
+<li><strong><a href="1992/buzzard.1/index.html">1992/buzzard.1</a></strong> - <strong>Most obfuscated algorithm</strong></li>
+<li><strong><a href="1992/buzzard.2/index.html">1992/buzzard.2</a></strong> - <strong>Best language tool</strong></li>
 </ul>
 <p>
 </p>
@@ -733,7 +733,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/dgbeards/index.html">2001/dgbeards</a> - Best AI</li>
+<li><strong><a href="2001/dgbeards/index.html">2001/dgbeards</a></strong> - <strong>Best AI</strong></li>
 </ul>
 <p>
 </p>
@@ -750,9 +750,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/bellard/index.html">2000/bellard</a> - Most specific output</li>
-<li><a href="2001/bellard/index.html">2001/bellard</a> - Best abuse of the rules</li>
-<li><a href="2018/bellard/index.html">2018/bellard</a> - Most inflationary</li>
+<li><strong><a href="2000/bellard/index.html">2000/bellard</a></strong> - <strong>Most specific output</strong></li>
+<li><strong><a href="2001/bellard/index.html">2001/bellard</a></strong> - <strong>Best abuse of the rules</strong></li>
+<li><strong><a href="2018/bellard/index.html">2018/bellard</a></strong> - <strong>Most inflationary</strong></li>
 </ul>
 <p>
 </p>
@@ -767,7 +767,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/ejb/index.html">1993/ejb</a> - Best obfuscated algorithm</li>
+<li><strong><a href="1993/ejb/index.html">1993/ejb</a></strong> - <strong>Best obfuscated algorithm</strong></li>
 </ul>
 <p>
 </p>
@@ -784,7 +784,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/brnstnd/index.html">1991/brnstnd</a> - Best of Show</li>
+<li><strong><a href="1991/brnstnd/index.html">1991/brnstnd</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -801,7 +801,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1987/biggar/index.html">1987/biggar</a> - Best abuse of the rules</li>
+<li><strong><a href="1987/biggar/index.html">1987/biggar</a></strong> - <strong>Best abuse of the rules</strong></li>
 </ul>
 <p>
 </p>
@@ -818,9 +818,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/birken/index.html">2006/birken</a> - EDAMAME Award</li>
-<li><a href="2013/birken/index.html">2013/birken</a> - Best painting tool</li>
-<li><a href="2014/birken/index.html">2014/birken</a> - Best use of port 1701</li>
+<li><strong><a href="2006/birken/index.html">2006/birken</a></strong> - <strong>EDAMAME Award</strong></li>
+<li><strong><a href="2013/birken/index.html">2013/birken</a></strong> - <strong>Best painting tool</strong></li>
+<li><strong><a href="2014/birken/index.html">2014/birken</a></strong> - <strong>Best use of port 1701</strong></li>
 </ul>
 <p>
 </p>
@@ -837,7 +837,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/paul/index.html">1989/paul</a> - Most complex algorithm</li>
+<li><strong><a href="1989/paul/index.html">1989/paul</a></strong> - <strong>Most complex algorithm</strong></li>
 </ul>
 <p>
 </p>
@@ -852,8 +852,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/blakely/index.html">2011/blakely</a> - Most devolving</li>
-<li><a href="2012/blakely/index.html">2012/blakely</a> - Most GIFted expressions</li>
+<li><strong><a href="2011/blakely/index.html">2011/blakely</a></strong> - <strong>Most devolving</strong></li>
+<li><strong><a href="2012/blakely/index.html">2012/blakely</a></strong> - <strong>Most GIFted expressions</strong></li>
 </ul>
 <p>
 </p>
@@ -868,9 +868,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/rince/index.html">1991/rince</a> - Best game</li>
-<li><a href="1993/rince/index.html">1993/rince</a> - Most well rounded</li>
-<li><a href="2000/rince/index.html">2000/rince</a> - Astronomically obfuscated</li>
+<li><strong><a href="1991/rince/index.html">1991/rince</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="1993/rince/index.html">1993/rince</a></strong> - <strong>Most well rounded</strong></li>
+<li><strong><a href="2000/rince/index.html">2000/rince</a></strong> - <strong>Astronomically obfuscated</strong></li>
 </ul>
 <p>
 </p>
@@ -885,8 +885,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/borsanyi/index.html">2006/borsanyi</a> - Most useful</li>
-<li><a href="2011/borsanyi/index.html">2011/borsanyi</a> - Best data utility</li>
+<li><strong><a href="2006/borsanyi/index.html">2006/borsanyi</a></strong> - <strong>Most useful</strong></li>
+<li><strong><a href="2011/borsanyi/index.html">2011/borsanyi</a></strong> - <strong>Best data utility</strong></li>
 </ul>
 <p>
 </p>
@@ -901,7 +901,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/boutines/index.html">2005/boutines</a> - Most superfluous output</li>
+<li><strong><a href="2005/boutines/index.html">2005/boutines</a></strong> - <strong>Most superfluous output</strong></li>
 </ul>
 <p>
 </p>
@@ -918,9 +918,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/vanb/index.html">1989/vanb</a> - Best one liner</li>
-<li><a href="1993/vanb/index.html">1993/vanb</a> - Most irregular expression</li>
-<li><a href="1995/vanschnitz/index.html">1995/vanschnitz</a> - Worst abuse of the C preprocessor and most likely to amaze</li>
+<li><strong><a href="1989/vanb/index.html">1989/vanb</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="1993/vanb/index.html">1993/vanb</a></strong> - <strong>Most irregular expression</strong></li>
+<li><strong><a href="1995/vanschnitz/index.html">1995/vanschnitz</a></strong> - <strong>Worst abuse of the C preprocessor and most likely to amaze</strong></li>
 </ul>
 <p>
 </p>
@@ -935,7 +935,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/briddlebane/index.html">2000/briddlebane</a> - Best abuse of user</li>
+<li><strong><a href="2000/briddlebane/index.html">2000/briddlebane</a></strong> - <strong>Best abuse of user</strong></li>
 </ul>
 <p>
 </p>
@@ -954,7 +954,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/bright/index.html">1986/bright</a> - Most useful obfuscation</li>
+<li><strong><a href="1986/bright/index.html">1986/bright</a></strong> - <strong>Most useful obfuscation</strong></li>
 </ul>
 <p>
 </p>
@@ -971,8 +971,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/leo/index.html">1993/leo</a> - Best game</li>
-<li><a href="1995/leo/index.html">1995/leo</a> - Best use of obfuscation</li>
+<li><strong><a href="1993/leo/index.html">1993/leo</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="1995/leo/index.html">1995/leo</a></strong> - <strong>Best use of obfuscation</strong></li>
 </ul>
 <p>
 </p>
@@ -987,7 +987,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/hamaji/index.html">2011/hamaji</a> - Best solved puzzle</li>
+<li><strong><a href="2011/hamaji/index.html">2011/hamaji</a></strong> - <strong>Best solved puzzle</strong></li>
 </ul>
 <p>
 </p>
@@ -1004,7 +1004,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/ldb/index.html">1994/ldb</a> - Best one liner</li>
+<li><strong><a href="1994/ldb/index.html">1994/ldb</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -1019,7 +1019,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/burley/index.html">2004/burley</a> - Best calculated risk</li>
+<li><strong><a href="2004/burley/index.html">2004/burley</a></strong> - <strong>Best calculated risk</strong></li>
 </ul>
 <p>
 </p>
@@ -1038,11 +1038,11 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2015/burton/index.html">2015/burton</a> - Most useful</li>
-<li><a href="2018/burton1/index.html">2018/burton1</a> - Best one liner</li>
-<li><a href="2018/burton2/index.html">2018/burton2</a> - Best abuse of the rules</li>
-<li><a href="2019/burton/index.html">2019/burton</a> - Best one liner</li>
-<li><a href="2020/burton/index.html">2020/burton</a> - Best one liner</li>
+<li><strong><a href="2015/burton/index.html">2015/burton</a></strong> - <strong>Most useful</strong></li>
+<li><strong><a href="2018/burton1/index.html">2018/burton1</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="2018/burton2/index.html">2018/burton2</a></strong> - <strong>Best abuse of the rules</strong></li>
+<li><strong><a href="2019/burton/index.html">2019/burton</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="2020/burton/index.html">2020/burton</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -1057,7 +1057,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/thadgavin/index.html">2000/thadgavin</a> - Most portable output</li>
+<li><strong><a href="2000/thadgavin/index.html">2000/thadgavin</a></strong> - <strong>Most portable output</strong></li>
 </ul>
 <!-- c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  c  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -1079,9 +1079,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2013/cable1/index.html">2013/cable1</a> - Most partisan one liner</li>
-<li><a href="2013/cable2/index.html">2013/cable2</a> - Best of Show</li>
-<li><a href="2013/cable3/index.html">2013/cable3</a> - Largest small system emulator</li>
+<li><strong><a href="2013/cable1/index.html">2013/cable1</a></strong> - <strong>Most partisan one liner</strong></li>
+<li><strong><a href="2013/cable2/index.html">2013/cable2</a></strong> - <strong>Best of Show</strong></li>
+<li><strong><a href="2013/cable3/index.html">2013/cable3</a></strong> - <strong>Largest small system emulator</strong></li>
 </ul>
 <p>
 </p>
@@ -1100,7 +1100,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2020/carlini/index.html">2020/carlini</a> - Best of Show - abuse of libc</li>
+<li><strong><a href="2020/carlini/index.html">2020/carlini</a></strong> - <strong>Best of Show - abuse of libc</strong></li>
 </ul>
 <p>
 </p>
@@ -1117,8 +1117,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/primenum/index.html">2000/primenum</a> - Best abuse of CPP</li>
-<li><a href="2001/cheong/index.html">2001/cheong</a> - Best short program</li>
+<li><strong><a href="2000/primenum/index.html">2000/primenum</a></strong> - <strong>Best abuse of CPP</strong></li>
+<li><strong><a href="2001/cheong/index.html">2001/cheong</a></strong> - <strong>Best short program</strong></li>
 </ul>
 <p>
 </p>
@@ -1133,7 +1133,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/chia/index.html">2005/chia</a> - Most ambiguous language</li>
+<li><strong><a href="2005/chia/index.html">2005/chia</a></strong> - <strong>Most ambiguous language</strong></li>
 </ul>
 <p>
 </p>
@@ -1148,8 +1148,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/ciura/index.html">2018/ciura</a> - Most likely to be awarded</li>
-<li><a href="2019/ciura/index.html">2019/ciura</a> - Most alphabetic</li>
+<li><strong><a href="2018/ciura/index.html">2018/ciura</a></strong> - <strong>Most likely to be awarded</strong></li>
+<li><strong><a href="2019/ciura/index.html">2019/ciura</a></strong> - <strong>Most alphabetic</strong></li>
 </ul>
 <p>
 </p>
@@ -1166,8 +1166,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/imc/index.html">1992/imc</a> - Best output</li>
-<li><a href="1994/imc/index.html">1994/imc</a> - Most obfuscated algorithm</li>
+<li><strong><a href="1992/imc/index.html">1992/imc</a></strong> - <strong>Best output</strong></li>
+<li><strong><a href="1994/imc/index.html">1994/imc</a></strong> - <strong>Most obfuscated algorithm</strong></li>
 </ul>
 <p>
 </p>
@@ -1182,7 +1182,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/coupard/index.html">2001/coupard</a> - Most obfuscated sound</li>
+<li><strong><a href="2001/coupard/index.html">2001/coupard</a></strong> - <strong>Most obfuscated sound</strong></li>
 </ul>
 <!-- d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  d  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -1206,8 +1206,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1996/dalbec/index.html">1996/dalbec</a> - Best numerical obfuscation</li>
-<li><a href="2004/jdalbec/index.html">2004/jdalbec</a> - Best abuse of the periodic table</li>
+<li><strong><a href="1996/dalbec/index.html">1996/dalbec</a></strong> - <strong>Best numerical obfuscation</strong></li>
+<li><strong><a href="2004/jdalbec/index.html">2004/jdalbec</a></strong> - <strong>Best abuse of the periodic table</strong></li>
 </ul>
 <p>
 </p>
@@ -1222,7 +1222,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/dale/index.html">1988/dale</a> - Best abuse of system calls</li>
+<li><strong><a href="1988/dale/index.html">1988/dale</a></strong> - <strong>Best abuse of system calls</strong></li>
 </ul>
 <p>
 </p>
@@ -1237,7 +1237,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2014/deak/index.html">2014/deak</a> - Most underscored argument</li>
+<li><strong><a href="2014/deak/index.html">2014/deak</a></strong> - <strong>Most underscored argument</strong></li>
 </ul>
 <p>
 </p>
@@ -1252,7 +1252,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2012/deckmyn/index.html">2012/deckmyn</a> - Most notable and best tool</li>
+<li><strong><a href="2012/deckmyn/index.html">2012/deckmyn</a></strong> - <strong>Most notable and best tool</strong></li>
 </ul>
 <p>
 </p>
@@ -1269,7 +1269,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1984/decot/index.html">1984/decot</a> - Second Place</li>
+<li><strong><a href="1984/decot/index.html">1984/decot</a></strong> - <strong>Second Place</strong></li>
 </ul>
 <p>
 </p>
@@ -1286,7 +1286,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1995/esde/index.html">1995/esde</a> - Interesting algorithm</li>
+<li><strong><a href="1995/esde/index.html">1995/esde</a></strong> - <strong>Interesting algorithm</strong></li>
 </ul>
 <p>
 </p>
@@ -1303,8 +1303,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2019/diels-grabsch1/index.html">2019/diels-grabsch1</a> - Best small program</li>
-<li><a href="2019/diels-grabsch2/index.html">2019/diels-grabsch2</a> - Most self-aware</li>
+<li><strong><a href="2019/diels-grabsch1/index.html">2019/diels-grabsch1</a></strong> - <strong>Best small program</strong></li>
+<li><strong><a href="2019/diels-grabsch2/index.html">2019/diels-grabsch2</a></strong> - <strong>Most self-aware</strong></li>
 </ul>
 <p>
 </p>
@@ -1321,10 +1321,10 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/dodsond1/index.html">1994/dodsond1</a> - Best game</li>
-<li><a href="1994/dodsond2/index.html">1994/dodsond2</a> - Most obfuscated packaging</li>
-<li><a href="1995/dodsond1/index.html">1995/dodsond1</a> - Most humorous</li>
-<li><a href="1995/dodsond2/index.html">1995/dodsond2</a> - Best game</li>
+<li><strong><a href="1994/dodsond1/index.html">1994/dodsond1</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="1994/dodsond2/index.html">1994/dodsond2</a></strong> - <strong>Most obfuscated packaging</strong></li>
+<li><strong><a href="1995/dodsond1/index.html">1995/dodsond1</a></strong> - <strong>Most humorous</strong></li>
+<li><strong><a href="1995/dodsond2/index.html">1995/dodsond2</a></strong> - <strong>Best game</strong></li>
 </ul>
 <p>
 </p>
@@ -1339,9 +1339,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/giljade/index.html">2005/giljade</a> - Best 2D puzzle</li>
-<li><a href="2015/dogon/index.html">2015/dogon</a> - Most crafty</li>
-<li><a href="2019/dogon/index.html">2019/dogon</a> - Best use of space and time</li>
+<li><strong><a href="2005/giljade/index.html">2005/giljade</a></strong> - <strong>Best 2D puzzle</strong></li>
+<li><strong><a href="2015/dogon/index.html">2015/dogon</a></strong> - <strong>Most crafty</strong></li>
+<li><strong><a href="2019/dogon/index.html">2019/dogon</a></strong> - <strong>Best use of space and time</strong></li>
 </ul>
 <p>
 </p>
@@ -1356,7 +1356,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/dorssel/index.html">1998/dorssel</a> - Obsolescent feature</li>
+<li><strong><a href="1998/dorssel/index.html">1998/dorssel</a></strong> - <strong>Obsolescent feature</strong></li>
 </ul>
 <p>
 </p>
@@ -1371,7 +1371,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/tbr/index.html">1990/tbr</a> - Best utility</li>
+<li><strong><a href="1990/tbr/index.html">1990/tbr</a></strong> - <strong>Best utility</strong></li>
 </ul>
 <p>
 </p>
@@ -1388,8 +1388,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1995/heathbar/index.html">1995/heathbar</a> - Best layout</li>
-<li><a href="1995/makarios/index.html">1995/makarios</a> - Best short program</li>
+<li><strong><a href="1995/heathbar/index.html">1995/heathbar</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="1995/makarios/index.html">1995/makarios</a></strong> - <strong>Best short program</strong></li>
 </ul>
 <p>
 </p>
@@ -1404,7 +1404,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1995/cdua/index.html">1995/cdua</a> - Best output</li>
+<li><strong><a href="1995/cdua/index.html">1995/cdua</a></strong> - <strong>Best output</strong></li>
 </ul>
 <p>
 </p>
@@ -1421,8 +1421,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2015/duble/index.html">2015/duble</a> - Best handwriting</li>
-<li><a href="2019/duble/index.html">2019/duble</a> - Best collaborative graphics</li>
+<li><strong><a href="2015/duble/index.html">2015/duble</a></strong> - <strong>Best handwriting</strong></li>
+<li><strong><a href="2019/duble/index.html">2019/duble</a></strong> - <strong>Best collaborative graphics</strong></li>
 </ul>
 <p>
 </p>
@@ -1437,7 +1437,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/cdupont/index.html">1991/cdupont</a> - Most useful label</li>
+<li><strong><a href="1991/cdupont/index.html">1991/cdupont</a></strong> - <strong>Most useful label</strong></li>
 </ul>
 <!-- e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  e  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -1459,7 +1459,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/eastman/index.html">2011/eastman</a> - Best ball</li>
+<li><strong><a href="2011/eastman/index.html">2011/eastman</a></strong> - <strong>Best ball</strong></li>
 </ul>
 <p>
 </p>
@@ -1474,7 +1474,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/jaw/index.html">1990/jaw</a> - Best entropy-reducer</li>
+<li><strong><a href="1990/jaw/index.html">1990/jaw</a></strong> - <strong>Best entropy-reducer</strong></li>
 </ul>
 <p>
 </p>
@@ -1489,7 +1489,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1996/eldby/index.html">1996/eldby</a> - Best output</li>
+<li><strong><a href="1996/eldby/index.html">1996/eldby</a></strong> - <strong>Best output</strong></li>
 </ul>
 <p>
 </p>
@@ -1510,24 +1510,24 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2012/endoh1/index.html">2012/endoh1</a> - Most complex ASCII fluid - Honorable mention</li>
-<li><a href="2012/endoh2/index.html">2012/endoh2</a> - PiE in the sky award</li>
-<li><a href="2013/endoh1/index.html">2013/endoh1</a> - Most lazy SKIer</li>
-<li><a href="2013/endoh2/index.html">2013/endoh2</a> - Most recyclable</li>
-<li><a href="2013/endoh3/index.html">2013/endoh3</a> - Most tweetable one liner</li>
-<li><a href="2013/endoh4/index.html">2013/endoh4</a> - Most solid</li>
-<li><a href="2014/endoh1/index.html">2014/endoh1</a> - Most square (YODA Award)</li>
-<li><a href="2014/endoh2/index.html">2014/endoh2</a> - Best use of bioinformatics</li>
-<li><a href="2015/endoh1/index.html">2015/endoh1</a> - Most diffused reaction</li>
-<li><a href="2015/endoh2/index.html">2015/endoh2</a> - Most overlooked obfuscation</li>
-<li><a href="2015/endoh3/index.html">2015/endoh3</a> - Back to the Future Award</li>
-<li><a href="2015/endoh4/index.html">2015/endoh4</a> - Best one liner</li>
-<li><a href="2018/endoh1/index.html">2018/endoh1</a> - Best tool to reveal holes</li>
-<li><a href="2018/endoh2/index.html">2018/endoh2</a> - Best use of python</li>
-<li><a href="2019/endoh/index.html">2019/endoh</a> - Most in need of debugging</li>
-<li><a href="2020/endoh1/index.html">2020/endoh1</a> - Most explosive</li>
-<li><a href="2020/endoh2/index.html">2020/endoh2</a> - Best perspective</li>
-<li><a href="2020/endoh3/index.html">2020/endoh3</a> - Most head-turning</li>
+<li><strong><a href="2012/endoh1/index.html">2012/endoh1</a></strong> - <strong>Most complex ASCII fluid - Honorable mention</strong></li>
+<li><strong><a href="2012/endoh2/index.html">2012/endoh2</a></strong> - <strong>PiE in the sky award</strong></li>
+<li><strong><a href="2013/endoh1/index.html">2013/endoh1</a></strong> - <strong>Most lazy SKIer</strong></li>
+<li><strong><a href="2013/endoh2/index.html">2013/endoh2</a></strong> - <strong>Most recyclable</strong></li>
+<li><strong><a href="2013/endoh3/index.html">2013/endoh3</a></strong> - <strong>Most tweetable one liner</strong></li>
+<li><strong><a href="2013/endoh4/index.html">2013/endoh4</a></strong> - <strong>Most solid</strong></li>
+<li><strong><a href="2014/endoh1/index.html">2014/endoh1</a></strong> - <strong>Most square (YODA Award)</strong></li>
+<li><strong><a href="2014/endoh2/index.html">2014/endoh2</a></strong> - <strong>Best use of bioinformatics</strong></li>
+<li><strong><a href="2015/endoh1/index.html">2015/endoh1</a></strong> - <strong>Most diffused reaction</strong></li>
+<li><strong><a href="2015/endoh2/index.html">2015/endoh2</a></strong> - <strong>Most overlooked obfuscation</strong></li>
+<li><strong><a href="2015/endoh3/index.html">2015/endoh3</a></strong> - <strong>Back to the Future Award</strong></li>
+<li><strong><a href="2015/endoh4/index.html">2015/endoh4</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="2018/endoh1/index.html">2018/endoh1</a></strong> - <strong>Best tool to reveal holes</strong></li>
+<li><strong><a href="2018/endoh2/index.html">2018/endoh2</a></strong> - <strong>Best use of python</strong></li>
+<li><strong><a href="2019/endoh/index.html">2019/endoh</a></strong> - <strong>Most in need of debugging</strong></li>
+<li><strong><a href="2020/endoh1/index.html">2020/endoh1</a></strong> - <strong>Most explosive</strong></li>
+<li><strong><a href="2020/endoh2/index.html">2020/endoh2</a></strong> - <strong>Best perspective</strong></li>
+<li><strong><a href="2020/endoh3/index.html">2020/endoh3</a></strong> - <strong>Most head-turning</strong></li>
 </ul>
 <!-- f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  f  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -1557,9 +1557,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/ferguson/index.html">2018/ferguson</a> - Best use of weasel words</li>
-<li><a href="2020/ferguson1/index.html">2020/ferguson1</a> - Don’t tread on me award</li>
-<li><a href="2020/ferguson2/index.html">2020/ferguson2</a> - Most enigmatic</li>
+<li><strong><a href="2018/ferguson/index.html">2018/ferguson</a></strong> - <strong>Best use of weasel words</strong></li>
+<li><strong><a href="2020/ferguson1/index.html">2020/ferguson1</a></strong> - <strong>Don’t tread on me award</strong></li>
+<li><strong><a href="2020/ferguson2/index.html">2020/ferguson2</a></strong> - <strong>Most enigmatic</strong></li>
 </ul>
 <p>
 </p>
@@ -1580,7 +1580,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/fanf/index.html">1998/fanf</a> - Most obfuscated translator</li>
+<li><strong><a href="1998/fanf/index.html">1998/fanf</a></strong> - <strong>Most obfuscated translator</strong></li>
 </ul>
 <p>
 </p>
@@ -1599,7 +1599,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/fine/index.html">1991/fine</a> - Best one liner</li>
+<li><strong><a href="1991/fine/index.html">1991/fine</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -1614,7 +1614,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/df/index.html">1998/df</a> - Best data hiding</li>
+<li><strong><a href="1998/df/index.html">1998/df</a></strong> - <strong>Best data hiding</strong></li>
 </ul>
 <p>
 </p>
@@ -1629,7 +1629,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/jaw/index.html">1990/jaw</a> - Best entropy-reducer</li>
+<li><strong><a href="1990/jaw/index.html">1990/jaw</a></strong> - <strong>Best entropy-reducer</strong></li>
 </ul>
 <p>
 </p>
@@ -1644,7 +1644,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/fredriksson/index.html">2011/fredriksson</a> - Most useful</li>
+<li><strong><a href="2011/fredriksson/index.html">2011/fredriksson</a></strong> - <strong>Most useful</strong></li>
 </ul>
 <p>
 </p>
@@ -1661,7 +1661,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/thadgavin/index.html">2000/thadgavin</a> - Most portable output</li>
+<li><strong><a href="2000/thadgavin/index.html">2000/thadgavin</a></strong> - <strong>Most portable output</strong></li>
 </ul>
 <!-- g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  g  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -1685,7 +1685,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/gavare/index.html">2004/gavare</a> - Best use of light and spheres</li>
+<li><strong><a href="2004/gavare/index.html">2004/gavare</a></strong> - <strong>Best use of light and spheres</strong></li>
 </ul>
 <p>
 </p>
@@ -1700,7 +1700,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/dgibson/index.html">1993/dgibson</a> - Best abuse of the C preprocessor</li>
+<li><strong><a href="1993/dgibson/index.html">1993/dgibson</a></strong> - <strong>Best abuse of the C preprocessor</strong></li>
 </ul>
 <p>
 </p>
@@ -1719,9 +1719,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/giles/index.html">2018/giles</a> - Most unstable</li>
-<li><a href="2019/giles/index.html">2019/giles</a> - Most in need of wide space</li>
-<li><a href="2020/giles/index.html">2020/giles</a> - Most phony</li>
+<li><strong><a href="2018/giles/index.html">2018/giles</a></strong> - <strong>Most unstable</strong></li>
+<li><strong><a href="2019/giles/index.html">2019/giles</a></strong> - <strong>Most in need of wide space</strong></li>
+<li><strong><a href="2020/giles/index.html">2020/giles</a></strong> - <strong>Most phony</strong></li>
 </ul>
 <p>
 </p>
@@ -1738,7 +1738,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1995/garry/index.html">1995/garry</a> - Best utility</li>
+<li><strong><a href="1995/garry/index.html">1995/garry</a></strong> - <strong>Best utility</strong></li>
 </ul>
 <p>
 </p>
@@ -1753,7 +1753,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/dg/index.html">1990/dg</a> - Best abuse of the C preprocessor</li>
+<li><strong><a href="1990/dg/index.html">1990/dg</a></strong> - <strong>Best abuse of the C preprocessor</strong></li>
 </ul>
 <p>
 </p>
@@ -1768,7 +1768,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/goren/index.html">2011/goren</a> - Most artistic</li>
+<li><strong><a href="2011/goren/index.html">2011/goren</a></strong> - <strong>Most artistic</strong></li>
 </ul>
 <p>
 </p>
@@ -1783,8 +1783,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/grothe/index.html">2006/grothe</a> - Most obfuscated audio</li>
-<li><a href="2012/grothe/index.html">2012/grothe</a> - Most conspiratorial</li>
+<li><strong><a href="2006/grothe/index.html">2006/grothe</a></strong> - <strong>Most obfuscated audio</strong></li>
+<li><strong><a href="2012/grothe/index.html">2012/grothe</a></strong> - <strong>Most conspiratorial</strong></li>
 </ul>
 <p>
 </p>
@@ -1801,7 +1801,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/gson/index.html">1992/gson</a> - Most humorous output</li>
+<li><strong><a href="1992/gson/index.html">1992/gson</a></strong> - <strong>Most humorous output</strong></li>
 </ul>
 <!-- h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  h  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -1825,7 +1825,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/hague/index.html">1986/hague</a> - Worst abuse of the C preprocessor</li>
+<li><strong><a href="1986/hague/index.html">1986/hague</a></strong> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <p>
 </p>
@@ -1840,7 +1840,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/hamaji/index.html">2011/hamaji</a> - Best solved puzzle</li>
+<li><strong><a href="2011/hamaji/index.html">2011/hamaji</a></strong> - <strong>Best solved puzzle</strong></li>
 </ul>
 <p>
 </p>
@@ -1855,7 +1855,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2012/hamano/index.html">2012/hamano</a> - Most elementary use of C - Silver Award</li>
+<li><strong><a href="2012/hamano/index.html">2012/hamano</a></strong> - <strong>Most elementary use of C - Silver Award</strong></li>
 </ul>
 <p>
 </p>
@@ -1870,7 +1870,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/hamre/index.html">2006/hamre</a> - Most irrational</li>
+<li><strong><a href="2006/hamre/index.html">2006/hamre</a></strong> - <strong>Most irrational</strong></li>
 </ul>
 <p>
 </p>
@@ -1887,7 +1887,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1987/heckbert/index.html">1987/heckbert</a> - Best obfuscator of programs</li>
+<li><strong><a href="1987/heckbert/index.html">1987/heckbert</a></strong> - <strong>Best obfuscator of programs</strong></li>
 </ul>
 <p>
 </p>
@@ -1904,7 +1904,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1985/applin/index.html">1985/applin</a> - Best one liner</li>
+<li><strong><a href="1985/applin/index.html">1985/applin</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -1919,7 +1919,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/timwi/index.html">2005/timwi</a> - Most discourteous interpreter</li>
+<li><strong><a href="2005/timwi/index.html">2005/timwi</a></strong> - <strong>Most discourteous interpreter</strong></li>
 </ul>
 <p>
 </p>
@@ -1936,7 +1936,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/stig/index.html">1990/stig</a> - Strangest abuse of the rules</li>
+<li><strong><a href="1990/stig/index.html">1990/stig</a></strong> - <strong>Strangest abuse of the rules</strong></li>
 </ul>
 <p>
 </p>
@@ -1953,8 +1953,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/herrmann1/index.html">2001/herrmann1</a> - Best abuse of the C preprocessor</li>
-<li><a href="2001/herrmann2/index.html">2001/herrmann2</a> - Most eye-crossing</li>
+<li><strong><a href="2001/herrmann1/index.html">2001/herrmann1</a></strong> - <strong>Best abuse of the C preprocessor</strong></li>
+<li><strong><a href="2001/herrmann2/index.html">2001/herrmann2</a></strong> - <strong>Most eye-crossing</strong></li>
 </ul>
 <p>
 </p>
@@ -1969,7 +1969,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1987/hines/index.html">1987/hines</a> - Worst style</li>
+<li><strong><a href="1987/hines/index.html">1987/hines</a></strong> - <strong>Worst style</strong></li>
 </ul>
 <p>
 </p>
@@ -1984,7 +1984,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/holloway/index.html">1986/holloway</a> - Best simple task performed in a complex way</li>
+<li><strong><a href="1986/holloway/index.html">1986/holloway</a></strong> - <strong>Best simple task performed in a complex way</strong></li>
 </ul>
 <p>
 </p>
@@ -2001,8 +2001,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/lmfjyh/index.html">1993/lmfjyh</a> - Most versatile source</li>
-<li><a href="2000/jarijyrki/index.html">2000/jarijyrki</a> - Best of Show</li>
+<li><strong><a href="1993/lmfjyh/index.html">1993/lmfjyh</a></strong> - <strong>Most versatile source</strong></li>
+<li><strong><a href="2000/jarijyrki/index.html">2000/jarijyrki</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -2019,7 +2019,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/albert/index.html">1992/albert</a> - Most useful program</li>
+<li><strong><a href="1992/albert/index.html">1992/albert</a></strong> - <strong>Most useful program</strong></li>
 </ul>
 <p>
 </p>
@@ -2036,7 +2036,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/horton/index.html">1994/horton</a> - Best utility</li>
+<li><strong><a href="1994/horton/index.html">1994/horton</a></strong> - <strong>Best utility</strong></li>
 </ul>
 <p>
 </p>
@@ -2051,11 +2051,11 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/hou/index.html">2011/hou</a> - Best self documenting program</li>
-<li><a href="2012/hou/index.html">2012/hou</a> - Most useful obfuscation</li>
-<li><a href="2013/hou/index.html">2013/hou</a> - Best use of one infinite loop</li>
-<li><a href="2015/hou/index.html">2015/hou</a> - Most well rounded hash</li>
-<li><a href="2018/hou/index.html">2018/hou</a> - Most likely to top the charts</li>
+<li><strong><a href="2011/hou/index.html">2011/hou</a></strong> - <strong>Best self documenting program</strong></li>
+<li><strong><a href="2012/hou/index.html">2012/hou</a></strong> - <strong>Most useful obfuscation</strong></li>
+<li><strong><a href="2013/hou/index.html">2013/hou</a></strong> - <strong>Best use of one infinite loop</strong></li>
+<li><strong><a href="2015/hou/index.html">2015/hou</a></strong> - <strong>Most well rounded hash</strong></li>
+<li><strong><a href="2018/hou/index.html">2018/hou</a></strong> - <strong>Most likely to top the charts</strong></li>
 </ul>
 <p>
 </p>
@@ -2072,12 +2072,12 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1991/ant/index.html">1991/ant</a> - Best utility</li>
-<li><a href="1992/ant/index.html">1992/ant</a> - Best utility</li>
-<li><a href="1993/ant/index.html">1993/ant</a> - Best utility</li>
-<li><a href="2004/hibachi/index.html">2004/hibachi</a> - Best abuse of the guidelines</li>
-<li><a href="2005/mynx/index.html">2005/mynx</a> - Best use of the WWW</li>
-<li><a href="2015/howe/index.html">2015/howe</a> - Most different</li>
+<li><strong><a href="1991/ant/index.html">1991/ant</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="1992/ant/index.html">1992/ant</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="1993/ant/index.html">1993/ant</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="2004/hibachi/index.html">2004/hibachi</a></strong> - <strong>Best abuse of the guidelines</strong></li>
+<li><strong><a href="2005/mynx/index.html">2005/mynx</a></strong> - <strong>Best use of the WWW</strong></li>
+<li><strong><a href="2015/howe/index.html">2015/howe</a></strong> - <strong>Most different</strong></li>
 </ul>
 <p>
 </p>
@@ -2094,7 +2094,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/hoyle/index.html">2004/hoyle</a> - Most functional output</li>
+<li><strong><a href="2004/hoyle/index.html">2004/hoyle</a></strong> - <strong>Most functional output</strong></li>
 </ul>
 <p>
 </p>
@@ -2111,7 +2111,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1996/huffman/index.html">1996/huffman</a> - Best obfuscated character set utility</li>
+<li><strong><a href="1996/huffman/index.html">1996/huffman</a></strong> - <strong>Best obfuscated character set utility</strong></li>
 </ul>
 <!-- i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  i  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2133,7 +2133,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/isaak/index.html">1988/isaak</a> - Best visuals</li>
+<li><strong><a href="1988/isaak/index.html">1988/isaak</a></strong> - <strong>Best visuals</strong></li>
 </ul>
 <!-- j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  j  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2157,7 +2157,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/tomx/index.html">2000/tomx</a> - Most complete program</li>
+<li><strong><a href="2000/tomx/index.html">2000/tomx</a></strong> - <strong>Most complete program</strong></li>
 </ul>
 <p>
 </p>
@@ -2174,7 +2174,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/arachnid/index.html">2004/arachnid</a> - Best use of vision</li>
+<li><strong><a href="2004/arachnid/index.html">2004/arachnid</a></strong> - <strong>Best use of vision</strong></li>
 </ul>
 <p>
 </p>
@@ -2189,7 +2189,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/scjones/index.html">1990/scjones</a> - ANSI Committee’s worst abuse of C</li>
+<li><strong><a href="1990/scjones/index.html">1990/scjones</a></strong> - <strong>ANSI Committee’s worst abuse of C</strong></li>
 </ul>
 <!-- k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  k  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2213,7 +2213,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2012/kang/index.html">2012/kang</a> - Best short program</li>
+<li><strong><a href="2012/kang/index.html">2012/kang</a></strong> - <strong>Best short program</strong></li>
 </ul>
 <p>
 </p>
@@ -2228,7 +2228,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2019/karns/index.html">2019/karns</a> - Most in need of whitespace</li>
+<li><strong><a href="2019/karns/index.html">2019/karns</a></strong> - <strong>Most in need of whitespace</strong></li>
 </ul>
 <p>
 </p>
@@ -2243,7 +2243,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/ctk/index.html">2001/ctk</a> - Worst driver</li>
+<li><strong><a href="2001/ctk/index.html">2001/ctk</a></strong> - <strong>Worst driver</strong></li>
 </ul>
 <p>
 </p>
@@ -2260,7 +2260,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/kivinen/index.html">1992/kivinen</a> - Best X program</li>
+<li><strong><a href="1992/kivinen/index.html">1992/kivinen</a></strong> - <strong>Best X program</strong></li>
 </ul>
 <p>
 </p>
@@ -2275,7 +2275,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/klausler/index.html">2005/klausler</a> - Abuse of the rules</li>
+<li><strong><a href="2005/klausler/index.html">2005/klausler</a></strong> - <strong>Abuse of the rules</strong></li>
 </ul>
 <p>
 </p>
@@ -2290,8 +2290,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/konno/index.html">2011/konno</a> - Best one liner</li>
-<li><a href="2012/konno/index.html">2012/konno</a> - Best one liner</li>
+<li><strong><a href="2011/konno/index.html">2011/konno</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="2012/konno/index.html">2012/konno</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -2308,7 +2308,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/kopczynski/index.html">2004/kopczynski</a> - Best one liner</li>
+<li><strong><a href="2004/kopczynski/index.html">2004/kopczynski</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -2327,7 +2327,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1987/korn/index.html">1987/korn</a> - Best one liner</li>
+<li><strong><a href="1987/korn/index.html">1987/korn</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -2346,10 +2346,10 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2020/kurdyukov1/index.html">2020/kurdyukov1</a> - Best utility</li>
-<li><a href="2020/kurdyukov2/index.html">2020/kurdyukov2</a> - Least detailed</li>
-<li><a href="2020/kurdyukov3/index.html">2020/kurdyukov3</a> - Bset slaml prragom</li>
-<li><a href="2020/kurdyukov4/index.html">2020/kurdyukov4</a> - Best abuse of lámatyávë</li>
+<li><strong><a href="2020/kurdyukov1/index.html">2020/kurdyukov1</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="2020/kurdyukov2/index.html">2020/kurdyukov2</a></strong> - <strong>Least detailed</strong></li>
+<li><strong><a href="2020/kurdyukov3/index.html">2020/kurdyukov3</a></strong> - <strong>Bset slaml prragom</strong></li>
+<li><strong><a href="2020/kurdyukov4/index.html">2020/kurdyukov4</a></strong> - <strong>Best abuse of lámatyávë</strong></li>
 </ul>
 <!-- l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  l  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2371,7 +2371,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1984/laman/index.html">1984/laman</a> - Third Place</li>
+<li><strong><a href="1984/laman/index.html">1984/laman</a></strong> - <strong>Third Place</strong></li>
 </ul>
 <p>
 </p>
@@ -2392,7 +2392,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/jar.2/index.html">1989/jar.2</a> - Best of Show</li>
+<li><strong><a href="1989/jar.2/index.html">1989/jar.2</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -2409,7 +2409,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/jetro/index.html">2005/jetro</a> - Most sonorous output</li>
+<li><strong><a href="2005/jetro/index.html">2005/jetro</a></strong> - <strong>Most sonorous output</strong></li>
 </ul>
 <p>
 </p>
@@ -2424,8 +2424,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1987/lievaart/index.html">1987/lievaart</a> - Grand Prize</li>
-<li><a href="1989/roemer/index.html">1989/roemer</a> - Best layout</li>
+<li><strong><a href="1987/lievaart/index.html">1987/lievaart</a></strong> - <strong>Grand Prize</strong></li>
+<li><strong><a href="1989/roemer/index.html">1989/roemer</a></strong> - <strong>Best layout</strong></li>
 </ul>
 <p>
 </p>
@@ -2440,7 +2440,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/litmaath/index.html">1988/litmaath</a> - Best small program</li>
+<li><strong><a href="1988/litmaath/index.html">1988/litmaath</a></strong> - <strong>Best small program</strong></li>
 </ul>
 <p>
 </p>
@@ -2459,12 +2459,12 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/dlowe/index.html">1998/dlowe</a> - Best utility</li>
-<li><a href="1998/dloweneil/index.html">1998/dloweneil</a> - Most fun</li>
-<li><a href="2000/dlowe/index.html">2000/dlowe</a> - Worst abuse of the rules</li>
-<li><a href="2011/dlowe/index.html">2011/dlowe</a> - Most self deprecating</li>
-<li><a href="2012/dlowe/index.html">2012/dlowe</a> - Best way to lose a life</li>
-<li><a href="2013/dlowe/index.html">2013/dlowe</a> - Best sparkling utility</li>
+<li><strong><a href="1998/dlowe/index.html">1998/dlowe</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="1998/dloweneil/index.html">1998/dloweneil</a></strong> - <strong>Most fun</strong></li>
+<li><strong><a href="2000/dlowe/index.html">2000/dlowe</a></strong> - <strong>Worst abuse of the rules</strong></li>
+<li><strong><a href="2011/dlowe/index.html">2011/dlowe</a></strong> - <strong>Most self deprecating</strong></li>
+<li><strong><a href="2012/dlowe/index.html">2012/dlowe</a></strong> - <strong>Best way to lose a life</strong></li>
+<li><strong><a href="2013/dlowe/index.html">2013/dlowe</a></strong> - <strong>Best sparkling utility</strong></li>
 </ul>
 <p>
 </p>
@@ -2479,7 +2479,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/ovdluhe/index.html">1989/ovdluhe</a> - Most humorous output</li>
+<li><strong><a href="1989/ovdluhe/index.html">1989/ovdluhe</a></strong> - <strong>Most humorous output</strong></li>
 </ul>
 <p>
 </p>
@@ -2496,7 +2496,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/lush/index.html">1992/lush</a> - Worst abuse of the C preprocessor</li>
+<li><strong><a href="1992/lush/index.html">1992/lush</a></strong> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <p>
 </p>
@@ -2511,7 +2511,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1985/lycklama/index.html">1985/lycklama</a> - Strangest appearing program</li>
+<li><strong><a href="1985/lycklama/index.html">1985/lycklama</a></strong> - <strong>Strangest appearing program</strong></li>
 </ul>
 <p>
 </p>
@@ -2528,7 +2528,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2019/lynn/index.html">2019/lynn</a> - Most functional compiler</li>
+<li><strong><a href="2019/lynn/index.html">2019/lynn</a></strong> - <strong>Most functional compiler</strong></li>
 </ul>
 <!-- m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  m  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2552,7 +2552,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2012/grothe/index.html">2012/grothe</a> - Most conspiratorial</li>
+<li><strong><a href="2012/grothe/index.html">2012/grothe</a></strong> - <strong>Most conspiratorial</strong></li>
 </ul>
 <p>
 </p>
@@ -2569,8 +2569,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2014/maffiodo1/index.html">2014/maffiodo1</a> - Homage to a classic game</li>
-<li><a href="2014/maffiodo2/index.html">2014/maffiodo2</a> - Most tweetable entry</li>
+<li><strong><a href="2014/maffiodo1/index.html">2014/maffiodo1</a></strong> - <strong>Homage to a classic game</strong></li>
+<li><strong><a href="2014/maffiodo2/index.html">2014/maffiodo2</a></strong> - <strong>Most tweetable entry</strong></li>
 </ul>
 <p>
 </p>
@@ -2587,8 +2587,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1995/heathbar/index.html">1995/heathbar</a> - Best layout</li>
-<li><a href="1995/makarios/index.html">1995/makarios</a> - Best short program</li>
+<li><strong><a href="1995/heathbar/index.html">1995/heathbar</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="1995/makarios/index.html">1995/makarios</a></strong> - <strong>Best short program</strong></li>
 </ul>
 <p>
 </p>
@@ -2605,7 +2605,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/marangon/index.html">1992/marangon</a> - Best game</li>
+<li><strong><a href="1992/marangon/index.html">1992/marangon</a></strong> - <strong>Best game</strong></li>
 </ul>
 <p>
 </p>
@@ -2620,8 +2620,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/theorem/index.html">1990/theorem</a> - Best of Show</li>
-<li><a href="1992/adrian/index.html">1992/adrian</a> - Most educational</li>
+<li><strong><a href="1990/theorem/index.html">1990/theorem</a></strong> - <strong>Best of Show</strong></li>
+<li><strong><a href="1992/adrian/index.html">1992/adrian</a></strong> - <strong>Most educational</strong></li>
 </ul>
 <p>
 </p>
@@ -2636,7 +2636,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/marshall/index.html">1986/marshall</a> - Best layout</li>
+<li><strong><a href="1986/marshall/index.html">1986/marshall</a></strong> - <strong>Best layout</strong></li>
 </ul>
 <p>
 </p>
@@ -2651,7 +2651,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1996/rcm/index.html">1996/rcm</a> - Best RFC obfuscation</li>
+<li><strong><a href="1996/rcm/index.html">1996/rcm</a></strong> - <strong>Best RFC obfuscation</strong></li>
 </ul>
 <p>
 </p>
@@ -2668,7 +2668,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/bmeyer/index.html">2000/bmeyer</a> - Best utility</li>
+<li><strong><a href="2000/bmeyer/index.html">2000/bmeyer</a></strong> - <strong>Best utility</strong></li>
 </ul>
 <p>
 </p>
@@ -2683,7 +2683,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/meyer/index.html">2006/meyer</a> - Best game</li>
+<li><strong><a href="2006/meyer/index.html">2006/meyer</a></strong> - <strong>Best game</strong></li>
 </ul>
 <p>
 </p>
@@ -2698,13 +2698,13 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/cmills/index.html">1990/cmills</a> - Best game</li>
-<li><a href="1993/cmills/index.html">1993/cmills</a> - Bill Gates Award</li>
-<li><a href="2013/mills/index.html">2013/mills</a> - Most timely rendered</li>
-<li><a href="2015/mills1/index.html">2015/mills1</a> - For the Birds! Award</li>
-<li><a href="2015/mills2/index.html">2015/mills2</a> - Most compact</li>
-<li><a href="2018/mills/index.html">2018/mills</a> - Best of Show</li>
-<li><a href="2019/mills/index.html">2019/mills</a> - Most in need to be tweeted</li>
+<li><strong><a href="1990/cmills/index.html">1990/cmills</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="1993/cmills/index.html">1993/cmills</a></strong> - <strong>Bill Gates Award</strong></li>
+<li><strong><a href="2013/mills/index.html">2013/mills</a></strong> - <strong>Most timely rendered</strong></li>
+<li><strong><a href="2015/mills1/index.html">2015/mills1</a></strong> - <strong>For the Birds! Award</strong></li>
+<li><strong><a href="2015/mills2/index.html">2015/mills2</a></strong> - <strong>Most compact</strong></li>
+<li><strong><a href="2018/mills/index.html">2018/mills</a></strong> - <strong>Best of Show</strong></li>
+<li><strong><a href="2019/mills/index.html">2019/mills</a></strong> - <strong>Most in need to be tweeted</strong></li>
 </ul>
 <p>
 </p>
@@ -2719,7 +2719,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/dloweneil/index.html">1998/dloweneil</a> - Most fun</li>
+<li><strong><a href="1998/dloweneil/index.html">1998/dloweneil</a></strong> - <strong>Most fun</strong></li>
 </ul>
 <p>
 </p>
@@ -2734,7 +2734,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/monge/index.html">2006/monge</a> - Best compiled graphics</li>
+<li><strong><a href="2006/monge/index.html">2006/monge</a></strong> - <strong>Best compiled graphics</strong></li>
 </ul>
 <p>
 </p>
@@ -2749,9 +2749,9 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2013/morgan1/index.html">2013/morgan1</a> - Smallest large system simulator</li>
-<li><a href="2013/morgan2/index.html">2013/morgan2</a> - Most playfully versatile</li>
-<li><a href="2014/morgan/index.html">2014/morgan</a> - Most likely to succeed</li>
+<li><strong><a href="2013/morgan1/index.html">2013/morgan1</a></strong> - <strong>Smallest large system simulator</strong></li>
+<li><strong><a href="2013/morgan2/index.html">2013/morgan2</a></strong> - <strong>Most playfully versatile</strong></li>
+<li><strong><a href="2014/morgan/index.html">2014/morgan</a></strong> - <strong>Most likely to succeed</strong></li>
 </ul>
 <p>
 </p>
@@ -2770,7 +2770,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1984/mullender/index.html">1984/mullender</a> - Grand Prize</li>
+<li><strong><a href="1984/mullender/index.html">1984/mullender</a></strong> - <strong>Grand Prize</strong></li>
 </ul>
 <p>
 </p>
@@ -2785,7 +2785,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2015/muth/index.html">2015/muth</a> - Most complete use of CPP</li>
+<li><strong><a href="2015/muth/index.html">2015/muth</a></strong> - <strong>Most complete use of CPP</strong></li>
 </ul>
 <!-- n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  n  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2807,7 +2807,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/newbern/index.html">2004/newbern</a> - Best font engine</li>
+<li><strong><a href="2004/newbern/index.html">2004/newbern</a></strong> - <strong>Best font engine</strong></li>
 </ul>
 <p>
 </p>
@@ -2824,7 +2824,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/night/index.html">2006/night</a> - Best abuse of computation</li>
+<li><strong><a href="2006/night/index.html">2006/night</a></strong> - <strong>Best abuse of computation</strong></li>
 </ul>
 <p>
 </p>
@@ -2839,7 +2839,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/baruch/index.html">1990/baruch</a> - Best small program</li>
+<li><strong><a href="1990/baruch/index.html">1990/baruch</a></strong> - <strong>Best small program</strong></li>
 </ul>
 <p>
 </p>
@@ -2856,7 +2856,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/jar.2/index.html">1989/jar.2</a> - Best of Show</li>
+<li><strong><a href="1989/jar.2/index.html">1989/jar.2</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <!-- o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  o  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2880,7 +2880,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/ollinger/index.html">2001/ollinger</a> - Best of Show</li>
+<li><strong><a href="2001/ollinger/index.html">2001/ollinger</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -2897,7 +2897,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/jason/index.html">2001/jason</a> - Best of Show</li>
+<li><strong><a href="2001/jason/index.html">2001/jason</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -2912,7 +2912,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/baruch/index.html">1990/baruch</a> - Best small program</li>
+<li><strong><a href="1990/baruch/index.html">1990/baruch</a></strong> - <strong>Best small program</strong></li>
 </ul>
 <p>
 </p>
@@ -2931,7 +2931,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2020/otterness/index.html">2020/otterness</a> - Most percussive</li>
+<li><strong><a href="2020/otterness/index.html">2020/otterness</a></strong> - <strong>Most percussive</strong></li>
 </ul>
 <!-- p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  p  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -2953,7 +2953,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/pawka/index.html">1986/pawka</a> - Most illegible code</li>
+<li><strong><a href="1986/pawka/index.html">1986/pawka</a></strong> - <strong>Most illegible code</strong></li>
 </ul>
 <p>
 </p>
@@ -2968,7 +2968,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/vern/index.html">1992/vern</a> - Best of Show</li>
+<li><strong><a href="1992/vern/index.html">1992/vern</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -2983,7 +2983,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/persano/index.html">2005/persano</a> - Best of Show</li>
+<li><strong><a href="2005/persano/index.html">2005/persano</a></strong> - <strong>Best of Show</strong></li>
 </ul>
 <p>
 </p>
@@ -2998,7 +2998,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/phillipps/index.html">1988/phillipps</a> - Least likely to compile successfully</li>
+<li><strong><a href="1988/phillipps/index.html">1988/phillipps</a></strong> - <strong>Least likely to compile successfully</strong></li>
 </ul>
 <p>
 </p>
@@ -3015,7 +3015,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/plummer/index.html">1993/plummer</a> - Best one liner</li>
+<li><strong><a href="1993/plummer/index.html">1993/plummer</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -3032,8 +3032,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/poikola/index.html">2018/poikola</a> - Most stellar</li>
-<li><a href="2019/poikola/index.html">2019/poikola</a> - Most calendrical</li>
+<li><strong><a href="2018/poikola/index.html">2018/poikola</a></strong> - <strong>Most stellar</strong></li>
+<li><strong><a href="2019/poikola/index.html">2019/poikola</a></strong> - <strong>Most calendrical</strong></li>
 </ul>
 <p>
 </p>
@@ -3052,7 +3052,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2014/birken/index.html">2014/birken</a> - Best use of port 1701</li>
+<li><strong><a href="2014/birken/index.html">2014/birken</a></strong> - <strong>Best use of port 1701</strong></li>
 </ul>
 <p>
 </p>
@@ -3071,7 +3071,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/kev/index.html">2001/kev</a> - Best curses game</li>
+<li><strong><a href="2001/kev/index.html">2001/kev</a></strong> - <strong>Best curses game</strong></li>
 </ul>
 <!-- q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  q  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3103,7 +3103,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/tbr/index.html">1990/tbr</a> - Best utility</li>
+<li><strong><a href="1990/tbr/index.html">1990/tbr</a></strong> - <strong>Best utility</strong></li>
 </ul>
 <p>
 </p>
@@ -3120,7 +3120,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/tvr/index.html">1994/tvr</a> - Best X11 program</li>
+<li><strong><a href="1994/tvr/index.html">1994/tvr</a></strong> - <strong>Best X11 program</strong></li>
 </ul>
 <p>
 </p>
@@ -3135,7 +3135,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/reddy/index.html">1988/reddy</a> - Most useful obfuscated C program</li>
+<li><strong><a href="1988/reddy/index.html">1988/reddy</a></strong> - <strong>Most useful obfuscated C program</strong></li>
 </ul>
 <p>
 </p>
@@ -3152,7 +3152,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1984/mullender/index.html">1984/mullender</a> - Grand Prize</li>
+<li><strong><a href="1984/mullender/index.html">1984/mullender</a></strong> - <strong>Grand Prize</strong></li>
 </ul>
 <p>
 </p>
@@ -3167,7 +3167,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/richards/index.html">2011/richards</a> - Most surprisingly portable</li>
+<li><strong><a href="2011/richards/index.html">2011/richards</a></strong> - <strong>Most surprisingly portable</strong></li>
 </ul>
 <p>
 </p>
@@ -3182,10 +3182,10 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/robison/index.html">1988/robison</a> - Best abuse of C constructs</li>
-<li><a href="1989/robison/index.html">1989/robison</a> - Best minimal use of C</li>
-<li><a href="2000/robison/index.html">2000/robison</a> - Best game</li>
-<li><a href="2013/robison/index.html">2013/robison</a> - Most poetic use of strings</li>
+<li><strong><a href="1988/robison/index.html">1988/robison</a></strong> - <strong>Best abuse of C constructs</strong></li>
+<li><strong><a href="1989/robison/index.html">1989/robison</a></strong> - <strong>Best minimal use of C</strong></li>
+<li><strong><a href="2000/robison/index.html">2000/robison</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="2013/robison/index.html">2013/robison</a></strong> - <strong>Most poetic use of strings</strong></li>
 </ul>
 <p>
 </p>
@@ -3202,7 +3202,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/rosten/index.html">2001/rosten</a> - Best abuse of the user</li>
+<li><strong><a href="2001/rosten/index.html">2001/rosten</a></strong> - <strong>Best abuse of the user</strong></li>
 </ul>
 <p>
 </p>
@@ -3219,7 +3219,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/pjr/index.html">1990/pjr</a> - Most unusual data structure</li>
+<li><strong><a href="1990/pjr/index.html">1990/pjr</a></strong> - <strong>Most unusual data structure</strong></li>
 </ul>
 <p>
 </p>
@@ -3238,7 +3238,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/smr/index.html">1994/smr</a> - Worst abuse of the rules</li>
+<li><strong><a href="1994/smr/index.html">1994/smr</a></strong> - <strong>Worst abuse of the rules</strong></li>
 </ul>
 <!-- s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  s  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3262,7 +3262,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1995/savastio/index.html">1995/savastio</a> - Most obfuscated syntax</li>
+<li><strong><a href="1995/savastio/index.html">1995/savastio</a></strong> - <strong>Most obfuscated syntax</strong></li>
 </ul>
 <p>
 </p>
@@ -3277,7 +3277,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/schneiderwent/index.html">2000/schneiderwent</a> - Most timely output</li>
+<li><strong><a href="2000/schneiderwent/index.html">2000/schneiderwent</a></strong> - <strong>Most timely output</strong></li>
 </ul>
 <p>
 </p>
@@ -3292,12 +3292,12 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/schnitzi/index.html">1993/schnitzi</a> - Obfuscated Intelligence Award</li>
-<li><a href="1994/schnitzi/index.html">1994/schnitzi</a> - Best layout</li>
-<li><a href="1995/schnitzi/index.html">1995/schnitzi</a> - Best one liner</li>
-<li><a href="1995/vanschnitz/index.html">1995/vanschnitz</a> - Worst abuse of the C preprocessor and most likely to amaze</li>
-<li><a href="1998/schnitzi/index.html">1998/schnitzi</a> - Best flow control</li>
-<li><a href="2004/schnitzi/index.html">2004/schnitzi</a> - Best non-use of curses</li>
+<li><strong><a href="1993/schnitzi/index.html">1993/schnitzi</a></strong> - <strong>Obfuscated Intelligence Award</strong></li>
+<li><strong><a href="1994/schnitzi/index.html">1994/schnitzi</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="1995/schnitzi/index.html">1995/schnitzi</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="1995/vanschnitz/index.html">1995/vanschnitz</a></strong> - <strong>Worst abuse of the C preprocessor and most likely to amaze</strong></li>
+<li><strong><a href="1998/schnitzi/index.html">1998/schnitzi</a></strong> - <strong>Best flow control</strong></li>
+<li><strong><a href="2004/schnitzi/index.html">2004/schnitzi</a></strong> - <strong>Best non-use of curses</strong></li>
 </ul>
 <p>
 </p>
@@ -3314,14 +3314,14 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1996/schweikh1/index.html">1996/schweikh1</a> - Worst abuse of the C preprocessor</li>
-<li><a href="1996/schweikh2/index.html">1996/schweikh2</a> - Best algorithm</li>
-<li><a href="1996/schweikh3/index.html">1996/schweikh3</a> - Best utility</li>
-<li><a href="1998/schweikh1/index.html">1998/schweikh1</a> - CPP abuse</li>
-<li><a href="1998/schweikh2/index.html">1998/schweikh2</a> - Most erratic behavior</li>
-<li><a href="1998/schweikh3/index.html">1998/schweikh3</a> - Most space efficient</li>
-<li><a href="2001/schweikh/index.html">2001/schweikh</a> - Best one liner</li>
-<li><a href="2015/schweikhardt/index.html">2015/schweikhardt</a> - Best documented</li>
+<li><strong><a href="1996/schweikh1/index.html">1996/schweikh1</a></strong> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><strong><a href="1996/schweikh2/index.html">1996/schweikh2</a></strong> - <strong>Best algorithm</strong></li>
+<li><strong><a href="1996/schweikh3/index.html">1996/schweikh3</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="1998/schweikh1/index.html">1998/schweikh1</a></strong> - <strong>CPP abuse</strong></li>
+<li><strong><a href="1998/schweikh2/index.html">1998/schweikh2</a></strong> - <strong>Most erratic behavior</strong></li>
+<li><strong><a href="1998/schweikh3/index.html">1998/schweikh3</a></strong> - <strong>Most space efficient</strong></li>
+<li><strong><a href="2001/schweikh/index.html">2001/schweikh</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="2015/schweikhardt/index.html">2015/schweikhardt</a></strong> - <strong>Best documented</strong></li>
 </ul>
 <p>
 </p>
@@ -3336,7 +3336,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/shapiro/index.html">1994/shapiro</a> - Most well rounded obfuscation</li>
+<li><strong><a href="1994/shapiro/index.html">1994/shapiro</a></strong> - <strong>Most well rounded obfuscation</strong></li>
 </ul>
 <p>
 </p>
@@ -3351,7 +3351,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1985/shapiro/index.html">1985/shapiro</a> - Grand Prize - Most well rounded in confusion</li>
+<li><strong><a href="1985/shapiro/index.html">1985/shapiro</a></strong> - <strong>Grand Prize - Most well rounded in confusion</strong></li>
 </ul>
 <p>
 </p>
@@ -3366,7 +3366,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/natori/index.html">2000/natori</a> - Best small program</li>
+<li><strong><a href="2000/natori/index.html">2000/natori</a></strong> - <strong>Best small program</strong></li>
 </ul>
 <p>
 </p>
@@ -3383,7 +3383,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1985/sicherman/index.html">1985/sicherman</a> - Worst abuse of the C preprocessor</li>
+<li><strong><a href="1985/sicherman/index.html">1985/sicherman</a></strong> - <strong>Worst abuse of the C preprocessor</strong></li>
 </ul>
 <p>
 </p>
@@ -3398,7 +3398,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1992/nathan/index.html">1992/nathan</a> - Worst abuse of the rules</li>
+<li><strong><a href="1992/nathan/index.html">1992/nathan</a></strong> - <strong>Worst abuse of the rules</strong></li>
 </ul>
 <p>
 </p>
@@ -3417,7 +3417,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2014/skeggs/index.html">2014/skeggs</a> - Most dynamic</li>
+<li><strong><a href="2014/skeggs/index.html">2014/skeggs</a></strong> - <strong>Most dynamic</strong></li>
 </ul>
 <p>
 </p>
@@ -3432,7 +3432,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/sloane/index.html">2006/sloane</a> - Homer’s favorite</li>
+<li><strong><a href="2006/sloane/index.html">2006/sloane</a></strong> - <strong>Homer’s favorite</strong></li>
 </ul>
 <p>
 </p>
@@ -3449,7 +3449,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/chaos/index.html">1998/chaos</a> - Best object orientation</li>
+<li><strong><a href="1998/chaos/index.html">1998/chaos</a></strong> - <strong>Best object orientation</strong></li>
 </ul>
 <p>
 </p>
@@ -3470,10 +3470,10 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1988/spinellis/index.html">1988/spinellis</a> - Best abuse of the rules</li>
-<li><a href="1990/dds/index.html">1990/dds</a> - Best language tool</li>
-<li><a href="1991/dds/index.html">1991/dds</a> - Most well rounded</li>
-<li><a href="1995/spinellis/index.html">1995/spinellis</a> - Abusing the rules</li>
+<li><strong><a href="1988/spinellis/index.html">1988/spinellis</a></strong> - <strong>Best abuse of the rules</strong></li>
+<li><strong><a href="1990/dds/index.html">1990/dds</a></strong> - <strong>Best language tool</strong></li>
+<li><strong><a href="1991/dds/index.html">1991/dds</a></strong> - <strong>Most well rounded</strong></li>
+<li><strong><a href="1995/spinellis/index.html">1995/spinellis</a></strong> - <strong>Abusing the rules</strong></li>
 </ul>
 <p>
 </p>
@@ -3488,7 +3488,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/stein/index.html">1986/stein</a> - Best one liner</li>
+<li><strong><a href="1986/stein/index.html">1986/stein</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <p>
 </p>
@@ -3503,7 +3503,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2006/stewart/index.html">2006/stewart</a> - Best computed graphics</li>
+<li><strong><a href="2006/stewart/index.html">2006/stewart</a></strong> - <strong>Best computed graphics</strong></li>
 </ul>
 <p>
 </p>
@@ -3518,7 +3518,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1996/gandalf/index.html">1996/gandalf</a> - Best layout</li>
+<li><strong><a href="1996/gandalf/index.html">1996/gandalf</a></strong> - <strong>Best layout</strong></li>
 </ul>
 <p>
 </p>
@@ -3535,10 +3535,10 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/sds/index.html">2004/sds</a> - Best abuse of indentation</li>
-<li><a href="2005/sykes/index.html">2005/sykes</a> - Best emulator</li>
-<li><a href="2006/sykes1/index.html">2006/sykes1</a> - Best assembler</li>
-<li><a href="2006/sykes2/index.html">2006/sykes2</a> - Best one liner</li>
+<li><strong><a href="2004/sds/index.html">2004/sds</a></strong> - <strong>Best abuse of indentation</strong></li>
+<li><strong><a href="2005/sykes/index.html">2005/sykes</a></strong> - <strong>Best emulator</strong></li>
+<li><strong><a href="2006/sykes1/index.html">2006/sykes1</a></strong> - <strong>Best assembler</strong></li>
+<li><strong><a href="2006/sykes2/index.html">2006/sykes2</a></strong> - <strong>Best one liner</strong></li>
 </ul>
 <!-- t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  t  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3560,8 +3560,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1993/jonth/index.html">1993/jonth</a> - Most obfuscated X program</li>
-<li><a href="1996/jonth/index.html">1996/jonth</a> - Best X11 entry</li>
+<li><strong><a href="1993/jonth/index.html">1993/jonth</a></strong> - <strong>Most obfuscated X program</strong></li>
+<li><strong><a href="1996/jonth/index.html">1996/jonth</a></strong> - <strong>Best X11 entry</strong></li>
 </ul>
 <p>
 </p>
@@ -3576,7 +3576,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/aidan/index.html">2005/aidan</a> - Most ingenious puzzle solution</li>
+<li><strong><a href="2005/aidan/index.html">2005/aidan</a></strong> - <strong>Most ingenious puzzle solution</strong></li>
 </ul>
 <p>
 </p>
@@ -3593,11 +3593,11 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/toledo/index.html">2005/toledo</a> - Best game</li>
-<li><a href="2006/toledo1/index.html">2006/toledo1</a> - Best small program</li>
-<li><a href="2006/toledo2/index.html">2006/toledo2</a> - Best of Show</li>
-<li><a href="2006/toledo3/index.html">2006/toledo3</a> - Most portable chess set</li>
-<li><a href="2011/toledo/index.html">2011/toledo</a> - Best non-chess game</li>
+<li><strong><a href="2005/toledo/index.html">2005/toledo</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="2006/toledo1/index.html">2006/toledo1</a></strong> - <strong>Best small program</strong></li>
+<li><strong><a href="2006/toledo2/index.html">2006/toledo2</a></strong> - <strong>Best of Show</strong></li>
+<li><strong><a href="2006/toledo3/index.html">2006/toledo3</a></strong> - <strong>Most portable chess set</strong></li>
+<li><strong><a href="2011/toledo/index.html">2011/toledo</a></strong> - <strong>Best non-chess game</strong></li>
 </ul>
 <p>
 </p>
@@ -3614,7 +3614,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1998/tomtorfs/index.html">1998/tomtorfs</a> - Best self-documenting</li>
+<li><strong><a href="1998/tomtorfs/index.html">1998/tomtorfs</a></strong> - <strong>Best self-documenting</strong></li>
 </ul>
 <p>
 </p>
@@ -3633,8 +3633,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/tromp/index.html">1989/tromp</a> - Best game</li>
-<li><a href="2012/tromp/index.html">2012/tromp</a> - Most functional</li>
+<li><strong><a href="1989/tromp/index.html">1989/tromp</a></strong> - <strong>Best game</strong></li>
+<li><strong><a href="2012/tromp/index.html">2012/tromp</a></strong> - <strong>Most functional</strong></li>
 </ul>
 <p>
 </p>
@@ -3653,7 +3653,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2020/tsoj/index.html">2020/tsoj</a> - Most misleading indentation</li>
+<li><strong><a href="2020/tsoj/index.html">2020/tsoj</a></strong> - <strong>Most misleading indentation</strong></li>
 </ul>
 <!-- u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  u  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3683,12 +3683,12 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2004/vik1/index.html">2004/vik1</a> - Best X11 game</li>
-<li><a href="2004/vik2/index.html">2004/vik2</a> - Best abuse of CPP</li>
-<li><a href="2005/vik/index.html">2005/vik</a> - Most circuitous walk</li>
-<li><a href="2011/vik/index.html">2011/vik</a> - Most sound</li>
-<li><a href="2012/vik/index.html">2012/vik</a> - Best use of cocoa - Bronze Award</li>
-<li><a href="2014/vik/index.html">2014/vik</a> - Best handling of beeps</li>
+<li><strong><a href="2004/vik1/index.html">2004/vik1</a></strong> - <strong>Best X11 game</strong></li>
+<li><strong><a href="2004/vik2/index.html">2004/vik2</a></strong> - <strong>Best abuse of CPP</strong></li>
+<li><strong><a href="2005/vik/index.html">2005/vik</a></strong> - <strong>Most circuitous walk</strong></li>
+<li><strong><a href="2011/vik/index.html">2011/vik</a></strong> - <strong>Most sound</strong></li>
+<li><strong><a href="2012/vik/index.html">2012/vik</a></strong> - <strong>Best use of cocoa - Bronze Award</strong></li>
+<li><strong><a href="2014/vik/index.html">2014/vik</a></strong> - <strong>Best handling of beeps</strong></li>
 </ul>
 <p>
 </p>
@@ -3703,7 +3703,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2018/vokes/index.html">2018/vokes</a> - Most connected</li>
+<li><strong><a href="2018/vokes/index.html">2018/vokes</a></strong> - <strong>Most connected</strong></li>
 </ul>
 <p>
 </p>
@@ -3718,7 +3718,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1989/fubar/index.html">1989/fubar</a> - Best self-modifying program</li>
+<li><strong><a href="1989/fubar/index.html">1989/fubar</a></strong> - <strong>Best self-modifying program</strong></li>
 </ul>
 <!-- w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  w  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3742,8 +3742,8 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1986/wall/index.html">1986/wall</a> - Grand Prize - Most well rounded in confusion</li>
-<li><a href="1987/wall/index.html">1987/wall</a> - Most useful obfuscation</li>
+<li><strong><a href="1986/wall/index.html">1986/wall</a></strong> - <strong>Grand Prize - Most well rounded in confusion</strong></li>
+<li><strong><a href="1987/wall/index.html">1987/wall</a></strong> - <strong>Most useful obfuscation</strong></li>
 </ul>
 <p>
 </p>
@@ -3760,7 +3760,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2005/vince/index.html">2005/vince</a> - Most beauteous visuals</li>
+<li><strong><a href="2005/vince/index.html">2005/vince</a></strong> - <strong>Most beauteous visuals</strong></li>
 </ul>
 <p>
 </p>
@@ -3777,7 +3777,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1994/weisberg/index.html">1994/weisberg</a> - Best short program</li>
+<li><strong><a href="1994/weisberg/index.html">1994/weisberg</a></strong> - <strong>Best short program</strong></li>
 </ul>
 <p>
 </p>
@@ -3794,15 +3794,15 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1987/westley/index.html">1987/westley</a> - Best layout</li>
-<li><a href="1988/westley/index.html">1988/westley</a> - Best layout</li>
-<li><a href="1989/westley/index.html">1989/westley</a> - Most algorithms in one program</li>
-<li><a href="1990/westley/index.html">1990/westley</a> - Best layout</li>
-<li><a href="1991/westley/index.html">1991/westley</a> - Grand Prize</li>
-<li><a href="1992/westley/index.html">1992/westley</a> - Best small program</li>
-<li><a href="1994/westley/index.html">1994/westley</a> - Worst abuse of the C preprocessor</li>
-<li><a href="1996/westley/index.html">1996/westley</a> - Best one liner</li>
-<li><a href="2001/westley/index.html">2001/westley</a> - Best position-independent code</li>
+<li><strong><a href="1987/westley/index.html">1987/westley</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="1988/westley/index.html">1988/westley</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="1989/westley/index.html">1989/westley</a></strong> - <strong>Most algorithms in one program</strong></li>
+<li><strong><a href="1990/westley/index.html">1990/westley</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="1991/westley/index.html">1991/westley</a></strong> - <strong>Grand Prize</strong></li>
+<li><strong><a href="1992/westley/index.html">1992/westley</a></strong> - <strong>Best small program</strong></li>
+<li><strong><a href="1994/westley/index.html">1994/westley</a></strong> - <strong>Worst abuse of the C preprocessor</strong></li>
+<li><strong><a href="1996/westley/index.html">1996/westley</a></strong> - <strong>Best one liner</strong></li>
+<li><strong><a href="2001/westley/index.html">2001/westley</a></strong> - <strong>Best position-independent code</strong></li>
 </ul>
 <p>
 </p>
@@ -3817,7 +3817,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2014/wiedijk/index.html">2014/wiedijk</a> - Most functional</li>
+<li><strong><a href="2014/wiedijk/index.html">2014/wiedijk</a></strong> - <strong>Most functional</strong></li>
 </ul>
 <p>
 </p>
@@ -3832,7 +3832,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2001/williams/index.html">2001/williams</a> - Best graphic game</li>
+<li><strong><a href="2001/williams/index.html">2001/williams</a></strong> - <strong>Best graphic game</strong></li>
 </ul>
 <p>
 </p>
@@ -3847,7 +3847,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="1990/jaw/index.html">1990/jaw</a> - Best entropy-reducer</li>
+<li><strong><a href="1990/jaw/index.html">1990/jaw</a></strong> - <strong>Best entropy-reducer</strong></li>
 </ul>
 <!-- x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  x  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3877,16 +3877,16 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/dhyang/index.html">2000/dhyang</a> - Best layout</li>
-<li><a href="2004/omoikane/index.html">2004/omoikane</a> - Best utility</li>
-<li><a href="2011/akari/index.html">2011/akari</a> - Best of Show - Most Shrinkable</li>
-<li><a href="2012/omoikane/index.html">2012/omoikane</a> - Most surreptitious</li>
-<li><a href="2013/misaka/index.html">2013/misaka</a> - Most catty</li>
-<li><a href="2014/sinon/index.html">2014/sinon</a> - Best choice of optimization</li>
-<li><a href="2015/yang/index.html">2015/yang</a> - Most pointed reaction</li>
-<li><a href="2018/yang/index.html">2018/yang</a> - Most shifty</li>
-<li><a href="2019/yang/index.html">2019/yang</a> - Most in need of transparency</li>
-<li><a href="2020/yang/index.html">2020/yang</a> - Best abuse of CPP</li>
+<li><strong><a href="2000/dhyang/index.html">2000/dhyang</a></strong> - <strong>Best layout</strong></li>
+<li><strong><a href="2004/omoikane/index.html">2004/omoikane</a></strong> - <strong>Best utility</strong></li>
+<li><strong><a href="2011/akari/index.html">2011/akari</a></strong> - <strong>Best of Show - Most Shrinkable</strong></li>
+<li><strong><a href="2012/omoikane/index.html">2012/omoikane</a></strong> - <strong>Most surreptitious</strong></li>
+<li><strong><a href="2013/misaka/index.html">2013/misaka</a></strong> - <strong>Most catty</strong></li>
+<li><strong><a href="2014/sinon/index.html">2014/sinon</a></strong> - <strong>Best choice of optimization</strong></li>
+<li><strong><a href="2015/yang/index.html">2015/yang</a></strong> - <strong>Most pointed reaction</strong></li>
+<li><strong><a href="2018/yang/index.html">2018/yang</a></strong> - <strong>Most shifty</strong></li>
+<li><strong><a href="2019/yang/index.html">2019/yang</a></strong> - <strong>Most in need of transparency</strong></li>
+<li><strong><a href="2020/yang/index.html">2020/yang</a></strong> - <strong>Best abuse of CPP</strong></li>
 </ul>
 <!-- z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  z  -->
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -3908,7 +3908,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2000/briddlebane/index.html">2000/briddlebane</a> - Best abuse of user</li>
+<li><strong><a href="2000/briddlebane/index.html">2000/briddlebane</a></strong> - <strong>Best abuse of user</strong></li>
 </ul>
 <p>
 </p>
@@ -3923,7 +3923,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2012/zeitak/index.html">2012/zeitak</a> - Balanced use of obfuscation - Gold Award</li>
+<li><strong><a href="2012/zeitak/index.html">2012/zeitak</a></strong> - <strong>Balanced use of obfuscation - Gold Award</strong></li>
 </ul>
 <p>
 </p>
@@ -3940,7 +3940,7 @@ author_handle: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master
 <p>
 </p>
 <ul>
-<li><a href="2011/zucker/index.html">2011/zucker</a> - Most shiny</li>
+<li><strong><a href="2011/zucker/index.html">2011/zucker</a></strong> - <strong>Most shiny</strong></li>
 </ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <h4>

--- a/bin/all-run.sh
+++ b/bin/all-run.sh
@@ -386,7 +386,7 @@ if [[ ! -x $TOOL ]]; then
     exit 5
 fi
 
-# verify that the md2html.sh is executable
+# verify that the md2html.sh is an executable file
 #
 if [[ ! -e $MD2HTML_SH ]]; then
     echo  "$0: ERROR: md2html.sh does not exist: $MD2HTML_SH" 1>&2

--- a/bin/all-years.sh
+++ b/bin/all-years.sh
@@ -385,7 +385,7 @@ if [[ ! -x $TOOL ]]; then
     exit 5
 fi
 
-# verify that the md2html.sh is executable
+# verify that the md2html.sh is an executable file
 #
 if [[ ! -e $MD2HTML_SH ]]; then
     echo  "$0: ERROR: md2html.sh does not exist: $MD2HTML_SH" 1>&2

--- a/bin/gen-authors.sh
+++ b/bin/gen-authors.sh
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
+# .. with very minor improvements in June 2024 by Cody Boone Ferguson.
+#
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
 # provided that the above copyright, this permission notice and text
@@ -1332,7 +1334,7 @@ EOF
 
 		# output the YYYY/dir entry for this author
 		#
-		echo "* <a href=\"$YYYY_DIR/index.html\">$YYYY_DIR</a> - $AWARD"
+		echo "* **<a href=\"$YYYY_DIR/index.html\">$YYYY_DIR</a>** - **$AWARD**"
 	    done
 	    echo
 	fi

--- a/bin/gen-other-html.sh
+++ b/bin/gen-other-html.sh
@@ -320,7 +320,7 @@ if [[ ! -s $TOP_FILE ]]; then
     exit 6
 fi
 
-# verify that the md2html.sh is executable
+# verify that the md2html.sh is an executable file
 #
 if [[ ! -e $MD2HTML_SH ]]; then
     echo  "$0: ERROR: md2html.sh does not exist: $MD2HTML_SH" 1>&2

--- a/bin/gen-year-index.sh
+++ b/bin/gen-year-index.sh
@@ -367,7 +367,7 @@ if [[ ! -s $README_FILE ]]; then
     exit 6
 fi
 
-# verify that the md2html.sh is executable
+# verify that the md2html.sh is an executable file
 #
 if [[ ! -e $MD2HTML_SH ]]; then
     echo  "$0: ERROR: md2html.sh does not exist: $MD2HTML_SH" 1>&2

--- a/bin/output-year-index.sh
+++ b/bin/output-year-index.sh
@@ -29,6 +29,8 @@
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
+# .. with very minor improvements in June 2024 by Cody Boone Ferguson.
+#
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
 # provided that the above copyright, this permission notice and text
@@ -220,7 +222,7 @@ function output_award
 	echo "$0: ERROR: in output_award: no award found in .entry.json file: $ENTRY_JSON_PATH" 1>&2
 	return 5
     fi
-    echo "$AWARD_STRING"
+    echo "**$AWARD_STRING**"
     return 0
 }
 
@@ -429,7 +431,7 @@ if [[ ! -x $PANDOC_WRAPPER ]]; then
     exit 5
 fi
 
-# verify that YYYY is a entry directory
+# verify that YYYY is an entry directory
 #
 if [[ ! -d $YYYY ]]; then
     echo "$0: ERROR: arg is not a directory: $YYYY" 1>&2
@@ -646,7 +648,7 @@ for YYYY_DIR in $(< "$YEAR_FILE"); do
     #
     ENTRY_NAME=$(basename "$YYYY_DIR")
     export ENTRY_NAME
-    echo "* [$YYYY_DIR]($ENTRY_NAME/index.html) - $AWARD"
+    echo "* [**$YYYY_DIR**]($ENTRY_NAME/index.html) - $AWARD"
 done | if [[ -z $NOOP ]]; then
     cat >> "$TMP_FILE"
 else


### PR DESCRIPTION

Make link to entries and award titles bold like the other files that 
have links to entries with the award title. This is done by modifying 
the bin/gen-authors.sh script.