### PR TITLE
Minor fixes in guidelines

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -724,12 +724,13 @@ transition: all .3s ease;
 
 blockquote {
     margin: 1em 0 1em 1.7em;
-    padding-left: 1em;
     border-top: 4px solid darkgreen;
     border-left: 4px solid darkgreen;
     border-bottom: 4px solid darkgreen;
     border-right: 4px solid darkgreen;
-    font-style: italic;
+    font-style: normal;
+    overflow-wrap: break-word;
+    width: fit-content;
 }
 
 /* This rule makes sure that text in <blockquote><p>..</p></blockquote> is

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1135,44 +1135,47 @@ architectures. For instance, more recent versions of <code>macOS</code> do <stro
 to note such limitations in your <code>remarks.md</code> file. For example if your
 submission factors values up to a certain size, you might want to state:</p>
 <blockquote>
-<p>This submission factors values up <code>2305567963945518424753102147331756070</code>.<br>
+<p>This submission factors values up <code>2305567963945518424753102147331756070</code>.
 Attempting to factor larger values will produce unpredictable results.</p>
 </blockquote>
 <p>The <a href="../judges.html">judges</a> might try to factor the value -5, so you want to might state:</p>
 <blockquote>
-<p>This submission factors positive values up <code>2305567963945518424753102147331756070</code>.<br>
-Attempting to factor large values will produce unpredictable results.</p>
+<p>This submission factors positive values up
+<code>2305567963945518424753102147331756070</code>. Attempting to factor large values will
+produce unpredictable results.</p>
 </blockquote>
 <p>However the <a href="../judges.html">judges</a> might try to also factor 0, so you want to might state:</p>
 <blockquote>
-<p>This submission factors values between 1 and <code>2305567963945518424753102147331756070</code>.<br>
-Attempting to factor values outside that range will produce unpredictable results.</p>
+<p>This submission factors values between 1 and
+<code>2305567963945518424753102147331756070</code>. Attempting to factor values outside
+that range will produce unpredictable results.</p>
 </blockquote>
 <p>Moreover the try to also factor 3.5 or 0x7, or Fred, so you want to might state:</p>
 <blockquote>
-<p>This submission factors integers between 1 and <code>2305567963945518424753102147331756070</code>.<br>
-Attempting to factor anything else will produce unpredictable results.</p>
+<p>This submission factors integers between 1 and
+<code>2305567963945518424753102147331756070</code>. Attempting to factor anything else
+will produce unpredictable results.</p>
 </blockquote>
 <p>You submission might be better off catching the attempt to factor bogus values
 and doing something interesting. So you might want to code accordingly and state:</p>
 <blockquote>
-<p>This submission factors integers between 1 and <code>2305567963945518424753102147331756070</code>.<br>
+<p>This submission factors integers between 1 and <code>2305567963945518424753102147331756070</code>.
 Attempting to factor anything else will cause the program to insult your pet fish Eric.</p>
 </blockquote>
 <p>The <a href="../judges.html">judges</a> might not have a pet fish named Eric, so might want to state:</p>
 <blockquote>
 <p>This submission factors integers between 1 and
-<code>2305567963945518424753102147331756070</code>.<br>
-Attempting to factor anything else will cause the program to insult your pet fish Eric,<br>
-or in the case that you lack such a pet, will insult the pet that you do not have.</p>
+<code>2305567963945518424753102147331756070</code>. Attempting to factor anything else
+will cause the program to insult your pet fish Eric, or in the case that you
+lack such a pet, will insult the pet that you do not have.</p>
 </blockquote>
 <p>When all other things are equal, a submission with fewer limitations will be judged
 better than a submission with lots of limitations. So you might want to code accordingly
 and state:</p>
 <blockquote>
-<p>This submission attempts to a factor value of any size provided that the program is<br>
-given enough time and memory. If the value is not a proper integer, the program<br>
-might insult a fish named Eric.</p>
+<p>This submission attempts to a factor value of any size provided that the
+program is given enough time and memory. If the value is not a proper integer,
+the program might insult a fish named Eric.</p>
 </blockquote>
 <p><strong><code>|</code></strong> Do not fear if you’re not 100% sure of the significance of <code>2305567963945518424753102147331756070</code> as it is not of prime importance: or is it? :-)</p>
 <p><strong><code>|</code></strong> We <strong>DISLIKE</strong> the use of use ASCII tab characters in markdown files, such as in the required <code>remarks.md</code> file.</p>

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1096,7 +1096,7 @@ Noll</a>, in which case they are original! :-)
 Submitting source that uses the content of these tools, unless you are
 <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might run the risk of
 violating <a href="rules.html#rule7">Rule 7</a>.</p>
-<p><strong><code>|</code></strong> Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">jparse tool and
+<p><strong><code>|</code></strong> Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and
 library</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c">jstrencode</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c">jstrdecode</a>
@@ -1162,7 +1162,7 @@ and doing something interesting. So you might want to code accordingly and state
 <p>This submission factors integers between 1 and <code>2305567963945518424753102147331756070</code>.
 Attempting to factor anything else will cause the program to insult your pet fish Eric.</p>
 </blockquote>
-<p>The <a href="../judges.html">judges</a> might not have a pet fish named Eric, so might want to state:</p>
+<p>The <a href="../judges.html">judges</a> might not have a pet fish named Eric, so you might want to state:</p>
 <blockquote>
 <p>This submission factors integers between 1 and
 <code>2305567963945518424753102147331756070</code>. Attempting to factor anything else

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -413,7 +413,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <div id="guidelines_version">
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
-<p><strong><code>|</code></strong> These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.5 2024-07-05</strong>.</p>
+<p><strong><code>|</code></strong> These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.6 2024-07-06</strong>.</p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <div id="change_marks">
 <h3 id="change-marks">Change marks</h3>
@@ -1070,7 +1070,7 @@ some Intel-like x86 architecture.</p>
 <p>Get your facts first, then you can distort them as you please.</p>
 </blockquote>
 <p>… is a good motto for those writing code for the IOCCC.</p>
-<p><strong><code>|</code></strong> The <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">IOCCC size tool source</a>
+<p>The <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">IOCCC size tool source</a>
 is not an original work, unless you are <a href="../authors.html#Anthony_C_Howe">Anthony C
 Howe</a>, in which case it is original! :-)
 Submitting source that uses the content of iocccsize.c, unless you are

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1070,17 +1070,17 @@ some Intel-like x86 architecture.</p>
 <p>Get your facts first, then you can distort them as you please.</p>
 </blockquote>
 <p>… is a good motto for those writing code for the IOCCC.</p>
-<p>The <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">IOCCC size tool source</a>
-is not an original work, unless you are <a href="../authors.html#Anthony_C_Howe">Anthony C
+<p>The IOCCC size tool source is not an original work, unless you are <a href="../authors.html#Anthony_C_Howe">Anthony C
 Howe</a>, in which case it is original! :-)
-Submitting source that uses the content of iocccsize.c, unless you are
+Submitting source that uses the content of
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">iocccsize.c</a>, unless you are
 <a href="../authors.html#Anthony_C_Howe">Anthony C Howe</a>, might run the risk of
 violating <a href="rules.html#rule7">Rule 7</a>.</p>
-<p><strong><code>|</code></strong> The <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk
-tool source</a>
-is not an original work, unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone
+<p><strong><code>|</code></strong> The <code>txzchk</code>
+tool source is not an original work, unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone
 Ferguson</a>, in which case it is original! :-)
-Submitting source that uses the content of txzchk.c, unless you are
+Submitting source that uses the content of
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk.c</a>, unless you are
 <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, might run the risk of
 violating <a href="rules.html#rule7">Rule 7</a>.</p>
 <p><strong><code>|</code></strong> Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -1034,44 +1034,47 @@ architectures. For instance, more recent versions of `macOS` do **NOT** support
 to note such limitations in your `remarks.md` file.  For example if your
 submission factors values up to a certain size, you might want to state:
 
->   This submission factors values up `2305567963945518424753102147331756070`.<br>
->   Attempting to factor larger values will produce unpredictable results.
+>   This submission factors values up `2305567963945518424753102147331756070`.
+Attempting to factor larger values will produce unpredictable results.
 
 The [judges](../judges.html) might try to factor the value -5, so you want to might state:
 
->   This submission factors positive values up `2305567963945518424753102147331756070`.<br>
->   Attempting to factor large values will produce unpredictable results.
+>   This submission factors positive values up
+`2305567963945518424753102147331756070`. Attempting to factor large values will
+produce unpredictable results.
 
 However the [judges](../judges.html) might try to also factor 0, so you want to might state:
 
->   This submission factors values between 1 and `2305567963945518424753102147331756070`.<br>
->   Attempting to factor values outside that range will produce unpredictable results.
+>   This submission factors values between 1 and
+`2305567963945518424753102147331756070`.  Attempting to factor values outside
+that range will produce unpredictable results.
 
 Moreover the try to also factor 3.5 or 0x7, or Fred, so you want to might state:
 
->   This submission factors integers between 1 and `2305567963945518424753102147331756070`.<br>
->   Attempting to factor anything else will produce unpredictable results.
+>   This submission factors integers between 1 and
+`2305567963945518424753102147331756070`.  Attempting to factor anything else
+will produce unpredictable results.
 
 You submission might be better off catching the attempt to factor bogus values
 and doing something interesting.  So you might want to code accordingly and state:
 
->   This submission factors integers between 1 and `2305567963945518424753102147331756070`.<br>
+>   This submission factors integers between 1 and `2305567963945518424753102147331756070`.
 >   Attempting to factor anything else will cause the program to insult your pet fish Eric.
 
 The [judges](../judges.html) might not have a pet fish named Eric, so might want to state:
 
 >   This submission factors integers between 1 and
-`2305567963945518424753102147331756070`.<br>
->   Attempting to factor anything else will cause the program to insult your pet fish Eric,<br>
->   or in the case that you lack such a pet, will insult the pet that you do not have.
+`2305567963945518424753102147331756070`.  Attempting to factor anything else
+will cause the program to insult your pet fish Eric, or in the case that you
+lack such a pet, will insult the pet that you do not have.
 
 When all other things are equal, a submission with fewer limitations will be judged
 better than a submission with lots of limitations.  So you might want to code accordingly
 and state:
 
->   This submission attempts to a factor value of any size provided that the program is<br>
->   given enough time and memory.  If the value is not a proper integer, the program<br>
->   might insult a fish named Eric.
+>   This submission attempts to a factor value of any size provided that the
+program is given enough time and memory.  If the value is not a proper integer,
+the program might insult a fish named Eric.
 
 **`|`**   Do not fear if you're not 100% sure of the significance of `2305567963945518424753102147331756070` as it is not of prime importance: or is it?  :-)
 

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -43,7 +43,7 @@ writing by [contacting the judges](../contact.html).
 ## IOCCC Guidelines version
 </div>
 
-**`|`**   These [IOCCC guidelines](guidelines.html) are version **28.5 2024-07-05**.
+**`|`**   These [IOCCC guidelines](guidelines.html) are version **28.6 2024-07-06**.
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
 
@@ -956,7 +956,7 @@ We believe that Mark Twain's quote:
 
 ... is a good motto for those writing code for the IOCCC.
 
-**`|`**   The [IOCCC size tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c)
+The [IOCCC size tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c)
 is not an original work, unless you are [Anthony C
 Howe](../authors.html#Anthony_C_Howe), in which case it is original!  :-)
 Submitting source that uses the content of iocccsize.c, unless you are

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -956,18 +956,18 @@ We believe that Mark Twain's quote:
 
 ... is a good motto for those writing code for the IOCCC.
 
-The [IOCCC size tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c)
-is not an original work, unless you are [Anthony C
+The IOCCC size tool source is not an original work, unless you are [Anthony C
 Howe](../authors.html#Anthony_C_Howe), in which case it is original!  :-)
-Submitting source that uses the content of iocccsize.c, unless you are
+Submitting source that uses the content of
+[iocccsize.c](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c), unless you are
 [Anthony C Howe](../authors.html#Anthony_C_Howe), might run the risk of
 violating [Rule 7](rules.html#rule7).
 
-**`|`**   The [txzchk
-tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c)
-is not an original work, unless you are [Cody Boone
+**`|`**   The `txzchk`
+tool source is not an original work, unless you are [Cody Boone
 Ferguson](../authors.html#Cody_Boone_Ferguson), in which case it is original!  :-)
-Submitting source that uses the content of txzchk.c, unless you are
+Submitting source that uses the content of
+[txzchk.c](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c), unless you are
 [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), might run the risk of
 violating [Rule 7](rules.html#rule7).
 

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -985,7 +985,7 @@ Submitting source that uses the content of these tools, unless you are
 [Landon Curt Noll](http://www.isthe.com/chongo/index.html), might run the risk of
 violating [Rule 7](rules.html#rule7).
 
-**`|`**   Neither the [jparse tool and
+**`|`**   Neither the [JSON parser and
 library](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
 nor [jstrencode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c)
 nor [jstrdecode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c)
@@ -1061,7 +1061,7 @@ and doing something interesting.  So you might want to code accordingly and stat
 >   This submission factors integers between 1 and `2305567963945518424753102147331756070`.
 >   Attempting to factor anything else will cause the program to insult your pet fish Eric.
 
-The [judges](../judges.html) might not have a pet fish named Eric, so might want to state:
+The [judges](../judges.html) might not have a pet fish named Eric, so you might want to state:
 
 >   This submission factors integers between 1 and
 `2305567963945518424753102147331756070`.  Attempting to factor anything else


### PR DESCRIPTION

A guideline that was there in previous years still had the '|' marker 
which is supposed to be only for changes. This has been removed.