### PR TITLE
Remove FAQ 0.0 reference in /index.html

### DIFF
--- a/bin/chk-entry.sh
+++ b/bin/chk-entry.sh
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
+# ... with a slight improvement by Cody Boone Ferguson.
+#
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
 # provided that the above copyright, this permission notice and text
@@ -449,7 +451,12 @@ fi
 #
 # We also add ioccc.css and var.mk from the top level.
 #
-git ls-files "$ENTRY_PATH" > "$TMP_FILE_LIST"
+# At the suggestion of Cody Boone Ferguson / @xexyl we use git ls-files instead
+# of find(1) because this way one needn't worry about other files that might be
+# in an entry's directory, be it a swap file or something else, that used to
+# cause a problem when updating the manifest. Since only files that are under
+# git control matter using git ls-files addresses this problem in a nice way.
+"$GIT_TOOL" ls-files "$ENTRY_PATH" > "$TMP_FILE_LIST"
 status="$?"
 if [[ $status -ne 0 ]]; then
     echo "$0: ERROR: find $ENTRY_PATH -type f -print > $TMP_FILE_LIST failed, error: $status" 1>&2

--- a/index.html
+++ b/index.html
@@ -428,7 +428,7 @@ plaintext menu even with JavaScript enabled, you can do so
 </ul>
 <h1 id="entering-the-contest">Entering the Contest</h1>
 <p>View the <a href="status.html">current status of the IOCCC</a> to see of the IOCCC is open for submissions.</p>
-<p>See <a href="faq.html#submit">FAQ 0.0: How may I submit to the IOCCC?</a> for more information.</p>
+<p>See <a href="faq.html#submit">the FAQ about how to enter the IOCCC</a> for more information.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/index.md
+++ b/index.md
@@ -64,7 +64,7 @@ The goals of the IOCCC:
 
 View the [current status of the IOCCC](status.html) to see of the IOCCC is open for submissions.
 
-See [FAQ 0.0: How may I submit to the IOCCC?](faq.html#submit) for more information.
+See [the FAQ about how to enter the IOCCC](faq.html#submit) for more information.
 
 
 <!--


### PR DESCRIPTION

It now is a nicer name and allows for us to reorder the FAQ. This was
only done as I saw it and it's a quick fix. More have to be fixed 
another time.