### PR TITLE
Fix colouring problem in blockquote

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -423,10 +423,6 @@ blockquote {
     font-style: italic;
 }
 
-blockquote p {
-    color: blue;
-}
-
 a {
     outline-color: transparent;
     text-decoration: none;
@@ -731,6 +727,10 @@ transition: all .3s ease;
     padding-top: 0;
     padding-bottom: 0;
     color: black;
+}
+
+.content blockquote p {
+    color: blue;
 }
 
 /* content links */


### PR DESCRIPTION
The problem was that later in the stylesheet there is '.content p' and since the <blockquote><p>..</p></blockquote> is in the content class the colour was being overridden. Thus there is now:

	.content blockquote p {
		color: blue;
	}

which fixes the problem.