### PR TITLE
Roll back faq.{md,html} pre 68ddba5

### DIFF
--- a/.github/ISSUE_TEMPLATE/author_details.yml
+++ b/.github/ISSUE_TEMPLATE/author_details.yml
@@ -8,7 +8,7 @@ body:
     label: Is there an existing issue for this?
     description: Please search to see if an issue already exists for the problem you're reporting.
     options:
-    - label: I have searched for existing issues and did not find anything like it
+    - label: I have searched for existing issues and did not find anything like this
       required: true
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
     label: Is there an existing issue for this?
     description: Please search to see if an issue already exists for the feature you're suggesting.
     options:
-    - label: I have searched for existing issues and did not find anything like it
+    - label: I have searched for existing issues and did not find anything like this
       required: true
 
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yml
@@ -7,7 +7,7 @@ body:
     label: Is there an existing issue for this?
     description: Please search to see if an issue already exists for the problem you're reporting.
     options:
-    - label: I have searched for existing issues and did not find anything like it
+    - label: I have searched for existing issues and did not find anything like this
       required: true
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/website_issue.yml
+++ b/.github/ISSUE_TEMPLATE/website_issue.yml
@@ -8,7 +8,7 @@ body:
     label: Is there an existing issue for this?
     description: Please search to see if an issue already exists for the problem you're reporting.
     options:
-    - label: I have searched for existing issues and did not find anything like it
+    - label: I have searched for existing issues and did not find anything like this
       required: true
 - type: textarea
   attributes:

--- a/Makefile
+++ b/Makefile
@@ -444,6 +444,21 @@ gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md
 	${GEN_TOP_HTML} -v 1 next/guidelines
 	${GEN_TOP_HTML} -v 1 next/rules
 
+rules: ${GEN_TOP_HTML} next/rules.md
+	@echo "Making rules ..."
+	@${GEN_TOP_HTML} next/rules
+	@echo "Rules? We don't need no stinking rules!"
+
+guidelines: ${GEN_TOP_HTML} next/guidelines.md
+	@echo "Making guidelines ..."
+	@${GEN_TOP_HTML} next/guidelines
+	@echo "Guidelines? We don't need no stinking guidelines!"
+
+faq: ${GEN_TOP_HTML} faq.md
+	@echo "Wait, you have questions? Uh oh!"
+	@${GEN_TOP_HTML} next/guidelines
+	@echo "Well, okay then!"
+
 # build entry HTML files from markdown other than README.md to index.html
 #
 gen_other_html: ${GEN_OTHER_HTML}

--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,7 @@ guidelines: ${GEN_TOP_HTML} next/guidelines.md
 
 faq: ${GEN_TOP_HTML} faq.md
 	@echo "Wait, you have questions? Uh oh!"
-	@${GEN_TOP_HTML} next/guidelines
+	@${GEN_TOP_HTML} faq
 	@echo "Well, okay then!"
 
 # build entry HTML files from markdown other than README.md to index.html

--- a/faq.html
+++ b/faq.html
@@ -652,7 +652,9 @@ of your <code>remarks.md</code> file, see <a href="#remarks_md">FAQ 2.1</a>,
 submitted theme</strong> and <strong>how compares with previous IOCCC winners</strong>
 of the same theme.</p>
 <div id="faq0_2">
+<div id="submission_makefiles">
 <h3 id="faq-0.2-what-should-i-put-in-my-entrys-makefile">FAQ 0.2: What should I put in my entry’s Makefile?</h3>
+</div>
 </div>
 <p>We recommend starting with the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">sample
 Makefile</a>

--- a/faq.html
+++ b/faq.html
@@ -652,7 +652,9 @@ of your <code>remarks.md</code> file, see <a href="#remarks_md">FAQ 2.1</a>,
 submitted theme</strong> and <strong>how compares with previous IOCCC winners</strong>
 of the same theme.</p>
 <div id="faq0_2">
+<div id="submission_makefile">
 <h3 id="faq-0.2-what-should-i-put-in-my-entrys-makefile">FAQ 0.2: What should I put in my entry’s Makefile?</h3>
+</div>
 </div>
 <p>We recommend starting with the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">sample
 Makefile</a>

--- a/faq.html
+++ b/faq.html
@@ -387,9 +387,9 @@
 <ul>
 <li><a href="#faq0_0">0.0 - How may I enter the IOCCC?</a></li>
 <li><a href="#faq0_1">0.1 - What types of entries have been frequently submitted to the IOCCC?</a></li>
-<li><a href="#faq0_2">0.2 - What should I put in my submission’s Makefile?</a></li>
+<li><a href="#faq0_2">0.2 - What should I put in my entry’s Makefile?</a></li>
 <li><a href="#faq0_3">0.3 - May I use a different source or compiled filename than prog.c or prog?</a></li>
-<li><a href="#faq0_4">0.4 - What platform should I assume for my submission?</a></li>
+<li><a href="#faq0_4">0.4 - What platform should I assume for my entry?</a></li>
 <li><a href="#faq0_5">0.5 - How may I comment or make a suggestion on IOCCC rules, guidelines and tools?</a></li>
 <li><a href="#faq0_6">0.6 - What are the IOCCC best practices for using markdown?</a></li>
 </ul>
@@ -403,12 +403,12 @@
 <h2 id="section-2---ioccc-judging-process">Section 2 - <a href="#faq2">IOCCC Judging process</a></h2>
 <ul>
 <li><a href="#faq2_0">2.0 - How many entries do the judges receive for a given IOCCC?</a></li>
-<li><a href="#faq2_1">2.1 - What should I put in the remarks.md file of my submission?</a></li>
+<li><a href="#faq2_1">2.1 - What should I put in the remarks.md file of my entry?</a></li>
 <li><a href="#faq2_2">2.2 - Why don’t you publish entries that do not win?</a></li>
 <li><a href="#faq2_3">2.3 - How much time does it take to judge the contest?</a></li>
 <li><a href="#faq2_4">2.4 - How many judging rounds do you have?</a></li>
 <li><a href="#faq2_5">2.5 - Why do some IOCCC entries receive the Grand Prize or Best of Show award?</a></li>
-<li><a href="#faq2_6">2.6 - How are winning IOCCC entries announced?</a></li>
+<li><a href="#faq2_6">2.6 - How are IOCCC entries announced?</a></li>
 </ul>
 <h2 id="section-3---compiling-and-running-ioccc-entries">Section 3 - <a href="#faq3">Compiling and running IOCCC entries</a></h2>
 <ul>
@@ -438,7 +438,7 @@
 <ul>
 <li><a href="#faq4_0">4.0 - Why are some winning author remarks incongruent with the winning IOCCC code?</a></li>
 <li><a href="#faq4_1">4.1 - Why were some calls to the libc function gets(3) changed to use fgets(3)?</a></li>
-<li><a href="#faq4_2">4.2 - What was changed in an IOCCC entry’s source code?</a></li>
+<li><a href="#faq4_2">4.2 - What was changed in an IOCCC entry source code?</a></li>
 <li><a href="#faq4_3">4.3 - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?</a></li>
 <li><a href="#faq4_4">4.4 - What is the meaning of the file ending in .orig.c in IOCCC entries?</a></li>
@@ -519,34 +519,34 @@ to our submission portal.</p>
 <span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">git</span> rebase</span></code></pre></div>
 <h4 id="make-the-mkiocccentry-toolkit">4. Make the mkiocccentry toolkit</h4>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>    <span class="fu">make</span> clobber all</span></code></pre></div>
-<h4 id="run-the-mkiocccentry-tool-to-form-your-submission-tarball">5. Run the mkiocccentry tool to form your submission tarball</h4>
+<h4 id="run-the-mkiocccentry-tool-to-form-your-entry-tarball">5. Run the mkiocccentry tool to form your entry tarball</h4>
 <div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>    <span class="ex">mkiocccentry</span> work_dir prog.c Makefile remarks.md [file ...]</span></code></pre></div>
 <p>where:</p>
 <ul>
 <li><p>work_dir</p>
-<p>directory where the submission directory and tarball are formed</p></li>
+<p>directory where the entry directory and tarball are formed</p></li>
 <li><p>prog.c</p>
-<p>path to the C source for your submission</p></li>
+<p>path to the C source for your entry</p></li>
 <li><p>Makefile</p>
 <p>Makefile to build (make all) and cleanup (make clean &amp; make clobber)</p></li>
 <li><p>remarks.md</p>
-<p>Remarks about your submission in markdown format: see <a href="#remarks_md">FAQ 2.1</a> for more info.</p></li>
+<p>Remarks about your entry in markdown format: see <a href="#remarks_md">FAQ 2.1</a> for more info.</p></li>
 <li><p>[file …]</p>
-<p>Optional extra data files to include with your submission</p></li>
+<p>Optional extra data files to include with your entry</p></li>
 </ul>
 <p>NOTE: Please see our <a href="markdown.html">IOCCC markdown guide</a> for <strong>important information</strong> on using markdown in the IOCCC.</p>
 <p>NOTE: It is <em>NOT</em> necessary to install the tools to use them as you can run
 the tools from the top of the <em>mkiocccentry repo</em> directory just fine.</p>
-<p>If <code>mkiocccentry</code> tool indicates that there is a problem with your submission,
+<p>If <code>mkiocccentry</code> tool indicates that there is a problem with your entry,
 especially if it identifies a <a href="next/rules.html#2">rule 2</a> related problem,
-you are <strong>strongly</strong> encouraged to revise and correct your submission and
+you are <strong>strongly</strong> encouraged to revise and correct your entry and
 then re-run the <code>mkiocccentry</code> tool.</p>
 <p>If you choose to risk violating rules, be sure an explain your reason
 for doing so in your <code>remarks.md</code> file.</p>
-<h4 id="upload-your-submission-tarball-to-the-ioccc-submit-server">6. Upload your submission tarball to the IOCCC submit server</h4>
+<h4 id="upload-your-entry-to-the-ioccc-submit-server">6. Upload your entry to the IOCCC submit server</h4>
 <p>The <strong>IOCCC submit server</strong> is still being written.
 <!--XXX--> As such, we do not yet have instructions
-on how upload your submission tarball to the <strong>IOCCC submit server</strong>. Once
+on how upload your entry to the <strong>IOCCC submit server</strong>. Once
 <strong>IOCCC submit server</strong> is ready, we will update this section
 with the proper instructions. Watch the <a href="news.html">IOCCC news</a>
 for an announcement of the availability of the <strong>IOCCC submit server</strong>.</p>
@@ -648,24 +648,21 @@ state something along the lines of:</p>
 <pre><code>    We tend to dislike programs that: are similar to previous winning entries.</code></pre>
 <p><strong>FAIR WARNING</strong>: Be sure to <strong>clearly explain</strong> near the beginning
 of your <code>remarks.md</code> file, see <a href="#remarks_md">FAQ 2.1</a>,
-<strong>why you are submitting an entry based on a frequently
+<strong>why you are submitting a entry based on a frequently
 submitted theme</strong> and <strong>how compares with previous IOCCC winners</strong>
 of the same theme.</p>
 <div id="faq0_2">
-<div id="submission_makefiles">
-<h3 id="faq-0.2-what-should-i-put-in-my-submissionss-makefile">FAQ 0.2: What should I put in my submissions’s Makefile?</h3>
-</div>
+<h3 id="faq-0.2-what-should-i-put-in-my-entrys-makefile">FAQ 0.2: What should I put in my entry’s Makefile?</h3>
 </div>
 <p>We recommend starting with the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">sample
 Makefile</a>
 as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry GitHub repo</a>,
 (renamed as <code>Makefile</code> of course) as a starting point for your
-submission’s <code>Makefile</code>.</p>
+entry’s <code>Makefile</code>.</p>
 <p>The <code>Makefile</code> is a file used by the <code>make(1)</code> command that contains
 rules and UNIX shell-style commands.</p>
-<p>The first and default rule should be the <code>all</code> rule and should build your
-submission’s executable file.</p>
-<p>If your submission depends on a particular source file name during compilation or execution,
+<p>The first and default rule should be the <code>all</code> rule and should build your entry’s executable file.</p>
+<p>If your entry depends on a particular source file name during compilation or execution,
 your <code>Makefile</code> should copy <code>prog.c</code> into the desired filename. For example:</p>
 <p>If you are not familiar <code>Makefile</code>s, you might consider the following tutorials:</p>
 <ul>
@@ -679,8 +676,7 @@ command that is compatible with GNU Make version 3.81.</p>
 <div id="faq0_3">
 <h3 id="faq-0.3-may-i-use-a-different-source-or-compiled-filename-than-prog.c-or-prog">FAQ 0.3: May I use a different source or compiled filename than prog.c or prog?</h3>
 </div>
-<p>While your submission’s source filename, as submitted, must be <code>prog.c</code>, your
-submission’s <code>Makefile</code>
+<p>While your entry’s source filename, as submitted, must be <code>prog.c</code>, your entry’s <code>Makefile</code>
 may copy <code>prog.c</code> to a different filename as part of the compiling/building process. For example:</p>
 <pre><code>    all: desired_name
 
@@ -693,7 +689,7 @@ may copy <code>prog.c</code> to a different filename as part of the compiling/bu
 
     clobber:
             rm -f desired_name.c desired_name</code></pre>
-<p>We recommend that the <code>make clobber</code> rule remove files that your submission
+<p>We recommend that the <code>make clobber</code> rule remove files that your entry
 creates as part of the compiling/building process.</p>
 <p>You may also copy the compiled <code>prog</code> into a different file as part of compiling process.
 For example:</p>
@@ -702,10 +698,10 @@ For example:</p>
             cp -f prog $@</code></pre>
 <div id="faq0_4">
 <div id="SUS">
-<h3 id="faq-0.4-what-platform-should-i-assume-for-my-submission">FAQ 0.4: What platform should I assume for my submission?</h3>
+<h3 id="faq-0.4-what-platform-should-i-assume-for-my-entry">FAQ 0.4: What platform should I assume for my entry?</h3>
 </div>
 </div>
-<p>Your submission must compile with <strong>clang</strong> or <strong>gcc</strong> and run under at least one flavor of a UNIX
+<p>Your entry must compile with <strong>clang</strong> or <strong>gcc</strong> and run under at least one flavor of a UNIX
 system that conforms to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">SUS</a>,
 otherwise known as the <a href="https://unix.org/version4/">The Single UNIX Specification Version 4</a>
 or <a href="https://unix.org/online.html">later SUS</a>.</p>
@@ -739,8 +735,8 @@ discussion with the <a href="judges.html">IOCCC judges</a>, then see
 </div>
 </div>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
-For example, when <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
-submit remarks about submissions in markdown format. Every
+For example, we <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
+to submit remarks about entry in markdown format. Every
 <a href="years.html">winning IOCCC entry</a> uses a <code>README.md</code> markdown file
 as the basis for forming the <code>index.html</code> web page for that entry.
 All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>
@@ -1028,66 +1024,66 @@ to the <a href="https://www.ioccc.org">official IOCCC website</a>.</p>
 </div>
 <div id="faq2_0">
 <div id="how_many">
-<h3 id="faq-2.0-how-many-submissions-do-the-judges-receive-for-a-given-ioccc">FAQ 2.0: How many submissions do the judges receive for a given IOCCC?</h3>
+<h3 id="faq-2.0-how-many-entries-do-the-judges-receive-for-a-given-ioccc">FAQ 2.0: How many entries do the judges receive for a given IOCCC?</h3>
 </div>
 </div>
 <p>By tradition, we do not say.</p>
 <div id="faq2_1">
 <div id="remarks_md">
-<h3 id="faq-2.1-what-should-i-put-in-the-remarks.md-file-of-my-submission">FAQ 2.1: What should I put in the remarks.md file of my submission?</h3>
+<h3 id="faq-2.1-what-should-i-put-in-the-remarks.md-file-of-my-entry">FAQ 2.1: What should I put in the remarks.md file of my entry?</h3>
 </div>
 </div>
-<p>While you may put in as much or as little as you wish into your submission’s
+<p>While you may put in as much or as little as you wish into your entry’s
 <code>remarks.md</code> file, we do have few important suggestions:</p>
-<p>We recommend that you explain how to use your submission. Explain the
+<p>We recommend that you explain how to use your entry. Explain the
 command line (if any command line options and arguments are used)
 and any input or actions if applicable.</p>
-<p>We highly recommend that you explain why you think your submission is
+<p>We highly recommend that you explain why you think your entry is
 well obfuscated.</p>
-<p>For those submission that win the IOCCC, we often use much of text from the
+<p>For those entries that win the IOCCC, we often use much of text from the
 <code>remarks.md</code> file in the <em>Author’s remarks</em> section of the <code>index.html</code> file.
 For this reason, a well written <code>remarks.md</code> file is considered a plus.</p>
 <p>While not required, consider adding bit of humor to your <code>remarks.md</code>
 as most people who are not humor impaired, as well as the IOCCC judges
 appreciate the opportunity for a fun read as well as a chuckle or two.</p>
-<p><strong>PLEASE</strong> also look at <a href="markdown.html">markdown.html</a> for the IOCCC markdown
-guidelines.</p>
 <h4 id="what-helps">What helps:</h4>
 <ul>
-<li>explaining what your submission does</li>
+<li>explaining what your entry does</li>
 <li>how to entice it to do what it is supposed to do</li>
 <li>what obfuscations are used</li>
-<li>what are the limitations of your submission in respect of portability and/or input data</li>
+<li>what are the limitations of your entry in respect of portability and/or input data</li>
 <li>how it works (if you are really condescending)</li>
 </ul>
 <h4 id="what-does-not-help">What does not help:</h4>
 <ul>
-<li>admitting that your submission is not very obfuscated (you see, the contest is
+<li>admitting that your entry is not very obfuscated (you see, the contest is
 called the <strong>IOCCC</strong>, not the <strong>INVOCCC</strong> :-) ); but even if you do not admit
-it, not very obfuscated submission have a minuscule chance to win (although
+it, not very obfuscated entries have a minuscule chance to win (although
 <a href="2000/tomx/index.html">2000/tomx</a> is a notable counterexample).</li>
 <li>mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if a submission wins. See the guidelines if
+rounds; we look at the author name only if an entry wins. See the guidelines if
 this is not clear!</li>
 <li>leaving the remark section empty.</li>
 </ul>
-<h3 id="faq-2.2-why-dont-you-publish-submissions-that-do-not-win">FAQ 2.2: Why don’t you publish submissions that do not win?</h3>
+https://github.com/ioccc-src/temp-test-ioccc/blob/master/
+<div id="faq2_2">
+<h3 id="faq-2.2-why-dont-you-publish-entries-that-do-not-win">FAQ 2.2: Why don’t you publish entries that do not win?</h3>
 </div>
 <p>Because the publication on the IOCCC site <strong><em>IS</em></strong> the award!
 Anyone is free to put their IOCCC hopefuls, lookalikes and/or
-submissions that do not win on their web page for everyone to see.</p>
+entries that do not win on their web page for everyone to see.</p>
 <div id="faq2_3">
 <h3 id="faq-2.3-how-much-time-does-it-take-to-judge-the-contest">FAQ 2.3: How much time does it take to judge the contest?</h3>
 </div>
-<p>It takes a fair amount of time to setup, run, answer email, process submissions,
-review submissions, trim down the set submissions to a set of winning entries, doing the
+<p>It takes a fair amount of time to setup, run, answer email, process entries,
+review entries, trim down the set entries to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
 late entries to wait until the next contest, etc… It takes a few weekends and
 a number nights of study and work … which is hard given that we are busy with
 many other activities as well.</p>
-<p>Note that <strong>we do not</strong> contact the author if a submission does not compile or does not
+<p>Note that we do not contact the author if an entry does not compile or does not
 work as advertised, we might attempt to fix obvious compilation problems or
 incompatibilities, but no more than that - so be sure that your entry does work
 on at least a couple different platforms, at least one of them being UNIX or
@@ -1138,7 +1134,7 @@ from the judges, they used the following awards:</p>
 <p>These could be considered the ‘best entry’ for those years with 1 or
 more other entries that came in close behind.</p>
 <div id="faq2_6">
-<h3 id="faq-2.6-how-are-winning-ioccc-entries-announced">FAQ 2.6: How are winning IOCCC entries announced?</h3>
+<h3 id="faq-2.6-how-are-ioccc-entries-announced">FAQ 2.6: How are IOCCC entries announced?</h3>
 </div>
 <p>Once the <a href="index.html">IOCCC</a> closes, the judges will:</p>
 <ul>
@@ -1266,7 +1262,7 @@ for details.</p>
 <div id="faq3_4">
 <h3 id="faq-3.4-why-does-clang-or-gcc-fail-to-compile-an-ioccc-entry">FAQ 3.4: Why does clang or gcc fail to compile an IOCCC entry?</h3>
 </div>
-<p>Although we have fixed most entries to work with clang (sometimes in an alt
+<p>Although we have fixed numerous entries to work with clang (sometimes in an alt
 version but usually in the program itself) there are some that simply cannot be
 fixed or if they are fixable they have not yet been fixed (we are working on
 this but other things have to be done too and all on free time).</p>
@@ -1583,7 +1579,7 @@ however, it is not even possible to fix let alone is it worth it. Of course
 if you’re running out of bytes due to rule 2[ab] one might not have much choice.
 This is something that obfuscation authors simply sometimes have to deal with!</p>
 <p>If you try to minimize the number of <code>-Wno-foo</code> options needed with
-<code>-Weverything</code>, please mention this in your remarks about the submission, as the
+<code>-Weverything</code>, please mention this in your remarks about the entry, as the
 judges note you attempt to honor it (see also below). In some cases your
 obfuscated code will issue warnings with <code>-Weverything</code> no matter what: the
 <code>-Wno-poison-system-directories</code> is a common example of this but there are
@@ -1593,12 +1589,12 @@ compile environment might be warning free, a different clang version or a
 different build environment might still have warnings. For instance the warning
 set is different in macOS (which by default is <code>clang</code>: even when run as <code>gcc</code>!)
 than Linux (due to versions and possibly other things)!</p>
-<p>Given that your submission <strong>MUST</strong> work as documented, you may be safer to
-say that your submission keeps the number of warnings and <code>-Wno-foo</code> options while
+<p>Given that your entry <strong>MUST</strong> work as documented, you may be safer to
+say that your entry keeps the number of warnings and <code>-Wno-foo</code> options while
 compiling with <code>clang -Weverything</code> at a minimum. You might want to say the
 version number and platform too as an extra safety net. Because if you claim zero
 warnings, and we find a warning situation, this may diminish the value of your
-submission as it is not as documented. Thus it might be wise to point this out and
+entry as it is not as documented. Thus it might be wise to point this out and
 if you can test it in multiple platforms (or versions of <code>clang</code>, see
 below note) this would be advisable.</p>
 <p>NOTE: different versions of <code>clang</code> have other differences as well. For instance
@@ -1621,8 +1617,8 @@ differences, try from <code>1989/westley</code>:</p>
 <p>Alternatively you can try:</p>
 <pre><code>    git diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..eb9e69fde657acc8c85a618a8a99af4c2f93b21d westley.c</code></pre>
 <p>As you can see, using <code>clang</code> has some additional problems to work out but if
-you can get your submission to work well in <code>clang</code> it might very well be considered
-better than other submissions.</p>
+you can get your entry to work well in <code>clang</code> it might very well be considered
+better than other entries.</p>
 <div id="faq3_12">
 <h3 id="faq-3.12-how-do-i-find-out-how-to-send-interrupteof-etc.-for-entries-that-require-it">FAQ 3.12: How do I find out how to send interrupt/EOF etc. for entries that require it?</h3>
 </div>
@@ -1948,8 +1944,8 @@ if you switched to each entry’s directory and ran <code>make everything</code>
 <p>If you download the 1984 tarball, i.e. <code>1984/1984.tar.bz2</code>, then you might
 extract it and then switch to the directory and compile everything of each
 entry:</p>
-<pre><code>        cd 1984
-        make everything</code></pre>
+<div class="sourceCode" id="cb59"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a>        <span class="bu">cd</span> 1984</span>
+<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a>        <span class="fu">make</span> everything</span></code></pre></div>
 <p>For more help on compiling entries, see also <a href="#faq3_0">3.0 - What Makefile rules are
 available to build or clean up IOCCC entries?</a>.</p>
 <p>Of course in this case you can also switch to individual entries and look at the

--- a/faq.html
+++ b/faq.html
@@ -387,9 +387,9 @@
 <ul>
 <li><a href="#faq0_0">0.0 - How may I enter the IOCCC?</a></li>
 <li><a href="#faq0_1">0.1 - What types of entries have been frequently submitted to the IOCCC?</a></li>
-<li><a href="#faq0_2">0.2 - What should I put in my entry’s Makefile?</a></li>
+<li><a href="#faq0_2">0.2 - What should I put in my submission’s Makefile?</a></li>
 <li><a href="#faq0_3">0.3 - May I use a different source or compiled filename than prog.c or prog?</a></li>
-<li><a href="#faq0_4">0.4 - What platform should I assume for my entry?</a></li>
+<li><a href="#faq0_4">0.4 - What platform should I assume for my submission?</a></li>
 <li><a href="#faq0_5">0.5 - How may I comment or make a suggestion on IOCCC rules, guidelines and tools?</a></li>
 <li><a href="#faq0_6">0.6 - What are the IOCCC best practices for using markdown?</a></li>
 </ul>
@@ -403,12 +403,12 @@
 <h2 id="section-2---ioccc-judging-process">Section 2 - <a href="#faq2">IOCCC Judging process</a></h2>
 <ul>
 <li><a href="#faq2_0">2.0 - How many entries do the judges receive for a given IOCCC?</a></li>
-<li><a href="#faq2_1">2.1 - What should I put in the remarks.md file of my entry?</a></li>
+<li><a href="#faq2_1">2.1 - What should I put in the remarks.md file of my submission?</a></li>
 <li><a href="#faq2_2">2.2 - Why don’t you publish entries that do not win?</a></li>
 <li><a href="#faq2_3">2.3 - How much time does it take to judge the contest?</a></li>
 <li><a href="#faq2_4">2.4 - How many judging rounds do you have?</a></li>
 <li><a href="#faq2_5">2.5 - Why do some IOCCC entries receive the Grand Prize or Best of Show award?</a></li>
-<li><a href="#faq2_6">2.6 - How are IOCCC entries announced?</a></li>
+<li><a href="#faq2_6">2.6 - How are winning IOCCC entries announced?</a></li>
 </ul>
 <h2 id="section-3---compiling-and-running-ioccc-entries">Section 3 - <a href="#faq3">Compiling and running IOCCC entries</a></h2>
 <ul>
@@ -438,7 +438,7 @@
 <ul>
 <li><a href="#faq4_0">4.0 - Why are some winning author remarks incongruent with the winning IOCCC code?</a></li>
 <li><a href="#faq4_1">4.1 - Why were some calls to the libc function gets(3) changed to use fgets(3)?</a></li>
-<li><a href="#faq4_2">4.2 - What was changed in an IOCCC entry source code?</a></li>
+<li><a href="#faq4_2">4.2 - What was changed in an IOCCC entry’s source code?</a></li>
 <li><a href="#faq4_3">4.3 - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?</a></li>
 <li><a href="#faq4_4">4.4 - What is the meaning of the file ending in .orig.c in IOCCC entries?</a></li>
@@ -519,34 +519,34 @@ to our submission portal.</p>
 <span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a>    <span class="fu">git</span> rebase</span></code></pre></div>
 <h4 id="make-the-mkiocccentry-toolkit">4. Make the mkiocccentry toolkit</h4>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>    <span class="fu">make</span> clobber all</span></code></pre></div>
-<h4 id="run-the-mkiocccentry-tool-to-form-your-entry-tarball">5. Run the mkiocccentry tool to form your entry tarball</h4>
+<h4 id="run-the-mkiocccentry-tool-to-form-your-submission-tarball">5. Run the mkiocccentry tool to form your submission tarball</h4>
 <div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>    <span class="ex">mkiocccentry</span> work_dir prog.c Makefile remarks.md [file ...]</span></code></pre></div>
 <p>where:</p>
 <ul>
 <li><p>work_dir</p>
-<p>directory where the entry directory and tarball are formed</p></li>
+<p>directory where the submission directory and tarball are formed</p></li>
 <li><p>prog.c</p>
-<p>path to the C source for your entry</p></li>
+<p>path to the C source for your submission</p></li>
 <li><p>Makefile</p>
 <p>Makefile to build (make all) and cleanup (make clean &amp; make clobber)</p></li>
 <li><p>remarks.md</p>
-<p>Remarks about your entry in markdown format: see <a href="#remarks_md">FAQ 2.1</a> for more info.</p></li>
+<p>Remarks about your submission in markdown format: see <a href="#remarks_md">FAQ 2.1</a> for more info.</p></li>
 <li><p>[file …]</p>
-<p>Optional extra data files to include with your entry</p></li>
+<p>Optional extra data files to include with your submission</p></li>
 </ul>
 <p>NOTE: Please see our <a href="markdown.html">IOCCC markdown guide</a> for <strong>important information</strong> on using markdown in the IOCCC.</p>
 <p>NOTE: It is <em>NOT</em> necessary to install the tools to use them as you can run
 the tools from the top of the <em>mkiocccentry repo</em> directory just fine.</p>
-<p>If <code>mkiocccentry</code> tool indicates that there is a problem with your entry,
+<p>If <code>mkiocccentry</code> tool indicates that there is a problem with your submission,
 especially if it identifies a <a href="next/rules.html#2">rule 2</a> related problem,
-you are <strong>strongly</strong> encouraged to revise and correct your entry and
+you are <strong>strongly</strong> encouraged to revise and correct your submission and
 then re-run the <code>mkiocccentry</code> tool.</p>
 <p>If you choose to risk violating rules, be sure an explain your reason
 for doing so in your <code>remarks.md</code> file.</p>
-<h4 id="upload-your-entry-to-the-ioccc-submit-server">6. Upload your entry to the IOCCC submit server</h4>
+<h4 id="upload-your-submission-tarball-to-the-ioccc-submit-server">6. Upload your submission tarball to the IOCCC submit server</h4>
 <p>The <strong>IOCCC submit server</strong> is still being written.
 <!--XXX--> As such, we do not yet have instructions
-on how upload your entry to the <strong>IOCCC submit server</strong>. Once
+on how upload your submission tarball to the <strong>IOCCC submit server</strong>. Once
 <strong>IOCCC submit server</strong> is ready, we will update this section
 with the proper instructions. Watch the <a href="news.html">IOCCC news</a>
 for an announcement of the availability of the <strong>IOCCC submit server</strong>.</p>
@@ -648,23 +648,24 @@ state something along the lines of:</p>
 <pre><code>    We tend to dislike programs that: are similar to previous winning entries.</code></pre>
 <p><strong>FAIR WARNING</strong>: Be sure to <strong>clearly explain</strong> near the beginning
 of your <code>remarks.md</code> file, see <a href="#remarks_md">FAQ 2.1</a>,
-<strong>why you are submitting a entry based on a frequently
+<strong>why you are submitting an entry based on a frequently
 submitted theme</strong> and <strong>how compares with previous IOCCC winners</strong>
 of the same theme.</p>
 <div id="faq0_2">
 <div id="submission_makefiles">
-<h3 id="faq-0.2-what-should-i-put-in-my-entrys-makefile">FAQ 0.2: What should I put in my entry’s Makefile?</h3>
+<h3 id="faq-0.2-what-should-i-put-in-my-submissionss-makefile">FAQ 0.2: What should I put in my submissions’s Makefile?</h3>
 </div>
 </div>
 <p>We recommend starting with the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">sample
 Makefile</a>
 as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry GitHub repo</a>,
 (renamed as <code>Makefile</code> of course) as a starting point for your
-entry’s <code>Makefile</code>.</p>
+submission’s <code>Makefile</code>.</p>
 <p>The <code>Makefile</code> is a file used by the <code>make(1)</code> command that contains
 rules and UNIX shell-style commands.</p>
-<p>The first and default rule should be the <code>all</code> rule and should build your entry’s executable file.</p>
-<p>If your entry depends on a particular source file name during compilation or execution,
+<p>The first and default rule should be the <code>all</code> rule and should build your
+submission’s executable file.</p>
+<p>If your submission depends on a particular source file name during compilation or execution,
 your <code>Makefile</code> should copy <code>prog.c</code> into the desired filename. For example:</p>
 <p>If you are not familiar <code>Makefile</code>s, you might consider the following tutorials:</p>
 <ul>
@@ -678,7 +679,8 @@ command that is compatible with GNU Make version 3.81.</p>
 <div id="faq0_3">
 <h3 id="faq-0.3-may-i-use-a-different-source-or-compiled-filename-than-prog.c-or-prog">FAQ 0.3: May I use a different source or compiled filename than prog.c or prog?</h3>
 </div>
-<p>While your entry’s source filename, as submitted, must be <code>prog.c</code>, your entry’s <code>Makefile</code>
+<p>While your submission’s source filename, as submitted, must be <code>prog.c</code>, your
+submission’s <code>Makefile</code>
 may copy <code>prog.c</code> to a different filename as part of the compiling/building process. For example:</p>
 <pre><code>    all: desired_name
 
@@ -691,7 +693,7 @@ may copy <code>prog.c</code> to a different filename as part of the compiling/bu
 
     clobber:
             rm -f desired_name.c desired_name</code></pre>
-<p>We recommend that the <code>make clobber</code> rule remove files that your entry
+<p>We recommend that the <code>make clobber</code> rule remove files that your submission
 creates as part of the compiling/building process.</p>
 <p>You may also copy the compiled <code>prog</code> into a different file as part of compiling process.
 For example:</p>
@@ -700,10 +702,10 @@ For example:</p>
             cp -f prog $@</code></pre>
 <div id="faq0_4">
 <div id="SUS">
-<h3 id="faq-0.4-what-platform-should-i-assume-for-my-entry">FAQ 0.4: What platform should I assume for my entry?</h3>
+<h3 id="faq-0.4-what-platform-should-i-assume-for-my-submission">FAQ 0.4: What platform should I assume for my submission?</h3>
 </div>
 </div>
-<p>Your entry must compile with <strong>clang</strong> or <strong>gcc</strong> and run under at least one flavor of a UNIX
+<p>Your submission must compile with <strong>clang</strong> or <strong>gcc</strong> and run under at least one flavor of a UNIX
 system that conforms to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">SUS</a>,
 otherwise known as the <a href="https://unix.org/version4/">The Single UNIX Specification Version 4</a>
 or <a href="https://unix.org/online.html">later SUS</a>.</p>
@@ -737,8 +739,8 @@ discussion with the <a href="judges.html">IOCCC judges</a>, then see
 </div>
 </div>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
-For example, we <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
-to submit remarks about entry in markdown format. Every
+For example, when <a href="faq.html#submit">submitting to the IOCCC</a>, we have people
+submit remarks about submissions in markdown format. Every
 <a href="years.html">winning IOCCC entry</a> uses a <code>README.md</code> markdown file
 as the basis for forming the <code>index.html</code> web page for that entry.
 All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>
@@ -1026,66 +1028,66 @@ to the <a href="https://www.ioccc.org">official IOCCC website</a>.</p>
 </div>
 <div id="faq2_0">
 <div id="how_many">
-<h3 id="faq-2.0-how-many-entries-do-the-judges-receive-for-a-given-ioccc">FAQ 2.0: How many entries do the judges receive for a given IOCCC?</h3>
+<h3 id="faq-2.0-how-many-submissions-do-the-judges-receive-for-a-given-ioccc">FAQ 2.0: How many submissions do the judges receive for a given IOCCC?</h3>
 </div>
 </div>
 <p>By tradition, we do not say.</p>
 <div id="faq2_1">
 <div id="remarks_md">
-<h3 id="faq-2.1-what-should-i-put-in-the-remarks.md-file-of-my-entry">FAQ 2.1: What should I put in the remarks.md file of my entry?</h3>
+<h3 id="faq-2.1-what-should-i-put-in-the-remarks.md-file-of-my-submission">FAQ 2.1: What should I put in the remarks.md file of my submission?</h3>
 </div>
 </div>
-<p>While you may put in as much or as little as you wish into your entry’s
+<p>While you may put in as much or as little as you wish into your submission’s
 <code>remarks.md</code> file, we do have few important suggestions:</p>
-<p>We recommend that you explain how to use your entry. Explain the
+<p>We recommend that you explain how to use your submission. Explain the
 command line (if any command line options and arguments are used)
 and any input or actions if applicable.</p>
-<p>We highly recommend that you explain why you think your entry is
+<p>We highly recommend that you explain why you think your submission is
 well obfuscated.</p>
-<p>For those entries that win the IOCCC, we often use much of text from the
+<p>For those submission that win the IOCCC, we often use much of text from the
 <code>remarks.md</code> file in the <em>Author’s remarks</em> section of the <code>index.html</code> file.
 For this reason, a well written <code>remarks.md</code> file is considered a plus.</p>
 <p>While not required, consider adding bit of humor to your <code>remarks.md</code>
 as most people who are not humor impaired, as well as the IOCCC judges
 appreciate the opportunity for a fun read as well as a chuckle or two.</p>
+<p><strong>PLEASE</strong> also look at <a href="markdown.html">markdown.html</a> for the IOCCC markdown
+guidelines.</p>
 <h4 id="what-helps">What helps:</h4>
 <ul>
-<li>explaining what your entry does</li>
+<li>explaining what your submission does</li>
 <li>how to entice it to do what it is supposed to do</li>
 <li>what obfuscations are used</li>
-<li>what are the limitations of your entry in respect of portability and/or input data</li>
+<li>what are the limitations of your submission in respect of portability and/or input data</li>
 <li>how it works (if you are really condescending)</li>
 </ul>
 <h4 id="what-does-not-help">What does not help:</h4>
 <ul>
-<li>admitting that your entry is not very obfuscated (you see, the contest is
+<li>admitting that your submission is not very obfuscated (you see, the contest is
 called the <strong>IOCCC</strong>, not the <strong>INVOCCC</strong> :-) ); but even if you do not admit
-it, not very obfuscated entries have a minuscule chance to win (although
+it, not very obfuscated submission have a minuscule chance to win (although
 <a href="2000/tomx/index.html">2000/tomx</a> is a notable counterexample).</li>
 <li>mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if an entry wins. See the guidelines if
+rounds; we look at the author name only if a submission wins. See the guidelines if
 this is not clear!</li>
 <li>leaving the remark section empty.</li>
 </ul>
-https://github.com/ioccc-src/temp-test-ioccc/blob/master/
-<div id="faq2_2">
-<h3 id="faq-2.2-why-dont-you-publish-entries-that-do-not-win">FAQ 2.2: Why don’t you publish entries that do not win?</h3>
+<h3 id="faq-2.2-why-dont-you-publish-submissions-that-do-not-win">FAQ 2.2: Why don’t you publish submissions that do not win?</h3>
 </div>
 <p>Because the publication on the IOCCC site <strong><em>IS</em></strong> the award!
 Anyone is free to put their IOCCC hopefuls, lookalikes and/or
-entries that do not win on their web page for everyone to see.</p>
+submissions that do not win on their web page for everyone to see.</p>
 <div id="faq2_3">
 <h3 id="faq-2.3-how-much-time-does-it-take-to-judge-the-contest">FAQ 2.3: How much time does it take to judge the contest?</h3>
 </div>
-<p>It takes a fair amount of time to setup, run, answer email, process entries,
-review entries, trim down the set entries to a set of winning entries, doing the
+<p>It takes a fair amount of time to setup, run, answer email, process submissions,
+review submissions, trim down the set submissions to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
 late entries to wait until the next contest, etc… It takes a few weekends and
 a number nights of study and work … which is hard given that we are busy with
 many other activities as well.</p>
-<p>Note that we do not contact the author if an entry does not compile or does not
+<p>Note that <strong>we do not</strong> contact the author if a submission does not compile or does not
 work as advertised, we might attempt to fix obvious compilation problems or
 incompatibilities, but no more than that - so be sure that your entry does work
 on at least a couple different platforms, at least one of them being UNIX or
@@ -1136,7 +1138,7 @@ from the judges, they used the following awards:</p>
 <p>These could be considered the ‘best entry’ for those years with 1 or
 more other entries that came in close behind.</p>
 <div id="faq2_6">
-<h3 id="faq-2.6-how-are-ioccc-entries-announced">FAQ 2.6: How are IOCCC entries announced?</h3>
+<h3 id="faq-2.6-how-are-winning-ioccc-entries-announced">FAQ 2.6: How are winning IOCCC entries announced?</h3>
 </div>
 <p>Once the <a href="index.html">IOCCC</a> closes, the judges will:</p>
 <ul>
@@ -1264,7 +1266,7 @@ for details.</p>
 <div id="faq3_4">
 <h3 id="faq-3.4-why-does-clang-or-gcc-fail-to-compile-an-ioccc-entry">FAQ 3.4: Why does clang or gcc fail to compile an IOCCC entry?</h3>
 </div>
-<p>Although we have fixed numerous entries to work with clang (sometimes in an alt
+<p>Although we have fixed most entries to work with clang (sometimes in an alt
 version but usually in the program itself) there are some that simply cannot be
 fixed or if they are fixable they have not yet been fixed (we are working on
 this but other things have to be done too and all on free time).</p>
@@ -1581,7 +1583,7 @@ however, it is not even possible to fix let alone is it worth it. Of course
 if you’re running out of bytes due to rule 2[ab] one might not have much choice.
 This is something that obfuscation authors simply sometimes have to deal with!</p>
 <p>If you try to minimize the number of <code>-Wno-foo</code> options needed with
-<code>-Weverything</code>, please mention this in your remarks about the entry, as the
+<code>-Weverything</code>, please mention this in your remarks about the submission, as the
 judges note you attempt to honor it (see also below). In some cases your
 obfuscated code will issue warnings with <code>-Weverything</code> no matter what: the
 <code>-Wno-poison-system-directories</code> is a common example of this but there are
@@ -1591,12 +1593,12 @@ compile environment might be warning free, a different clang version or a
 different build environment might still have warnings. For instance the warning
 set is different in macOS (which by default is <code>clang</code>: even when run as <code>gcc</code>!)
 than Linux (due to versions and possibly other things)!</p>
-<p>Given that your entry <strong>MUST</strong> work as documented, you may be safer to
-say that your entry keeps the number of warnings and <code>-Wno-foo</code> options while
+<p>Given that your submission <strong>MUST</strong> work as documented, you may be safer to
+say that your submission keeps the number of warnings and <code>-Wno-foo</code> options while
 compiling with <code>clang -Weverything</code> at a minimum. You might want to say the
 version number and platform too as an extra safety net. Because if you claim zero
 warnings, and we find a warning situation, this may diminish the value of your
-entry as it is not as documented. Thus it might be wise to point this out and
+submission as it is not as documented. Thus it might be wise to point this out and
 if you can test it in multiple platforms (or versions of <code>clang</code>, see
 below note) this would be advisable.</p>
 <p>NOTE: different versions of <code>clang</code> have other differences as well. For instance
@@ -1619,8 +1621,8 @@ differences, try from <code>1989/westley</code>:</p>
 <p>Alternatively you can try:</p>
 <pre><code>    git diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..eb9e69fde657acc8c85a618a8a99af4c2f93b21d westley.c</code></pre>
 <p>As you can see, using <code>clang</code> has some additional problems to work out but if
-you can get your entry to work well in <code>clang</code> it might very well be considered
-better than other entries.</p>
+you can get your submission to work well in <code>clang</code> it might very well be considered
+better than other submissions.</p>
 <div id="faq3_12">
 <h3 id="faq-3.12-how-do-i-find-out-how-to-send-interrupteof-etc.-for-entries-that-require-it">FAQ 3.12: How do I find out how to send interrupt/EOF etc. for entries that require it?</h3>
 </div>
@@ -1946,8 +1948,8 @@ if you switched to each entry’s directory and ran <code>make everything</code>
 <p>If you download the 1984 tarball, i.e. <code>1984/1984.tar.bz2</code>, then you might
 extract it and then switch to the directory and compile everything of each
 entry:</p>
-<div class="sourceCode" id="cb59"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb59-1"><a href="#cb59-1" aria-hidden="true" tabindex="-1"></a>        <span class="bu">cd</span> 1984</span>
-<span id="cb59-2"><a href="#cb59-2" aria-hidden="true" tabindex="-1"></a>        <span class="fu">make</span> everything</span></code></pre></div>
+<pre><code>        cd 1984
+        make everything</code></pre>
 <p>For more help on compiling entries, see also <a href="#faq3_0">3.0 - What Makefile rules are
 available to build or clean up IOCCC entries?</a>.</p>
 <p>Of course in this case you can also switch to individual entries and look at the

--- a/faq.md
+++ b/faq.md
@@ -4,9 +4,9 @@
 ## Section  0 - [Submitting entries to a new IOCCC](#faq0)
 - [0.0  - How may I enter the IOCCC?](#faq0_0)
 - [0.1  - What types of entries have been frequently submitted to the IOCCC?](#faq0_1)
-- [0.2  - What should I put in my entry's Makefile?](#faq0_2)
+- [0.2  - What should I put in my submission's Makefile?](#faq0_2)
 - [0.3  - May I use a different source or compiled filename than prog.c or prog?](#faq0_3)
-- [0.4  - What platform should I assume for my entry?](#faq0_4)
+- [0.4  - What platform should I assume for my submission?](#faq0_4)
 - [0.5  - How may I comment or make a suggestion on IOCCC rules, guidelines and tools?](#faq0_5)
 - [0.6  - What are the IOCCC best practices for using markdown?](#faq0_6)
 
@@ -20,12 +20,12 @@
 
 ## Section  2 - [IOCCC Judging process](#faq2)
 - [2.0  - How many entries do the judges receive for a given IOCCC?](#faq2_0)
-- [2.1  - What should I put in the remarks.md file of my entry?](#faq2_1)
+- [2.1  - What should I put in the remarks.md file of my submission?](#faq2_1)
 - [2.2  - Why don't you publish entries that do not win?](#faq2_2)
 - [2.3  - How much time does it take to judge the contest?](#faq2_3)
 - [2.4  - How many judging rounds do you have?](#faq2_4)
 - [2.5  - Why do some IOCCC entries receive the Grand Prize or Best of Show award?](#faq2_5)
-- [2.6  - How are IOCCC entries announced?](#faq2_6)
+- [2.6  - How are winning IOCCC entries announced?](#faq2_6)
 
 
 ## Section  3 - [Compiling and running IOCCC entries](#faq3)
@@ -55,7 +55,7 @@
 ## Section  4 - [Changes made to IOCCC entries](#faq4)
 - [4.0  - Why are some winning author remarks incongruent with the winning IOCCC code?](#faq4_0)
 - [4.1  - Why were some calls to the libc function gets&#x28;3&#x29; changed to use fgets&#x28;3&#x29;?](#faq4_1)
-- [4.2  - What was changed in an IOCCC entry source code?](#faq4_2)
+- [4.2  - What was changed in an IOCCC entry's source code?](#faq4_2)
 - [4.3  - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?](#faq4_3)
 - [4.4  - What is the meaning of the file ending in .orig.c in IOCCC entries?](#faq4_4)
@@ -171,7 +171,7 @@ If you already have an mkiocccentry tool directory:
     make clobber all
 ```
 
-#### 5. Run the mkiocccentry tool to form your entry tarball
+#### 5. Run the mkiocccentry tool to form your submission tarball
 
 ```sh
     mkiocccentry work_dir prog.c Makefile remarks.md [file ...]
@@ -181,11 +181,11 @@ where:
 
 * work_dir
 
-    directory where the entry directory and tarball are formed
+    directory where the submission directory and tarball are formed
 
 * prog.c
 
-    path to the C source for your entry
+    path to the C source for your submission
 
 * Makefile
 
@@ -193,31 +193,31 @@ where:
 
 * remarks.md
 
-    Remarks about your entry in markdown format: see [FAQ 2.1](#remarks_md) for more info.
+    Remarks about your submission in markdown format: see [FAQ 2.1](#remarks_md) for more info.
 
 * [file ...]
 
-    Optional extra data files to include with your entry
+    Optional extra data files to include with your submission
 
 NOTE: Please see our [IOCCC markdown guide](markdown.html) for **important information** on using markdown in the IOCCC.
 
 NOTE: It is *NOT* necessary to install the tools to use them as you can run
 the tools from the top of the _mkiocccentry repo_ directory just fine.
 
-If `mkiocccentry` tool indicates that there is a problem with your entry,
+If `mkiocccentry` tool indicates that there is a problem with your submission,
 especially if it identifies a [rule 2](next/rules.html#2) related problem,
-you are **strongly** encouraged to revise and correct your entry and
+you are **strongly** encouraged to revise and correct your submission and
 then re-run the `mkiocccentry` tool.
 
 If you choose to risk violating rules, be sure an explain your reason
 for doing so in your `remarks.md` file.
 
 
-#### 6. Upload your entry to the IOCCC submit server
+#### 6. Upload your submission tarball to the IOCCC submit server
 
 The **IOCCC submit server** is still being written.
 <!--XXX--> As such, we do not yet have instructions
-on how upload your entry to the **IOCCC submit server**.  Once
+on how upload your submission tarball to the **IOCCC submit server**.  Once
 **IOCCC submit server** is ready, we will update this section
 with the proper instructions.  Watch the [IOCCC news](news.html)
 for an announcement of the availability of the **IOCCC submit server**.
@@ -349,28 +349,31 @@ state something along the lines of:
 
 **FAIR WARNING**: Be sure to **clearly explain** near the beginning
 of your `remarks.md` file, see [FAQ 2.1](#remarks_md),
-**why you are submitting a entry based on a frequently
+**why you are submitting an entry based on a frequently
 submitted theme** and **how compares with previous IOCCC winners**
 of the same theme.
 
 
 
 <div id="faq0_2">
-### FAQ 0.2: What should I put in my entry's Makefile?
+<div id="submission_makefiles">
+### FAQ 0.2: What should I put in my submissions's Makefile?
+</div>
 </div>
 
 We recommend starting with the [sample
 Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
 as found in the [mkiocccentry GitHub repo](https://github.com/ioccc-src/mkiocccentry),
 (renamed as `Makefile` of course) as a starting point for your
-entry's `Makefile`.
+submission's `Makefile`.
 
 The `Makefile` is a file used by the `make(1)` command that contains
 rules and UNIX shell-style commands.
 
-The first and default rule should be the `all` rule and should build your entry's executable file.
+The first and default rule should be the `all` rule and should build your
+submission's executable file.
 
-If your entry depends on a particular source file name during compilation or execution,
+If your submission depends on a particular source file name during compilation or execution,
 your `Makefile` should copy `prog.c` into the desired filename.  For example:
 
 If you are not familiar `Makefile`s, you might consider the following tutorials:
@@ -388,7 +391,8 @@ command that is compatible with GNU Make version 3.81.
 ### FAQ 0.3: May I use a different source or compiled filename than prog.c or prog?
 </div>
 
-While your entry's source filename, as submitted, must be `prog.c`, your entry's `Makefile`
+While your submission's source filename, as submitted, must be `prog.c`, your
+submission's `Makefile`
 may copy `prog.c` to a different filename as part of the compiling/building process.  For example:
 
 ``` <!---make-->
@@ -405,7 +409,7 @@ may copy `prog.c` to a different filename as part of the compiling/building proc
             rm -f desired_name.c desired_name
 ```
 
-We recommend that the `make clobber` rule remove files that your entry
+We recommend that the `make clobber` rule remove files that your submission
 creates as part of the compiling/building process.
 
 You may also copy the compiled `prog` into a different file as part of compiling process.
@@ -420,11 +424,11 @@ For example:
 
 <div id="faq0_4">
 <div id="SUS">
-### FAQ 0.4: What platform should I assume for my entry?
+### FAQ 0.4: What platform should I assume for my submission?
 </div>
 </div>
 
-Your entry must compile with **clang** or **gcc** and run under at least one flavor of a UNIX
+Your submission must compile with **clang** or **gcc** and run under at least one flavor of a UNIX
 system that conforms to the [SUS](https://en.wikipedia.org/wiki/Single_UNIX_Specification),
 otherwise known as the [The Single UNIX Specification Version 4](https://unix.org/version4/)
 or [later SUS](https://unix.org/online.html).
@@ -467,8 +471,8 @@ discussion with the [IOCCC judges](judges.html), then see
 </div>
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
-For example, we [submitting to the IOCCC](faq.html#submit), we have people
-to submit remarks about entry in markdown format.  Every
+For example, when [submitting to the IOCCC](faq.html#submit), we have people
+submit remarks about submissions in markdown format.  Every
 [winning IOCCC entry](years.html) uses a `README.md` markdown file
 as the basis for forming the `index.html` web page for that entry.
 All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
@@ -831,7 +835,7 @@ NOTE: The size rule was actually rule 1.
 
 <div id="faq2_0">
 <div id="how_many">
-### FAQ 2.0: How many entries do the judges receive for a given IOCCC?
+### FAQ 2.0: How many submissions do the judges receive for a given IOCCC?
 </div>
 </div>
 
@@ -840,21 +844,21 @@ By tradition, we do not say.
 
 <div id="faq2_1">
 <div id="remarks_md">
-### FAQ 2.1: What should I put in the remarks.md file of my entry?
+### FAQ 2.1: What should I put in the remarks.md file of my submission?
 </div>
 </div>
 
-While you may put in as much or as little as you wish into your entry's
+While you may put in as much or as little as you wish into your submission's
 `remarks.md` file, we do have few important suggestions:
 
-We recommend that you explain how to use your entry.  Explain the
+We recommend that you explain how to use your submission.  Explain the
 command line (if any command line options and arguments are used)
 and any input or actions if applicable.
 
-We highly recommend that you explain why you think your entry is
+We highly recommend that you explain why you think your submission is
 well obfuscated.
 
-For those entries that win the IOCCC, we often use much of text from the
+For those submission that win the IOCCC, we often use much of text from the
 `remarks.md` file in the _Author's remarks_ section of the `index.html` file.
 For this reason, a well written `remarks.md` file is considered a plus.
 
@@ -862,51 +866,53 @@ While not required, consider adding bit of humor to your `remarks.md`
 as most people who are not humor impaired, as well as the IOCCC judges
 appreciate the opportunity for a fun read as well as a chuckle or two.
 
+**PLEASE** also look at [markdown.html](markdown.html) for the IOCCC markdown
+guidelines.
+
 
 #### What helps:
 
-- explaining what your entry does
+- explaining what your submission does
 - how to entice it to do what it is supposed to do
 - what obfuscations are used
-- what are the limitations of your entry in respect of portability and/or input data
+- what are the limitations of your submission in respect of portability and/or input data
 - how it works (if you are really condescending)
 
 
 #### What does not help:
 
-- admitting that your entry is not very obfuscated (you see, the contest is
+- admitting that your submission is not very obfuscated (you see, the contest is
 called the **IOCCC**, not the **INVOCCC** :-) ); but even if you do not admit
-it, not very obfuscated entries have a minuscule chance to win (although
+it, not very obfuscated submission have a minuscule chance to win (although
 [2000/tomx](2000/tomx/index.html) is a notable counterexample).
 - mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if an entry wins. See the guidelines if
+rounds; we look at the author name only if a submission wins. See the guidelines if
 this is not clear!
 - leaving the remark section empty.
 
 
-%%REPO_URL%%/<div id="faq2_2">
-### FAQ 2.2: Why don't you publish entries that do not win?
+### FAQ 2.2: Why don't you publish submissions that do not win?
 </div>
 
 Because the publication on the IOCCC site **_IS_** the award!
 Anyone is free to put their IOCCC hopefuls, lookalikes and/or
-entries that do not win on their web page for everyone to see.
+submissions that do not win on their web page for everyone to see.
 
 
 <div id="faq2_3">
 ### FAQ 2.3: How much time does it take to judge the contest?
 </div>
 
-It takes a fair amount of time to setup, run, answer email, process entries,
-review entries, trim down the set entries to a set of winning entries, doing the
+It takes a fair amount of time to setup, run, answer email, process submissions,
+review submissions, trim down the set submissions to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
 late entries to wait until the next contest, etc... It takes a few weekends and
 a number nights of study and work ... which is hard given that we are busy with
 many other activities as well.
 
-Note that we do not contact the author if an entry does not compile or does not
+Note that **we do not** contact the author if a submission does not compile or does not
 work as advertised, we might attempt to fix obvious compilation problems or
 incompatibilities, but no more than that - so be sure that your entry does work
 on at least a couple different platforms, at least one of them being UNIX or
@@ -969,7 +975,7 @@ more other entries that came in close behind.
 
 
 <div id="faq2_6">
-### FAQ 2.6: How are IOCCC entries announced?
+### FAQ 2.6: How are winning IOCCC entries announced?
 </div>
 
 Once the [IOCCC](index.html) closes, the judges will:
@@ -1149,7 +1155,7 @@ for details.
 ### FAQ 3.4: Why does clang or gcc fail to compile an IOCCC entry?
 </div>
 
-Although we have fixed numerous entries to work with clang (sometimes in an alt
+Although we have fixed most entries to work with clang (sometimes in an alt
 version but usually in the program itself) there are some that simply cannot be
 fixed or if they are fixable they have not yet been fixed (we are working on
 this but other things have to be done too and all on free time).
@@ -1691,7 +1697,7 @@ if you're running out of bytes due to rule 2[ab] one might not have much choice.
 This is something that obfuscation authors simply sometimes have to deal with!
 
 If you try to minimize the number of `-Wno-foo` options needed with
-`-Weverything`, please mention this in your remarks about the entry, as the
+`-Weverything`, please mention this in your remarks about the submission, as the
 judges note you attempt to honor it (see also below). In some cases your
 obfuscated code will issue warnings with `-Weverything` no matter what: the
 `-Wno-poison-system-directories` is a common example of this but there are
@@ -1703,12 +1709,12 @@ different build environment might still have warnings. For instance the warning
 set is different in macOS (which by default is `clang`: even when run as `gcc`!)
 than Linux (due to versions and possibly other things)!
 
-Given that your entry **MUST** work as documented, you may be safer to
-say that your entry keeps the number of warnings and `-Wno-foo` options while
+Given that your submission **MUST** work as documented, you may be safer to
+say that your submission keeps the number of warnings and `-Wno-foo` options while
 compiling with `clang -Weverything` at a minimum. You might want to say the
 version number and platform too as an extra safety net. Because if you claim zero
 warnings, and we find a warning situation, this may diminish the value of your
-entry as it is not as documented. Thus it might be wise to point this out and
+submission as it is not as documented. Thus it might be wise to point this out and
 if you can test it in multiple platforms (or versions of `clang`, see
 below note) this would be advisable.
 
@@ -1744,8 +1750,8 @@ Alternatively you can try:
 ```
 
 As you can see, using `clang` has some additional problems to work out but if
-you can get your entry to work well in `clang` it might very well be considered
-better than other entries.
+you can get your submission to work well in `clang` it might very well be considered
+better than other submissions.
 
 
 <div id="faq3_12">
@@ -2300,7 +2306,7 @@ If you download the 1984 tarball, i.e. `1984/1984.tar.bz2`, then you might
 extract it and then switch to the directory and compile everything of each
 entry:
 
-```sh
+``` <!---sh-->
         cd 1984
         make everything
 ```

--- a/faq.md
+++ b/faq.md
@@ -4,9 +4,9 @@
 ## Section  0 - [Submitting entries to a new IOCCC](#faq0)
 - [0.0  - How may I enter the IOCCC?](#faq0_0)
 - [0.1  - What types of entries have been frequently submitted to the IOCCC?](#faq0_1)
-- [0.2  - What should I put in my submission's Makefile?](#faq0_2)
+- [0.2  - What should I put in my entry's Makefile?](#faq0_2)
 - [0.3  - May I use a different source or compiled filename than prog.c or prog?](#faq0_3)
-- [0.4  - What platform should I assume for my submission?](#faq0_4)
+- [0.4  - What platform should I assume for my entry?](#faq0_4)
 - [0.5  - How may I comment or make a suggestion on IOCCC rules, guidelines and tools?](#faq0_5)
 - [0.6  - What are the IOCCC best practices for using markdown?](#faq0_6)
 
@@ -20,12 +20,12 @@
 
 ## Section  2 - [IOCCC Judging process](#faq2)
 - [2.0  - How many entries do the judges receive for a given IOCCC?](#faq2_0)
-- [2.1  - What should I put in the remarks.md file of my submission?](#faq2_1)
+- [2.1  - What should I put in the remarks.md file of my entry?](#faq2_1)
 - [2.2  - Why don't you publish entries that do not win?](#faq2_2)
 - [2.3  - How much time does it take to judge the contest?](#faq2_3)
 - [2.4  - How many judging rounds do you have?](#faq2_4)
 - [2.5  - Why do some IOCCC entries receive the Grand Prize or Best of Show award?](#faq2_5)
-- [2.6  - How are winning IOCCC entries announced?](#faq2_6)
+- [2.6  - How are IOCCC entries announced?](#faq2_6)
 
 
 ## Section  3 - [Compiling and running IOCCC entries](#faq3)
@@ -55,7 +55,7 @@
 ## Section  4 - [Changes made to IOCCC entries](#faq4)
 - [4.0  - Why are some winning author remarks incongruent with the winning IOCCC code?](#faq4_0)
 - [4.1  - Why were some calls to the libc function gets&#x28;3&#x29; changed to use fgets&#x28;3&#x29;?](#faq4_1)
-- [4.2  - What was changed in an IOCCC entry's source code?](#faq4_2)
+- [4.2  - What was changed in an IOCCC entry source code?](#faq4_2)
 - [4.3  - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?](#faq4_3)
 - [4.4  - What is the meaning of the file ending in .orig.c in IOCCC entries?](#faq4_4)
@@ -171,7 +171,7 @@ If you already have an mkiocccentry tool directory:
     make clobber all
 ```
 
-#### 5. Run the mkiocccentry tool to form your submission tarball
+#### 5. Run the mkiocccentry tool to form your entry tarball
 
 ```sh
     mkiocccentry work_dir prog.c Makefile remarks.md [file ...]
@@ -181,11 +181,11 @@ where:
 
 * work_dir
 
-    directory where the submission directory and tarball are formed
+    directory where the entry directory and tarball are formed
 
 * prog.c
 
-    path to the C source for your submission
+    path to the C source for your entry
 
 * Makefile
 
@@ -193,31 +193,31 @@ where:
 
 * remarks.md
 
-    Remarks about your submission in markdown format: see [FAQ 2.1](#remarks_md) for more info.
+    Remarks about your entry in markdown format: see [FAQ 2.1](#remarks_md) for more info.
 
 * [file ...]
 
-    Optional extra data files to include with your submission
+    Optional extra data files to include with your entry
 
 NOTE: Please see our [IOCCC markdown guide](markdown.html) for **important information** on using markdown in the IOCCC.
 
 NOTE: It is *NOT* necessary to install the tools to use them as you can run
 the tools from the top of the _mkiocccentry repo_ directory just fine.
 
-If `mkiocccentry` tool indicates that there is a problem with your submission,
+If `mkiocccentry` tool indicates that there is a problem with your entry,
 especially if it identifies a [rule 2](next/rules.html#2) related problem,
-you are **strongly** encouraged to revise and correct your submission and
+you are **strongly** encouraged to revise and correct your entry and
 then re-run the `mkiocccentry` tool.
 
 If you choose to risk violating rules, be sure an explain your reason
 for doing so in your `remarks.md` file.
 
 
-#### 6. Upload your submission tarball to the IOCCC submit server
+#### 6. Upload your entry to the IOCCC submit server
 
 The **IOCCC submit server** is still being written.
 <!--XXX--> As such, we do not yet have instructions
-on how upload your submission tarball to the **IOCCC submit server**.  Once
+on how upload your entry to the **IOCCC submit server**.  Once
 **IOCCC submit server** is ready, we will update this section
 with the proper instructions.  Watch the [IOCCC news](news.html)
 for an announcement of the availability of the **IOCCC submit server**.
@@ -349,31 +349,28 @@ state something along the lines of:
 
 **FAIR WARNING**: Be sure to **clearly explain** near the beginning
 of your `remarks.md` file, see [FAQ 2.1](#remarks_md),
-**why you are submitting an entry based on a frequently
+**why you are submitting a entry based on a frequently
 submitted theme** and **how compares with previous IOCCC winners**
 of the same theme.
 
 
 
 <div id="faq0_2">
-<div id="submission_makefiles">
-### FAQ 0.2: What should I put in my submissions's Makefile?
-</div>
+### FAQ 0.2: What should I put in my entry's Makefile?
 </div>
 
 We recommend starting with the [sample
 Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
 as found in the [mkiocccentry GitHub repo](https://github.com/ioccc-src/mkiocccentry),
 (renamed as `Makefile` of course) as a starting point for your
-submission's `Makefile`.
+entry's `Makefile`.
 
 The `Makefile` is a file used by the `make(1)` command that contains
 rules and UNIX shell-style commands.
 
-The first and default rule should be the `all` rule and should build your
-submission's executable file.
+The first and default rule should be the `all` rule and should build your entry's executable file.
 
-If your submission depends on a particular source file name during compilation or execution,
+If your entry depends on a particular source file name during compilation or execution,
 your `Makefile` should copy `prog.c` into the desired filename.  For example:
 
 If you are not familiar `Makefile`s, you might consider the following tutorials:
@@ -391,8 +388,7 @@ command that is compatible with GNU Make version 3.81.
 ### FAQ 0.3: May I use a different source or compiled filename than prog.c or prog?
 </div>
 
-While your submission's source filename, as submitted, must be `prog.c`, your
-submission's `Makefile`
+While your entry's source filename, as submitted, must be `prog.c`, your entry's `Makefile`
 may copy `prog.c` to a different filename as part of the compiling/building process.  For example:
 
 ``` <!---make-->
@@ -409,7 +405,7 @@ may copy `prog.c` to a different filename as part of the compiling/building proc
             rm -f desired_name.c desired_name
 ```
 
-We recommend that the `make clobber` rule remove files that your submission
+We recommend that the `make clobber` rule remove files that your entry
 creates as part of the compiling/building process.
 
 You may also copy the compiled `prog` into a different file as part of compiling process.
@@ -424,11 +420,11 @@ For example:
 
 <div id="faq0_4">
 <div id="SUS">
-### FAQ 0.4: What platform should I assume for my submission?
+### FAQ 0.4: What platform should I assume for my entry?
 </div>
 </div>
 
-Your submission must compile with **clang** or **gcc** and run under at least one flavor of a UNIX
+Your entry must compile with **clang** or **gcc** and run under at least one flavor of a UNIX
 system that conforms to the [SUS](https://en.wikipedia.org/wiki/Single_UNIX_Specification),
 otherwise known as the [The Single UNIX Specification Version 4](https://unix.org/version4/)
 or [later SUS](https://unix.org/online.html).
@@ -471,8 +467,8 @@ discussion with the [IOCCC judges](judges.html), then see
 </div>
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
-For example, when [submitting to the IOCCC](faq.html#submit), we have people
-submit remarks about submissions in markdown format.  Every
+For example, we [submitting to the IOCCC](faq.html#submit), we have people
+to submit remarks about entry in markdown format.  Every
 [winning IOCCC entry](years.html) uses a `README.md` markdown file
 as the basis for forming the `index.html` web page for that entry.
 All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
@@ -835,7 +831,7 @@ NOTE: The size rule was actually rule 1.
 
 <div id="faq2_0">
 <div id="how_many">
-### FAQ 2.0: How many submissions do the judges receive for a given IOCCC?
+### FAQ 2.0: How many entries do the judges receive for a given IOCCC?
 </div>
 </div>
 
@@ -844,21 +840,21 @@ By tradition, we do not say.
 
 <div id="faq2_1">
 <div id="remarks_md">
-### FAQ 2.1: What should I put in the remarks.md file of my submission?
+### FAQ 2.1: What should I put in the remarks.md file of my entry?
 </div>
 </div>
 
-While you may put in as much or as little as you wish into your submission's
+While you may put in as much or as little as you wish into your entry's
 `remarks.md` file, we do have few important suggestions:
 
-We recommend that you explain how to use your submission.  Explain the
+We recommend that you explain how to use your entry.  Explain the
 command line (if any command line options and arguments are used)
 and any input or actions if applicable.
 
-We highly recommend that you explain why you think your submission is
+We highly recommend that you explain why you think your entry is
 well obfuscated.
 
-For those submission that win the IOCCC, we often use much of text from the
+For those entries that win the IOCCC, we often use much of text from the
 `remarks.md` file in the _Author's remarks_ section of the `index.html` file.
 For this reason, a well written `remarks.md` file is considered a plus.
 
@@ -866,53 +862,51 @@ While not required, consider adding bit of humor to your `remarks.md`
 as most people who are not humor impaired, as well as the IOCCC judges
 appreciate the opportunity for a fun read as well as a chuckle or two.
 
-**PLEASE** also look at [markdown.html](markdown.html) for the IOCCC markdown
-guidelines.
-
 
 #### What helps:
 
-- explaining what your submission does
+- explaining what your entry does
 - how to entice it to do what it is supposed to do
 - what obfuscations are used
-- what are the limitations of your submission in respect of portability and/or input data
+- what are the limitations of your entry in respect of portability and/or input data
 - how it works (if you are really condescending)
 
 
 #### What does not help:
 
-- admitting that your submission is not very obfuscated (you see, the contest is
+- admitting that your entry is not very obfuscated (you see, the contest is
 called the **IOCCC**, not the **INVOCCC** :-) ); but even if you do not admit
-it, not very obfuscated submission have a minuscule chance to win (although
+it, not very obfuscated entries have a minuscule chance to win (although
 [2000/tomx](2000/tomx/index.html) is a notable counterexample).
 - mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if a submission wins. See the guidelines if
+rounds; we look at the author name only if an entry wins. See the guidelines if
 this is not clear!
 - leaving the remark section empty.
 
 
-### FAQ 2.2: Why don't you publish submissions that do not win?
+%%REPO_URL%%/<div id="faq2_2">
+### FAQ 2.2: Why don't you publish entries that do not win?
 </div>
 
 Because the publication on the IOCCC site **_IS_** the award!
 Anyone is free to put their IOCCC hopefuls, lookalikes and/or
-submissions that do not win on their web page for everyone to see.
+entries that do not win on their web page for everyone to see.
 
 
 <div id="faq2_3">
 ### FAQ 2.3: How much time does it take to judge the contest?
 </div>
 
-It takes a fair amount of time to setup, run, answer email, process submissions,
-review submissions, trim down the set submissions to a set of winning entries, doing the
+It takes a fair amount of time to setup, run, answer email, process entries,
+review entries, trim down the set entries to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
 late entries to wait until the next contest, etc... It takes a few weekends and
 a number nights of study and work ... which is hard given that we are busy with
 many other activities as well.
 
-Note that **we do not** contact the author if a submission does not compile or does not
+Note that we do not contact the author if an entry does not compile or does not
 work as advertised, we might attempt to fix obvious compilation problems or
 incompatibilities, but no more than that - so be sure that your entry does work
 on at least a couple different platforms, at least one of them being UNIX or
@@ -975,7 +969,7 @@ more other entries that came in close behind.
 
 
 <div id="faq2_6">
-### FAQ 2.6: How are winning IOCCC entries announced?
+### FAQ 2.6: How are IOCCC entries announced?
 </div>
 
 Once the [IOCCC](index.html) closes, the judges will:
@@ -1155,7 +1149,7 @@ for details.
 ### FAQ 3.4: Why does clang or gcc fail to compile an IOCCC entry?
 </div>
 
-Although we have fixed most entries to work with clang (sometimes in an alt
+Although we have fixed numerous entries to work with clang (sometimes in an alt
 version but usually in the program itself) there are some that simply cannot be
 fixed or if they are fixable they have not yet been fixed (we are working on
 this but other things have to be done too and all on free time).
@@ -1697,7 +1691,7 @@ if you're running out of bytes due to rule 2[ab] one might not have much choice.
 This is something that obfuscation authors simply sometimes have to deal with!
 
 If you try to minimize the number of `-Wno-foo` options needed with
-`-Weverything`, please mention this in your remarks about the submission, as the
+`-Weverything`, please mention this in your remarks about the entry, as the
 judges note you attempt to honor it (see also below). In some cases your
 obfuscated code will issue warnings with `-Weverything` no matter what: the
 `-Wno-poison-system-directories` is a common example of this but there are
@@ -1709,12 +1703,12 @@ different build environment might still have warnings. For instance the warning
 set is different in macOS (which by default is `clang`: even when run as `gcc`!)
 than Linux (due to versions and possibly other things)!
 
-Given that your submission **MUST** work as documented, you may be safer to
-say that your submission keeps the number of warnings and `-Wno-foo` options while
+Given that your entry **MUST** work as documented, you may be safer to
+say that your entry keeps the number of warnings and `-Wno-foo` options while
 compiling with `clang -Weverything` at a minimum. You might want to say the
 version number and platform too as an extra safety net. Because if you claim zero
 warnings, and we find a warning situation, this may diminish the value of your
-submission as it is not as documented. Thus it might be wise to point this out and
+entry as it is not as documented. Thus it might be wise to point this out and
 if you can test it in multiple platforms (or versions of `clang`, see
 below note) this would be advisable.
 
@@ -1750,8 +1744,8 @@ Alternatively you can try:
 ```
 
 As you can see, using `clang` has some additional problems to work out but if
-you can get your submission to work well in `clang` it might very well be considered
-better than other submissions.
+you can get your entry to work well in `clang` it might very well be considered
+better than other entries.
 
 
 <div id="faq3_12">
@@ -2306,7 +2300,7 @@ If you download the 1984 tarball, i.e. `1984/1984.tar.bz2`, then you might
 extract it and then switch to the directory and compile everything of each
 entry:
 
-``` <!---sh-->
+```sh
         cd 1984
         make everything
 ```

--- a/faq.md
+++ b/faq.md
@@ -356,7 +356,9 @@ of the same theme.
 
 
 <div id="faq0_2">
+<div id="submission_makefile">
 ### FAQ 0.2: What should I put in my entry's Makefile?
+</div>
 </div>
 
 We recommend starting with the [sample

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -694,7 +694,7 @@ a one-liner in our vague opinion.</p>
 <strong><code>|</code></strong> * are “blob-ier” (just a pile of unformatted C code) than they need to be</li>
 <li>are rather similar to <strong>previous winners</strong> :-(</li>
 <li>are identical to <strong>previous losers</strong> :-)</li>
-<li>that mandate the exclusive the use of an specific Integrated Development Environment (IDE)</li>
+<li>that mandate the exclusive use of a specific Integrated Development Environment (IDE)</li>
 </ul>
 <p>In order to encourage submission portability, we <strong>DISLIKE</strong> entries that
 fail to build unless one is using an IDE. For example, do not

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -454,7 +454,7 @@ We tend to **DISLIKE** programs that:
 **`|`**   * are "blob-ier" (just a pile of unformatted C code) than they need to be
 * are rather similar to **previous winners** :-(
 * are identical to **previous losers** :-)
-* that mandate the exclusive the use of an specific Integrated Development Environment (IDE)
+* that mandate the exclusive use of a specific Integrated Development Environment (IDE)
 
 In order to encourage submission portability, we **DISLIKE** entries that
 fail to build unless one is using an IDE. For example, do not

--- a/next/rules.html
+++ b/next/rules.html
@@ -435,12 +435,11 @@ IOCCC start with the <strong><code>|</code></strong> symbol.</p>
 <p><strong><code>|</code></strong> This IOCCC runs from <strong>2024-MMM-DD HH:MM:SS UTC</strong> to <strong>202x-MMM-DD HH:MM:SS UTC</strong>.<br>
 <strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
 <p><strong><code>|</code></strong> Until the start of this IOCCC, these <a href="rules.html">IOCCC rules</a>,
-<a href="guidelines.html">IOCCC guidelines</a> and iocccsize.c (contained in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a> and invoked by the
-<code>mkiocccentry(1)</code> tool) should be considered provisional <strong>BETA</strong> versions and
-<strong>may be adjusted <em>AT ANY TIME</em></strong>.</p>
+<a href="guidelines.html">IOCCC guidelines</a> and the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+toolkit</a> should be considered
+provisional <strong>BETA</strong> versions and <strong>may be adjusted <em>AT ANY TIME</em></strong>.</p>
 <p>When the IOCCC is open, the submission URL is:
-<a href="https://submit.ioccc.org/">https://submit.ioccc.org/</a>, at all other
+<a href="https://submit.ioccc.org">https://submit.ioccc.org</a>; at all other
 times that link is likely to be unresponsive.</p>
 <p>Please check the <a href="../faq.html#submit">How to enter FAQ</a>
 for <strong>important information</strong> on how to submit to the IOCCC.</p>
@@ -451,13 +450,15 @@ for <strong>important information</strong> on how to submit to the IOCCC.</p>
 available on the <a href="../index.html">official IOCCC website</a> on or slightly before
 the start of this IOCCC. The <code>mkiocccentry</code> toolkit may be obtained at any time
 at the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p>Please recheck on or after the start of this IOCCC to be sure you
-are using the correct versions of these items before using the IOCCC
-submission URL.</p>
+<p><strong>Please recheck on or after the start of this IOCCC to be sure you
+are using the correct versions of these items <em>before using the IOCCC
+submission URL</em></strong>.</p>
 <h1 id="ioccc-rules">IOCCC RULES</h1>
 <p>To help us with the volume of entries, we ask that you follow these rules:</p>
+<div id="rule0">
 <h2 id="rule-0">Rule 0</h2>
-<p>We need a rule 0. :-)</p>
+</div>
+<p>We need a <a href="#rule0">rule 0</a>. :-)</p>
 <div id="rule1">
 <h2 id="rule-1">Rule 1</h2>
 </div>
@@ -470,17 +471,19 @@ submission URL.</p>
 <h2 id="rule-2a">Rule 2a</h2>
 </div>
 <p><strong><code>|</code></strong> The size of your program source <strong>should not exceed 4993 bytes</strong>.</p>
-<p><strong><code>|</code></strong> If you use the most recently released official IOCCC submission packaging tool
-(hereby referred to as <code>mkiocccentry(1)</code>), which we <strong>STRONGLY recommend you use</strong>,
-then the <code>mkiocccentry(1)</code> tool will warn you if there appears to be a <a href="#rule2a">Rule 2a</a> violation.</p>
+<p><strong><code>|</code></strong> If you use the most recently released official IOCCC submission
+packaging tool (hereby referred to as <code>mkiocccentry(1)</code>), which we <strong>STRONGLY
+recommend you do</strong> (see also <a href="#rule17">Rule 17</a>), then the <code>mkiocccentry(1)</code>
+tool will warn you if there appears to be a <a href="#rule2a">Rule 2a</a> violation.</p>
 <p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2a">Rule 2a</a> warning.
-Overriding a <a href="#rule2a">Rule 2a</a> warning carries a <strong>fair amount of risk</strong> that your submission
-will be <strong>rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
+Overriding a <a href="#rule2a">Rule 2a</a> warning carries a <strong>fair amount of risk that your submission
+will be rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
 ahead of time if you plan to override the <a href="#rule2a">Rule 2a</a> warning.</p>
-<p><strong><code>|</code></strong> If you do override the <a href="#rule2a">Rule 2a</a> warning from the <code>mkiocccentry(1)</code> tool,
-or otherwise plan to violate <a href="#rule2a">Rule 2a</a>, then you <strong>must clearly explain the rationale</strong>
-of why you are doing so in your <code>remarks.md</code> file. Even if you do explain this in your <code>remarks.md</code> file
-your submission may still be rejected.</p>
+<p><strong><code>|</code></strong> If you do override the <a href="#rule2a">Rule 2a</a> warning from the
+<code>mkiocccentry(1)</code> tool, or otherwise plan to violate <a href="#rule2a">Rule 2a</a>, then
+you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong> of why you are doing so in your
+<code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your <code>remarks.md</code> file your
+submission may still be rejected</strong>.</p>
 <p><strong><code>|</code></strong> You may check your code prior to submission by giving the filename
 as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
@@ -488,19 +491,21 @@ as a command like argument to the <code>iocccsize(1)</code> tool. For example:</
 <h2 id="rule-2b">Rule 2b</h2>
 </div>
 <p><strong><code>|</code></strong> When the filename of your program source is given as a command line argument to the latest version
-of the official IOCCC size tool (hereby referred to as <code>iocccsize(1)</code>), the value printed <strong>should not exceed 2503</strong>.</p>
+of the official IOCCC size tool (hereby referred to as <code>iocccsize(1)</code>), the
+value printed <strong>should NOT exceed <em>2503</em></strong>.</p>
 <p><strong><code>|</code></strong> The source to <code>iocccsize(1)</code> may be found in the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p><strong><code>|</code></strong> If you use the <code>mkiocccentry(1)</code> tool, which we <strong>STRONGLY recommend you use</strong>,
+<p><strong><code>|</code></strong> If you use the <code>mkiocccentry(1)</code> tool, which we <strong>STRONGLY recommend
+you do</strong> (again, see also <a href="#rule17">Rule 17</a>),
 then <code>mkiocccentry(1)</code> will invoke <code>iocccsize(1)</code> before packaging your submission.</p>
 <p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2b">Rule 2b</a> warning.
-Overriding a <a href="#rule2b">Rule 2b</a> warning carries a <strong>fair amount of risk</strong> that your submission
-will be <strong>rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
+Overriding a <a href="#rule2b">Rule 2b</a> warning carries a <strong>fair amount of risk that your submission
+will be rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
 ahead of time if you plan to override the <a href="#rule2b">Rule 2b</a> warning.</p>
 <p><strong><code>|</code></strong> If you do override the <a href="#rule2b">Rule 2b</a> warning from the <code>mkiocccentry(1)</code> tool,
-or otherwise plan to violate <a href="#rule2b">Rule 2a</a>, then you <strong>must clearly explain the rationale</strong>
-of why you are doing so in your <code>remarks.md</code> file. Even if you do explain this in your <code>remarks.md</code> file
-your submission may still be rejected.</p>
+or otherwise plan to violate <a href="#rule2b">Rule 2a</a>, then you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong>
+of why you are doing so in your <code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your <code>remarks.md</code> file
+your submission may still be rejected</strong>.</p>
 <p><strong><code>|</code></strong> You may check your code prior to submission by giving the filename
 as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
@@ -509,27 +514,28 @@ as a command like argument to the <code>iocccsize(1)</code> tool. For example:</
 </div>
 <p>Submissions should be performed using the instructions outlined at:
 the <a href="../faq.html#submit">How to enter FAQ</a>.</p>
-<p>To submit to an open IOCCC, you must use the <a href="https://submit.ioccc.org/">IOCCC submit server</a>.</p>
-<p>When the IOCCC is not open, that link will likely be unresponsive.</p>
+<p>To submit to an open IOCCC, you must use the <a href="https://submit.ioccc.org/">IOCCC submit
+server</a>. Unless the IOCCC is open, that link will
+likely be unresponsive.</p>
 <p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
 <strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
-<p>Please wait to submit your entries until after that time.</p>
+<p><strong>Please wait to submit</strong> your entries until after that time.</p>
 <div id="rule4">
 <h2 id="rule-4">Rule 4</h2>
 </div>
 <p><strong><code>|</code></strong> If your submission is selected as a winner, it may be modified in order
-for into the Makefile structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
-<p><strong><code>|</code></strong> For example, your submission’s ‘Makefile’ maybe be modified.</p>
-<p><strong><code>|</code></strong> Your source code will be the file <strong>prog.c</strong>. The compiled binary
-will be called <strong>prog</strong>. If you submission requires different filenames,
-then modify your submission’s ‘Makefile’ to <strong>COPY</strong> (<strong>NOT</strong> move)
+to fit into the structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
+<p><strong><code>|</code></strong> For example, your submission’s <code>Makefile</code> might be modified.</p>
+<p><strong><code>|</code></strong> Your source code will be the file <code>prog.c</code>. The compiled binary
+will be called <code>prog</code>. If you submission requires different filenames,
+then modify your submission’s <code>Makefile</code> to <strong>COPY</strong> (<strong>NOT</strong> move)
 the files accordingly.</p>
-<p><strong><code>|</code></strong> See also <a href="#rile5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
+<p><strong><code>|</code></strong> See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
 <div id="rule5">
 <h2 id="rule-5">Rule 5</h2>
 </div>
 <p>Your submission <strong>MUST</strong> not modify the content or filename of any part of your
-original submission including, but not limited to <strong>prog.c</strong>, the <strong>Makefile</strong>
+original submission including, but not limited to <code>prog.c</code>, the <code>Makefile</code>
 (that we create from your how to build instructions), as well as any data
 files you submit.</p>
 <p>If you submission wishes to modify such content, it <strong>MUST</strong> first copy the
@@ -549,8 +555,8 @@ file to a new filename and then modify that copy.</p>
 you must have permission from the owner(s) to submit their content
 under the following license:</p>
 <p><strong><code>|</code></strong> <strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
-<p>If you submit any content that is owned by others, you <strong>MUST</strong>
-detail that ownership (i.e., who owns what) <strong>AND document the
+<p>If you submit any content that is owned by others, you <strong>MUST
+detail that ownership</strong> (i.e., who owns what) <strong><em>AND</em> document the
 permission you obtained</strong>.</p>
 <p>Please note that the IOCCC size tool is <strong>NOT</strong> an original work.</p>
 <div id="rule8">
@@ -563,12 +569,13 @@ before the close of the contest.</p>
 <div id="rule9">
 <h2 id="rule-9">Rule 9</h2>
 </div>
-<p><strong><code>|</code></strong> Each person may submit up to and including 10.000000 entries per contest.</p>
-<p>Each submission must be submitted separately.</p>
+<p><strong><code>|</code></strong> Each person may submit up to and including <strong>10.000000</strong> entries per contest.</p>
+<p><strong>Each submission <em>must be submitted separately</em></strong>.</p>
 <div id="rule10">
 <h2 id="rule-10">Rule 10</h2>
 </div>
-<p>Entries requiring human interaction to be initially compiled are not permitted.</p>
+<p>Entries requiring human interaction to be initially compiled <strong>are not
+permitted</strong>. However, see the <a href="guidelines.html">guidelines</a>.</p>
 <div id="rule11">
 <h2 id="rule-11">Rule 11</h2>
 </div>
@@ -601,27 +608,27 @@ any control-M at the end of remark file lines.</p>
 <div id="rule15">
 <h2 id="rule-15">Rule 15</h2>
 </div>
-<p><strong><code>|</code></strong> In order to register for the IOCCC, you <strong>MUST</strong> have a valid Email address.</p>
-<p>The judges are not responsible for delays in email, please plan
+<p><strong><code>|</code></strong> In order to register for the IOCCC, you <strong>MUST</strong> have a valid email address.</p>
+<p>The judges <strong>are not responsible for delays in email</strong>, please plan
 enough time for one automated exchange of email as part of your
 submission.</p>
-<p><strong><code>|</code></strong> See <a href="../faq.html#register">How may I register for the IOCCC?</a> in the
+<p><strong><code>|</code></strong> See <a href="../faq.html#register">the FAQ on how to register for the IOCCC</a> in the
 <a href="../faq.html">FAQ</a> for details.</p>
 <div id="rule16">
 <h2 id="rule-16">Rule 16</h2>
 </div>
-<p>You are <strong>STRONGLY</strong> encouraged to submit a previously unpublished <em>AND</em>
-original submission. Submissions that are similar to previous entries are
+<p>You are <strong>STRONGLY</strong> encouraged to submit <strong>a previously unpublished <em>AND</em>
+original submission</strong>. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.</p>
 <div id="rule17">
 <h2 id="rule-17">Rule 17</h2>
 </div>
 <h3 id="tldr-rule-17---use-mkiocccentry1">TL;DR Rule 17 - Use <code>mkiocccentry(1)</code></h3>
-<p><strong><code>|</code></strong> This is a <strong>COMPLEX</strong> rule. Violating this rule will cause your submission to <strong>REJECTED</strong>.
+<p><strong><code>|</code></strong> This is a <strong>COMPLEX</strong> rule. <strong>Violating this rule will cause your submission to REJECTED</strong>!
 To help you avoid such a rejection, you are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code> tool,
 based on the latest release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>,
-to form your submission’s bzip2 compressed tarball.</p>
+to form your submission’s xz compressed tarball.</p>
 <p><strong><code>|</code></strong> The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 contains <strong>IMPORTANT</strong> tools such as:</p>
 <ul>
@@ -629,22 +636,26 @@ contains <strong>IMPORTANT</strong> tools such as:</p>
 <li><code>iocccsize(1)</code></li>
 <li><code>mkiocccentry(1)</code></li>
 <li><code>txzchk(1)</code></li>
+<li><code>fnamchk(1)</code></li>
 </ul>
 <p><strong><code>|</code></strong> The above mentioned tools will help you verify that your submission
 conforms to <a href="#rule17">Rule 17</a>.</p>
-<p><strong><code>|</code></strong> Each above mentioned tools has a <strong><code>-h</code></strong> that provides command line help. For additional details, see the tool man pages.</p>
+<p><strong><code>|</code></strong> Each above mentioned tools has a <code>-h</code> option that provides command
+line help. For additional details, see the tools’ man pages.</p>
 <h3 id="rule-17---the-complex-details">Rule 17 - The COMPLEX details</h3>
-<p><strong><code>|</code></strong> Each submission <strong>MUST</strong> be in the form of a bzip2 compressed tarball file.</p>
-<p><strong><code>|</code></strong> The bzip2 compressed tarball filename must be of the form:</p>
-<ul>
-<li>^submit.” + <em>username</em> + - + <em>slot_num</em> + .[1-9][0-9]{9,}.txz$</li>
-</ul>
-<p>where <em><code>username</code></em> is the your IOCCC registration username in the form of a
-<a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a> (see
+<p><strong><code>|</code></strong> Each submission <strong>MUST</strong> be in the form of a xz compressed tarball.</p>
+<p><strong><code>|</code></strong> The xz compressed tarball filename must be of the form:</p>
+<pre><code>    ^submit.username-slot_num.[1-9][0-9]{9,}.txz$</code></pre>
+<p><strong><code>|</code></strong> where <em><code>username</code></em> is your IOCCC registration username <strong>in the form of a
+<a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a></strong> (see
 <a href="https://datatracker.ietf.org/doc/html/rfc9562">RFC 9562</a> for
 details), and where <em><code>slot_num</code></em> is a single decimal digit integer
-(i.e., &gt;= 0 and &lt; 9), and where <em><code>+</code></em> is the concatenation operator,</p>
-<p><strong><code>|</code></strong> Your bzip2 compressed tarball file <strong>MUST</strong> contain, at a minimum,
+(i.e., &gt;= <code>0</code> and &lt; <code>9</code>).</p>
+<p><strong><code>|</code></strong> In particular, <em><code>username</code></em> is in the form of:
+<code>xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx</code> where <code>x</code> is a hexadecimal digit in the
+range <code>[0-9a-f]</code>. And yes, there is a 4 (UUID version 4) and an <code>a</code> (UUID variant
+1) in there.</p>
+<p><strong><code>|</code></strong> Your xz compressed tarball <strong>MUST</strong> contain, at a minimum,
 the following files:</p>
 <ul>
 <li><code>Makefile</code></li>
@@ -655,52 +666,65 @@ the following files:</p>
 </ul>
 <p><strong><code>|</code></strong> The <code>.info.json</code> must be valid JSON and pass the <code>chkentry(1)</code> test.</p>
 <p><strong><code>|</code></strong> The <code>.auth.json</code> must be valid JSON and pass the <code>chkentry(1)</code> test.</p>
-<p><strong><code>|</code></strong> You submission may have additional files, however <code>basename(1)</code> of the filenames of those additional files <strong>MUST</strong>:</p>
+<p><strong><code>|</code></strong> You submission may have additional files, however the filenames of those additional files <strong>MUST</strong>:</p>
 <ul>
 <li>Be less than <strong>100</strong> characters in length</li>
 <li>Match the regular expression: <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code></li>
 </ul>
-<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file in <a href="https://www.gnu.org/software/make/manual/make.html">Gnu Makefile</a> form.</p>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also <a href="#rule18">Rule 18</a>.</p>
-<p><strong><code>|</code></strong> The bzip2 compressed tarball file <strong>MUST</strong> be less than
+<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file in <a href="https://www.gnu.org/software/make/manual/make.html">GNU
+Makefile</a> form. See the
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">Makefile.example</a>,
+the <a href="../faq.html#submission_makefiles">FAQ about your submission’s Makefile</a> and
+the <a href="../faq.html#make_compatibility">FAQ about IOCCC Makefile compatibility</a> for help.</p>
+<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also
+<a href="#rule18">Rule 18</a> and our <a href="../faq.html#remarks_md">FAQ about what to put in your
+remarks.md</a>.</p>
+<p><strong><code>|</code></strong> The xz compressed tarball file <strong>MUST</strong> be less than
 or equal <strong>3999971</strong> octets in size.</p>
-<p><strong><code>|</code></strong> When your submission’s bzip2 compressed tarball is uncompressed,
+<p><strong><code>|</code></strong> When your submission’s xz compressed tarball is uncompressed,
 the total size of your submission: the sum of the size of the program,
 hints, comments, build and info files <strong>MUST</strong> be less than or equal
-to 28314624 octets (27651K) in size.</p>
+to <strong>28314624</strong> octets (<strong>27651K</strong>) in size.</p>
+<p><strong><code>|</code></strong> Your submission’s xz compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> test.</p>
 <p><strong><code>|</code></strong> You are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code>
-tool to form your submission’s bzip2 compressed tarball. The</p>
-<p><strong><code>|</code></strong> You submission may have additional files, however filenames of those additional files <strong>MUST</strong>:</p>
-<ul>
-<li>be less than <strong>100</strong> characters in length</li>
-<li>conform to the regular expression: <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code></li>
-</ul>
-<p><strong><code>|</code></strong> Your entry may have sub-directories, however the sub-directories <strong>MUST</strong> only
-reside under the submission’s top level directory.</p>
-<p><strong><code>|</code></strong> The directory names of sub-directories path, <strong>MUST</strong>:</p>
+tool to form your submission’s xz compressed tarball.</p>
+<p><strong><code>|</code></strong> Your entry may <strong>NOT</strong> have subdirectories.</p>
+<p><strong><code>|</code></strong> Filenames in your entry (that is, not including the files generated by
+the <code>mkiocccentry(1)</code> tool or the tools it invokes) <strong>MUST</strong>:</p>
 <ul>
 <li>Be less than <strong>100</strong> characters in length</li>
-<li><strong>NOT</strong> start with: <strong><code>/</code></strong></li>
-<li><strong>NOT</strong> contain a path component of: <strong><code>.</code></strong></li>
-<li><strong>NOT</strong> contain a path component of: <strong><code>..</code></strong></li>
-<li>Match the regular expression <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code>.</li>
+<li><strong>NOT</strong> have a <strong><code>/</code></strong> (excluding the entry directory that the
+<code>mkiocccentry(1)</code> tool generates).</li>
+<li><strong>NOT</strong> contain a path component of: <strong><code>.</code></strong> (that is, with the exception of
+files generated by <code>mkiocccentry(1)</code> itself, it must have <strong>NO</strong> <strong><code>.</code></strong>).</li>
+<li><strong>NOT</strong> contain a path component of: <strong><code>..</code></strong> (that is, <strong>NO</strong> <strong><code>..</code></strong>).</li>
+<li>Match the regular expression <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code> (again, excluding
+files generated by <code>mkiocccentry(1)</code>).</li>
 </ul>
-<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file.</p>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also <a href="#rule18">Rule 18</a>.</p>
-<p><strong><code>|</code></strong> The bzip2 compressed tarball file <strong>MUST</strong> be less than
-or equal <strong>3999971</strong> octets in size.</p>
-<p><strong><code>|</code></strong> When your submission’s bzip2 compressed tarball is uncompressed,
-the total size of your submission: the sum of the size of the program,
-hints, comments, build and info files <strong>MUST</strong> be less than or equal
-to 28314624 octets (27651K) in size.</p>
-<p><strong><code>|</code></strong> Your submission’s bzip2 compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> test.</p>
+<p><strong><code>|</code></strong> Additionally, the tarball <strong>MUST</strong> have the following files (generated
+by the <code>mkiocccentry(1)</code> tool):</p>
+<ul>
+<li><code>.auth.json</code> which contains information about the author or authors (that will
+only be looked at if the submission wins).</li>
+<li><code>.info.json</code> which contains information about the entry.</li>
+</ul>
+<p><strong><code>|</code></strong> The <code>txzchk(1)</code> tool will verify these for you and the <code>chkentry(1)</code>
+tool will do additional checks on the contents of the <code>.auth.json</code> and
+<code>.info.json</code> files.</p>
+<p><strong><code>|</code></strong> The tarball filename <strong>MUST</strong> pass <code>fnamchk(1)</code>; the tool <code>txzchk(1)</code>
+which is run by <code>mkiocccentry(1)</code> <strong>before packaging your tarball</strong> will run
+<code>fnamchk(1)</code>.</p>
+<p><strong><code>|</code></strong> These checks <strong>MUST PASS</strong>.</p>
 <p><strong><code>|</code></strong> Where <a href="#rule17">Rule 17</a> and the tools from the latest
 release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 conflict, the <a href="../judges.html">IOCCC Judges</a> will use their best judgment which
 is likely to favor <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> code.</p>
+<p><strong><code>|</code></strong> This means you <strong>MAKE SURE</strong> that you use <code>mkiocccentry(1)</code> to
+package your submission; <code>mkiocccentry(1)</code> will run the above mentioned tools
+<strong>before</strong> creating the tarball.</p>
 <p><strong><code>|</code></strong> To state the obvious: submissions that violate <a href="#rule17">Rule 17</a> <strong>will be rejected</strong>,
 so be sure to use the latest release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>,
-to form and test your submission’s bzip2 compressed tarball.</p>
+to form and test your submission’s xz compressed tarball.</p>
 <div id="rule18">
 <h2 id="rule-18">Rule 18</h2>
 </div>
@@ -712,11 +736,13 @@ you <strong>MUST HAVE PERMISSION</strong> from the owner(s) to submit their cont
 <div id="rule19">
 <h2 id="rule-19">Rule 19</h2>
 </div>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> file, a required non-empty file, must be written in markdown format. See
-the Daring Fireball <a href="http://daringfireball.net/projects/markdown/basics">Markdown: Basics</a>
-for more information.</p>
+<p><strong><code>|</code></strong> The <code>remarks.md</code> file, a required non-empty file, must be written in
+markdown format. See the Daring Fireball <a href="http://daringfireball.net/projects/markdown/basics">Markdown:
+Basics</a>.</p>
 <p><strong><code>|</code></strong> We currently use <a href="https://pandoc.org">pandoc</a> to convert markdown to HTML.</p>
-<p><strong><code>|</code></strong> Please see our <a href="../markdown.html">IOCCC markdown guidelines</a> for additional markdown guidance.</p>
+<p><strong><code>|</code></strong> Please see our <a href="../faq.html#remarks_md">FAQ about what to put in your
+remarks.md</a> and the <a href="../markdown.html">IOCCC markdown
+guidelines</a> for additional markdown guidance.</p>
 <div id="rule20">
 <h2 id="rule-20">Rule 20</h2>
 </div>
@@ -731,7 +757,9 @@ C source file must be called <code>prog.c</code>.</p>
 <p>To invoke the C compiler, use <code>${CC}</code>.
 To invoke the C preprocessor use <code>${CPP}</code>.</p>
 <p>Do not assume that <code>.</code> (the current directory) is in the <code>$PATH</code>.</p>
-<p><strong><code>|</code></strong> Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with bash. You are <strong>ENCOURAGED</strong> to use set <code>SHELL= bash</code> in your <code>Makefile.</code></p>
+<p><strong><code>|</code></strong> Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with bash
+and GNU <code>make(1)</code>. You are <strong>ENCOURAGED</strong> to use set <code>SHELL= bash</code> in
+your <code>Makefile</code>.</p>
 <p><strong><code>|</code></strong> Assume that commands commonly found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environments and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
@@ -740,16 +768,16 @@ available in the <code>$PATH</code> search path.</p>
 <div id="rule21">
 <h2 id="rule-21">Rule 21</h2>
 </div>
-<p>Your submission must not create or modify files above the current directory
+<p>Your submission <strong>must NOT</strong> create or modify files above the current directory
 with the exception of the <code>/tmp</code> and the <code>/var/tmp</code> directories. Your submission
 <strong>MAY</strong> create subdirectories below the current directory, or in <code>/tmp</code>,
 or in <code>/var/tmp</code> provided that <code>.</code> is <strong>NOT</strong> the first octet in any
-directory name or filename you submit.</p>
+directory name or filename you create.</p>
 <div id="rule22">
 <h2 id="rule-22">Rule 22</h2>
 </div>
 <p>Catch 22:</p>
-<p>Your source code, data files, remarks and program output must <strong>NOT</strong>
+<p>Your source code, data files, remarks and program output <strong>must NOT</strong>
 identify the authors of your code. The judges <strong>STRONGLY prefer</strong> to
 NOT know who is submitting entries to the IOCCC.</p>
 <p>Even if you are a previous IOCCC winner, catch 22 still applies.</p>
@@ -791,18 +819,19 @@ for disqualification of your submission.</p>
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 <p><strong><code>|</code></strong> For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.</p>
 <p><strong><code>|</code></strong> Be sure to review the <a href="index.html">IOCCC Rules and Guidelines</a> as
-<a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and often do) change from year to year.</p>
+<a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and
+<strong>often do</strong>) change from year to year.</p>
 <p><strong><code>|</code></strong> You should be sure you have the current <a href="rules.html">IOCCC rules</a> and
 <a href="guidelines.html">IOCCC guidelines</a> prior to submitting entries.</p>
 <p><strong><code>|</code></strong> See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
 <p><strong><code>|</code></strong> For the updates and breaking IOCCC news, you are encouraged to follow
 the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a> account. See our
-<a href="../faq.html#try_mastodon">FAQ</a> for more information. Please do note that unless
-you are mentioned by us you will <strong>NOT</strong> get a notification from the app so you
-should refresh the page even if you do follow us.</p>
+<a href="../faq.html#try_mastodon">FAQ about Mastodon</a> for more information. Please do note that unless
+you are mentioned by us you will <strong>NOT</strong> get a notification from the app <em>so you
+should refresh the page <strong>even if you do follow us</strong></em>.</p>
 <p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
-<p>Leonid A. Broukhis<br>
-chongo (Landon Curt Noll) <code>/\cc/\</code></p>
+<p><strong>Leonid A. Broukhis</strong><br>
+<strong>chongo (Landon Curt Noll) <code>/\cc/\</code></strong></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a>
 <!-- AFTER: last line of markdown file: next/rules.md --></p>

--- a/next/rules.html
+++ b/next/rules.html
@@ -676,7 +676,7 @@ the following files:</p>
 <p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file in <a href="https://www.gnu.org/software/make/manual/make.html">GNU
 Makefile</a> form. See the
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">Makefile.example</a>,
-the <a href="../faq.html#submission_makefiles">FAQ about your submission’s Makefile</a> and
+the <a href="../faq.html#submission_makefile">FAQ about your submission’s Makefile</a> and
 the <a href="../faq.html#make_compatibility">FAQ about IOCCC Makefile compatibility</a> for help.</p>
 <p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also
 <a href="#rule18">Rule 18</a> and our <a href="../faq.html#remarks_md">FAQ about what to put in your

--- a/next/rules.html
+++ b/next/rules.html
@@ -395,7 +395,9 @@ winning entries page</a> for the entries that have won the IOCCC in
 the past.</p>
 <p>Watch both <a href="../status.html">the IOCCC status page</a> and the
 <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> mastodon feed</a> for information about
-future IOCCC openings.</p>
+future IOCCC openings. <strong>Please note</strong> that unless you are mentioned you will
+<strong>NOT</strong> get a push notification with the app so you should refresh the feed from
+time to time.</p>
 <!-- END: the next line ends content from: inc/rules.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 <h1 id="th-international-obfuscated-c-code-contest-official-rules">28th International Obfuscated C Code Contest Official Rules</h1>

--- a/next/rules.md
+++ b/next/rules.md
@@ -77,13 +77,12 @@ The goals of the IOCCC:
 **`|`**   **XXX - date/time is TBD - XXX**
 
 **`|`**   Until the start of this IOCCC, these [IOCCC rules](rules.html),
-[IOCCC guidelines](guidelines.html) and iocccsize.c (contained in the [mkiocccentry
-repo](https://github.com/ioccc-src/mkiocccentry) and invoked by the
-`mkiocccentry(1)` tool) should be considered provisional **BETA** versions and
-**may be adjusted _AT ANY TIME_**.
+[IOCCC guidelines](guidelines.html) and the [mkiocccentry
+toolkit](https://github.com/ioccc-src/mkiocccentry) should be considered
+provisional **BETA** versions and **may be adjusted _AT ANY TIME_**.
 
 When the IOCCC is open, the submission URL is:
-[https://submit.ioccc.org/](https://submit.ioccc.org/), at all other
+[https://submit.ioccc.org](https://submit.ioccc.org); at all other
 times that link is likely to be unresponsive.
 
 Please check the [How to enter FAQ](../faq.html#submit)
@@ -99,9 +98,9 @@ available on the [official IOCCC website](../index.html) on or slightly before
 the start of this IOCCC. The `mkiocccentry` toolkit may be obtained at any time
 at the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
-Please recheck on or after the start of this IOCCC to be sure you
-are using the correct versions of these items before using the IOCCC
-submission URL.
+**Please recheck on or after the start of this IOCCC to be sure you
+are using the correct versions of these items _before using the IOCCC
+submission URL_**.
 
 
 # IOCCC RULES
@@ -109,9 +108,11 @@ submission URL.
 To help us with the volume of entries, we ask that you follow these rules:
 
 
+<div id="rule0">
 ## Rule 0
+</div>
 
-We need a rule 0.  :-)
+We need a [rule 0](#rule0).  :-)
 
 
 <div id="rule1">
@@ -134,19 +135,21 @@ The size rule requires your submission to satisfy **BOTH** [Rule 2a](#rule2a) an
 
 **`|`**   The size of your program source **should not exceed 4993 bytes**.
 
-**`|`**   If you use the most recently released official IOCCC submission packaging tool
-(hereby referred to as `mkiocccentry(1)`), which we **STRONGLY recommend you use**,
-then the `mkiocccentry(1)` tool will warn you if there appears to be a [Rule 2a](#rule2a) violation.
+**`|`**   If you use the most recently released official IOCCC submission
+packaging tool (hereby referred to as `mkiocccentry(1)`), which we **STRONGLY
+recommend you do** (see also [Rule 17](#rule17)), then the `mkiocccentry(1)`
+tool will warn you if there appears to be a [Rule 2a](#rule2a) violation.
 
 **`|`**   The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2a](#rule2a) warning.
-Overriding a [Rule 2a](#rule2a) warning carries a **fair amount of risk** that your submission
-will be **rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
+Overriding a [Rule 2a](#rule2a) warning carries a **fair amount of risk that your submission
+will be rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
 ahead of time if you plan to override the [Rule 2a](#rule2a) warning.
 
-**`|`**   If you do override the [Rule 2a](#rule2a) warning from the `mkiocccentry(1)` tool,
-or otherwise plan to violate [Rule 2a](#rule2a), then you **must clearly explain the rationale**
-of why you are doing so in your `remarks.md` file.  Even if you do explain this in your `remarks.md` file
-your submission may still be rejected.
+**`|`**   If you do override the [Rule 2a](#rule2a) warning from the
+`mkiocccentry(1)` tool, or otherwise plan to violate [Rule 2a](#rule2a), then
+you **MUST CLEARLY EXPLAIN THE RATIONALE** of why you are doing so in your
+`remarks.md` file.  **_Even if you do_ explain this in your `remarks.md` file your
+submission may still be rejected**.
 
 **`|`**   You may check your code prior to submission by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
@@ -161,23 +164,25 @@ as a command like argument to the `iocccsize(1)` tool. For example:
 </div>
 
 **`|`**   When the filename of your program source is given as a command line argument to the latest version
-of the official IOCCC size tool (hereby referred to as `iocccsize(1)`), the value printed **should not exceed 2503**.
+of the official IOCCC size tool (hereby referred to as `iocccsize(1)`), the
+value printed **should NOT exceed _2503_**.
 
 **`|`**   The source to `iocccsize(1)` may be found in the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
-**`|`**   If you use the `mkiocccentry(1)` tool, which we **STRONGLY recommend you use**,
+**`|`**   If you use the `mkiocccentry(1)` tool, which we **STRONGLY recommend
+you do** (again, see also [Rule 17](#rule17)),
 then `mkiocccentry(1)` will invoke `iocccsize(1)` before packaging your submission.
 
 **`|`**   The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2b](#rule2b) warning.
-Overriding a [Rule 2b](#rule2b) warning carries a **fair amount of risk** that your submission
-will be **rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
+Overriding a [Rule 2b](#rule2b) warning carries a **fair amount of risk that your submission
+will be rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
 ahead of time if you plan to override the [Rule 2b](#rule2b) warning.
 
 **`|`**   If you do override the [Rule 2b](#rule2b) warning from the `mkiocccentry(1)` tool,
-or otherwise plan to violate [Rule 2a](#rule2b), then you **must clearly explain the rationale**
-of why you are doing so in your `remarks.md` file.  Even if you do explain this in your `remarks.md` file
-your submission may still be rejected.
+or otherwise plan to violate [Rule 2a](#rule2b), then you **MUST CLEARLY EXPLAIN THE RATIONALE**
+of why you are doing so in your `remarks.md` file.  **_Even if you do_ explain this in your `remarks.md` file
+your submission may still be rejected**.
 
 **`|`**   You may check your code prior to submission by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
@@ -193,14 +198,14 @@ as a command like argument to the `iocccsize(1)` tool. For example:
 Submissions should be performed using the instructions outlined at:
 the [How to enter FAQ](../faq.html#submit).
 
-To submit to an open IOCCC, you must use the [IOCCC submit server](https://submit.ioccc.org/).
-
-When the IOCCC is not open, that link will likely be unresponsive.
+To submit to an open IOCCC, you must use the [IOCCC submit
+server](https://submit.ioccc.org/). Unless the IOCCC is open, that link will
+likely be unresponsive.
 
 **`|`**   The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
 **`|`**   **XXX - date/time is TBD - XXX**
 
-Please wait to submit your entries until after that time.
+**Please wait to submit** your entries until after that time.
 
 
 <div id="rule4">
@@ -208,16 +213,16 @@ Please wait to submit your entries until after that time.
 </div>
 
 **`|`**   If your submission is selected as a winner, it may be modified in order
-for into the Makefile structure of the [Official IOCCC winner website](https://www.ioccc.org/index.html).
+to fit into the structure of the [Official IOCCC winner website](https://www.ioccc.org/index.html).
 
-**`|`**   For example, your submission's 'Makefile' maybe be modified.
+**`|`**   For example, your submission's `Makefile` might be modified.
 
-**`|`**   Your source code will be the file **prog.c**.  The compiled binary
-will be called **prog**.  If you submission requires different filenames,
-then modify your submission's 'Makefile' to **COPY** (**NOT** move)
+**`|`**   Your source code will be the file `prog.c`.  The compiled binary
+will be called `prog`.  If you submission requires different filenames,
+then modify your submission's `Makefile` to **COPY** (**NOT** move)
 the files accordingly.
 
-**`|`**   See also [Rule 5](#rile5), [Rule 18](#rule18) and [Rule 21](#rule21).
+**`|`**   See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
 
 
 <div id="rule5">
@@ -225,7 +230,7 @@ the files accordingly.
 </div>
 
 Your submission **MUST** not modify the content or filename of any part of your
-original submission including, but not limited to **prog.c**, the **Makefile**
+original submission including, but not limited to `prog.c`, the `Makefile`
 (that we create from your how to build instructions), as well as any data
 files you submit.
 
@@ -256,8 +261,8 @@ under the following license:
 
 **`|`**   **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
 
-If you submit any content that is owned by others, you **MUST**
-detail that ownership (i.e., who owns what) **AND document the
+If you submit any content that is owned by others, you **MUST
+detail that ownership** (i.e., who owns what) **_AND_ document the
 permission you obtained**.
 
 Please note that the IOCCC size tool is **NOT** an original work.
@@ -279,16 +284,17 @@ before the close of the contest.
 ## Rule 9
 </div>
 
-**`|`**   Each person may submit up to and including 10.000000 entries per contest.
+**`|`**   Each person may submit up to and including **10.000000** entries per contest.
 
-Each submission must be submitted separately.
+**Each submission _must be submitted separately_**.
 
 
 <div id="rule10">
 ## Rule 10
 </div>
 
-Entries requiring human interaction to be initially compiled are not permitted.
+Entries requiring human interaction to be initially compiled **are not
+permitted**. However, see the [guidelines](guidelines.html).
 
 
 <div id="rule11">
@@ -337,13 +343,13 @@ any control-M at the end of remark file lines.
 ## Rule 15
 </div>
 
-**`|`**   In order to register for the IOCCC, you **MUST** have a valid Email address.
+**`|`**   In order to register for the IOCCC, you **MUST** have a valid email address.
 
-The judges are not responsible for delays in email, please plan
+The judges **are not responsible for delays in email**, please plan
 enough time for one automated exchange of email as part of your
 submission.
 
-**`|`**  See [How may I register for the IOCCC?](../faq.html#register) in the
+**`|`**  See [the FAQ on how to register for the IOCCC](../faq.html#register) in the
 [FAQ](../faq.html) for details.
 
 
@@ -351,8 +357,8 @@ submission.
 ## Rule 16
 </div>
 
-You are **STRONGLY** encouraged to submit a previously unpublished _AND_
-original submission. Submissions that are similar to previous entries are
+You are **STRONGLY** encouraged to submit **a previously unpublished _AND_
+original submission**. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.
 
@@ -364,10 +370,10 @@ been published may be disqualified.
 
 ### TL;DR Rule 17 - Use `mkiocccentry(1)`
 
-**`|`**   This is a **COMPLEX** rule.  Violating this rule will cause your submission to **REJECTED**.
+**`|`**   This is a **COMPLEX** rule.  **Violating this rule will cause your submission to REJECTED**!
 To help you avoid such a rejection, you are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)` tool,
 based on the latest release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
-to form your submission's bzip2 compressed tarball.
+to form your submission's xz compressed tarball.
 
 **`|`**   The [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 contains **IMPORTANT** tools such as:
@@ -376,28 +382,37 @@ contains **IMPORTANT** tools such as:
 * `iocccsize(1)`
 * `mkiocccentry(1)`
 * `txzchk(1)`
+* `fnamchk(1)`
 
 **`|`**   The above mentioned tools will help you verify that your submission
 conforms to [Rule 17](#rule17).
 
-**`|`**   Each above mentioned tools has a **`-h`** that provides command line help.  For additional details, see the tool man pages.
+**`|`**   Each above mentioned tools has a `-h` option that provides command
+line help.  For additional details, see the tools' man pages.
 
 
 ### Rule 17 - The COMPLEX details
 
-**`|`**   Each submission **MUST** be in the form of a bzip2 compressed tarball file.
+**`|`**   Each submission **MUST** be in the form of a xz compressed tarball.
 
-**`|`**   The bzip2 compressed tarball filename must be of the form:
+**`|`**   The xz compressed tarball filename must be of the form:
 
-*  ^submit\." + _username_ + - + _slot_num_ + \.[1-9][0-9]{9,}\.txz$
+``` <!---re-->
+    ^submit.username-slot_num.[1-9][0-9]{9,}.txz$
+```
 
-where _`username`_ is the your IOCCC registration username in the form of a
-[UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) (see
+**`|`** where _`username`_ is your IOCCC registration username **in the form of a
+[UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)** (see
 [RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562) for
 details), and where _`slot_num`_ is a single decimal digit integer
-(i.e., >= 0 and < 9), and where _`+`_ is the concatenation operator,
+(i.e., >= `0` and < `9`).
 
-**`|`**   Your bzip2 compressed tarball file **MUST** contain, at a minimum,
+**`|`** In particular, _`username`_ is in the form of:
+`xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx` where `x` is a hexadecimal digit in the
+range `[0-9a-f]`.  And yes, there is a 4 (UUID version 4) and an `a` (UUID variant
+1) in there.
+
+**`|`**   Your xz compressed tarball **MUST** contain, at a minimum,
 the following files:
 
 * `Makefile`
@@ -410,64 +425,77 @@ the following files:
 
 **`|`**   The `.auth.json` must be valid JSON and pass the `chkentry(1)` test.
 
-**`|`**   You submission may have additional files, however `basename(1)` of the filenames of those additional files **MUST**:
+**`|`**   You submission may have additional files, however the filenames of those additional files **MUST**:
 
 * Be less than **100** characters in length
 * Match the regular expression: `^[0-9A-Za-z][0-9A-Za-z._+-]*$`
 
-**`|`**   The `Makefile` must be a non-empty file in [Gnu Makefile](https://www.gnu.org/software/make/manual/make.html) form.
+**`|`**   The `Makefile` must be a non-empty file in [GNU
+Makefile](https://www.gnu.org/software/make/manual/make.html) form. See the
+[Makefile.example](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
+the [FAQ about your submission's Makefile](../faq.html#submission_makefiles) and
+the [FAQ about IOCCC Makefile compatibility](../faq.html#make_compatibility) for help.
 
-**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also [Rule 18](#rule18).
+**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also
+[Rule 18](#rule18) and our [FAQ about what to put in your
+remarks.md](../faq.html#remarks_md).
 
-**`|`**   The bzip2 compressed tarball file **MUST** be less than
+**`|`**   The xz compressed tarball file **MUST** be less than
 or equal **3999971** octets in size.
 
-**`|`**   When your submission's bzip2 compressed tarball is uncompressed,
+**`|`**   When your submission's xz compressed tarball is uncompressed,
 the total size of your submission: the sum of the size of the program,
 hints, comments, build and info files **MUST** be less than or equal
-to 28314624 octets (27651K) in size.
+to **28314624** octets (**27651K**) in size.
+
+**`|`**  Your submission's xz compressed tarball **MUST** pass the `txzchk(1)` test.
 
 **`|`**   You are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)`
-tool to form your submission's bzip2 compressed tarball.  The
+tool to form your submission's xz compressed tarball.
 
-**`|`**   You submission may have additional files, however filenames of those additional files **MUST**:
+**`|`**   Your entry may **NOT** have subdirectories.
 
-* be less than **100** characters in length
-* conform to the regular expression: `^[0-9A-Za-z][0-9A-Za-z._+-]*$`
-
-**`|`**   Your entry may have sub-directories, however the sub-directories **MUST** only
-reside under the submission's top level directory.
-
-**`|`**   The directory names of sub-directories path, **MUST**:
+**`|`**   Filenames in your entry (that is, not including the files generated by
+the `mkiocccentry(1)` tool or the tools it invokes) **MUST**:
 
 * Be less than **100** characters in length
-* **NOT** start with: **`/`**
-* **NOT** contain a path component of: **`.`**
-* **NOT** contain a path component of: **`..`**
-* Match the regular expression `^[0-9A-Za-z][0-9A-Za-z._+-]*$`.
+* **NOT** have a **`/`** (excluding the entry directory that the
+`mkiocccentry(1)` tool generates).
+* **NOT** contain a path component of: **`.`** (that is, with the exception of
+files generated by `mkiocccentry(1)` itself, it must have **NO** **`.`**).
+* **NOT** contain a path component of: **`..`** (that is, **NO** **`..`**).
+* Match the regular expression `^[0-9A-Za-z][0-9A-Za-z._+-]*$` (again, excluding
+files generated by `mkiocccentry(1)`).
 
-**`|`**   The `Makefile` must be a non-empty file.
+**`|`** Additionally, the tarball **MUST** have the following files (generated
+by the `mkiocccentry(1)` tool):
 
-**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also [Rule 18](#rule18).
+* `.auth.json` which contains information about the author or authors (that will
+only be looked at if the submission wins).
+* `.info.json` which contains information about the entry.
 
-**`|`**   The bzip2 compressed tarball file **MUST** be less than
-or equal **3999971** octets in size.
+**`|`** The `txzchk(1)` tool will verify these for you and the `chkentry(1)`
+tool will do additional checks on the contents of the `.auth.json` and
+`.info.json` files.
 
-**`|`**   When your submission's bzip2 compressed tarball is uncompressed,
-the total size of your submission: the sum of the size of the program,
-hints, comments, build and info files **MUST** be less than or equal
-to 28314624 octets (27651K) in size.
+**`|`** The tarball filename **MUST** pass `fnamchk(1)`; the tool `txzchk(1)`
+which is run by `mkiocccentry(1)` **before packaging your tarball** will run
+`fnamchk(1)`.
 
-**`|`**  Your submission's bzip2 compressed tarball **MUST** pass the `txzchk(1)` test.
+**`|`** These checks **MUST PASS**.
 
 **`|`**  Where [Rule 17](#rule17) and the tools from the latest
 release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 conflict, the [IOCCC Judges](../judges.html) will use their best judgment which
 is likely to favor [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) code.
 
+**`|`** This means you **MAKE SURE** that you use `mkiocccentry(1)` to
+package your submission; `mkiocccentry(1)` will run the above mentioned tools
+**before** creating the tarball.
+
 **`|`**  To state the obvious: submissions that violate [Rule 17](#rule17) **will be rejected**,
 so be sure to use the latest release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
-to form and test your submission's bzip2 compressed tarball.
+to form and test your submission's xz compressed tarball.
 
 
 <div id="rule18">
@@ -488,13 +516,15 @@ You must not submit anything that cannot be submitted under that license.
 ## Rule 19
 </div>
 
-**`|`**  The `remarks.md` file, a required non-empty file, must be written in markdown format. See
-the Daring Fireball [Markdown: Basics](http://daringfireball.net/projects/markdown/basics)
-for more information.
+**`|`**  The `remarks.md` file, a required non-empty file, must be written in
+markdown format. See the Daring Fireball [Markdown:
+Basics](http://daringfireball.net/projects/markdown/basics).
 
 **`|`**   We currently use [pandoc](https://pandoc.org) to convert markdown to HTML.
 
-**`|`**   Please see our [IOCCC markdown guidelines](../markdown.html) for additional markdown guidance.
+**`|`**   Please see our [FAQ about what to put in your
+remarks.md](../faq.html#remarks_md) and the [IOCCC markdown
+guidelines](../markdown.html) for additional markdown guidance.
 
 
 <div id="rule20">
@@ -517,7 +547,9 @@ To invoke the C preprocessor use `${CPP}`.
 
 Do not assume that `.` (the current directory) is in the `$PATH`.
 
-**`|`**   Your `Makefile` **MUST** use a syntax that is compatible with bash.  You are **ENCOURAGED** to use set `SHELL= bash` in your `Makefile.`
+**`|`**   Your `Makefile` **MUST** use a syntax that is compatible with bash
+and GNU `make(1)`.  You are **ENCOURAGED** to use set `SHELL= bash` in
+your `Makefile`.
 
 **`|`**   Assume that commands commonly found in [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
@@ -530,11 +562,11 @@ available in the `$PATH` search path.
 ## Rule 21
 </div>
 
-Your submission must not create or modify files above the current directory
+Your submission **must NOT** create or modify files above the current directory
 with the exception of the `/tmp` and the `/var/tmp` directories.  Your submission
 **MAY** create subdirectories below the current directory, or in `/tmp`,
 or in `/var/tmp` provided that `.` is **NOT** the first octet in any
-directory name or filename you submit.
+directory name or filename you create.
 
 
 <div id="rule22">
@@ -543,7 +575,7 @@ directory name or filename you submit.
 
 Catch 22:
 
-Your source code, data files, remarks and program output must **NOT**
+Your source code, data files, remarks and program output **must NOT**
 identify the authors of your code.  The judges **STRONGLY prefer** to
 NOT know who is submitting entries to the IOCCC.
 
@@ -611,7 +643,8 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 **`|`**   For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
 
 **`|`**   Be sure to review the [IOCCC Rules and Guidelines](index.html) as
-[IOCCC rules](rules.html) and the [IOCCC guidelines](guidelines.html) may (and often do) change from year to year.
+[IOCCC rules](rules.html) and the [IOCCC guidelines](guidelines.html) may (and
+**often do**) change from year to year.
 
 **`|`**   You should be sure you have the current [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) prior to submitting entries.
@@ -620,15 +653,16 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 
 **`|`**   For the updates and breaking IOCCC news, you are encouraged to follow
 the [IOCCC on Mastodon](https://fosstodon.org/@ioccc) account.  See our
-[FAQ](../faq.html#try_mastodon) for more information. Please do note that unless
-you are mentioned by us you will **NOT** get a notification from the app so you
-should refresh the page even if you do follow us.
+[FAQ about Mastodon](../faq.html#try_mastodon) for more information. Please do note that unless
+you are mentioned by us you will **NOT** get a notification from the app _so you
+should refresh the page **even if you do follow us**_.
 
 **`|`**   Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
 
 
-Leonid A. Broukhis<br>
-chongo (Landon Curt Noll) `/\cc/\`
+**Leonid A. Broukhis**<br>
+**chongo (Landon Curt Noll) `/\cc/\`**
+
 
 
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/rules.md
+++ b/next/rules.md
@@ -436,7 +436,7 @@ the following files:
 **`|`**   The `Makefile` must be a non-empty file in [GNU
 Makefile](https://www.gnu.org/software/make/manual/make.html) form. See the
 [Makefile.example](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
-the [FAQ about your submission's Makefile](../faq.html#submission_makefiles) and
+the [FAQ about your submission's Makefile](../faq.html#submission_makefile) and
 the [FAQ about IOCCC Makefile compatibility](../faq.html#make_compatibility) for help.
 
 **`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also

--- a/next/rules.md
+++ b/next/rules.md
@@ -17,7 +17,10 @@ the past.
 
 Watch both [the IOCCC status page](../status.html) and the
 [@IOCCC mastodon feed](https://fosstodon.org/@ioccc) for information about
-future IOCCC openings.
+future IOCCC openings. **Please note** that unless you are mentioned you will
+**NOT** get a push notification with the app so you should refresh the feed from
+time to time.
+
 
 <!-- END: the next line ends content from: inc/rules.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->


### PR DESCRIPTION

A very strange problem occurred where after this commit trying to 
regenerate the FAQ caused very strange results in the browser. 
Unfortunately this likely means that a link to the FAQ is broken (from 
rules.html) but that will be fixed next.
