### PR TITLE
Improve blockquote styling

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -419,8 +419,13 @@ pre, code {
 blockquote {
     margin: 1em 0 1em 1.7em;
     padding-left: 1em;
-    border-left: 2px solid #e6e6e6;
-    color: inherit;
+    border-left: 4px solid darkgrey;
+    font-style: italic;
+    font-weight: bold;
+}
+
+blockquote p {
+    color: blue;
 }
 
 a {


### PR DESCRIPTION
To help the fact it's a quote stand out better the vertical bar is a bit thicker (4px instead of 2px) and the colour is a bit darker (darkgrey instead of #e6e6e6). Also the font style is italic (as quotes often are shown) and the font weight is bold to help it stand out even more (that might be worth changing). Finally the colour of the text is blue (which looks nice with bold so it might also be changed if the weight is not bold).

A point worth noting is that in CSS (tested on my apache server and also W3Schools) having:

	blockquote {
		color: blue;
	}

does not work (for <blockquote><p>...</p></blockquote>) as in the colour stays what was left for <p>...</p. which earlier in the stylesheet is set to black. On W3Schools what does work is:

	blockquote p {
		color: blue;
	}

but on the server for some reason it does not quite work. The rest of the change to blockquote do work but not the colour of the text. I am not sure if this is a cache or similar problem or not but clearing the cache and also history (of the past hour) does not seem to solve the problem at least at this time. Thus it is entirely possible that this has to be fixed too.

To put this another way this change might need some tweaking still but the blockquotes now stand out much better.