### PR TITLE
Format improvements in 1993/vanb/index.html

### DIFF
--- a/1993/vanb/README.md
+++ b/1993/vanb/README.md
@@ -39,14 +39,12 @@ What happens if you use something other than valid digits?
 
 The octal expression may contain:
 
-```
-    unary operators:    +, -
-    binary operators    +, -, *, /, %
-    hex numbers:        x or X followed by hex digits
-    decimal numbers:    d or D followed by decimal digits
-    octal numbers:      octal digits
-    grouping:           ()
-```
+- unary operators:     `+`, `-`
+- binary operators:    `+`, `-`, `*`, `/`, `%`
+- hex numbers:         `x` or `X` followed by hex digits
+- decimal numbers:     `d` or `D` followed by decimal digits
+- octal numbers:       octal digits
+- grouping:            `()`
 
 No spaces are allowed in the expression.  To avoid shell expansion,
 one should surround the expression in single quotes.
@@ -105,14 +103,29 @@ Here's the grammar (`'e'` denotes the empty string) :
 
 ```
     <E>  ::=  <T><E'>
-    <E'> ::=  +<T><E'> | -<T><E'> | e
+    <E'> ::=  +<T><E'> |
+              -<T><E'> | e
     <T>  ::=  <F><T'>
-    <T'> ::=  *<F><T'> | /<F><T'> | %<F><T'> | e
-    <F>  ::=  +<F> | -<F> | (<E><C> | d<D> | D<D> |  x<X> | X<X> | <O>
+    <T'> ::=  *<F><T'> |
+              /<F><T'> |
+              %<F><T'> | e
+    <F>  ::=  +<F> |
+              -<F> |
+              (<E><C> |
+              d<D> |
+              D<D> |
+              x<X> |
+              X<X> |
+              <O>
     <C>  ::=  )
-    <D>  ::=  [0-9]<D> | e
-    <X>  ::=  [0-9]<X> | [A-F]<X> | [a-f]<X> | e
-    <O>  ::=  [0-7]<O> | e
+    <D>  ::=  [0-9]<D> |
+              e
+    <X>  ::=  [0-9]<X> |
+              [A-F]<X> |
+              [a-f]<X> |
+              e
+    <O>  ::=  [0-7]<O> |
+              e
 ```
 
 Here's how the grammar nonterminals map to octal state numbers:

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -416,12 +416,14 @@ hexadecimal and decimal numbers.</p>
 <p>What happens if you use something other than valid digits?</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>The octal expression may contain:</p>
-<pre><code>    unary operators:    +, -
-    binary operators    +, -, *, /, %
-    hex numbers:        x or X followed by hex digits
-    decimal numbers:    d or D followed by decimal digits
-    octal numbers:      octal digits
-    grouping:           ()</code></pre>
+<ul>
+<li>unary operators: <code>+</code>, <code>-</code></li>
+<li>binary operators: <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>%</code></li>
+<li>hex numbers: <code>x</code> or <code>X</code> followed by hex digits</li>
+<li>decimal numbers: <code>d</code> or <code>D</code> followed by decimal digits</li>
+<li>octal numbers: octal digits</li>
+<li>grouping: <code>()</code></li>
+</ul>
 <p>No spaces are allowed in the expression. To avoid shell expansion,
 one should surround the expression in single quotes.</p>
 <p>It is a good thing that this program consists of only one
@@ -457,14 +459,29 @@ what grammar non-terminal to parse. <code>**O7</code> is the next character.
 involving <code>**O7</code> and octal constants are looking for certain characters.</p>
 <p>Here’s the grammar (<code>'e'</code> denotes the empty string) :</p>
 <pre><code>    &lt;E&gt;  ::=  &lt;T&gt;&lt;E&#39;&gt;
-    &lt;E&#39;&gt; ::=  +&lt;T&gt;&lt;E&#39;&gt; | -&lt;T&gt;&lt;E&#39;&gt; | e
+    &lt;E&#39;&gt; ::=  +&lt;T&gt;&lt;E&#39;&gt; |
+              -&lt;T&gt;&lt;E&#39;&gt; | e
     &lt;T&gt;  ::=  &lt;F&gt;&lt;T&#39;&gt;
-    &lt;T&#39;&gt; ::=  *&lt;F&gt;&lt;T&#39;&gt; | /&lt;F&gt;&lt;T&#39;&gt; | %&lt;F&gt;&lt;T&#39;&gt; | e
-    &lt;F&gt;  ::=  +&lt;F&gt; | -&lt;F&gt; | (&lt;E&gt;&lt;C&gt; | d&lt;D&gt; | D&lt;D&gt; |  x&lt;X&gt; | X&lt;X&gt; | &lt;O&gt;
+    &lt;T&#39;&gt; ::=  *&lt;F&gt;&lt;T&#39;&gt; |
+              /&lt;F&gt;&lt;T&#39;&gt; |
+              %&lt;F&gt;&lt;T&#39;&gt; | e
+    &lt;F&gt;  ::=  +&lt;F&gt; |
+              -&lt;F&gt; |
+              (&lt;E&gt;&lt;C&gt; |
+              d&lt;D&gt; |
+              D&lt;D&gt; |
+              x&lt;X&gt; |
+              X&lt;X&gt; |
+              &lt;O&gt;
     &lt;C&gt;  ::=  )
-    &lt;D&gt;  ::=  [0-9]&lt;D&gt; | e
-    &lt;X&gt;  ::=  [0-9]&lt;X&gt; | [A-F]&lt;X&gt; | [a-f]&lt;X&gt; | e
-    &lt;O&gt;  ::=  [0-7]&lt;O&gt; | e</code></pre>
+    &lt;D&gt;  ::=  [0-9]&lt;D&gt; |
+              e
+    &lt;X&gt;  ::=  [0-9]&lt;X&gt; |
+              [A-F]&lt;X&gt; |
+              [a-f]&lt;X&gt; |
+              e
+    &lt;O&gt;  ::=  [0-7]&lt;O&gt; |
+              e</code></pre>
 <p>Here’s how the grammar nonterminals map to octal state numbers:</p>
 <pre><code>    &lt;E&gt;  is  012
     &lt;E&#39;&gt; is  011


### PR DESCRIPTION
The list of expressions in the judges' remarks has been changed so that it fits nicer on smaller screens (it is no longer a code block but a list and each operator is surrounded by backticks).

The grammar provided by the author (not the code that explains it but the grammar) now also fits on smaller screens in a nicer way by breaking it into multiple lines.