### PR TITLE
Typo fixes in inc/ and next/

### DIFF
--- a/inc/guidelines.closed.hdr
+++ b/inc/guidelines.closed.hdr
@@ -10,7 +10,7 @@ even be a copy of the guidelines from the previous IOCCC.
 
 See our [FAQ about providing feedback](../faq.html#feedback) as well
 as our [FAQ about asking questions](../faq.html#question) about
-these quidelines.
+these guidelines.
 
 
 # The IOCCC is closed

--- a/inc/guidelines.open.hdr
+++ b/inc/guidelines.open.hdr
@@ -10,7 +10,7 @@ will remain **OFFICIAL** for this IOCCC.
 
 See our [FAQ about providing feedback](../faq.html#feedback) as well
 as our [FAQ about asking questions](../faq.html#question) about
-these quidelines.
+these guidelines.
 
 **SUGGESTION**: Watch both the [IOCCC news](../news.html) and the
 [IOCCC Mastodon](https://fosstodon.org/@ioccc) feed for the latest news

--- a/inc/guidelines.pending.hdr
+++ b/inc/guidelines.pending.hdr
@@ -13,7 +13,7 @@ Mastodon](https://fosstodon.org/@ioccc) feed as _sometimes_ the
 
 See our [FAQ about providing feedback](../faq.html#feedback) as well
 as our [FAQ about asking questions](../faq.html#question) about
-these quidelines.
+these guidelines.
 
 
 # The IOCCC is not yet open

--- a/inc/rules.open.hdr
+++ b/inc/rules.open.hdr
@@ -10,7 +10,7 @@ will remain **OFFICIAL** for this IOCCC.
 
 See our [FAQ about providing feedback](../faq.html#feedback) as well
 as our [FAQ about asking questions](../faq.html#question) about
-these quidelines.
+these guidelines.
 
 **SUGGESTION**: Watch both the [IOCCC news](../news.html) and the
 [IOCCC Mastodon](https://fosstodon.org/@ioccc) feed for the latest news

--- a/inc/rules.pending.hdr
+++ b/inc/rules.pending.hdr
@@ -13,7 +13,7 @@ Mastodon](https://fosstodon.org/@ioccc) feed as _sometimes_ the
 
 See our [FAQ about providing feedback](../faq.html#feedback) as well
 as our [FAQ about asking questions](../faq.html#question) about
-these quidelines.
+these guidelines.
 
 
 # The IOCCC is not yet open

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -391,7 +391,7 @@ MIGHT</strong> be used in the next IOCCC. In some cases they might
 even be a copy of the guidelines from the previous IOCCC.</p>
 <p>See our <a href="../faq.html#feedback">FAQ about providing feedback</a> as well
 as our <a href="../faq.html#question">FAQ about asking questions</a> about
-these quidelines.</p>
+these guidelines.</p>
 <h1 id="the-ioccc-is-closed">The IOCCC is closed</h1>
 <p>The IOCCC is <strong>NOT</strong> accepting new submissions at this time. See the
 <a href="../years.html">IOCCC winning entries page</a> for the entries that have won the

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -10,7 +10,7 @@ even be a copy of the guidelines from the previous IOCCC.
 
 See our [FAQ about providing feedback](../faq.html#feedback) as well
 as our [FAQ about asking questions](../faq.html#question) about
-these quidelines.
+these guidelines.
 
 
 # The IOCCC is closed


### PR DESCRIPTION
A typo that was missed because I did not look at that part of the file was 'quidelines' instead of 'guidelines'. This has been fixed in inc/ and next/.