### PR TITLE
Make blockquote p dark green italics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ debug.output.html
 .su[a-z]
 .*.sv[a-z]
 .*.sw[a-z]
+.sw[a-z]
 .tmp.*

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -28,7 +28,7 @@ If lost:
 
 Where `lat` and `long` correspond to your latitude and longitude.
 
-NOTE: you **MUST** have a terminal that is at least 80 columns for this to show
+**NOTE**: you **MUST** have a terminal that is at least 80 columns for this to show
 properly. The `whereami.sh` and `whereami.alt.sh` scripts check this but if you
 do not have such a terminal you can run the `whereami` (or for the alternate code
 described below, `whereami.alt`) directly.
@@ -59,7 +59,7 @@ The author provided a version for the US which we added.
     ./whereami.alt.sh lat long
 ```
 
-NOTE: this alternative version also needs a terminal with at least 80 columns
+**NOTE**: this alternative version also needs a terminal with at least 80 columns
 but if you do not have such a terminal you can run `whereami.alt` directly.
 
 
@@ -75,29 +75,29 @@ entry and the alternate code so one can try the same script for both:
 
 ## Judges' remarks:
 
-To find the approximate place where this entry was judged, type:
+Use `-` (negative number) for the south of the equator and/or west of the
+meridian.
+
+To find the approximate place where this entry was judged:
 
 ``` <!---sh-->
-    # NOTE: Use - for south of the equator and/or west of the meridian
-
+    # If you have at least 80 columns:
     ./whereami.sh 37 -122
 
     # If you don't have at least 80 columns, try:
-
     ./whereami 37 -122
 ```
 
 If you wish to see this on the US map:
 
 ``` <!---sh-->
+    # Make sure the alt version is built:
     make alt
 
-    # NOTE: Use - for south of the equator and/or west of the meridian
-
+    # If you have at least 80 columns:
     ./whereami.alt.sh 37 -122
 
     # If you don't have at least 80 columns, try:
-
     ./whereami.alt 37 -122
 ```
 

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -412,7 +412,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>If lost:</p>
 <pre><code>    ./whereami.sh lat long</code></pre>
 <p>Where <code>lat</code> and <code>long</code> correspond to your latitude and longitude.</p>
-<p>NOTE: you <strong>MUST</strong> have a terminal that is at least 80 columns for this to show
+<p><strong>NOTE</strong>: you <strong>MUST</strong> have a terminal that is at least 80 columns for this to show
 properly. The <code>whereami.sh</code> and <code>whereami.alt.sh</code> scripts check this but if you
 do not have such a terminal you can run the <code>whereami</code> (or for the alternate code
 described below, <code>whereami.alt</code>) directly.</p>
@@ -424,30 +424,29 @@ described below, <code>whereami.alt</code>) directly.</p>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>
 <pre><code>    ./whereami.alt.sh lat long</code></pre>
-<p>NOTE: this alternative version also needs a terminal with at least 80 columns
+<p><strong>NOTE</strong>: this alternative version also needs a terminal with at least 80 columns
 but if you do not have such a terminal you can run <code>whereami.alt</code> directly.</p>
 <h3 id="alternate-try">Alternate try:</h3>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/try.sh">try.sh</a> script uses both the original
 entry and the alternate code so one can try the same script for both:</p>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
-<p>To find the approximate place where this entry was judged, type:</p>
-<pre><code>    # NOTE: Use - for south of the equator and/or west of the meridian
-
+<p>Use <code>-</code> (negative number) for the south of the equator and/or west of the
+meridian.</p>
+<p>To find the approximate place where this entry was judged:</p>
+<pre><code>    # If you have at least 80 columns:
     ./whereami.sh 37 -122
 
     # If you don&#39;t have at least 80 columns, try:
-
     ./whereami 37 -122</code></pre>
 <p>If you wish to see this on the US map:</p>
-<pre><code>    make alt
+<pre><code>    # Make sure the alt version is built:
+    make alt
 
-    # NOTE: Use - for south of the equator and/or west of the meridian
-
+    # If you have at least 80 columns:
     ./whereami.alt.sh 37 -122
 
     # If you don&#39;t have at least 80 columns, try:
-
     ./whereami.alt 37 -122</code></pre>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>Run the program with your latitude &amp; longitude as integer

--- a/1993/cmills/.gitignore
+++ b/1993/cmills/.gitignore
@@ -1,6 +1,7 @@
 #
 # sort with: ../../bin/sgi.sh
 *.dSYM
+chris
 cmills
 cmills.alt
 cmills.orig

--- a/ioccc.css
+++ b/ioccc.css
@@ -729,8 +729,37 @@ transition: all .3s ease;
     color: black;
 }
 
+/* This rule makes sure that text in <blockquote><p>..</p></blockquote> is
+ * coloured right. Note that this MUST BE HERE and not earlier where the
+ * 'blockquote' rule is as otherwise the above '.content p' rule would
+ * override it.
+ *
+ * The following rationale with the blockquote rule above (in particular
+ * with italics) and the dark green selection, so that this is understood
+ * better:
+ *
+ *	 0.	Purple should NOT be used as this is being used for visited links.
+ *	 1.	Blue should NOT be used as this is being used for non-visited links.
+ *
+ * Now with context this might be okay but links can also be in blockquotes
+ * so this alone is reason not to: even if there are underlines in most
+ * links. Additionally:
+ *
+ *	 2. Bold seems to be too strong, especially when used for with a bright
+ *	 colour.
+ *
+ * Bold is used in headings (h1, h2, ..). A bold heading is not too much
+ * text (as headings tend to be short single lines): one does not become
+ * too tired looking at TOO MANY SHOUTING BOLD LETTERS. It seems preferable
+ * to reserve bold for those headings.
+ *
+ * Conclusions: dark blue seems to be slightly better but unfortunately the
+ * headings (h1, h2, ...) is too similar so we use dark green with italics
+ * as the choice.
+ */
 .content blockquote p {
-    color: blue;
+    color: darkgreen;
+    font-style: italic;
 }
 
 /* content links */


### PR DESCRIPTION
Although blockquote already is set to italic now blockquote p explicitly
sets it. The colour is dark green and the rationale is explained in the
comments as thus:

 /* This rule makes sure that text in `<blockquote><p>..</p></blockquote>` is
  * coloured right. Note that this MUST BE HERE and not earlier where the
  * 'blockquote' rule is as otherwise the above '.content p' rule would
  * override it.
  *
  * The following rationale with the blockquote rule above (in particular
  * with italics) and the dark green selection, so that this is understood
  * better:
  *
  *  0. Purple should NOT be used as this is being used for visited links.
  *  1. Blue should NOT be used as this is being used for non-visited links.
  *
  * Now with context this might be okay but links can also be in blockquotes
  * so this alone is reason not to: even if there are underlines in most
  * links. Additionally:
  *
  *  2. Bold seems to be too strong, especially when used for with a bright
  *  colour.
  *
  * Bold is used in headings (h1, h2, ..). A bold heading is not too much
  * text (as headings tend to be short single lines): one does not become
  * too tired looking at TOO MANY SHOUTING BOLD LETTERS. It seems preferable
  * to reserve bold for those headings.
  *
  * Conclusions: dark blue seems to be slightly better but unfortunately the
  * headings (h1, h2, ...) is too similar so we use dark green with italics
  * as the choice.
  */
