### PR TITLE
Fix quotes in 1984/anonymous

### DIFF
--- a/1984/anonymous/README.md
+++ b/1984/anonymous/README.md
@@ -63,26 +63,20 @@ the code, this is what it looks like:
 Some years after this entry was published we asked the author if they still
 wished to remain anonymous and they said:
 
-```
-    Yes, I want to keep my anonymity.  But you can tell them that I am well known
-    for my connection to the C language.
-```
+> Yes, I want to keep my anonymity.  But you can tell them that I am well known
+for my connection to the C language.
 
 
 ### On the famous tattoo (see above):
 
 The author, when told about this tattoo, said:
 
-```
-    I feel honored that my entry will be the first IOCCC winning entry to become a
-    tattoo. It is the first entry to become a tattoo isn't it?
-```
+> I feel honored that my entry will be the first IOCCC winning entry to become a
+tattoo. It is the first entry to become a tattoo isn't it?
 
 Landon Curt Noll, the one who told the author about the tattoo, wrote back:
 
-```
-    Yes, to our knowledge it is.
-```
+> Yes, to our knowledge it is.
 
 
 ### Regrets:

--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -433,14 +433,20 @@ the code, this is what it looks like:</p>
 <h3 id="on-remaining-anonymous">On remaining anonymous:</h3>
 <p>Some years after this entry was published we asked the author if they still
 wished to remain anonymous and they said:</p>
-<pre><code>    Yes, I want to keep my anonymity.  But you can tell them that I am well known
-    for my connection to the C language.</code></pre>
+<blockquote>
+<p>Yes, I want to keep my anonymity. But you can tell them that I am well known
+for my connection to the C language.</p>
+</blockquote>
 <h3 id="on-the-famous-tattoo-see-above">On the famous tattoo (see above):</h3>
 <p>The author, when told about this tattoo, said:</p>
-<pre><code>    I feel honored that my entry will be the first IOCCC winning entry to become a
-    tattoo. It is the first entry to become a tattoo isn&#39;t it?</code></pre>
+<blockquote>
+<p>I feel honored that my entry will be the first IOCCC winning entry to become a
+tattoo. It is the first entry to become a tattoo isn’t it?</p>
+</blockquote>
 <p>Landon Curt Noll, the one who told the author about the tattoo, wrote back:</p>
-<pre><code>    Yes, to our knowledge it is.</code></pre>
+<blockquote>
+<p>Yes, to our knowledge it is.</p>
+</blockquote>
 <h3 id="regrets">Regrets:</h3>
 <p>Landon Curt Noll wrote that the author regrets not making the program a
 one-liner and not moving the <code>int i</code> into an arg of <code>main()</code> (so that the line

--- a/ioccc.css
+++ b/ioccc.css
@@ -725,17 +725,21 @@ transition: all .3s ease;
 blockquote {
     margin: 1em 0 1em 1.7em;
     padding-left: 1em;
-    border-left: 4px solid darkgrey;
+    border-top: 4px solid darkgreen;
+    border-left: 4px solid darkgreen;
+    border-bottom: 4px solid darkgreen;
+    border-right: 4px solid darkgreen;
     font-style: italic;
 }
 
 /* This rule makes sure that text in <blockquote><p>..</p></blockquote> is
- * coloured right. Note that this MUST BE HERE because otherwise the rule
- * '.content p' would override it.
+ * formatted right. Note that this MUST BE HERE because otherwise the rule
+ * '.content p' could override it, if the formatting is ever changed there.
  *
- * The following rationale with the blockquote rule above (in particular
- * with italics) and the dark green selection, so that this is understood
- * better:
+ * ## Historical remarks
+ *
+ * We tried to change the colour and we went with dark green with the
+ * following rationale:
  *
  *	 0.	Purple should NOT be used as this is being used for visited links.
  *	 1.	Blue should NOT be used as this is being used for non-visited links.
@@ -755,9 +759,14 @@ blockquote {
  * Conclusions: dark blue seems to be slightly better but unfortunately the
  * headings (h1, h2, ...) is too similar so we use dark green with italics
  * as the choice.
+ *
+ * ... However, it was hard to find a good shade of green that would stand out
+ * against the white background and other colours did not do so well. Thus,
+ * the blockquote border was changed from just on the left side to make it into
+ * a box and went from grey (or actually dark grey) to dark green.
  */
 .content blockquote p, blockquote ol li {
-    color: darkgreen;
+    color: black;
     font-style: italic;
 }
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -4214,6 +4214,8 @@ files from compiling properly, trying instead to compile already compiled code.<
 <div id="2018">
 <h1 id="the-25th-ioccc"><a href="2018/index.html">2018 - The 25th IOCCC</a></h1>
 </div>
+<p><a href="#cody">Cody</a> added the missing <code>README.md</code> file from the winner archive back to
+the repo.</p>
 <div id="2018_anderson">
 <h2 id="winning-entry-2018anderson">Winning entry: <a href="2018/anderson/index.html">2018/anderson</a></h2>
 <h3 id="winning-entry-source-code-prog.c-24">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson//prog.c">prog.c</a></h3>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -5419,6 +5419,9 @@ He also added the [try.sh](%%REPO_URL%%/2015/yang/try.sh) script.
 # [2018 - The 25th IOCCC](2018/index.html)
 </div>
 
+[Cody](#cody) added the missing `README.md` file from the winner archive back to
+the repo.
+
 
 <div id="2018_anderson">
 ## Winning entry: [2018/anderson](2018/anderson/index.html)


### PR DESCRIPTION

There is a back and forth dialogue between Landon and the author that
should have been quotes but was code and this commit changes them to
blockquotes. This was one of the tests for commit 
95db577489ede4dc5e7d388c9b02b0d8b82dfaf2.