### PR TITLE
Slight improvement to 7af7a8 (bin/chk-entry.sh)

### DIFF
--- a/bin/chk-entry.sh
+++ b/bin/chk-entry.sh
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
+# ... with a slight improvement by Cody Boone Ferguson.
+#
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
 # provided that the above copyright, this permission notice and text
@@ -449,7 +451,12 @@ fi
 #
 # We also add ioccc.css and var.mk from the top level.
 #
-git ls-files "$ENTRY_PATH" > "$TMP_FILE_LIST"
+# At the suggestion of Cody Boone Ferguson / @xexyl we use git ls-files instead
+# of find(1) because this way one needn't worry about other files that might be
+# in an entry's directory, be it a swap file or something else, that used to
+# cause a problem when updating the manifest. Since only files that are under
+# git control matter using git ls-files addresses this problem in a nice way.
+"$GIT_TOOL" ls-files "$ENTRY_PATH" > "$TMP_FILE_LIST"
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: find $ENTRY_PATH -type f -print > $TMP_FILE_LIST failed, error: $status" 1>&2


### PR DESCRIPTION
Instead of using just git use "$GIT_TOOL" as the script already establishes what git to use.

The comment I added also explains the rationale about this a bit, as it might not seem immediately clear why it's useful over find(1).

And although it was already tested I forced what would have caused a failure before, to happen, so that I could verify that this works as I had originally imagined it: put a file in an entry directory that does not belong there and then run the script again, to make sure it does not detect any problem.

Of course with this change one still has to make sure to add valid files to git but that always was how it was anyway.