### PR TITLE
Fix technical details with rules (esp 17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,6 +444,21 @@ gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md
 	${GEN_TOP_HTML} -v 1 next/guidelines
 	${GEN_TOP_HTML} -v 1 next/rules
 
+rules: ${GEN_TOP_HTML} next/rules.md
+	@echo "Making rules ..."
+	@${GEN_TOP_HTML} next/rules
+	@echo "Rules? We don't need no stinking rules!"
+
+guidelines: ${GEN_TOP_HTML} next/guidelines.md
+	@echo "Making guidelines ..."
+	@${GEN_TOP_HTML} next/guidelines
+	@echo "Guidelines? We don't need no stinking guidelines!"
+
+faq: ${GEN_TOP_HTML} faq.md
+	@echo "Wait, you have questions? Uh oh!"
+	@${GEN_TOP_HTML} next/guidelines
+	@echo "Well, okay then!"
+
 # build entry HTML files from markdown other than README.md to index.html
 #
 gen_other_html: ${GEN_OTHER_HTML}

--- a/Makefile
+++ b/Makefile
@@ -292,12 +292,20 @@ help:
 	@echo 'make quick_entry_index	 - build winner index.html files that might be out of date'
 	@echo 'make find_missing_links	 - find markdown links to missing local files'
 	@echo
+	@echo '# Rules for building specific web pages - a subset of rules mentioned above:'
+	@echo
+	@echo 'make thanks		 - generqte thanks-for-help.html'
+	@echo 'make bugs		 - generqte bugs.html'
+	@echo 'make rules		 - generqte next/rules.hmtl'
+	@echo 'make guidelines		 - generqte next/guidelines.hmtl'
+	@echo 'make faq		 - generqte faq.html'
+	@echo
 	@echo '# Compound make rules for building a local copy of the IOCCC website:'
 	@echo
 	@echo 'make quick_www		 - generate html files more quickly, checking timestamps'
 	@echo 'make www		 - build html pages for website'
 	@echo
-	@echo '# Rules that are useful only for those IOCCC judges who mainain the official IOCCC website:'
+	@echo '# Rules that are useful only for those IOCCC judges who maintain the official IOCCC website:'
 	@echo
 	@echo 'make sort_gitignore	 - sort .gitignore files according to rules in bin/sgi.sh'
 	@echo
@@ -313,6 +321,11 @@ help:
 	@echo 'make timestamp		 - generate things with timestamps (status, sitemap etc.)'
 	@echo
 	@echo 'make update		 - update everything in a local copy of the website'
+
+
+######################################################
+# Rules for building a local copy of the IOCCC website
+######################################################
 
 # verify that there are no leading ASCII tabs in leading whitespace in markdown files
 tab_check:
@@ -424,41 +437,6 @@ gen_top_html: ${GEN_TOP_HTML}
 	${GEN_TOP_HTML} -v 1
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
-# generate thanks-for-help.html
-#
-# So Long, and Thanks for All the Fish :-)
-#
-thanks: ${GEN_TOP_HTML} thanks-for-help.md
-	@echo "Thanks for all the help ..."
-	@${GEN_TOP_HTML} thanks-for-help
-	@echo "... and thanks for all the fish :-)"
-
-# Bugs Bunny rule
-bugs: ${GEN_TOP_HTML} bugs.md
-	@echo "Shhh. Be vewy vewy quiet, I'm hunting wabbits .. and bugs."
-	@${GEN_TOP_HTML} bugs
-	@echo "Eh, what's up, doc?"
-
-gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md
-	${GEN_TOP_HTML} -v 1 next/README
-	${GEN_TOP_HTML} -v 1 next/guidelines
-	${GEN_TOP_HTML} -v 1 next/rules
-
-rules: ${GEN_TOP_HTML} next/rules.md
-	@echo "Making rules ..."
-	@${GEN_TOP_HTML} next/rules
-	@echo "Rules? We don't need no stinking rules!"
-
-guidelines: ${GEN_TOP_HTML} next/guidelines.md
-	@echo "Making guidelines ..."
-	@${GEN_TOP_HTML} next/guidelines
-	@echo "Guidelines? We don't need no stinking guidelines!"
-
-faq: ${GEN_TOP_HTML} faq.md
-	@echo "Wait, you have questions? Uh oh!"
-	@${GEN_TOP_HTML} next/guidelines
-	@echo "Well, okay then!"
-
 # build entry HTML files from markdown other than README.md to index.html
 #
 gen_other_html: ${GEN_OTHER_HTML}
@@ -492,6 +470,61 @@ find_missing_links:
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	${FIND_MISSING_LINKS} -v 1
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+
+###########################################################################
+# Rules for building specific web pages - a subset of rules mentioned above
+###########################################################################
+
+.PHONY: thanks bugs gen_next rules guidelines faq
+
+# generate thanks-for-help.html
+#
+# So Long, and Thanks for All the Fish :-)
+#
+thanks: ${GEN_TOP_HTML} thanks-for-help.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@echo "Thanks for all the help ..."
+	@${GEN_TOP_HTML} thanks-for-help
+	@echo "... and thanks for all the fish :-)"
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+# Bugs Bunny rule
+bugs: ${GEN_TOP_HTML} bugs.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@echo "Shhh. Be vewy vewy quiet, I'm hunting wabbits .. and bugs."
+	@${GEN_TOP_HTML} bugs
+	@echo "Eh, what's up, doc?"
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	${GEN_TOP_HTML} -v 1 next/README
+	${GEN_TOP_HTML} -v 1 next/guidelines
+	${GEN_TOP_HTML} -v 1 next/rules
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+rules: ${GEN_TOP_HTML} next/rules.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@${GEN_TOP_HTML} next/rules
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+guidelines: ${GEN_TOP_HTML} next/guidelines.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@${GEN_TOP_HTML} next/guidelines
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+faq: ${GEN_TOP_HTML} faq.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@echo "Wait, you have questions? Uh oh!"
+	@${GEN_TOP_HTML} next/guidelines
+	@echo "Well, okay then!"
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+
+####################################################################
+# Compound make rules for building a local copy of the IOCCC website
+####################################################################
 
 # do work to build HTML content for the website
 #
@@ -550,6 +583,11 @@ www:
 	${MAKE} gen_other_html
 	${MAKE} find_missing_links
 	@echo '=-=-=-=-=-= IOCCC complete make $@ =-=-=-=-=-='
+
+
+###########################################################################################
+# Rules that are useful only for those IOCCC judges who maintain the official IOCCC website
+###########################################################################################
 
 # untar all entry tarballs
 #
@@ -626,6 +664,9 @@ update:
 	${MAKE} timestamp
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
+
+# NOTE: Don't worry if you don't understand stuff below
+#
 ##################
 # 133t hacker rulz
 ##################

--- a/faq.html
+++ b/faq.html
@@ -652,7 +652,9 @@ of your <code>remarks.md</code> file, see <a href="#remarks_md">FAQ 2.1</a>,
 submitted theme</strong> and <strong>how compares with previous IOCCC winners</strong>
 of the same theme.</p>
 <div id="faq0_2">
+<div id="submission_makefiles">
 <h3 id="faq-0.2-what-should-i-put-in-my-entrys-makefile">FAQ 0.2: What should I put in my entry’s Makefile?</h3>
+</div>
 </div>
 <p>We recommend starting with the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">sample
 Makefile</a>

--- a/faq.md
+++ b/faq.md
@@ -4,9 +4,9 @@
 ## Section  0 - [Submitting entries to a new IOCCC](#faq0)
 - [0.0  - How may I enter the IOCCC?](#faq0_0)
 - [0.1  - What types of entries have been frequently submitted to the IOCCC?](#faq0_1)
-- [0.2  - What should I put in my entry's Makefile?](#faq0_2)
+- [0.2  - What should I put in my submission's Makefile?](#faq0_2)
 - [0.3  - May I use a different source or compiled filename than prog.c or prog?](#faq0_3)
-- [0.4  - What platform should I assume for my entry?](#faq0_4)
+- [0.4  - What platform should I assume for my submission?](#faq0_4)
 - [0.5  - How may I comment or make a suggestion on IOCCC rules, guidelines and tools?](#faq0_5)
 - [0.6  - What are the IOCCC best practices for using markdown?](#faq0_6)
 
@@ -20,12 +20,12 @@
 
 ## Section  2 - [IOCCC Judging process](#faq2)
 - [2.0  - How many entries do the judges receive for a given IOCCC?](#faq2_0)
-- [2.1  - What should I put in the remarks.md file of my entry?](#faq2_1)
+- [2.1  - What should I put in the remarks.md file of my submission?](#faq2_1)
 - [2.2  - Why don't you publish entries that do not win?](#faq2_2)
 - [2.3  - How much time does it take to judge the contest?](#faq2_3)
 - [2.4  - How many judging rounds do you have?](#faq2_4)
 - [2.5  - Why do some IOCCC entries receive the Grand Prize or Best of Show award?](#faq2_5)
-- [2.6  - How are IOCCC entries announced?](#faq2_6)
+- [2.6  - How are winning IOCCC entries announced?](#faq2_6)
 
 
 ## Section  3 - [Compiling and running IOCCC entries](#faq3)
@@ -55,7 +55,7 @@
 ## Section  4 - [Changes made to IOCCC entries](#faq4)
 - [4.0  - Why are some winning author remarks incongruent with the winning IOCCC code?](#faq4_0)
 - [4.1  - Why were some calls to the libc function gets&#x28;3&#x29; changed to use fgets&#x28;3&#x29;?](#faq4_1)
-- [4.2  - What was changed in an IOCCC entry source code?](#faq4_2)
+- [4.2  - What was changed in an IOCCC entry's source code?](#faq4_2)
 - [4.3  - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?](#faq4_3)
 - [4.4  - What is the meaning of the file ending in .orig.c in IOCCC entries?](#faq4_4)
@@ -171,7 +171,7 @@ If you already have an mkiocccentry tool directory:
     make clobber all
 ```
 
-#### 5. Run the mkiocccentry tool to form your entry tarball
+#### 5. Run the mkiocccentry tool to form your submission tarball
 
 ```sh
     mkiocccentry work_dir prog.c Makefile remarks.md [file ...]
@@ -181,11 +181,11 @@ where:
 
 * work_dir
 
-    directory where the entry directory and tarball are formed
+    directory where the submission directory and tarball are formed
 
 * prog.c
 
-    path to the C source for your entry
+    path to the C source for your submission
 
 * Makefile
 
@@ -193,31 +193,31 @@ where:
 
 * remarks.md
 
-    Remarks about your entry in markdown format: see [FAQ 2.1](#remarks_md) for more info.
+    Remarks about your submission in markdown format: see [FAQ 2.1](#remarks_md) for more info.
 
 * [file ...]
 
-    Optional extra data files to include with your entry
+    Optional extra data files to include with your submission
 
 NOTE: Please see our [IOCCC markdown guide](markdown.html) for **important information** on using markdown in the IOCCC.
 
 NOTE: It is *NOT* necessary to install the tools to use them as you can run
 the tools from the top of the _mkiocccentry repo_ directory just fine.
 
-If `mkiocccentry` tool indicates that there is a problem with your entry,
+If `mkiocccentry` tool indicates that there is a problem with your submission,
 especially if it identifies a [rule 2](next/rules.html#2) related problem,
-you are **strongly** encouraged to revise and correct your entry and
+you are **strongly** encouraged to revise and correct your submission and
 then re-run the `mkiocccentry` tool.
 
 If you choose to risk violating rules, be sure an explain your reason
 for doing so in your `remarks.md` file.
 
 
-#### 6. Upload your entry to the IOCCC submit server
+#### 6. Upload your submission tarball to the IOCCC submit server
 
 The **IOCCC submit server** is still being written.
 <!--XXX--> As such, we do not yet have instructions
-on how upload your entry to the **IOCCC submit server**.  Once
+on how upload your submission tarball to the **IOCCC submit server**.  Once
 **IOCCC submit server** is ready, we will update this section
 with the proper instructions.  Watch the [IOCCC news](news.html)
 for an announcement of the availability of the **IOCCC submit server**.
@@ -349,28 +349,31 @@ state something along the lines of:
 
 **FAIR WARNING**: Be sure to **clearly explain** near the beginning
 of your `remarks.md` file, see [FAQ 2.1](#remarks_md),
-**why you are submitting a entry based on a frequently
+**why you are submitting an entry based on a frequently
 submitted theme** and **how compares with previous IOCCC winners**
 of the same theme.
 
 
 
 <div id="faq0_2">
-### FAQ 0.2: What should I put in my entry's Makefile?
+<div id="submission_makefiles">
+### FAQ 0.2: What should I put in my submissions's Makefile?
+</div>
 </div>
 
 We recommend starting with the [sample
 Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
 as found in the [mkiocccentry GitHub repo](https://github.com/ioccc-src/mkiocccentry),
 (renamed as `Makefile` of course) as a starting point for your
-entry's `Makefile`.
+submission's `Makefile`.
 
 The `Makefile` is a file used by the `make(1)` command that contains
 rules and UNIX shell-style commands.
 
-The first and default rule should be the `all` rule and should build your entry's executable file.
+The first and default rule should be the `all` rule and should build your
+submission's executable file.
 
-If your entry depends on a particular source file name during compilation or execution,
+If your submission depends on a particular source file name during compilation or execution,
 your `Makefile` should copy `prog.c` into the desired filename.  For example:
 
 If you are not familiar `Makefile`s, you might consider the following tutorials:
@@ -388,7 +391,8 @@ command that is compatible with GNU Make version 3.81.
 ### FAQ 0.3: May I use a different source or compiled filename than prog.c or prog?
 </div>
 
-While your entry's source filename, as submitted, must be `prog.c`, your entry's `Makefile`
+While your submission's source filename, as submitted, must be `prog.c`, your
+submission's `Makefile`
 may copy `prog.c` to a different filename as part of the compiling/building process.  For example:
 
 ``` <!---make-->
@@ -405,7 +409,7 @@ may copy `prog.c` to a different filename as part of the compiling/building proc
             rm -f desired_name.c desired_name
 ```
 
-We recommend that the `make clobber` rule remove files that your entry
+We recommend that the `make clobber` rule remove files that your submission
 creates as part of the compiling/building process.
 
 You may also copy the compiled `prog` into a different file as part of compiling process.
@@ -420,11 +424,11 @@ For example:
 
 <div id="faq0_4">
 <div id="SUS">
-### FAQ 0.4: What platform should I assume for my entry?
+### FAQ 0.4: What platform should I assume for my submission?
 </div>
 </div>
 
-Your entry must compile with **clang** or **gcc** and run under at least one flavor of a UNIX
+Your submission must compile with **clang** or **gcc** and run under at least one flavor of a UNIX
 system that conforms to the [SUS](https://en.wikipedia.org/wiki/Single_UNIX_Specification),
 otherwise known as the [The Single UNIX Specification Version 4](https://unix.org/version4/)
 or [later SUS](https://unix.org/online.html).
@@ -467,8 +471,8 @@ discussion with the [IOCCC judges](judges.html), then see
 </div>
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
-For example, we [submitting to the IOCCC](faq.html#submit), we have people
-to submit remarks about entry in markdown format.  Every
+For example, when [submitting to the IOCCC](faq.html#submit), we have people
+submit remarks about submissions in markdown format.  Every
 [winning IOCCC entry](years.html) uses a `README.md` markdown file
 as the basis for forming the `index.html` web page for that entry.
 All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
@@ -831,7 +835,7 @@ NOTE: The size rule was actually rule 1.
 
 <div id="faq2_0">
 <div id="how_many">
-### FAQ 2.0: How many entries do the judges receive for a given IOCCC?
+### FAQ 2.0: How many submissions do the judges receive for a given IOCCC?
 </div>
 </div>
 
@@ -840,21 +844,21 @@ By tradition, we do not say.
 
 <div id="faq2_1">
 <div id="remarks_md">
-### FAQ 2.1: What should I put in the remarks.md file of my entry?
+### FAQ 2.1: What should I put in the remarks.md file of my submission?
 </div>
 </div>
 
-While you may put in as much or as little as you wish into your entry's
+While you may put in as much or as little as you wish into your submission's
 `remarks.md` file, we do have few important suggestions:
 
-We recommend that you explain how to use your entry.  Explain the
+We recommend that you explain how to use your submission.  Explain the
 command line (if any command line options and arguments are used)
 and any input or actions if applicable.
 
-We highly recommend that you explain why you think your entry is
+We highly recommend that you explain why you think your submission is
 well obfuscated.
 
-For those entries that win the IOCCC, we often use much of text from the
+For those submission that win the IOCCC, we often use much of text from the
 `remarks.md` file in the _Author's remarks_ section of the `index.html` file.
 For this reason, a well written `remarks.md` file is considered a plus.
 
@@ -862,51 +866,53 @@ While not required, consider adding bit of humor to your `remarks.md`
 as most people who are not humor impaired, as well as the IOCCC judges
 appreciate the opportunity for a fun read as well as a chuckle or two.
 
+**PLEASE** also look at [markdown.html](markdown.html) for the IOCCC markdown
+guidelines.
+
 
 #### What helps:
 
-- explaining what your entry does
+- explaining what your submission does
 - how to entice it to do what it is supposed to do
 - what obfuscations are used
-- what are the limitations of your entry in respect of portability and/or input data
+- what are the limitations of your submission in respect of portability and/or input data
 - how it works (if you are really condescending)
 
 
 #### What does not help:
 
-- admitting that your entry is not very obfuscated (you see, the contest is
+- admitting that your submission is not very obfuscated (you see, the contest is
 called the **IOCCC**, not the **INVOCCC** :-) ); but even if you do not admit
-it, not very obfuscated entries have a minuscule chance to win (although
+it, not very obfuscated submission have a minuscule chance to win (although
 [2000/tomx](2000/tomx/index.html) is a notable counterexample).
 - mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if an entry wins. See the guidelines if
+rounds; we look at the author name only if a submission wins. See the guidelines if
 this is not clear!
 - leaving the remark section empty.
 
 
-%%REPO_URL%%/<div id="faq2_2">
-### FAQ 2.2: Why don't you publish entries that do not win?
+### FAQ 2.2: Why don't you publish submissions that do not win?
 </div>
 
 Because the publication on the IOCCC site **_IS_** the award!
 Anyone is free to put their IOCCC hopefuls, lookalikes and/or
-entries that do not win on their web page for everyone to see.
+submissions that do not win on their web page for everyone to see.
 
 
 <div id="faq2_3">
 ### FAQ 2.3: How much time does it take to judge the contest?
 </div>
 
-It takes a fair amount of time to setup, run, answer email, process entries,
-review entries, trim down the set entries to a set of winning entries, doing the
+It takes a fair amount of time to setup, run, answer email, process submissions,
+review submissions, trim down the set submissions to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
 late entries to wait until the next contest, etc... It takes a few weekends and
 a number nights of study and work ... which is hard given that we are busy with
 many other activities as well.
 
-Note that we do not contact the author if an entry does not compile or does not
+Note that **we do not** contact the author if a submission does not compile or does not
 work as advertised, we might attempt to fix obvious compilation problems or
 incompatibilities, but no more than that - so be sure that your entry does work
 on at least a couple different platforms, at least one of them being UNIX or
@@ -969,7 +975,7 @@ more other entries that came in close behind.
 
 
 <div id="faq2_6">
-### FAQ 2.6: How are IOCCC entries announced?
+### FAQ 2.6: How are winning IOCCC entries announced?
 </div>
 
 Once the [IOCCC](index.html) closes, the judges will:
@@ -1149,7 +1155,7 @@ for details.
 ### FAQ 3.4: Why does clang or gcc fail to compile an IOCCC entry?
 </div>
 
-Although we have fixed numerous entries to work with clang (sometimes in an alt
+Although we have fixed most entries to work with clang (sometimes in an alt
 version but usually in the program itself) there are some that simply cannot be
 fixed or if they are fixable they have not yet been fixed (we are working on
 this but other things have to be done too and all on free time).
@@ -1691,7 +1697,7 @@ if you're running out of bytes due to rule 2[ab] one might not have much choice.
 This is something that obfuscation authors simply sometimes have to deal with!
 
 If you try to minimize the number of `-Wno-foo` options needed with
-`-Weverything`, please mention this in your remarks about the entry, as the
+`-Weverything`, please mention this in your remarks about the submission, as the
 judges note you attempt to honor it (see also below). In some cases your
 obfuscated code will issue warnings with `-Weverything` no matter what: the
 `-Wno-poison-system-directories` is a common example of this but there are
@@ -1703,12 +1709,12 @@ different build environment might still have warnings. For instance the warning
 set is different in macOS (which by default is `clang`: even when run as `gcc`!)
 than Linux (due to versions and possibly other things)!
 
-Given that your entry **MUST** work as documented, you may be safer to
-say that your entry keeps the number of warnings and `-Wno-foo` options while
+Given that your submission **MUST** work as documented, you may be safer to
+say that your submission keeps the number of warnings and `-Wno-foo` options while
 compiling with `clang -Weverything` at a minimum. You might want to say the
 version number and platform too as an extra safety net. Because if you claim zero
 warnings, and we find a warning situation, this may diminish the value of your
-entry as it is not as documented. Thus it might be wise to point this out and
+submission as it is not as documented. Thus it might be wise to point this out and
 if you can test it in multiple platforms (or versions of `clang`, see
 below note) this would be advisable.
 
@@ -1744,8 +1750,8 @@ Alternatively you can try:
 ```
 
 As you can see, using `clang` has some additional problems to work out but if
-you can get your entry to work well in `clang` it might very well be considered
-better than other entries.
+you can get your submission to work well in `clang` it might very well be considered
+better than other submissions.
 
 
 <div id="faq3_12">
@@ -2300,7 +2306,7 @@ If you download the 1984 tarball, i.e. `1984/1984.tar.bz2`, then you might
 extract it and then switch to the directory and compile everything of each
 entry:
 
-```sh
+``` <!---sh-->
         cd 1984
         make everything
 ```

--- a/next/rules.html
+++ b/next/rules.html
@@ -435,12 +435,11 @@ IOCCC start with the <strong><code>|</code></strong> symbol.</p>
 <p><strong><code>|</code></strong> This IOCCC runs from <strong>2024-MMM-DD HH:MM:SS UTC</strong> to <strong>202x-MMM-DD HH:MM:SS UTC</strong>.<br>
 <strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
 <p><strong><code>|</code></strong> Until the start of this IOCCC, these <a href="rules.html">IOCCC rules</a>,
-<a href="guidelines.html">IOCCC guidelines</a> and iocccsize.c (contained in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a> and invoked by the
-<code>mkiocccentry(1)</code> tool) should be considered provisional <strong>BETA</strong> versions and
-<strong>may be adjusted <em>AT ANY TIME</em></strong>.</p>
+<a href="guidelines.html">IOCCC guidelines</a> and the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+toolkit</a> should be considered
+provisional <strong>BETA</strong> versions and <strong>may be adjusted <em>AT ANY TIME</em></strong>.</p>
 <p>When the IOCCC is open, the submission URL is:
-<a href="https://submit.ioccc.org/">https://submit.ioccc.org/</a>, at all other
+<a href="https://submit.ioccc.org">https://submit.ioccc.org</a>; at all other
 times that link is likely to be unresponsive.</p>
 <p>Please check the <a href="../faq.html#submit">How to enter FAQ</a>
 for <strong>important information</strong> on how to submit to the IOCCC.</p>
@@ -451,13 +450,15 @@ for <strong>important information</strong> on how to submit to the IOCCC.</p>
 available on the <a href="../index.html">official IOCCC website</a> on or slightly before
 the start of this IOCCC. The <code>mkiocccentry</code> toolkit may be obtained at any time
 at the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p>Please recheck on or after the start of this IOCCC to be sure you
-are using the correct versions of these items before using the IOCCC
-submission URL.</p>
+<p><strong>Please recheck on or after the start of this IOCCC to be sure you
+are using the correct versions of these items <em>before using the IOCCC
+submission URL</em></strong>.</p>
 <h1 id="ioccc-rules">IOCCC RULES</h1>
 <p>To help us with the volume of entries, we ask that you follow these rules:</p>
+<div id="rule0">
 <h2 id="rule-0">Rule 0</h2>
-<p>We need a rule 0. :-)</p>
+</div>
+<p>We need a <a href="#rule0">rule 0</a>. :-)</p>
 <div id="rule1">
 <h2 id="rule-1">Rule 1</h2>
 </div>
@@ -470,17 +471,19 @@ submission URL.</p>
 <h2 id="rule-2a">Rule 2a</h2>
 </div>
 <p><strong><code>|</code></strong> The size of your program source <strong>should not exceed 4993 bytes</strong>.</p>
-<p><strong><code>|</code></strong> If you use the most recently released official IOCCC submission packaging tool
-(hereby referred to as <code>mkiocccentry(1)</code>), which we <strong>STRONGLY recommend you use</strong>,
-then the <code>mkiocccentry(1)</code> tool will warn you if there appears to be a <a href="#rule2a">Rule 2a</a> violation.</p>
+<p><strong><code>|</code></strong> If you use the most recently released official IOCCC submission
+packaging tool (hereby referred to as <code>mkiocccentry(1)</code>), which we <strong>STRONGLY
+recommend you do</strong> (see also <a href="#rule17">Rule 17</a>), then the <code>mkiocccentry(1)</code>
+tool will warn you if there appears to be a <a href="#rule2a">Rule 2a</a> violation.</p>
 <p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2a">Rule 2a</a> warning.
-Overriding a <a href="#rule2a">Rule 2a</a> warning carries a <strong>fair amount of risk</strong> that your submission
-will be <strong>rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
+Overriding a <a href="#rule2a">Rule 2a</a> warning carries a <strong>fair amount of risk that your submission
+will be rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
 ahead of time if you plan to override the <a href="#rule2a">Rule 2a</a> warning.</p>
-<p><strong><code>|</code></strong> If you do override the <a href="#rule2a">Rule 2a</a> warning from the <code>mkiocccentry(1)</code> tool,
-or otherwise plan to violate <a href="#rule2a">Rule 2a</a>, then you <strong>must clearly explain the rationale</strong>
-of why you are doing so in your <code>remarks.md</code> file. Even if you do explain this in your <code>remarks.md</code> file
-your submission may still be rejected.</p>
+<p><strong><code>|</code></strong> If you do override the <a href="#rule2a">Rule 2a</a> warning from the
+<code>mkiocccentry(1)</code> tool, or otherwise plan to violate <a href="#rule2a">Rule 2a</a>, then
+you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong> of why you are doing so in your
+<code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your <code>remarks.md</code> file your
+submission may still be rejected</strong>.</p>
 <p><strong><code>|</code></strong> You may check your code prior to submission by giving the filename
 as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
@@ -488,19 +491,21 @@ as a command like argument to the <code>iocccsize(1)</code> tool. For example:</
 <h2 id="rule-2b">Rule 2b</h2>
 </div>
 <p><strong><code>|</code></strong> When the filename of your program source is given as a command line argument to the latest version
-of the official IOCCC size tool (hereby referred to as <code>iocccsize(1)</code>), the value printed <strong>should not exceed 2503</strong>.</p>
+of the official IOCCC size tool (hereby referred to as <code>iocccsize(1)</code>), the
+value printed <strong>should NOT exceed <em>2503</em></strong>.</p>
 <p><strong><code>|</code></strong> The source to <code>iocccsize(1)</code> may be found in the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p><strong><code>|</code></strong> If you use the <code>mkiocccentry(1)</code> tool, which we <strong>STRONGLY recommend you use</strong>,
+<p><strong><code>|</code></strong> If you use the <code>mkiocccentry(1)</code> tool, which we <strong>STRONGLY recommend
+you do</strong> (again, see also <a href="#rule17">Rule 17</a>),
 then <code>mkiocccentry(1)</code> will invoke <code>iocccsize(1)</code> before packaging your submission.</p>
 <p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2b">Rule 2b</a> warning.
-Overriding a <a href="#rule2b">Rule 2b</a> warning carries a <strong>fair amount of risk</strong> that your submission
-will be <strong>rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
+Overriding a <a href="#rule2b">Rule 2b</a> warning carries a <strong>fair amount of risk that your submission
+will be rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
 ahead of time if you plan to override the <a href="#rule2b">Rule 2b</a> warning.</p>
 <p><strong><code>|</code></strong> If you do override the <a href="#rule2b">Rule 2b</a> warning from the <code>mkiocccentry(1)</code> tool,
-or otherwise plan to violate <a href="#rule2b">Rule 2a</a>, then you <strong>must clearly explain the rationale</strong>
-of why you are doing so in your <code>remarks.md</code> file. Even if you do explain this in your <code>remarks.md</code> file
-your submission may still be rejected.</p>
+or otherwise plan to violate <a href="#rule2b">Rule 2a</a>, then you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong>
+of why you are doing so in your <code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your <code>remarks.md</code> file
+your submission may still be rejected</strong>.</p>
 <p><strong><code>|</code></strong> You may check your code prior to submission by giving the filename
 as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
@@ -509,27 +514,28 @@ as a command like argument to the <code>iocccsize(1)</code> tool. For example:</
 </div>
 <p>Submissions should be performed using the instructions outlined at:
 the <a href="../faq.html#submit">How to enter FAQ</a>.</p>
-<p>To submit to an open IOCCC, you must use the <a href="https://submit.ioccc.org/">IOCCC submit server</a>.</p>
-<p>When the IOCCC is not open, that link will likely be unresponsive.</p>
+<p>To submit to an open IOCCC, you must use the <a href="https://submit.ioccc.org/">IOCCC submit
+server</a>. Unless the IOCCC is open, that link will
+likely be unresponsive.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
 <strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
-<p>Please wait to submit your entries until after that time.</p>
+<p><strong>Please wait to submit</strong> your entries until after that time.</p>
 <div id="rule4">
 <h2 id="rule-4">Rule 4</h2>
 </div>
 <p><strong><code>|</code></strong> If your submission is selected as a winner, it may be modified in order
-for into the Makefile structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
-<p><strong><code>|</code></strong> For example, your submission’s ‘Makefile’ maybe be modified.</p>
-<p><strong><code>|</code></strong> Your source code will be the file <strong>prog.c</strong>. The compiled binary
-will be called <strong>prog</strong>. If you submission requires different filenames,
-then modify your submission’s ‘Makefile’ to <strong>COPY</strong> (<strong>NOT</strong> move)
+to fit into the structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
+<p><strong><code>|</code></strong> For example, your submission’s <code>Makefile</code> might be modified.</p>
+<p><strong><code>|</code></strong> Your source code will be the file <code>prog.c</code>. The compiled binary
+will be called <code>prog</code>. If you submission requires different filenames,
+then modify your submission’s <code>Makefile</code> to <strong>COPY</strong> (<strong>NOT</strong> move)
 the files accordingly.</p>
-<p><strong><code>|</code></strong> See also <a href="#rile5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
+<p><strong><code>|</code></strong> See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
 <div id="rule5">
 <h2 id="rule-5">Rule 5</h2>
 </div>
 <p>Your submission <strong>MUST</strong> not modify the content or filename of any part of your
-original submission including, but not limited to <strong>prog.c</strong>, the <strong>Makefile</strong>
+original submission including, but not limited to <code>prog.c</code>, the <code>Makefile</code>
 (that we create from your how to build instructions), as well as any data
 files you submit.</p>
 <p>If you submission wishes to modify such content, it <strong>MUST</strong> first copy the
@@ -549,8 +555,8 @@ file to a new filename and then modify that copy.</p>
 you must have permission from the owner(s) to submit their content
 under the following license:</p>
 <p><strong><code>|</code></strong> <strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
-<p>If you submit any content that is owned by others, you <strong>MUST</strong>
-detail that ownership (i.e., who owns what) <strong>AND document the
+<p>If you submit any content that is owned by others, you <strong>MUST
+detail that ownership</strong> (i.e., who owns what) <strong><em>AND</em> document the
 permission you obtained</strong>.</p>
 <p>Please note that the IOCCC size tool is <strong>NOT</strong> an original work.</p>
 <div id="rule8">
@@ -563,12 +569,13 @@ before the close of the contest.</p>
 <div id="rule9">
 <h2 id="rule-9">Rule 9</h2>
 </div>
-<p><strong><code>|</code></strong> Each person may submit up to and including 10.000000 entries per contest.</p>
-<p>Each submission must be submitted separately.</p>
+<p><strong><code>|</code></strong> Each person may submit up to and including <strong>10.000000</strong> entries per contest.</p>
+<p><strong>Each submission <em>must be submitted separately</em></strong>.</p>
 <div id="rule10">
 <h2 id="rule-10">Rule 10</h2>
 </div>
-<p>Entries requiring human interaction to be initially compiled are not permitted.</p>
+<p>Entries requiring human interaction to be initially compiled <strong>are not
+permitted</strong>. However, see the <a href="guidelines.html">guidelines</a>.</p>
 <div id="rule11">
 <h2 id="rule-11">Rule 11</h2>
 </div>
@@ -601,27 +608,27 @@ any control-M at the end of remark file lines.</p>
 <div id="rule15">
 <h2 id="rule-15">Rule 15</h2>
 </div>
-<p><strong><code>|</code></strong> In order to register for the IOCCC, you <strong>MUST</strong> have a valid Email address.</p>
-<p>The judges are not responsible for delays in email, please plan
+<p><strong><code>|</code></strong> In order to register for the IOCCC, you <strong>MUST</strong> have a valid email address.</p>
+<p>The judges <strong>are not responsible for delays in email</strong>, please plan
 enough time for one automated exchange of email as part of your
 submission.</p>
-<p><strong><code>|</code></strong> See <a href="../faq.html#register">How may I register for the IOCCC?</a> in the
+<p><strong><code>|</code></strong> See <a href="../faq.html#register">the FAQ on how to register for the IOCCC</a> in the
 <a href="../faq.html">FAQ</a> for details.</p>
 <div id="rule16">
 <h2 id="rule-16">Rule 16</h2>
 </div>
-<p>You are <strong>STRONGLY</strong> encouraged to submit a previously unpublished <em>AND</em>
-original submission. Submissions that are similar to previous entries are
+<p>You are <strong>STRONGLY</strong> encouraged to submit <strong>a previously unpublished <em>AND</em>
+original submission</strong>. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.</p>
 <div id="rule17">
 <h2 id="rule-17">Rule 17</h2>
 </div>
 <h3 id="tldr-rule-17---use-mkiocccentry1">TL;DR Rule 17 - Use <code>mkiocccentry(1)</code></h3>
-<p><strong><code>|</code></strong> This is a <strong>COMPLEX</strong> rule. Violating this rule will cause your submission to <strong>REJECTED</strong>.
+<p><strong><code>|</code></strong> This is a <strong>COMPLEX</strong> rule. <strong>Violating this rule will cause your submission to REJECTED</strong>!
 To help you avoid such a rejection, you are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code> tool,
 based on the latest release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>,
-to form your submission’s bzip2 compressed tarball.</p>
+to form your submission’s xz compressed tarball.</p>
 <p><strong><code>|</code></strong> The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 contains <strong>IMPORTANT</strong> tools such as:</p>
 <ul>
@@ -629,22 +636,26 @@ contains <strong>IMPORTANT</strong> tools such as:</p>
 <li><code>iocccsize(1)</code></li>
 <li><code>mkiocccentry(1)</code></li>
 <li><code>txzchk(1)</code></li>
+<li><code>fnamchk(1)</code></li>
 </ul>
 <p><strong><code>|</code></strong> The above mentioned tools will help you verify that your submission
 conforms to <a href="#rule17">Rule 17</a>.</p>
-<p><strong><code>|</code></strong> Each above mentioned tools has a <strong><code>-h</code></strong> that provides command line help. For additional details, see the tool man pages.</p>
+<p><strong><code>|</code></strong> Each above mentioned tools has a <code>-h</code> option that provides command
+line help. For additional details, see the tools’ man pages.</p>
 <h3 id="rule-17---the-complex-details">Rule 17 - The COMPLEX details</h3>
-<p><strong><code>|</code></strong> Each submission <strong>MUST</strong> be in the form of a bzip2 compressed tarball file.</p>
-<p><strong><code>|</code></strong> The bzip2 compressed tarball filename must be of the form:</p>
-<ul>
-<li>^submit.” + <em>username</em> + - + <em>slot_num</em> + .[1-9][0-9]{9,}.txz$</li>
-</ul>
-<p>where <em><code>username</code></em> is the your IOCCC registration username in the form of a
-<a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a> (see
+<p><strong><code>|</code></strong> Each submission <strong>MUST</strong> be in the form of a xz compressed tarball.</p>
+<p><strong><code>|</code></strong> The xz compressed tarball filename must be of the form:</p>
+<pre><code>    ^submit.username-slot_num.[1-9][0-9]{9,}.txz$</code></pre>
+<p><strong><code>|</code></strong> where <em><code>username</code></em> is your IOCCC registration username <strong>in the form of a
+<a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a></strong> (see
 <a href="https://datatracker.ietf.org/doc/html/rfc9562">RFC 9562</a> for
 details), and where <em><code>slot_num</code></em> is a single decimal digit integer
-(i.e., &gt;= 0 and &lt; 9), and where <em><code>+</code></em> is the concatenation operator,</p>
-<p><strong><code>|</code></strong> Your bzip2 compressed tarball file <strong>MUST</strong> contain, at a minimum,
+(i.e., &gt;= <code>0</code> and &lt; <code>9</code>).</p>
+<p><strong><code>|</code></strong> In particular, <em><code>username</code></em> is in the form of:
+<code>xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx</code> where <code>x</code> is a hexadecimal digit in the
+range <code>[0-9a-f]</code>. And yes, there is a 4 (UUID version 4) and an <code>a</code> (UUID variant
+1) in there.</p>
+<p><strong><code>|</code></strong> Your xz compressed tarball <strong>MUST</strong> contain, at a minimum,
 the following files:</p>
 <ul>
 <li><code>Makefile</code></li>
@@ -655,52 +666,65 @@ the following files:</p>
 </ul>
 <p><strong><code>|</code></strong> The <code>.info.json</code> must be valid JSON and pass the <code>chkentry(1)</code> test.</p>
 <p><strong><code>|</code></strong> The <code>.auth.json</code> must be valid JSON and pass the <code>chkentry(1)</code> test.</p>
-<p><strong><code>|</code></strong> You submission may have additional files, however <code>basename(1)</code> of the filenames of those additional files <strong>MUST</strong>:</p>
+<p><strong><code>|</code></strong> You submission may have additional files, however the filenames of those additional files <strong>MUST</strong>:</p>
 <ul>
 <li>Be less than <strong>100</strong> characters in length</li>
 <li>Match the regular expression: <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code></li>
 </ul>
-<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file in <a href="https://www.gnu.org/software/make/manual/make.html">Gnu Makefile</a> form.</p>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also <a href="#rule18">Rule 18</a>.</p>
-<p><strong><code>|</code></strong> The bzip2 compressed tarball file <strong>MUST</strong> be less than
+<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file in <a href="https://www.gnu.org/software/make/manual/make.html">GNU
+Makefile</a> form. See the
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">Makefile.example</a>,
+the <a href="../faq.html#submission_makefiles">FAQ about your submission’s Makefile</a> and
+the <a href="../faq.html#make_compatibility">FAQ about IOCCC Makefile compatibility</a> for help.</p>
+<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also
+<a href="#rule18">Rule 18</a> and our <a href="../faq.html#remarks_md">FAQ about what to put in your
+remarks.md</a>.</p>
+<p><strong><code>|</code></strong> The xz compressed tarball file <strong>MUST</strong> be less than
 or equal <strong>3999971</strong> octets in size.</p>
-<p><strong><code>|</code></strong> When your submission’s bzip2 compressed tarball is uncompressed,
+<p><strong><code>|</code></strong> When your submission’s xz compressed tarball is uncompressed,
 the total size of your submission: the sum of the size of the program,
 hints, comments, build and info files <strong>MUST</strong> be less than or equal
-to 28314624 octets (27651K) in size.</p>
+to <strong>28314624</strong> octets (<strong>27651K</strong>) in size.</p>
+<p><strong><code>|</code></strong> Your submission’s xz compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> test.</p>
 <p><strong><code>|</code></strong> You are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code>
-tool to form your submission’s bzip2 compressed tarball. The</p>
-<p><strong><code>|</code></strong> You submission may have additional files, however filenames of those additional files <strong>MUST</strong>:</p>
-<ul>
-<li>be less than <strong>100</strong> characters in length</li>
-<li>conform to the regular expression: <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code></li>
-</ul>
-<p><strong><code>|</code></strong> Your entry may have sub-directories, however the sub-directories <strong>MUST</strong> only
-reside under the submission’s top level directory.</p>
-<p><strong><code>|</code></strong> The directory names of sub-directories path, <strong>MUST</strong>:</p>
+tool to form your submission’s xz compressed tarball.</p>
+<p><strong><code>|</code></strong> Your entry may <strong>NOT</strong> have subdirectories.</p>
+<p><strong><code>|</code></strong> Filenames in your entry (that is, not including the files generated by
+the <code>mkiocccentry(1)</code> tool or the tools it invokes) <strong>MUST</strong>:</p>
 <ul>
 <li>Be less than <strong>100</strong> characters in length</li>
-<li><strong>NOT</strong> start with: <strong><code>/</code></strong></li>
-<li><strong>NOT</strong> contain a path component of: <strong><code>.</code></strong></li>
-<li><strong>NOT</strong> contain a path component of: <strong><code>..</code></strong></li>
-<li>Match the regular expression <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code>.</li>
+<li><strong>NOT</strong> have a <strong><code>/</code></strong> (excluding the entry directory that the
+<code>mkiocccentry(1)</code> tool generates).</li>
+<li><strong>NOT</strong> contain a path component of: <strong><code>.</code></strong> (that is, with the exception of
+files generated by <code>mkiocccentry(1)</code> itself, it must have <strong>NO</strong> <strong><code>.</code></strong>).</li>
+<li><strong>NOT</strong> contain a path component of: <strong><code>..</code></strong> (that is, <strong>NO</strong> <strong><code>..</code></strong>).</li>
+<li>Match the regular expression <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code> (again, excluding
+files generated by <code>mkiocccentry(1)</code>).</li>
 </ul>
-<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file.</p>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also <a href="#rule18">Rule 18</a>.</p>
-<p><strong><code>|</code></strong> The bzip2 compressed tarball file <strong>MUST</strong> be less than
-or equal <strong>3999971</strong> octets in size.</p>
-<p><strong><code>|</code></strong> When your submission’s bzip2 compressed tarball is uncompressed,
-the total size of your submission: the sum of the size of the program,
-hints, comments, build and info files <strong>MUST</strong> be less than or equal
-to 28314624 octets (27651K) in size.</p>
-<p><strong><code>|</code></strong> Your submission’s bzip2 compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> test.</p>
+<p><strong><code>|</code></strong> Additionally, the tarball <strong>MUST</strong> have the following files (generated
+by the <code>mkiocccentry(1)</code> tool):</p>
+<ul>
+<li><code>.auth.json</code> which contains information about the author or authors (that will
+only be looked at if the submission wins).</li>
+<li><code>.info.json</code> which contains information about the entry.</li>
+</ul>
+<p><strong><code>|</code></strong> The <code>txzchk(1)</code> tool will verify these for you and the <code>chkentry(1)</code>
+tool will do additional checks on the contents of the <code>.auth.json</code> and
+<code>.info.json</code> files.</p>
+<p><strong><code>|</code></strong> The tarball filename <strong>MUST</strong> pass <code>fnamchk(1)</code>; the tool <code>txzchk(1)</code>
+which is run by <code>mkiocccentry(1)</code> <strong>before packaging your tarball</strong> will run
+<code>fnamchk(1)</code>.</p>
+<p><strong><code>|</code></strong> These checks <strong>MUST PASS</strong>.</p>
 <p><strong><code>|</code></strong> Where <a href="#rule17">Rule 17</a> and the tools from the latest
 release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 conflict, the <a href="../judges.html">IOCCC Judges</a> will use their best judgment which
 is likely to favor <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> code.</p>
+<p><strong><code>|</code></strong> This means you <strong>MAKE SURE</strong> that you use <code>mkiocccentry(1)</code> to
+package your submission; <code>mkiocccentry(1)</code> will run the above mentioned tools
+<strong>before</strong> creating the tarball.</p>
 <p><strong><code>|</code></strong> To state the obvious: submissions that violate <a href="#rule17">Rule 17</a> <strong>will be rejected</strong>,
 so be sure to use the latest release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>,
-to form and test your submission’s bzip2 compressed tarball.</p>
+to form and test your submission’s xz compressed tarball.</p>
 <div id="rule18">
 <h2 id="rule-18">Rule 18</h2>
 </div>
@@ -712,11 +736,13 @@ you <strong>MUST HAVE PERMISSION</strong> from the owner(s) to submit their cont
 <div id="rule19">
 <h2 id="rule-19">Rule 19</h2>
 </div>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> file, a required non-empty file, must be written in markdown format. See
-the Daring Fireball <a href="http://daringfireball.net/projects/markdown/basics">Markdown: Basics</a>
-for more information.</p>
+<p><strong><code>|</code></strong> The <code>remarks.md</code> file, a required non-empty file, must be written in
+markdown format. See the Daring Fireball <a href="http://daringfireball.net/projects/markdown/basics">Markdown:
+Basics</a>.</p>
 <p><strong><code>|</code></strong> We currently use <a href="https://pandoc.org">pandoc</a> to convert markdown to HTML.</p>
-<p><strong><code>|</code></strong> Please see our <a href="../markdown.html">IOCCC markdown guidelines</a> for additional markdown guidance.</p>
+<p><strong><code>|</code></strong> Please see our <a href="../faq.html#remarks_md">FAQ about what to put in your
+remarks.md</a> and the <a href="../markdown.html">IOCCC markdown
+guidelines</a> for additional markdown guidance.</p>
 <div id="rule20">
 <h2 id="rule-20">Rule 20</h2>
 </div>
@@ -731,7 +757,9 @@ C source file must be called <code>prog.c</code>.</p>
 <p>To invoke the C compiler, use <code>${CC}</code>.
 To invoke the C preprocessor use <code>${CPP}</code>.</p>
 <p>Do not assume that <code>.</code> (the current directory) is in the <code>$PATH</code>.</p>
-<p><strong><code>|</code></strong> Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with bash. You are <strong>ENCOURAGED</strong> to use set <code>SHELL= bash</code> in your <code>Makefile.</code></p>
+<p><strong><code>|</code></strong> Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with bash
+and GNU <code>make(1)</code>. You are <strong>ENCOURAGED</strong> to use set <code>SHELL= bash</code> in
+your <code>Makefile</code>.</p>
 <p><strong><code>|</code></strong> Assume that commands commonly found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environments and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
@@ -740,16 +768,16 @@ available in the <code>$PATH</code> search path.</p>
 <div id="rule21">
 <h2 id="rule-21">Rule 21</h2>
 </div>
-<p>Your submission must not create or modify files above the current directory
+<p>Your submission <strong>must NOT</strong> create or modify files above the current directory
 with the exception of the <code>/tmp</code> and the <code>/var/tmp</code> directories. Your submission
 <strong>MAY</strong> create subdirectories below the current directory, or in <code>/tmp</code>,
 or in <code>/var/tmp</code> provided that <code>.</code> is <strong>NOT</strong> the first octet in any
-directory name or filename you submit.</p>
+directory name or filename you create.</p>
 <div id="rule22">
 <h2 id="rule-22">Rule 22</h2>
 </div>
 <p>Catch 22:</p>
-<p>Your source code, data files, remarks and program output must <strong>NOT</strong>
+<p>Your source code, data files, remarks and program output <strong>must NOT</strong>
 identify the authors of your code. The judges <strong>STRONGLY prefer</strong> to
 NOT know who is submitting entries to the IOCCC.</p>
 <p>Even if you are a previous IOCCC winner, catch 22 still applies.</p>
@@ -791,18 +819,19 @@ for disqualification of your submission.</p>
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 <p><strong><code>|</code></strong> For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.</p>
 <p><strong><code>|</code></strong> Be sure to review the <a href="index.html">IOCCC Rules and Guidelines</a> as
-<a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and often do) change from year to year.</p>
+<a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and
+<strong>often do</strong>) change from year to year.</p>
 <p><strong><code>|</code></strong> You should be sure you have the current <a href="rules.html">IOCCC rules</a> and
 <a href="guidelines.html">IOCCC guidelines</a> prior to submitting entries.</p>
 <p><strong><code>|</code></strong> See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
 <p><strong><code>|</code></strong> For the updates and breaking IOCCC news, you are encouraged to follow
 the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a> account. See our
-<a href="../faq.html#try_mastodon">FAQ</a> for more information. Please do note that unless
-you are mentioned by us you will <strong>NOT</strong> get a notification from the app so you
-should refresh the page even if you do follow us.</p>
+<a href="../faq.html#try_mastodon">FAQ about Mastodon</a> for more information. Please do note that unless
+you are mentioned by us you will <strong>NOT</strong> get a notification from the app <em>so you
+should refresh the page <strong>even if you do follow us</strong></em>.</p>
 <p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
-<p>Leonid A. Broukhis<br>
-chongo (Landon Curt Noll) <code>/\cc/\</code></p>
+<p><strong>Leonid A. Broukhis</strong><br>
+<strong>chongo (Landon Curt Noll) <code>/\cc/\</code></strong></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a>
 <!-- AFTER: last line of markdown file: next/rules.md --></p>

--- a/next/rules.md
+++ b/next/rules.md
@@ -77,13 +77,12 @@ The goals of the IOCCC:
 **`|`**   **XXX - date/time is TBD - XXX**
 
 **`|`**   Until the start of this IOCCC, these [IOCCC rules](rules.html),
-[IOCCC guidelines](guidelines.html) and iocccsize.c (contained in the [mkiocccentry
-repo](https://github.com/ioccc-src/mkiocccentry) and invoked by the
-`mkiocccentry(1)` tool) should be considered provisional **BETA** versions and
-**may be adjusted _AT ANY TIME_**.
+[IOCCC guidelines](guidelines.html) and the [mkiocccentry
+toolkit](https://github.com/ioccc-src/mkiocccentry) should be considered
+provisional **BETA** versions and **may be adjusted _AT ANY TIME_**.
 
 When the IOCCC is open, the submission URL is:
-[https://submit.ioccc.org/](https://submit.ioccc.org/), at all other
+[https://submit.ioccc.org](https://submit.ioccc.org); at all other
 times that link is likely to be unresponsive.
 
 Please check the [How to enter FAQ](../faq.html#submit)
@@ -99,9 +98,9 @@ available on the [official IOCCC website](../index.html) on or slightly before
 the start of this IOCCC. The `mkiocccentry` toolkit may be obtained at any time
 at the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
-Please recheck on or after the start of this IOCCC to be sure you
-are using the correct versions of these items before using the IOCCC
-submission URL.
+**Please recheck on or after the start of this IOCCC to be sure you
+are using the correct versions of these items _before using the IOCCC
+submission URL_**.
 
 
 # IOCCC RULES
@@ -109,9 +108,11 @@ submission URL.
 To help us with the volume of entries, we ask that you follow these rules:
 
 
+<div id="rule0">
 ## Rule 0
+</div>
 
-We need a rule 0.  :-)
+We need a [rule 0](#rule0).  :-)
 
 
 <div id="rule1">
@@ -134,19 +135,21 @@ The size rule requires your submission to satisfy **BOTH** [Rule 2a](#rule2a) an
 
 **`|`**   The size of your program source **should not exceed 4993 bytes**.
 
-**`|`**   If you use the most recently released official IOCCC submission packaging tool
-(hereby referred to as `mkiocccentry(1)`), which we **STRONGLY recommend you use**,
-then the `mkiocccentry(1)` tool will warn you if there appears to be a [Rule 2a](#rule2a) violation.
+**`|`**   If you use the most recently released official IOCCC submission
+packaging tool (hereby referred to as `mkiocccentry(1)`), which we **STRONGLY
+recommend you do** (see also [Rule 17](#rule17)), then the `mkiocccentry(1)`
+tool will warn you if there appears to be a [Rule 2a](#rule2a) violation.
 
 **`|`**   The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2a](#rule2a) warning.
-Overriding a [Rule 2a](#rule2a) warning carries a **fair amount of risk** that your submission
-will be **rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
+Overriding a [Rule 2a](#rule2a) warning carries a **fair amount of risk that your submission
+will be rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
 ahead of time if you plan to override the [Rule 2a](#rule2a) warning.
 
-**`|`**   If you do override the [Rule 2a](#rule2a) warning from the `mkiocccentry(1)` tool,
-or otherwise plan to violate [Rule 2a](#rule2a), then you **must clearly explain the rationale**
-of why you are doing so in your `remarks.md` file.  Even if you do explain this in your `remarks.md` file
-your submission may still be rejected.
+**`|`**   If you do override the [Rule 2a](#rule2a) warning from the
+`mkiocccentry(1)` tool, or otherwise plan to violate [Rule 2a](#rule2a), then
+you **MUST CLEARLY EXPLAIN THE RATIONALE** of why you are doing so in your
+`remarks.md` file.  **_Even if you do_ explain this in your `remarks.md` file your
+submission may still be rejected**.
 
 **`|`**   You may check your code prior to submission by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
@@ -161,23 +164,25 @@ as a command like argument to the `iocccsize(1)` tool. For example:
 </div>
 
 **`|`**   When the filename of your program source is given as a command line argument to the latest version
-of the official IOCCC size tool (hereby referred to as `iocccsize(1)`), the value printed **should not exceed 2503**.
+of the official IOCCC size tool (hereby referred to as `iocccsize(1)`), the
+value printed **should NOT exceed _2503_**.
 
 **`|`**   The source to `iocccsize(1)` may be found in the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
-**`|`**   If you use the `mkiocccentry(1)` tool, which we **STRONGLY recommend you use**,
+**`|`**   If you use the `mkiocccentry(1)` tool, which we **STRONGLY recommend
+you do** (again, see also [Rule 17](#rule17)),
 then `mkiocccentry(1)` will invoke `iocccsize(1)` before packaging your submission.
 
 **`|`**   The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2b](#rule2b) warning.
-Overriding a [Rule 2b](#rule2b) warning carries a **fair amount of risk** that your submission
-will be **rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
+Overriding a [Rule 2b](#rule2b) warning carries a **fair amount of risk that your submission
+will be rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
 ahead of time if you plan to override the [Rule 2b](#rule2b) warning.
 
 **`|`**   If you do override the [Rule 2b](#rule2b) warning from the `mkiocccentry(1)` tool,
-or otherwise plan to violate [Rule 2a](#rule2b), then you **must clearly explain the rationale**
-of why you are doing so in your `remarks.md` file.  Even if you do explain this in your `remarks.md` file
-your submission may still be rejected.
+or otherwise plan to violate [Rule 2a](#rule2b), then you **MUST CLEARLY EXPLAIN THE RATIONALE**
+of why you are doing so in your `remarks.md` file.  **_Even if you do_ explain this in your `remarks.md` file
+your submission may still be rejected**.
 
 **`|`**   You may check your code prior to submission by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
@@ -193,14 +198,14 @@ as a command like argument to the `iocccsize(1)` tool. For example:
 Submissions should be performed using the instructions outlined at:
 the [How to enter FAQ](../faq.html#submit).
 
-To submit to an open IOCCC, you must use the [IOCCC submit server](https://submit.ioccc.org/).
-
-When the IOCCC is not open, that link will likely be unresponsive.
+To submit to an open IOCCC, you must use the [IOCCC submit
+server](https://submit.ioccc.org/). Unless the IOCCC is open, that link will
+likely be unresponsive.
 
 **`|`**   The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
 **`|`**   **XXX - date/time is TBD - XXX**
 
-Please wait to submit your entries until after that time.
+**Please wait to submit** your entries until after that time.
 
 
 <div id="rule4">
@@ -208,16 +213,16 @@ Please wait to submit your entries until after that time.
 </div>
 
 **`|`**   If your submission is selected as a winner, it may be modified in order
-for into the Makefile structure of the [Official IOCCC winner website](https://www.ioccc.org/index.html).
+to fit into the structure of the [Official IOCCC winner website](https://www.ioccc.org/index.html).
 
-**`|`**   For example, your submission's 'Makefile' maybe be modified.
+**`|`**   For example, your submission's `Makefile` might be modified.
 
-**`|`**   Your source code will be the file **prog.c**.  The compiled binary
-will be called **prog**.  If you submission requires different filenames,
-then modify your submission's 'Makefile' to **COPY** (**NOT** move)
+**`|`**   Your source code will be the file `prog.c`.  The compiled binary
+will be called `prog`.  If you submission requires different filenames,
+then modify your submission's `Makefile` to **COPY** (**NOT** move)
 the files accordingly.
 
-**`|`**   See also [Rule 5](#rile5), [Rule 18](#rule18) and [Rule 21](#rule21).
+**`|`**   See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
 
 
 <div id="rule5">
@@ -225,7 +230,7 @@ the files accordingly.
 </div>
 
 Your submission **MUST** not modify the content or filename of any part of your
-original submission including, but not limited to **prog.c**, the **Makefile**
+original submission including, but not limited to `prog.c`, the `Makefile`
 (that we create from your how to build instructions), as well as any data
 files you submit.
 
@@ -256,8 +261,8 @@ under the following license:
 
 **`|`**   **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
 
-If you submit any content that is owned by others, you **MUST**
-detail that ownership (i.e., who owns what) **AND document the
+If you submit any content that is owned by others, you **MUST
+detail that ownership** (i.e., who owns what) **_AND_ document the
 permission you obtained**.
 
 Please note that the IOCCC size tool is **NOT** an original work.
@@ -279,16 +284,17 @@ before the close of the contest.
 ## Rule 9
 </div>
 
-**`|`**   Each person may submit up to and including 10.000000 entries per contest.
+**`|`**   Each person may submit up to and including **10.000000** entries per contest.
 
-Each submission must be submitted separately.
+**Each submission _must be submitted separately_**.
 
 
 <div id="rule10">
 ## Rule 10
 </div>
 
-Entries requiring human interaction to be initially compiled are not permitted.
+Entries requiring human interaction to be initially compiled **are not
+permitted**. However, see the [guidelines](guidelines.html).
 
 
 <div id="rule11">
@@ -337,13 +343,13 @@ any control-M at the end of remark file lines.
 ## Rule 15
 </div>
 
-**`|`**   In order to register for the IOCCC, you **MUST** have a valid Email address.
+**`|`**   In order to register for the IOCCC, you **MUST** have a valid email address.
 
-The judges are not responsible for delays in email, please plan
+The judges **are not responsible for delays in email**, please plan
 enough time for one automated exchange of email as part of your
 submission.
 
-**`|`**  See [How may I register for the IOCCC?](../faq.html#register) in the
+**`|`**  See [the FAQ on how to register for the IOCCC](../faq.html#register) in the
 [FAQ](../faq.html) for details.
 
 
@@ -351,8 +357,8 @@ submission.
 ## Rule 16
 </div>
 
-You are **STRONGLY** encouraged to submit a previously unpublished _AND_
-original submission. Submissions that are similar to previous entries are
+You are **STRONGLY** encouraged to submit **a previously unpublished _AND_
+original submission**. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.
 
@@ -364,10 +370,10 @@ been published may be disqualified.
 
 ### TL;DR Rule 17 - Use `mkiocccentry(1)`
 
-**`|`**   This is a **COMPLEX** rule.  Violating this rule will cause your submission to **REJECTED**.
+**`|`**   This is a **COMPLEX** rule.  **Violating this rule will cause your submission to REJECTED**!
 To help you avoid such a rejection, you are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)` tool,
 based on the latest release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
-to form your submission's bzip2 compressed tarball.
+to form your submission's xz compressed tarball.
 
 **`|`**   The [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 contains **IMPORTANT** tools such as:
@@ -376,28 +382,37 @@ contains **IMPORTANT** tools such as:
 * `iocccsize(1)`
 * `mkiocccentry(1)`
 * `txzchk(1)`
+* `fnamchk(1)`
 
 **`|`**   The above mentioned tools will help you verify that your submission
 conforms to [Rule 17](#rule17).
 
-**`|`**   Each above mentioned tools has a **`-h`** that provides command line help.  For additional details, see the tool man pages.
+**`|`**   Each above mentioned tools has a `-h` option that provides command
+line help.  For additional details, see the tools' man pages.
 
 
 ### Rule 17 - The COMPLEX details
 
-**`|`**   Each submission **MUST** be in the form of a bzip2 compressed tarball file.
+**`|`**   Each submission **MUST** be in the form of a xz compressed tarball.
 
-**`|`**   The bzip2 compressed tarball filename must be of the form:
+**`|`**   The xz compressed tarball filename must be of the form:
 
-*  ^submit\." + _username_ + - + _slot_num_ + \.[1-9][0-9]{9,}\.txz$
+``` <!---re-->
+    ^submit.username-slot_num.[1-9][0-9]{9,}.txz$
+```
 
-where _`username`_ is the your IOCCC registration username in the form of a
-[UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) (see
+**`|`** where _`username`_ is your IOCCC registration username **in the form of a
+[UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)** (see
 [RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562) for
 details), and where _`slot_num`_ is a single decimal digit integer
-(i.e., >= 0 and < 9), and where _`+`_ is the concatenation operator,
+(i.e., >= `0` and < `9`).
 
-**`|`**   Your bzip2 compressed tarball file **MUST** contain, at a minimum,
+**`|`** In particular, _`username`_ is in the form of:
+`xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx` where `x` is a hexadecimal digit in the
+range `[0-9a-f]`.  And yes, there is a 4 (UUID version 4) and an `a` (UUID variant
+1) in there.
+
+**`|`**   Your xz compressed tarball **MUST** contain, at a minimum,
 the following files:
 
 * `Makefile`
@@ -410,64 +425,77 @@ the following files:
 
 **`|`**   The `.auth.json` must be valid JSON and pass the `chkentry(1)` test.
 
-**`|`**   You submission may have additional files, however `basename(1)` of the filenames of those additional files **MUST**:
+**`|`**   You submission may have additional files, however the filenames of those additional files **MUST**:
 
 * Be less than **100** characters in length
 * Match the regular expression: `^[0-9A-Za-z][0-9A-Za-z._+-]*$`
 
-**`|`**   The `Makefile` must be a non-empty file in [Gnu Makefile](https://www.gnu.org/software/make/manual/make.html) form.
+**`|`**   The `Makefile` must be a non-empty file in [GNU
+Makefile](https://www.gnu.org/software/make/manual/make.html) form. See the
+[Makefile.example](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
+the [FAQ about your submission's Makefile](../faq.html#submission_makefiles) and
+the [FAQ about IOCCC Makefile compatibility](../faq.html#make_compatibility) for help.
 
-**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also [Rule 18](#rule18).
+**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also
+[Rule 18](#rule18) and our [FAQ about what to put in your
+remarks.md](../faq.html#remarks_md).
 
-**`|`**   The bzip2 compressed tarball file **MUST** be less than
+**`|`**   The xz compressed tarball file **MUST** be less than
 or equal **3999971** octets in size.
 
-**`|`**   When your submission's bzip2 compressed tarball is uncompressed,
+**`|`**   When your submission's xz compressed tarball is uncompressed,
 the total size of your submission: the sum of the size of the program,
 hints, comments, build and info files **MUST** be less than or equal
-to 28314624 octets (27651K) in size.
+to **28314624** octets (**27651K**) in size.
+
+**`|`**  Your submission's xz compressed tarball **MUST** pass the `txzchk(1)` test.
 
 **`|`**   You are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)`
-tool to form your submission's bzip2 compressed tarball.  The
+tool to form your submission's xz compressed tarball.
 
-**`|`**   You submission may have additional files, however filenames of those additional files **MUST**:
+**`|`**   Your entry may **NOT** have subdirectories.
 
-* be less than **100** characters in length
-* conform to the regular expression: `^[0-9A-Za-z][0-9A-Za-z._+-]*$`
-
-**`|`**   Your entry may have sub-directories, however the sub-directories **MUST** only
-reside under the submission's top level directory.
-
-**`|`**   The directory names of sub-directories path, **MUST**:
+**`|`**   Filenames in your entry (that is, not including the files generated by
+the `mkiocccentry(1)` tool or the tools it invokes) **MUST**:
 
 * Be less than **100** characters in length
-* **NOT** start with: **`/`**
-* **NOT** contain a path component of: **`.`**
-* **NOT** contain a path component of: **`..`**
-* Match the regular expression `^[0-9A-Za-z][0-9A-Za-z._+-]*$`.
+* **NOT** have a **`/`** (excluding the entry directory that the
+`mkiocccentry(1)` tool generates).
+* **NOT** contain a path component of: **`.`** (that is, with the exception of
+files generated by `mkiocccentry(1)` itself, it must have **NO** **`.`**).
+* **NOT** contain a path component of: **`..`** (that is, **NO** **`..`**).
+* Match the regular expression `^[0-9A-Za-z][0-9A-Za-z._+-]*$` (again, excluding
+files generated by `mkiocccentry(1)`).
 
-**`|`**   The `Makefile` must be a non-empty file.
+**`|`** Additionally, the tarball **MUST** have the following files (generated
+by the `mkiocccentry(1)` tool):
 
-**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also [Rule 18](#rule18).
+* `.auth.json` which contains information about the author or authors (that will
+only be looked at if the submission wins).
+* `.info.json` which contains information about the entry.
 
-**`|`**   The bzip2 compressed tarball file **MUST** be less than
-or equal **3999971** octets in size.
+**`|`** The `txzchk(1)` tool will verify these for you and the `chkentry(1)`
+tool will do additional checks on the contents of the `.auth.json` and
+`.info.json` files.
 
-**`|`**   When your submission's bzip2 compressed tarball is uncompressed,
-the total size of your submission: the sum of the size of the program,
-hints, comments, build and info files **MUST** be less than or equal
-to 28314624 octets (27651K) in size.
+**`|`** The tarball filename **MUST** pass `fnamchk(1)`; the tool `txzchk(1)`
+which is run by `mkiocccentry(1)` **before packaging your tarball** will run
+`fnamchk(1)`.
 
-**`|`**  Your submission's bzip2 compressed tarball **MUST** pass the `txzchk(1)` test.
+**`|`** These checks **MUST PASS**.
 
 **`|`**  Where [Rule 17](#rule17) and the tools from the latest
 release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 conflict, the [IOCCC Judges](../judges.html) will use their best judgment which
 is likely to favor [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) code.
 
+**`|`** This means you **MAKE SURE** that you use `mkiocccentry(1)` to
+package your submission; `mkiocccentry(1)` will run the above mentioned tools
+**before** creating the tarball.
+
 **`|`**  To state the obvious: submissions that violate [Rule 17](#rule17) **will be rejected**,
 so be sure to use the latest release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
-to form and test your submission's bzip2 compressed tarball.
+to form and test your submission's xz compressed tarball.
 
 
 <div id="rule18">
@@ -488,13 +516,15 @@ You must not submit anything that cannot be submitted under that license.
 ## Rule 19
 </div>
 
-**`|`**  The `remarks.md` file, a required non-empty file, must be written in markdown format. See
-the Daring Fireball [Markdown: Basics](http://daringfireball.net/projects/markdown/basics)
-for more information.
+**`|`**  The `remarks.md` file, a required non-empty file, must be written in
+markdown format. See the Daring Fireball [Markdown:
+Basics](http://daringfireball.net/projects/markdown/basics).
 
 **`|`**   We currently use [pandoc](https://pandoc.org) to convert markdown to HTML.
 
-**`|`**   Please see our [IOCCC markdown guidelines](../markdown.html) for additional markdown guidance.
+**`|`**   Please see our [FAQ about what to put in your
+remarks.md](../faq.html#remarks_md) and the [IOCCC markdown
+guidelines](../markdown.html) for additional markdown guidance.
 
 
 <div id="rule20">
@@ -517,7 +547,9 @@ To invoke the C preprocessor use `${CPP}`.
 
 Do not assume that `.` (the current directory) is in the `$PATH`.
 
-**`|`**   Your `Makefile` **MUST** use a syntax that is compatible with bash.  You are **ENCOURAGED** to use set `SHELL= bash` in your `Makefile.`
+**`|`**   Your `Makefile` **MUST** use a syntax that is compatible with bash
+and GNU `make(1)`.  You are **ENCOURAGED** to use set `SHELL= bash` in
+your `Makefile`.
 
 **`|`**   Assume that commands commonly found in [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
@@ -530,11 +562,11 @@ available in the `$PATH` search path.
 ## Rule 21
 </div>
 
-Your submission must not create or modify files above the current directory
+Your submission **must NOT** create or modify files above the current directory
 with the exception of the `/tmp` and the `/var/tmp` directories.  Your submission
 **MAY** create subdirectories below the current directory, or in `/tmp`,
 or in `/var/tmp` provided that `.` is **NOT** the first octet in any
-directory name or filename you submit.
+directory name or filename you create.
 
 
 <div id="rule22">
@@ -543,7 +575,7 @@ directory name or filename you submit.
 
 Catch 22:
 
-Your source code, data files, remarks and program output must **NOT**
+Your source code, data files, remarks and program output **must NOT**
 identify the authors of your code.  The judges **STRONGLY prefer** to
 NOT know who is submitting entries to the IOCCC.
 
@@ -611,7 +643,8 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 **`|`**   For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
 
 **`|`**   Be sure to review the [IOCCC Rules and Guidelines](index.html) as
-[IOCCC rules](rules.html) and the [IOCCC guidelines](guidelines.html) may (and often do) change from year to year.
+[IOCCC rules](rules.html) and the [IOCCC guidelines](guidelines.html) may (and
+**often do**) change from year to year.
 
 **`|`**   You should be sure you have the current [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) prior to submitting entries.
@@ -620,15 +653,16 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 
 **`|`**   For the updates and breaking IOCCC news, you are encouraged to follow
 the [IOCCC on Mastodon](https://fosstodon.org/@ioccc) account.  See our
-[FAQ](../faq.html#try_mastodon) for more information. Please do note that unless
-you are mentioned by us you will **NOT** get a notification from the app so you
-should refresh the page even if you do follow us.
+[FAQ about Mastodon](../faq.html#try_mastodon) for more information. Please do note that unless
+you are mentioned by us you will **NOT** get a notification from the app _so you
+should refresh the page **even if you do follow us**_.
 
 **`|`**   Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
 
 
-Leonid A. Broukhis<br>
-chongo (Landon Curt Noll) `/\cc/\`
+**Leonid A. Broukhis**<br>
+**chongo (Landon Curt Noll) `/\cc/\`**
+
 
 
 <hr style="width:10%;text-align:left;margin-left:0">


### PR DESCRIPTION
There were numerous things that had to be fixed and there will likely have to be some discussion as well.

Some formatting fixes and additional links were also added.

This commit involves some updates to the FAQ and while I was at it I fixed some references of 'entry'/'entries' to 'submission'/'submissions' (those that should not be 'entry' or 'entries').