### PR TITLE
Improve change mark in guidelines and rules

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -796,6 +796,13 @@ blockquote {
     color: DarkBlue;
 }
 
+/* Guidelines / Rules change bar ============================================================================ */
+
+.leftbar {
+    border-left: 4px solid black;
+}
+
+
 /* Footer  ======================================================================================== */
 
 /* Style footer */

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -413,14 +413,20 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <div id="guidelines_version">
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
-<p><strong><code>|</code></strong> These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.6 2024-07-06</strong>.</p>
+<p class="leftbar">
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.7 2024-07-08</strong>.
+</p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <div id="change_marks">
 <h3 id="change-marks">Change marks</h3>
 </div>
-<p><strong><code>|</code></strong> <strong>← Lines that start with this symbol indicate a change from the previous IOCCC</strong></p>
+<p class="leftbar">
+<strong>← Lines that start with this symbol indicate a change from the
+previous IOCCC</strong>.
+</p>
 <p>Most lines (we sometimes make mistakes) that were modified since the previous
-IOCCC start with the <strong><code>|</code></strong> symbol.</p>
+IOCCC start with a solid 4 pixel black left border (or, in the case of a code
+block, just a vertical bar).</p>
 <div id="about_guidelines">
 <h1 id="about-this-file">ABOUT THIS FILE:</h1>
 </div>
@@ -439,39 +445,68 @@ guidelines</a>..</p>
 <div id="new">
 <h1 id="whats-new-this-ioccc">WHAT’S NEW THIS IOCCC</h1>
 </div>
-<p><strong><code>|</code></strong> This IOCCC runs from <strong>2024-MMM-DD HH:MM:SS UTC</strong> to <strong>YYYY-MMM-DD HH:MM:SS UTC</strong>.<br>
-<strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
-<p><strong><code>|</code></strong> The reason for the times of day are so that key IOCCC events are <strong>calculated</strong>
-to be a <strong>fun</strong>ctional UTC time. :-)</p>
-<p><strong><code>|</code></strong> Until the start of this IOCCC, the <a href="rules.html">IOCCC rules</a>,
+<p class="leftbar">
+This IOCCC runs from <strong>2024-MMM-DD HH:MM:SS UTC</strong> to <strong>YYYY-MMM-DD HH:MM:SS UTC</strong>.<br>
+<strong>XXX - date/time is TBD - XXX</strong>
+</p>
+<p class="leftbar">
+The reason for the times of day are so that key IOCCC events are <strong>calculated</strong>
+to be a <strong>fun</strong>ctional UTC time. :-)
+</p>
+<p class="leftbar">
+Until the start of this IOCCC, the <a href="rules.html">IOCCC rules</a>,
 <a href="guidelines.html">IOCCC guidelines</a> and the tools in the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>, should be
 considered provisional <strong>BETA</strong> versions and <strong>may be adjusted <em>AT
-ANY TIME</em></strong>.</p>
-<p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
-<strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
-<p><strong><code>|</code></strong> The <a href="rules.html">IOCCC rules</a>, <a href="guidelines.html">IOCCC
+ANY TIME</em></strong>.
+</p>
+<p class="leftbar">
+The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
+<strong>XXX - date/time is TBD - XXX</strong>
+</p>
+<p class="leftbar">
+The <a href="rules.html">IOCCC rules</a>, <a href="guidelines.html">IOCCC
 guidelines</a> will be available on the <a href="https://www.ioccc.org">Official IOCCC
 website</a> on or slightly before start of this IOCCC. Please check
 <a href="../faq.html#submit">the IOCCC FAQ about how to submit</a> to see how
 to submit entries, on or after the start of this IOCCC, to be sure
 you are using the correct versions of these items before using the
-IOCCC submission URL.</p>
-<p><strong><code>|</code></strong> The <a href="rules.html#rule2a">Rule 2a</a> size has <strong>increased from 4096 to 4993</strong> bytes.</p>
-<p><strong><code>|</code></strong> The <a href="rules.html#rule2b">Rule 2b</a> size has <strong>increased from 2053 to 2503</strong> bytes.</p>
-<p><strong><code>|</code></strong> The new default way to compile submissions: <code>-std=gnu17 -O3 -g3 -Wall -Wextra -pedantic</code>. See below for more details about the example Makefile
-for more help.</p>
-<p><strong><code>|</code></strong> Submissions are in the form of a single xz compressed tarball.</p>
-<p><strong><code>|</code></strong> To assist in the formation of the xz compressed tarball for submission, use the
-<code>mkiocccentry(1)</code> tool as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p><strong><code>|</code></strong> <a href="rules.html#rule17">Rule 17</a> has been <strong>significantly modified</strong>
-to account for the new <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> tools.</p>
-<p><strong><code>|</code></strong> An <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example
+IOCCC submission URL.
+</p>
+<p class="leftbar">
+The <a href="rules.html#rule2a">Rule 2a</a> size has <strong>increased from 4096 to 4993</strong> bytes.
+</p>
+<p class="leftbar">
+The <a href="rules.html#rule2b">Rule 2b</a> size has <strong>increased from 2053 to 2503</strong>
+bytes.
+</p>
+<p class="leftbar">
+The new default way to compile submissions: <code>-std=gnu17 -O3 -g3 -Wall -Wextra -pedantic</code>. See below for more details about the example Makefile
+for more help.
+</p>
+<p class="leftbar">
+Submissions are in the form of a single xz compressed tarball.
+</p>
+<p class="leftbar">
+To assist in the formation of the xz compressed tarball for submission, use the
+<code>mkiocccentry(1)</code> tool as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+repo</a>.
+</p>
+<p class="leftbar">
+<a href="rules.html#rule17">Rule 17</a> has been <strong>significantly modified</strong>
+to account for the new <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> tools.
+</p>
+<p class="leftbar">
+An <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example
 Makefile</a>
 is now available from the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a> and you are encouraged to use
-it.</p>
-<p><strong><code>|</code></strong> The IOCCC submission URL, <a href="../status.html#open">when the IOCCC is open</a>, is <a href="https://submit.ioccc.org/">submit.ioccc.org</a>.</p>
+repo</a> <strong>and you are encouraged to use
+it</strong>.
+</p>
+<p class="leftbar">
+The IOCCC submission URL, <a href="../status.html#open">when the IOCCC is open</a>, is
+<a href="https://submit.ioccc.org/">submit.ioccc.org</a>.
+</p>
 <div id="hints">
 <div id="suggestions">
 <h1 id="hints-and-suggestions">HINTS AND SUGGESTIONS:</h1>
@@ -513,15 +548,21 @@ point in an ironic way.</p>
 entries to attempt to exploit them. We will award ‘<strong>Worst abuse of the
 <a href="rules.html">rules</a></strong>’ or ‘<strong>Best abuse of the <a href="rules.html">rules</a></strong>’ or some
 variation and then plug the hole next year.</p>
-<p><strong><code>|</code></strong> When we do need to plug a hole in the <a href="rules.html">IOCCC rules</a>
-or <a href="guidelines.html">IOCCC guidelines</a>, we will attempt to use a very
-small plug, if not smaller. Or, maybe not. :-)</p>
-<p><strong><code>|</code></strong> There may be less than 2^7+1 reasons why these <a href="guidelines.html">IOCCC guidelines</a> seem obfuscated.</p>
+<p class="leftbar">
+When we do need to plug a hole in the <a href="rules.html">IOCCC rules</a> or <a href="guidelines.html">IOCCC
+guidelines</a>, we will attempt to use a very small plug, if not
+smaller. Or, maybe not. :-)
+</p>
+<p class="leftbar">
+There may be less than 2^7+1 reasons why these <a href="guidelines.html">IOCCC
+guidelines</a> seem obfuscated.
+</p>
 <p>Check out your program and be sure that it works. We sometimes make
 the effort to debug a submission that has a slight problem, particularly
 in or near the final round. On the other hand, we have seen some
 of the best entries fall down because they didn’t work.</p>
-<p><strong><code>|</code></strong> We tend to look down on a <a href="https://en.wikipedia.org/wiki/Prime_number">prime
+<p class="leftbar">
+We tend to look down on a <a href="https://en.wikipedia.org/wiki/Prime_number">prime
 number</a> printer that claims that
 16 is a prime number. If you do have a bug, you are better off
 documenting it. Noting “<em>this submission sometimes prints the 4th power
@@ -529,7 +570,8 @@ of a prime by mistake</em>” would save the above submission. And sometimes,
 a strange bug/feature can even help the submission! Of course, a correctly
 working submission is best. Clever people will note that 16 might be prime
 under certain conditions. Wise people, when submitting something clever
-will fully explain such cleverness in their submission’s <code>remarks.md</code> file.</p>
+will fully explain such cleverness in their submission’s <code>remarks.md</code> file.
+</p>
 <p>People who are considering to just use some complex mathematical
 function or state machine to spell out something such as “<em>hello,
 world!</em>” <strong>really really, <em>and we do mean REALLY</em>, do need to be more creative</strong>.</p>
@@ -541,16 +583,31 @@ misleading comments and variable names might be a good start.</p>
 <p>When programs use VTxxx/ANSI sequences, they should NOT be limited to a
 specific terminal brand. Those programs that work in a standard xterm
 are considered more portable.</p>
-<p><strong><code>|</code></strong> <a href="rules.html#rule2">Rule 2</a> (the size rule) refers to the use of the IOCCC size tool called <code>iocccsize(1)</code>.</p>
-<p><strong><code>|</code></strong> See the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> for the <code>iocccsize(1)</code> tool.</p>
-<p><strong><code>|</code></strong> To further clarify <a href="rules.html#rule2">Rule 2</a>, we subdivided it into two parts, <strong>2a</strong> and <strong>2b</strong>.</p>
-<p><strong><code>|</code></strong> The overall size limit (see <a href="rules.html#rule2a">Rule 2a</a>) on <code>prog.c</code> is now <strong>4993 bytes</strong>.</p>
-<p><strong><code>|</code></strong> Your submission must satisfy BOTH the maximum size <a href="rules.html#rule2a">Rule
-2a</a> AND the IOCCC size tool <a href="rules.html#rule2b">Rule 2b</a>.</p>
-<p><strong><code>|</code></strong> This IOCCC size tool imposes a 2nd limit on C code size (see <a href="rules.html#rule2a">Rule 2a</a>. To check your
-code against <a href="rules.html#rule2">Rule 2</a>:</p>
+<p class="leftbar">
+<a href="rules.html#rule2">Rule 2</a> (the size rule) refers to the use of the IOCCC size
+tool called <code>iocccsize(1)</code>.
+</p>
+<p class="leftbar">
+See the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+repo</a> for the <code>iocccsize(1)</code> tool.
+</p>
+<p class="leftbar">
+To further clarify <a href="rules.html#rule2">Rule 2</a>, we subdivided it into two parts,
+<strong>2a</strong> and <strong>2b</strong>.
+</p>
+<p class="leftbar">
+The overall size limit (see <a href="rules.html#rule2a">Rule 2a</a>) on <code>prog.c</code> is now <strong>4993 bytes</strong>.
+</p>
+<p class="leftbar">
+Your submission must satisfy BOTH the maximum size <a href="rules.html#rule2a">Rule
+2a</a> AND the IOCCC size tool <a href="rules.html#rule2b">Rule 2b</a>.
+</p>
+<p class="leftbar">
+This IOCCC size tool imposes a 2nd limit on C code size (see <a href="rules.html#rule2a">Rule 2a</a>. To check your
+code against <a href="rules.html#rule2">Rule 2</a>:
+</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
-<p><strong><code>|</code></strong> The IOCCC size tool algorithm may be summarized as follows:</p>
+<p>The IOCCC size tool algorithm may be summarized as follows:</p>
 <blockquote>
 <p>The size tool counts most C reserved words (keyword, secondary, and selected
 preprocessor keywords) as 1. The size tool counts all other octets as 1
@@ -560,111 +617,163 @@ before the end of file.</p>
 </blockquote>
 <p>ASCII whitespace includes ASCII tab, ASCII space, ASCII newline,
 ASCII formfeed, and ASCII carriage return.</p>
-<p><strong><code>|</code></strong> When ‘<code>;</code>’, ‘<code>{</code>’ or ‘<code>}</code>’ are within a C string, they may still not be<br>
-<strong><code>|</code></strong> counted by the IOCCC size tool. This is a feature, not a bug!</p>
+<p class="leftbar">
+When ‘<code>;</code>’, ‘<code>{</code>’ or ‘<code>}</code>’ are within a C string, they may still not be
+counted by the IOCCC size tool. This is a feature, not a bug!
+</p>
 <p>In cases where the above summary and the algorithm implemented by
 the IOCCC size tool source code conflict, the algorithm implemented
 by the IOCCC size tool source code is preferred by the judges.</p>
-<p><strong><code>|</code></strong> There are at least 2 other reasons for selecting<br>
-<strong><code>|</code></strong> 2503 as the 2nd limit besides the fact that 2503<br>
-<strong><code>|</code></strong> is a prime. These reasons may be searched for<br>
-<strong><code>|</code></strong> and discovered if you are <a href="https://t5k.org/curios/page.php/2503.html">“Curios!” about 2503</a>. :-)<br>
-<strong><code>|</code></strong> Moreover, 2053 was the number of the kernel disk<br>
-<strong><code>|</code></strong> pack of one of the judge’s BESM-6, and 2503 is a<br>
-<strong><code>|</code></strong> decimal anagram of 2053.</p>
+<p class="leftbar">
+There are at least 2 other reasons for selecting 2503 as the 2nd limit besides
+the fact that 2503 is a prime. These reasons may be searched for and discovered
+if you are <a href="https://t5k.org/curios/page.php/2503.html">“Curios!” about 2503</a>.
+:-) Moreover, 2053 was the number of the kernel disk pack of one of the judge’s
+BESM-6, and 2503 is a decimal anagram of 2053.
+</p>
 <p>Take note that this secondary limit imposed by the IOCCC size tool
 obviates some of the need to <code>#define</code> C reserved words in an effort
 to get around the size limits of <a href="rules.html#rule2">Rule 2</a>.</p>
 <p>Yes Virginia, <strong>that is a hint</strong>!</p>
-<p><strong><code>|</code></strong> The <a href="rules.html#rule2a">Rule 2a</a> size was changed from
+<p class="leftbar">
+The <a href="rules.html#rule2a">Rule 2a</a> size was changed from
 4096 to 4993: a change that keeps the “2b to 2a” size ratio to a
 value similar to the <a href="../faq.html#size_rule2001-2012">2001-2012</a> and
-<a href="../faq.html#size_rule2013-2020">2013-2020</a> IOCCC eras.</p>
-<p><strong><code>|</code></strong> <a href="rules.html#rule17">Rule 17</a> (the <code>mkiocccentry(1)</code> rule) states that
-you <strong>MUST</strong> use the <code>mkiocccentry(1)</code> tool to package your submission tarball.</p>
-<p><strong><code>|</code></strong> See the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
-for the <code>mkiocccentry(1)</code> tool.</p>
-<p><strong><code>|</code></strong> This tool invokes a number of other tools and one, <code>txzchk(1)</code>,
-invokes another, <code>fnamchk(1)</code>.</p>
-<p><strong><code>|</code></strong> Although the <code>mkiocccentry(1)</code> tool will verify everything for you,
+<a href="../faq.html#size_rule2013-2020">2013-2020</a> IOCCC eras.
+</p>
+<p class="leftbar">
+<a href="rules.html#rule17">Rule 17</a> (the <code>mkiocccentry(1)</code> rule) states that
+you <strong>MUST</strong> use the <code>mkiocccentry(1)</code> tool to package your submission tarball.
+</p>
+<p class="leftbar">
+See the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
+for the <code>mkiocccentry(1)</code> tool.
+</p>
+<p class="leftbar">
+This tool invokes a number of other tools and one, <code>txzchk(1)</code>,
+invokes another, <code>fnamchk(1)</code>.
+</p>
+<p class="leftbar">
+Although the <code>mkiocccentry(1)</code> tool will verify everything for you,
 you may wish to validate each part individually. As the <a href="rules.html">rules</a>
 state, each of these tools have a <code>-h</code> option. However, to help simplify
-matters, we give you a brief overview below.</p>
-<p><strong><code>|</code></strong> The synopsis of the <code>mkiocccentry(1)</code> tool is:</p>
+matters, we give you a brief overview below.
+</p>
+<p class="leftbar">
+The synopsis of the <code>mkiocccentry(1)</code> tool is:
+</p>
 <pre><code>    ./mkiocccentry [options] work_dir prog.c \
          Makefile remarks.md [file ...]</code></pre>
-<p><strong><code>|</code></strong> where the <code>work_dir</code> is a directory that is used to form the
+<p class="leftbar">
+… where the <code>work_dir</code> is a directory that is used to form the
 xz compressed tarball that <code>txzchk(1)</code> validates, <code>prog.c</code> is your submission
 source code, <code>Makefile</code> is your <code>Makefile</code>, <code>remarks.md</code> is your remarks and
-<code>[file ...]</code> are any additional files you wish to provide.</p>
-<p><strong><code>|</code></strong> If the <code>work_dir</code> already exists it is an error.</p>
-<p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will ask you for information about your
+<code>[file ...]</code> are any additional files you wish to provide.
+</p>
+<p class="leftbar">
+If the <code>work_dir</code> already exists it is an error. In the case this happens you
+will have to choose a different directory, or if it is safe to remove, you may
+do so and try again.
+</p>
+<p class="leftbar">
+The <code>mkiocccentry(1)</code> tool will ask you for information about your
 submission as well as author details and it will run the <code>iocccsize(1)</code> tool; if
 either <a href="rules.html#rule2a">Rule 2a</a> or <a href="rules.html#rule2b">Rule 2b</a> are broken,
 it will give you the option to ignore them, if you are willing to risk this. The
 tool will also do a rudimentary check on the <code>Makefile</code> and run other checks as
 well. You can override warnings but doing so puts you at risk of violating
-<a href="rules.html">rules</a>.</p>
-<p><strong><code>|</code></strong> On the other hand, some <strong>issues are an error</strong> and the xz compressed
+<a href="rules.html">rules</a>.
+</p>
+<p class="leftbar">
+On the other hand, some <strong>issues are an error</strong> and the xz compressed
 tarball <strong>will not be formed</strong>. For instance, if <code>chkentry(1)</code> fails to validate
 the <code>.auth.json</code> or <code>.info.json</code> <a href="https://www.json.org/json-en.html">JSON</a> files
 that <code>mkiocccentry(1)</code> creates, it is an error and possibly a bug that you
 should report at the <a href="https://github.com/ioccc-src/mkiocccentry/issues">mkiocccentry issues
 page</a>. <strong>PLEASE run the
 <code>bug_report.sh</code> script to help us out here!</strong> See the <a href="../faq.html#mkiocccentry_bugs">the FAQ about reporting
-bugs in the mkiocccentry repo</a>.</p>
-<p><strong><code>|</code></strong> Assuming that <code>chkentry(1)</code> passes for both <code>.auth.json</code> and
+bugs in the mkiocccentry repo</a>.
+</p>
+<p class="leftbar">
+Assuming that <code>chkentry(1)</code> passes for both <code>.auth.json</code> and
 <code>.info.json</code> then the tarball will be formed and then <code>txzchk(1)</code> will be
 executed. In this case, there should be no problems as <code>mkiocccentry(1)</code> would
-<strong>NOT</strong> form a tarball if there are any issues.</p>
-<p><strong><code>|</code></strong> <code>txzchk(1)</code> performs a wide number of sanity checks on the xz
+<strong>NOT</strong> form a tarball if there are any issues.
+</p>
+<p class="leftbar">
+<code>txzchk(1)</code> performs a wide number of sanity checks on the xz
 compressed tarball and if any issues (<code>feathers</code> :-) ) are found and if you used
 <code>mkiocccentry(1)</code>, then it is very possibly a bug in one of the tools and you
 should report it at the <a href="https://github.com/ioccc-src/mkiocccentry/issues">mkiocccentry issues
 page</a>. <strong>PLEASE run the
 <code>bug_report.sh</code> script to help us out here!</strong> See <a href="../faq.html#mkiocccentry_bugs">the FAQ about reporting bugs
-in the mkiocccentry repo</a>.</p>
-<p><strong><code>|</code></strong> As part of its sanity checks, <code>txzchk(1)</code> will run <code>fnamchk(1)</code> on the
+in the mkiocccentry repo</a>.
+</p>
+<p class="leftbar">
+As part of its sanity checks, <code>txzchk(1)</code> will run <code>fnamchk(1)</code> on the
 <em>filename</em> to verify that the name is valid. If this test does not pass, then it
 is flagged by <code>txzchk(1)</code> but it is not an error if you wish to ignore it.
 Ignoring this, however, risks violating <a href="rules.html#rule17">Rule 17</a> which is a
-big risk. Of course, using <code>mkiocccentry(1)</code> would prevent this from happening.</p>
-<p><strong><code>|</code></strong> By default, <code>txzchk(1)</code> will show the contents of the tarball which is
-how the <code>mkiocccentry(1)</code> shows you the tarball contents for you to review.</p>
-<p><strong><code>|</code></strong> To help you with editing a submission, the <code>mkiocccentry(1)</code> tool has
+big risk. Of course, using <code>mkiocccentry(1)</code> would prevent this from happening.
+</p>
+<p class="leftbar">
+By default, <code>txzchk(1)</code> will show the contents of the tarball which is
+how the <code>mkiocccentry(1)</code> shows you the tarball contents for you to review.
+</p>
+<p class="leftbar">
+To help you with editing a submission, the <code>mkiocccentry(1)</code> tool has
 some options to write <em>OR</em> read from an answers file so you do not have to input
-the information again. To write to <code>answers.txt</code> try:</p>
+the information again. To write to <code>answers.txt</code> try:
+</p>
 <pre><code>    ./mkiocccentry -a answers.txt ...</code></pre>
-<p><strong><code>|</code></strong> Alternatively, if you wish to overwrite a file, you can use the <code>-A</code>
+<p class="leftbar">
+Alternatively, if you wish to overwrite a file, you can use the <code>-A</code>
 flag with the same option argument. Be careful that you do not accidentally
-overwrite your <code>prog.c</code>!</p>
-<p><strong><code>|</code></strong> To make use of the answers file, use the <code>-i answers</code> option like:</p>
+overwrite your <code>prog.c</code>!
+</p>
+<p class="leftbar">
+To make use of the answers file, use the <code>-i answers</code> option like:
+</p>
 <pre><code>    ./mkiocccentry -i answers.txt ...</code></pre>
-<p><strong><code>|</code></strong> If you wish to manually run the commands you can do so. For instance, to
-check the validity of the tarball
-<code>submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz</code> you can do:</p>
+<p class="leftbar">
+If you wish to manually run the commands you can do so. For instance, to check
+the validity of the tarball
+<code>submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz</code> you can do:
+</p>
 <pre><code>    ./txzchk submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz</code></pre>
-<p><strong><code>|</code></strong> Assuming that the tarball exists and is valid, you should see the
-contents of the tarball and the words:</p>
+<p class="leftbar">
+Assuming that the tarball exists and is valid, you should see the
+contents of the tarball and the words:
+</p>
 <blockquote>
 <p>No feathers stuck in tarball.</p>
 </blockquote>
-<p><strong><code>|</code></strong> If you give the option <code>-q</code> it will not report anything unless there
+<p class="leftbar">
+If you give the option <code>-q</code> it will not report anything unless there
 are certain error conditions, for instance if <code>fnamchk(1)</code> reports there is a
 problem with the filename; if <code>txzchk(1)</code> exits 0 then there are no problems
-detected.</p>
-<p><strong><code>|</code></strong> If you wish to run <code>fnamchk(1)</code> directly you can do so like:</p>
+detected.
+</p>
+<p class="leftbar">
+If you wish to run <code>fnamchk(1)</code> directly you can do so like:
+</p>
 <pre><code>    ./fnamchk submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz</code></pre>
-<p><strong><code>|</code></strong> Assuming everything is OK, it would show:</p>
+<p class="leftbar">
+Assuming everything is OK, it would show:
+</p>
 <blockquote>
 <p><code>12345678-1234-4321-abcd-1234567890ab-2</code></p>
 </blockquote>
-<p><strong><code>|</code></strong> … which <code>txzchk(1)</code> uses.</p>
-<p><strong><code>|</code></strong> If you want to validate the <code>.auth.json</code> or <code>.info.json</code> files you
+<p class="leftbar">
+… which <code>txzchk(1)</code> uses.
+</p>
+<p class="leftbar">
+If you want to validate the <code>.auth.json</code> or <code>.info.json</code> files you
 should use <code>chkentry(1)</code>. <code>chkentry(1)</code> accepts more than one command line form.
 If you pass a single argument, it is expected to be a directory that has both
 <code>.auth.json</code> and <code>.info.json</code> in it. You can also specify a <code>.auth.json</code> and/or
-<code>.info.json</code> file. An argument of <code>.</code> will skip that file. For instance:</p>
+<code>.info.json</code> file. An argument of <code>.</code> will skip that file. For instance:
+</p>
 <pre><code>    # test entry directory test_work:
     ./chkentry test_work
 
@@ -676,108 +785,156 @@ If you pass a single argument, it is expected to be a directory that has both
 
     # run checks on .info.json and .auth.json:
     ./chkentry .info.json .auth.json</code></pre>
-<p><strong><code>|</code></strong> If there is a <a href="https://www.json.org/json-en.html">JSON</a> issue detected
+<p class="leftbar">
+If there is a <a href="https://www.json.org/json-en.html">JSON</a> issue detected
 by <code>jparse(8)</code>, <strong>then there is a <a href="https://www.json.org/json-en.html">JSON</a>
 error and <code>chkentry(1)</code> will report it as an <em>error</em></strong>. If the parsing is OK <strong>but
 there <em>is an issue</em> in one or both of the
 <a href="https://www.json.org/json-en.html">JSON</a></strong> files <strong>in the context of the IOCCC</strong>,
 <em>it will <strong>report this as an error</strong></em>. Thus, if you were to package this manually
-then you would be violating <a href="rules.html#rule17">Rule 17</a>.</p>
-<p><strong><code>|</code></strong> At the risk of stating the obvious: you run <strong>a very big risk</strong> of having
+then you would be violating <a href="rules.html#rule17">Rule 17</a>.
+</p>
+<p class="leftbar">
+At the risk of stating the obvious: you run <strong>a very big risk</strong> of having
 your submission rejected if you package your own tarball and there are <strong>any
 problems</strong>. For instance, if <code>chkentry(1)</code> found a problem in your <code>.info.json</code>
 file, the <code>mkiocccentry(1)</code> tool would not package it. But if you were to package
 it manually, you would be violating <a href="rules.html#rule17">Rule 17</a>. But even if
-everything checks out OK you should not expect that everything <strong>IS</strong> OK.</p>
-<p><strong><code>|</code></strong> As you can see, the use of <code>mkiocccentry(1)</code> is <strong>HIGHLY RECOMMENDED</strong>.</p>
-<p><strong><code>|</code></strong> We recommend that you use the
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example Makefile</a>
-from the <a href="https://github.com/ioccc-src/mkiocccentry">IOCCC mkiocccentry repo</a>.
+everything checks out OK you should not expect that everything <strong>IS</strong> OK.
+</p>
+<p class="leftbar">
+As you can see, the use of <code>mkiocccentry(1)</code> is <strong>HIGHLY RECOMMENDED</strong>.
+</p>
+<p class="leftbar">
+<p>We recommend that you use the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example
+Makefile</a>
+from the <a href="https://github.com/ioccc-src/mkiocccentry">IOCCC mkiocccentry repo</a>,
 renamed as <code>Makefile</code> of course, as the starting point for your submission’s
-required <code>Makefile</code>. Feel free to modify the <code>Makefile</code> to suit your obfuscated needs.</p>
-<p><strong><code>|</code></strong> The rest of these guidelines will assume that you are using some variant of the
+required <code>Makefile</code>. Feel free to modify the <code>Makefile</code> to suit your obfuscated
+needs.</p>
+<p class="leftbar">
+The rest of these guidelines will assume that you are using some variant of the
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example Makefile</a>,
-renamed as <code>Makefile</code> of course.</p>
-<p><strong><code>|</code></strong> We suggest that you compile your submission with a commonly available
-<code>-std=gnu17</code> (ISO C 2017 with GNU extensions) C compiler.</p>
-<p><strong><code>|</code></strong> Unless you clearly state otherwise in your <code>remarks.md</code> file AND put into your
-submission’s <code>Makefile</code>, we will compile using <code>-std=gnu17 -O3 -g3</code>.</p>
-<p><strong><code>|</code></strong> It is <strong>OK</strong> to require your submission to not be compiled
+renamed as <code>Makefile</code> of course.
+</p>
+<p class="leftbar">
+We suggest that you compile your submission with a commonly available
+<code>-std=gnu17</code> (ISO C 2017 with GNU extensions) C compiler.
+</p>
+<p class="leftbar">
+Unless you <strong>clearly state</strong> otherwise in your <code>remarks.md</code> file AND put into your
+submission’s <code>Makefile</code>, we will compile using <code>-std=gnu17 -O3 -g3</code>.
+</p>
+<p class="leftbar">
+It is <strong>OK</strong> to require your submission to not be compiled
 using the default <code>-std=gnu17 -O3 -g3</code> settings. Simply explain why
 your submission should not be compiled using <code>-std=gnu17 -O3 -g3</code> in
-your <code>remarks.md</code> file and adjust your <code>Makefile</code> accordingly.</p>
-<p><strong><code>|</code></strong> <strong>IMPORTANT NOTE</strong>: The use of <code>-std=gnu17</code> does <strong>NOT</strong> imply the use of the <code>gcc</code>
-compiler! We often start by compiling using the <strong>clang</strong> C compiler instead.</p>
-<p><strong><code>|</code></strong> You may change the standard under which your submission is compiled
-by modifying the <code>CSTD</code> Makefile variable. For example, to use <code>c17</code> instead:</p>
+your <code>remarks.md</code> file and adjust your <code>Makefile</code> accordingly.
+</p>
+<p class="leftbar">
+<strong>IMPORTANT NOTE</strong>: The use of <code>-std=gnu17</code> does <strong>NOT</strong> imply the use of the <code>gcc</code>
+compiler! We often start by compiling using the <strong>clang</strong> C compiler instead.
+</p>
+<p class="leftbar">
+You may change the standard under which your submission is compiled
+by modifying the <code>CSTD</code> Makefile variable. For example, to use <code>c17</code> instead:
+</p>
 <pre><code>    CSTD= -std=c17</code></pre>
-<p><strong><code>|</code></strong> For compilers, such as <code>clang</code>, that have the <code>-Weverything</code> option,
+<p class="leftbar">
+For compilers, such as <code>clang</code>, that have the <code>-Weverything</code> option,
 while you may wish to try it, you should look at <a href="../faq.html#weverything">the FAQ about clang
 -Weverything</a>. We do <strong>NOT</strong> recommend that you put
 the use of <code>-Weverything</code> into your submission’s <code>Makefile</code> for the reasons
 cited there. This goes even if your version does not trigger a warning as some
-other version might!</p>
-<p><strong><code>|</code></strong> You may change the level of optimization and compiler debug level
+other version might!
+</p>
+<p class="leftbar">
+You may change the level of optimization and compiler debug level
 that your submission is compiled with, by modifying the <code>OPT</code> Makefile variable.
-For example, to compile without optimization and debug symbols:</p>
+For example, to compile without optimization and debug symbols:
+</p>
 <pre><code>    OPT= -O0 -g3</code></pre>
-<p><strong><code>|</code></strong> There is no real penalty for compiler warnings. Sometimes
+<p class="leftbar">
+There is no real penalty for compiler warnings. Sometimes
 compiler warnings cannot be helped: especially in the case of
 obfuscated C. :-) So if you cannot easily get rid of a compiler
-warning, try not fret too much.</p>
-<p><strong><code>|</code></strong> We <strong>LIKE</strong> code that has a minimum of warnings, especially under the
-more strict <code>-Wall -Wextra -pedantic</code> mode:</p>
+warning, try not fret too much.
+</p>
+<p class="leftbar">
+We <strong>LIKE</strong> code that has a minimum of warnings, especially under the
+more strict <code>-Wall -Wextra -pedantic</code> mode:
+</p>
 <pre><code>    CWARN= -Wall -Wextra -pedantic</code></pre>
-<p><strong><code>|</code></strong> The two previous guidelines may be thought by some as being somewhat
+<p class="leftbar">
+The two previous guidelines may be thought by some as being somewhat
 contradictory. Isn’t life, and isn’t trying to satisfy “contradictory customer
 requirements” all too often like that? :-) Try to minimize warnings if you
-can.</p>
-<p><strong><code>|</code></strong> If you manage to produce very few warnings, or perhaps no warnings at
+can.
+</p>
+<p class="leftbar">
+If you manage to produce very few warnings, or perhaps no warnings at
 all under the <code>-Wall -Wextra -pedantic</code> mode, then by all means brag about it in
 your <code>remarks.md</code> file <strong>AND BE SURE TO TELL US</strong> the OS, OS version, compiler
 and compiler version in which you observed this occurring (in case our OS and
 compiler produces a different result: so your submission won’t be penalized for
-not meeting your claims).</p>
-<p><strong><code>|</code></strong> If your submission issues lots of warnings but is otherwise
+not meeting your claims).
+</p>
+<p class="leftbar">
+If your submission issues lots of warnings but is otherwise
 marvelously obfuscated in multiple levels, don’t worry about it. Nevertheless,
 be sure that the warnings do not constitute a potential “<strong>show stopper</strong>”
 compiler problem. Be sure that compilers such as both <code>gcc</code> and <code>clang</code> won’t
 produce a compile <strong>error</strong> and refuse to compile your code: unless for some
 reason that is what you intend to happen in which case document that too in your
-<code>remarks.md</code> file. :-)</p>
+<code>remarks.md</code> file. :-)
+</p>
 <p>All other things being equal, a program that must turn off fewer
 warnings will be considered better, for certain values of better.</p>
-<p><strong><code>|</code></strong> To turn off a compiler warning, in your submission’s <code>Makefile</code>,
-try something such as:</p>
+<p class="leftbar">
+To turn off a compiler warning, in your submission’s <code>Makefile</code>,
+try something such as:
+</p>
 <pre><code>    CSILENCE= -Wno-some-thing -Wno-another-thing -Wno-unknown-warning-option</code></pre>
-<p><strong><code>|</code></strong> If you do add “<code>-Wno-some-thing</code>” to your Makefile,
-consider changing:</p>
+<p class="leftbar">
+<p>If you do add “<code>-Wno-some-thing</code>” to your Makefile, consider changing:</p>
 <pre><code>    CUNKNOWN=</code></pre>
 <p>to:</p>
 <pre><code>    CUNKNOWN= -Wno-unknown-warning-option</code></pre>
-<p><strong><code>|</code></strong> Some compilers have reported this as an error, however, and if you have
-such a compiler you might want to not add it and note it in your <code>remarks.md</code>.</p>
-<p><strong><code>|</code></strong> If you need to define something on the compile line, use
-the <code>CDEFINE</code> Makefile variable. For example:</p>
+<p class="leftbar">
+Some compilers have reported this as an error, however, and if you have
+such a compiler you might want to not add it and note it in your <code>remarks.md</code>.
+</p>
+<p class="leftbar">
+If you need to define something on the compile line, use
+the <code>CDEFINE</code> Makefile variable. For example:
+</p>
 <pre><code>    CDEFINE= -Dfoo -Dbar=baz</code></pre>
-<p><strong><code>|</code></strong> If you need to include a file on the command line, use
-the <code>CINCLUDE</code> Makefile variable. For example:</p>
+<p class="leftbar">
+If you need to include a file on the command line, use
+the <code>CINCLUDE</code> Makefile variable. For example:
+</p>
 <pre><code>    CINCLUDE= -include stdio.h</code></pre>
-<p><strong><code>|</code></strong> If need to add other “<strong>magic</strong>” flags to your compile line,
-use the <code>COTHER</code> Makefile variable. For example:</p>
+<p class="leftbar">
+If you need to add other “<strong>magic</strong>” flags to your compile line,
+use the <code>COTHER</code> Makefile variable. For example:
+</p>
 <pre><code>    COTHER= -fno-math-errno</code></pre>
-<p><strong>NOTE</strong>: <strong>We only recommend using “<em>magic</em>” flags if <em>BOTH</em> <code>gcc</code>
-<em>and</em> <code>clang</code></strong> support it.</p>
+<p class="leftbar">
+<strong>NOTE</strong>: <strong>We only recommend using “<em>magic</em>” flags if <em>BOTH</em> <code>gcc</code>
+<em>and</em> <code>clang</code></strong> support it.
+</p>
 <div id="likes">
 <div id="dislikes">
 <h1 id="our-likes-and-dislikes">OUR LIKES AND DISLIKES:</h1>
 </div>
 </div>
-<p><strong><code>|</code></strong> We <strong>LIKE</strong> entries that use an edited variant of the
+<p class="leftbar">
+We <strong>LIKE</strong> entries that use an edited variant of the
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example Makefile</a>,
 renamed as <code>Makefile</code> of course. This makes it easier for the <a href="../judges.html">IOCCC Judges</a>
 to test your submission. And if your submissions wins, it makes it easier to integrate it into
-the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
+the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.
+</p>
 <p>Doing masses of <code>#define</code>s to obscure the source has become ‘old’. We
 tend to ‘see thru’ masses of <code>#define</code>s due to our pre-processor tests
 that we apply. Simply abusing <code>#define</code>s or <code>-Dfoo=bar</code> won’t go as far
@@ -785,18 +942,26 @@ as a program that is more well rounded in confusion.</p>
 <p><strong>Many</strong> C compilers <strong>DISLIKE</strong> the following code, and so do we:</p>
 <pre><code>    #define d define
     #d foo             /* &lt;-- don&#39;t expect this to turn into #define foo */</code></pre>
-<p><strong><code>|</code></strong> In other words, it is a compilation error.</p>
+<p class="leftbar">
+In other words, it is a compilation error.
+</p>
 <p>When declaring local or global variables, you should declare the type:</p>
 <pre><code>    int this_is_fine;
     this_is_not;       /* &lt;-- Try to avoid implicit type declarations */</code></pre>
-<p><strong><code>|</code></strong> We tend to <strong>like <em>less</em></strong> a submission that requires either
+<p class="leftbar">
+We tend to <strong>like <em>less</em></strong> a submission that requires either
 <code>gcc</code> <strong>OR</strong> <code>clang</code>. <strong>We <em>prefer</em> submissions</strong> that can compile
-under <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.</p>
-<p><strong><code>|</code></strong> We <strong>RECOMMEND</strong> that the compiler flags you use in your
-submission’s <code>Makefile</code> are supported by <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.</p>
-<p><strong><code>|</code></strong> We <strong>DISLIKE</strong> the use of obscure compiler flags, especially
+under <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.
+</p>
+<p class="leftbar">
+We <strong>RECOMMEND</strong> that the compiler flags you use in your
+submission’s <code>Makefile</code> are supported by <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.
+</p>
+<p class="leftbar">
+We <strong>DISLIKE</strong> the use of obscure compiler flags, especially
 if <code>gcc</code> and/or <code>clang</code> do not support it. We <strong>suggest</strong>
-that you not use any really obscure compiler flags if you can help it.</p>
+that you not use any really obscure compiler flags if you can help it.
+</p>
 <p>One side effect of the above is that you cannot assume the use
 of nested functions such as:</p>
 <pre><code>     main() {
@@ -805,11 +970,13 @@ of nested functions such as:</p>
          }
 |        please_dont_submit_this();
      }</code></pre>
-<p><strong><code>|</code></strong> On 2012 July 20, the judges rescinded the encouragement of
+<p>On 2012 July 20, the judges rescinded the encouragement of
 nested functions. Such constructions, while interesting and sometimes
 amusing, will have to wait until they required by a C standard that are
 actually implemented in <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.</p>
-<p><strong><code>|</code></strong> We <strong>DISLIKE</strong> submissions that require the use of <code>-fnested-functions</code>.</p>
+<p class="leftbar">
+We <strong>DISLIKE</strong> submissions that require the use of <code>-fnested-functions</code>.
+</p>
 <p>We prefer programs that do not require a fish license: crayons and
 cat detector vans not withstanding.</p>
 <p>If your submission uses functions that have a variable number of
@@ -825,43 +992,80 @@ not portable and <em>must not</em> be used</strong>:</p>
 <li>using <code>va_list</code> as a structure or union</li>
 </ul>
 <p>In particular, do not treat <code>va_list</code> variables as if they were a <code>char **</code>s.</p>
-<p><strong><code>|</code></strong> We <strong>DISLIKE</strong> the use of <code>varargs.h</code>. Use <code>stdarg.h</code> instead.</p>
-<p><strong><code>|</code></strong> We <strong>DISLIKE</strong> the use of <code>gets(3)</code>. Use <code>fgets(3)</code> instead.</p>
+<p class="leftbar">
+We <strong>DISLIKE</strong> the use of <code>varargs.h</code>. Use <code>stdarg.h</code> instead.
+</p>
+<p class="leftbar">
+We <strong>DISLIKE</strong> the use of <code>gets(3)</code>. Use <code>fgets(3)</code> instead.
+</p>
 <p>On 28 January 2007, the Judges rescinded the requirement that the
 <code>#</code> in a C preprocessor directive must be the 1st non-whitespace octet.</p>
 <p>The <code>exit(3)</code> function returns <code>void</code>. Some broken systems have <code>exit(3)</code>
 return <code>int</code>; your submission should assume that <code>exit(3)</code> returns a <code>void</code>.</p>
-<p><strong><code>|</code></strong> This <em>guideline</em> has a change mark at the very start of this line.</p>
+<p class="leftbar">
+This <em>guideline</em> has a change mark at the very start of this line.
+</p>
 <p>Small programs are best when they are short, obscure and concise.
 While such programs are not as complex as other winners, they do
 serve a useful purpose: they are often the only program that people
 attempt to completely understand. For this reason, we look for
 programs that are compact, and are instructional.</p>
-<p><strong><code>|</code></strong> While those who are used to temperatures found on <a href="https://science.nasa.gov/dwarf-planets/">dwarf
+<p class="leftbar">
+While those who are used to temperatures found on <a href="https://science.nasa.gov/dwarf-planets/">dwarf
 planets</a>
 (<strong>yes Virginia, dwarf planets <em>ARE</em> planets!</strong>), such as
 <a href="https://science.nasa.gov/dwarf-planets/pluto/">Pluto</a>, might be able to
 explain to the Walrus why our seas are boiling hot, the question of
-whether pigs have wings is likely to remain a debatable point to most.</p>
+whether pigs have wings is likely to remain a debatable point to most.
+</p>
 <p>One line programs should be short one line programs: say around 80 to 120
 octets long. Going well beyond 140 octets is a bit too long to be called
 a one-liner in our vague opinion.</p>
 <p>We tend to <strong>DISLIKE</strong> programs that:</p>
 <ul>
 <li>are very hardware specific</li>
-<li><strong><code>|</code></strong> are very OS version specific (<code>index(3)</code>/<code>strchr(3)</code> differences are OK, but sockets/streams specific code is likely not to be)<br>
-<strong><code>|</code></strong> * dump core or have compiler warnings (it is OK only if you warn us in your <code>remarks.md</code> file)<br>
-<strong><code>|</code></strong> * won’t compile or run in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
-Specification</a> environment<br>
-<strong><code>|</code></strong> * depend on a utility or application not normally found in systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX Specification</a></li>
-<li>abuse the build file to get around the size limit<br>
-<strong><code>|</code></strong> * obfuscate by use of ANSI trigraphs<br>
-<strong><code>|</code></strong> * obfuscate by use of digraphs<br>
-<strong><code>|</code></strong> * are larger than they need to be<br>
-<strong><code>|</code></strong> * have more lines than they need to have<br>
-<strong><code>|</code></strong> * are “blob-ier” (just a pile of unformatted C code) than they need to be
-<strong><code>|</code></strong> * are rather similar to <strong><a href="../years.html">previous winners</a></strong> :-(
-<strong><code>|</code></strong> * are <strong>identical</strong> to <strong>previous losers</strong> :-)</li>
+<li><p class="leftbar">
+are very OS version specific
+(<code>index(3)</code>/<code>strchr(3)</code> differences are OK, but sockets/streams specific code is
+likely not to be)
+</p></li>
+<li>dump core or have compiler warnings (it is OK only if
+you warn us in your <code>remarks.md</code> file)</li>
+<li><p class="leftbar">
+won’t compile or run in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+Specification</a>
+environment
+</p></li>
+<li><p class="leftbar">
+depend on a utility or application not normally found
+in systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+Specification</a>
+</p></li>
+<li>abuse the build file to get around the size limit<br></li>
+<li><p class="leftbar">
+obfuscate by use of ANSI trigraphs
+</p></li>
+<li><p class="leftbar">
+obfuscate by use of digraphs
+</p></li>
+<li><p class="leftbar">
+are larger than they need to be
+</p></li>
+<li><p class="leftbar">
+have more lines than they need to have
+</p></li>
+<li><p class="leftbar">
+are “blob-ier” (just a pile of unformatted C code)
+than they need to be
+</p></li>
+<li><p class="leftbar">
+are rather similar to <strong><a href="../years.html">previous
+winners</a></strong> :-(
+</p></li>
+<li><p class="leftbar">
+are <strong>identical</strong> to <strong><a href="https://en.wikipedia.org/wiki/Null_device">previous
+losers</a></strong> :-)
+</p></li>
 <li>that mandate the exclusive use of a specific Integrated Development Environment (IDE)</li>
 </ul>
 <p>In order to encourage submission portability, we <strong>DISLIKE</strong> entries that
@@ -869,10 +1073,12 @@ fail to build unless one is using an IDE. For example, do not
 mandate that one must use Microsoft Visual Studio to compile
 your submission. Nevertheless some of the better IDEs have command-line
 interfaces to their compilers, once one learns how to invoke a shell.</p>
-<p><strong><code>|</code></strong> The program must compile and link cleanly in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+<p class="leftbar">
+The program must compile and link cleanly in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environment. Therefore do not assume the system has a
-<a href="https://en.wikipedia.org/wiki/Windows.h">windows.h</a> include file:</p>
+<a href="https://en.wikipedia.org/wiki/Windows.h">windows.h</a> include file:
+</p>
 <pre><code>    #include &lt;windows.h&gt;  /* we DISLIKE this */</code></pre>
 <p>Unless you are cramped for space, or unless you are entering the
 ‘<strong>Best one liner</strong>’ category, we suggest that you format your program
@@ -889,19 +1095,25 @@ several <code>-D</code>s on the compile line to help out, but it is quite anothe
 many bytes of <code>-D</code>s in order to try and squeeze the source under the size limit.</p>
 <p>Your source code, post-pre-processing, should not exceed the size of
 <a href="https://en.wikipedia.org/wiki/Microsoft_Windows">Microsoft Windows</a>. :-)</p>
-<p><strong><code>|</code></strong> Other windows, on the other hand, might be OK: especially where “<strong>X
+<p class="leftbar">
+Other windows, on the other hand, might be OK: especially where “<strong>X
 marks the spot</strong>”. Yet on the third hand, windows are best when they are
-“unseen” (i.e., not dirty). :-)</p>
+“unseen” (i.e., not dirty). :-)
+</p>
 <p>The judges, as a group, have a history giving wide degree of latitude
 to reasonable entries. And recently they have had as much longitudinal
 variation as it is possible to have on <a href="https://science.nasa.gov/earth/">Earth</a>. :-)</p>
-<p><strong><code>|</code></strong> You should try to restrict commands used in the build file to
+<p class="leftbar">
+You should try to restrict commands used in the build file to
 commands found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX Specification</a> environments
-and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX Specification</a>.</p>
-<p><strong><code>|</code></strong> You may compile and use your own programs. If you do, try to build and execute
+and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX Specification</a>.
+</p>
+<p class="leftbar">
+You may compile and use your own programs. If you do, try to build and execute
 from the current directory. This restriction is not a hard and
 absolute one. The intent is to ensure that the building if your
-program is reasonably portable.</p>
+program is reasonably portable.
+</p>
 <p>We prefer programs that are portable across a wide variety of Unix-like
 operating systems (e.g., Linux, GNU Hurd, BSD, Unix, etc.).</p>
 <blockquote>
@@ -957,15 +1169,22 @@ they do not work as documented.</p>
 <p>Please note that the C source below, besides lacking in obfuscation,
 is NOT the smallest C source file that when compiled and run, dumps core:</p>
 <pre><code>    main;</code></pre>
-<p><strong><code>|</code></strong> Unless you specify <code>-fwritable-strings</code> (see <code>COTHER</code> in the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example
-Makefile</a>) do not assume this sort of code will work:</p>
+<p class="leftbar">
+Unless you specify <code>-fwritable-strings</code> (see <code>COTHER</code> in the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example
+Makefile</a>)
+do not assume this sort of code will work:
+</p>
 <pre><code>    char *T = &quot;So many primes, so little time!&quot;;
     ...
     T[14] = &#39;;&#39;;    /* modifying a string requires: -fwritable-strings */</code></pre>
-<p><strong><code>|</code></strong> Initialized char arrays are OK to write over. For instance, this is OK:</p>
+<p class="leftbar">
+Initialized char arrays are OK to write over. For instance, this is OK:
+</p>
 <pre><code>    char b[] = &quot;Is this OK&quot;;
     b[9] = &#39;k&#39;;     /* modifying an initialized char array is OK */</code></pre>
-<p><strong><code>|</code></strong> There are more than 1 typos in this very sentence.</p>
+<p class="leftbar">
+There are more than 1 typos in this very sentence.
+</p>
 <p>X client entries should be as portable as possible. Submissions that
 adapt to a wide collection of environments will be favored. For
 example, don’t depend on a particular type or size of display.
@@ -979,22 +1198,41 @@ source program (one that actually works) to display audio/visual data.</p>
 software that are not in wide spread use.</p>
 <p>This is the only <em>guideline</em> that contains the word
 <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>.</p>
-<p><strong><code>|</code></strong> However, do you know how to play <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>?
-You do?!? (Except on Tuesday?)</p>
-<p><strong><code>|</code></strong> OK, there are actually 3 <em>guidelines</em> that contain the word
-<a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>.</p>
+<p class="leftbar">
+However, do you know how to play <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>?
+You do?!? (Except on Tuesday?)
+</p>
+<p class="leftbar">
+OK, there are actually 3 <em>guidelines</em> that contain the word
+<a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>.
+</p>
 <p>We <strong>DISLIKE</strong> entries that use proprietary toolkits such as the <code>M*tif</code>,
 <code>Xv*ew</code>, or <code>OpenL*ok</code> toolkits, since not everyone has them. Use an
 open source toolkit that is widely and freely available instead.</p>
 <p><strong>NOTE</strong>: The previous <em>guideline</em> in this spot has been replaced by this <em>guideline</em>:</p>
-<p><strong><code>|</code></strong> X client entries should try to not to depend on particular items in
+<p class="leftbar">
+X client entries should try to not to depend on particular items in
 <code>.Xdefaults</code>. If you must do so, be sure to note the required lines
 in the your <code>remarks.md</code> file. They should also not depend on any
-particular window manager.</p>
-<p><strong><code>|</code></strong> Try to avoid entries that play music that some people believe is copyrighted music.</p>
-<p><strong><code>|</code></strong> While we recognize that UNIX is not a universal operating system, the contest does have a bias towards such systems. In an effort to expand the scope of the contest, we phrase our bias to favor the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX Specification</a>.</p>
-<p><strong><code>|</code></strong> You are <strong>well advised</strong> to submit entries that conform to the <a href="https://unix.org/version4/overview.html">Single UNIX Specification Version 4</a>.</p>
-<p><strong><code>|</code></strong> To quote the <a href="../judges.html">IOCCC judges</a>:</p>
+particular window manager.
+</p>
+<p class="leftbar">
+Try to avoid entries that play music that some people believe is copyrighted
+music.
+</p>
+<p class="leftbar">
+While we recognize that UNIX is not a universal operating system, the contest
+does have a bias towards such systems. In an effort to expand the scope of the
+contest, we phrase our bias to favor the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+Specification</a>.
+</p>
+<p class="leftbar">
+You are <strong>well advised</strong> to submit entries that conform to the <a href="https://unix.org/version4/overview.html">Single UNIX
+Specification Version 4</a>.
+</p>
+<p class="leftbar">
+To quote the <a href="../judges.html">IOCCC judges</a>:
+</p>
 <blockquote>
 <p>You very well might not be completely be prohibited from failing to not partly
 misunderstand this particular <em>guideline</em>, but of course, we could not possibly
@@ -1019,17 +1257,23 @@ parliament should you have one.</p>
 <p>Some types of programs can’t excel (anti-tm) in some areas. Your
 program doesn’t have to excel in all areas, but doing well in several
 areas really does help.</p>
-<p><strong><code>|</code></strong> You are better off explaining what your submission does in your
+<p class="leftbar">
+You are better off explaining what your submission does in your
 <code>remarks.md</code> file section rather than leaving it obscure for the
 <a href="../judges.html">judges</a> as we might miss something and/or be too tired to
-notice.</p>
-<p><strong><code>|</code></strong> Please avoid this specific individual <em>guideline</em>, if it at all possible.</p>
-<p><strong><code>|</code></strong> We freely admit that interesting, creative or humorous comments in
+notice.
+</p>
+<p class="leftbar">
+Please avoid this specific individual <em>guideline</em>, if it at all possible.
+</p>
+<p class="leftbar">
+We freely admit that interesting, creative or humorous comments in
 your <code>remarks.md</code> file help your chances of winning. If you had to
 read so many twisted submissions, you too would enjoy a good laugh or two.
 We think the readers of the contest winners do as well. We do read
 your <code>remarks.md</code> content during the judging process, so it is worth your
-while to write remarkable <code>remarks.md</code> file.</p>
+while to write remarkable <code>remarks.md</code> file.
+</p>
 <p>We <strong>DISLIKE</strong> C code with trailing control-M’s (<code>\r</code> or <code>\015</code>) that results
 in compilation failures. Some non-Unix/non-Linux tools such as
 MS Visual C and MS Visual C++ leave trailing control-M’s on lines.
@@ -1047,10 +1291,12 @@ Instead of unescaped octets, you should use or escapes:</p>
           /* This octet requires 4 octets of source ^^^^ */
     if (strlen(foo) == 36) printf(&quot;foo is 36 octets plus a final NUL\n&quot;);
     else printf(&quot;This code should not print this message\n&quot;);</code></pre>
-<p><strong><code>|</code></strong> It is a very good idea to, in your <code>remarks.md</code> file, tell us why you
+<p class="leftbar">
+It is a very good idea to, in your <code>remarks.md</code> file, tell us why you
 think your submission is obfuscated. This is particularly true if
 your submission has some very subtle obfuscations that we might
-otherwise overlook. <strong>&lt;&lt;– Hint!</strong></p>
+otherwise overlook. <strong>&lt;&lt;– Hint!</strong>
+</p>
 <p>Anyone can format their code into a dense blob. A really clever
 author will try format their submission using a “normal” formatting style
 such that at first glance (if you squint and don’t look at the details)
@@ -1062,9 +1308,11 @@ suggest you remark on this point in your <code>remarks.md</code> where you talk
 about why you think your submission is obfuscated. On the other hand,
 if you are pushing up against the size limits, you may be forced
 into creating a dense blob. Such are the trade-offs that obfuscators face!</p>
-<p><strong><code>|</code></strong> We prefer code that can run on either a 64-bit or 32-bit
+<p class="leftbar">
+We prefer code that can run on either a 64-bit or 32-bit
 processor. However, it is <strong>UNWISE </strong>to assume it will run on an
-some Intel-like x86 architecture.</p>
+some Intel-like x86 architecture.
+</p>
 <p>We believe that Mark Twain’s quote:</p>
 <blockquote>
 <p>Get your facts first, then you can distort them as you please.</p>
@@ -1076,27 +1324,30 @@ Submitting source that uses the content of
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">iocccsize.c</a>, unless you are
 <a href="../authors.html#Anthony_C_Howe">Anthony C Howe</a>, might run the risk of
 violating <a href="rules.html#rule7">Rule 7</a>.</p>
-<p><strong><code>|</code></strong> The <code>txzchk</code>
-tool source is not an original work, unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone
-Ferguson</a>, in which case it is original! :-)
-Submitting source that uses the content of
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk.c</a>, unless you are
-<a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, might run the risk of
-violating <a href="rules.html#rule7">Rule 7</a>.</p>
-<p><strong><code>|</code></strong> Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry
-tool source</a> nor the
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry
-tool source</a> nor
-the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c">fnamchk tool
+<p class="leftbar">
+The <code>txzchk</code> tool source is not an original work,
+unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, in
+which case it is original! :-) Submitting source that uses the content of
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk.c</a>,
+unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, might
+run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
+</p>
+<p class="leftbar">
+Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry tool
 source</a> nor
-various others in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a>
-are original works, unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt
-Noll</a>, in which case they are original! :-)
-Submitting source that uses the content of these tools, unless you are
-<a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might run the risk of
-violating <a href="rules.html#rule7">Rule 7</a>.</p>
-<p><strong><code>|</code></strong> Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and
+the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry tool
+source</a>
+nor the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c">fnamchk tool
+source</a>
+nor various others in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+repo</a> are original works, unless you
+are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, in which case
+they are original! :-) Submitting source that uses the content of these tools,
+unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might
+run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
+</p>
+<p class="leftbar">
+Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and
 library</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c">jstrencode</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c">jstrdecode</a>
@@ -1107,33 +1358,44 @@ Noll</a>, in which case they are original!
 :-) Submitting source that uses the code of these tools or library, unless you
 are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> or <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, might run the risk of violating
-<a href="rules.html#rule7">Rule 7</a>.</p>
-<p><strong><code>|</code></strong> <a href="rules.html#rule7">Rule 7</a> does not prohibit you from writing your own
+<a href="rules.html#rule7">Rule 7</a>.
+</p>
+<p class="leftbar">
+<a href="rules.html#rule7">Rule 7</a> does not prohibit you from writing your own
 obfuscated versions of these tools, unless of course you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, in which case you <em>probably</em> won’t
 win since judges are disqualified! :-)
 However, <em><strong>if you do</strong> write your own version, <strong>you might wish</strong> to make it do something more
 interesting</em> than simply implementing the <a href="../index.html">IOCCC</a> tools’ algorithms. On the other
 hand, writing an obfuscated version of a library runs the risk of violating
-<a href="rules.html#rule1">Rule 1</a> as it is likely not a complete program.</p>
+<a href="rules.html#rule1">Rule 1</a> as it is likely not a complete program.
+</p>
 <p>While programs that only run in a specific word size are OK, if you have
 to pick, choose a 64-bit word size.</p>
-<p><strong><code>|</code></strong> If <a href="../judges.html">IOCCC judges</a> are feeling ornery we
+<p class="leftbar">
+If <a href="../judges.html">IOCCC judges</a> are feeling ornery we
 might choose to compile your program for running on an Arduino or
 a PDP-11. Heck, should we ever find an emulator of 60-bit CDC Cyber
-CPU, we might just try your submission on that emulator as well :-)</p>
-<p><strong><code>|</code></strong> If your submission <strong>MUST</strong> run only on a 64-bit or 32-bit architecture,
+CPU, we might just try your submission on that emulator as well :-)
+</p>
+<p class="leftbar">
+If your submission <strong>MUST</strong> run only on a 64-bit or 32-bit architecture,
 then you <strong>MUST</strong> specify the <code>-arch</code> on your command line
 (see <code>ARCH</code> in the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">example
-Makefile</a>). Do not assume a processor word size without specifying <code>-arch</code>. For example:</p>
+Makefile</a>). Do not assume a processor word size without specifying <code>-arch</code>. For example:
+</p>
 <pre><code>    ARCH= -m64</code></pre>
-<p><strong><code>|</code></strong> Note, however, that some platforms will not necessarily support some
+<p class="leftbar">
+Note, however, that some platforms will not necessarily support some
 architectures. For instance, more recent versions of <code>macOS</code> do <strong>NOT</strong> support
-32-bit!</p>
-<p><strong><code>|</code></strong> Try to be even more creative!</p>
-<p><strong><code>|</code></strong> If there are limitations in your submission, you are highly encouraged
+32-bit!
+</p>
+<p>Try to be even more creative!</p>
+<p class="leftbar">
+If there are limitations in your submission, you are highly encouraged
 to note such limitations in your <code>remarks.md</code> file. For example if your
-submission factors values up to a certain size, you might want to state:</p>
+submission factors values up to a certain size, you might want to state:
+</p>
 <blockquote>
 <p>This submission factors values up <code>2305567963945518424753102147331756070</code>.
 Attempting to factor larger values will produce unpredictable results.</p>
@@ -1177,24 +1439,41 @@ and state:</p>
 program is given enough time and memory. If the value is not a proper integer,
 the program might insult a fish named Eric.</p>
 </blockquote>
-<p><strong><code>|</code></strong> Do not fear if you’re not 100% sure of the significance of <code>2305567963945518424753102147331756070</code> as it is not of prime importance: or is it? :-)</p>
-<p><strong><code>|</code></strong> We <strong>DISLIKE</strong> the use of use ASCII tab characters in markdown files, such as in the required <code>remarks.md</code> file.</p>
-<p><strong><code>|</code></strong> We don’t mind the use ASCII tab characters in your C code. Feel free
+<p class="leftbar">
+Do not fear if you’re not 100% sure of the significance of
+<code>2305567963945518424753102147331756070</code> as it is not of prime importance: or is
+it? :-)
+</p>
+<p class="leftbar">
+We <strong>DISLIKE</strong> the use of use ASCII tab characters in markdown files, such as in the required <code>remarks.md</code> file.
+</p>
+<p class="leftbar">
+We don’t mind the use ASCII tab characters in your C code. Feel free
 to use ASCII tab characters if that suits your obfuscation needs. If is
 perfectly <strong>OK</strong> to use tab characters elsewhere in your submission, just not in
 markdown files as this tends complicate and annoy us when it comes time to
-rendering your markdown content.</p>
-<p><strong><code>|</code></strong> If you do use ASCII tab characters in your non-markdown files, be
+rendering your markdown content.
+</p>
+<p class="leftbar">
+If you do use ASCII tab characters in your non-markdown files, be
 aware that some people may use tab stop that is different than the common 8
-character tab stop.</p>
-<p><strong><code>|</code></strong> <strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC markdown guidelines</a>
+character tab stop.
+</p>
+<p class="leftbar">
+<strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC markdown guidelines</a>
 when forming your submission’s <code>remarks.md</code> file. And if your submission
 contains additional markdown files, please follow those same guidelines. See
-also <a href="rules.html#rule19">Rule 19</a>.</p>
-<p><strong><code>|</code></strong> We <strong>LIKE</strong> reading <code>remarks.md</code> files, especially if they contain
+also <a href="rules.html#rule19">Rule 19</a>.
+</p>
+<p class="leftbar">
+We <strong>LIKE</strong> reading <code>remarks.md</code> files, especially if they contain
 useful, informative, and even humorous content about your submission. Yes, this
-is a <strong>hint</strong>. :-)</p>
-<p><strong><code>|</code></strong> We <strong>RECOMMEND</strong> you put a reasonable amount effort into the content of the <code>remarks.md</code> file: it is a required for for a reason. :-)</p>
+is a <strong>hint</strong>. :-)
+</p>
+<p class="leftbar">
+We <strong>RECOMMEND</strong> you put a reasonable amount effort into the content of the
+<code>remarks.md</code> file: it is a required for for a reason. :-)
+</p>
 <div id="rules_abuse">
 <div id="abusing_rules">
 <h1 id="abusing-the-rules">ABUSING THE RULES:</h1>
@@ -1214,18 +1493,22 @@ disqualified. <strong><em>RULE ABUSE CARRIES A CERTAIN LEVEL OF RISK!</em></stro
 have a submission that might otherwise be interesting, you might want to
 submit two versions; one that does not abuse the <a href="rules.html">IOCCC rules</a> and one that
 does.</p>
-<p><strong><code>|</code></strong> If you intend to abuse the <a href="rules.html">IOCCC rules</a>,
+<p class="leftbar">
+If you intend to abuse the <a href="rules.html">IOCCC rules</a>,
 indicate so in your <code>remarks.md</code> file. You <strong>MUST</strong> try to justify
 why you consider your rule abuse to be allowed under the
 <a href="rules.html">IOCCC rules</a>. That is, you must plead your case as to why
 your submission is valid. Humor and/or creativity help plead a case.
 As there is no guarantee that you will succeed, you might consider
 submitting an alternate version that conforms to the
-<a href="rules.html">IOCCC rules</a>.</p>
-<p><strong><code>|</code></strong> If do bypass the <code>mkiocccentry(1)</code> warnings about <a href="rules.html#rule2a">Rule
+<a href="rules.html">IOCCC rules</a>.
+</p>
+<p class="leftbar">
+If you do bypass the <code>mkiocccentry(1)</code> warnings about <a href="rules.html#rule2a">Rule
 2a</a> and/or about <a href="rules.html#rule2b">Rule 2b</a>
 and submit a submission anyway, you <strong>MUST</strong> try to justify why the IOCCC
-judges should not reject your submission due to a rule violation.</p>
+judges should not reject your submission due to a rule violation.
+</p>
 <p>Abusing the web submission procedure tends to annoy us more
 than amuse us. Spend your creative energy on content of your
 submission rather than on the submission process itself.</p>
@@ -1281,7 +1564,7 @@ won an award. So it is theoretically possible that Peter Honeyman
 did submit to the IOCCC in the past. In the past, Peter had denied
 submitting anything to the IOCCC. Perhaps those entries were
 submitted by one of his students?</p>
-<p><strong><code>|</code></strong> Hopefully we are <strong>VERY CLEAR</strong> on this point! The rules now strongly state:
+<p>Hopefully we are <strong>VERY CLEAR</strong> on this point! The rules now strongly state:
 <strong>PLEASE <em>DO NOT</em> put a name of an author</strong>, in an obvious way, into your
 source code, <code>remarks.md</code>, data files, etc., the above “<strong>Peter Honeyman is
 exempt</strong>” notwithstanding.</p>
@@ -1294,11 +1577,15 @@ Because the main ‘prize’ of winning is being announced, we make all
 attempts to send non-winners into oblivion. We remove all non-winning
 files, and shred all related printouts. By tradition, we do not even
 reveal the number of entries that we received.</p>
-<p><strong><code>|</code></strong> During the judging process, a process that spans multiple sessions over
+<p class="leftbar">
+During the judging process, a process that spans multiple sessions over
 a few weeks, we post general updates from our <a href="https://fosstodon.org/@ioccc">Mastodon
-account</a>.</p>
-<p><strong><code>|</code></strong> <strong>Make sure you reload the feed</strong> every so often <strong>because unless you
-are mentioned you will NOT get a push notification!</strong></p>
+account</a>.
+</p>
+<p class="leftbar">
+<strong>Make sure you reload the feed</strong> every so often <strong>because unless you
+are mentioned you will NOT get a push notification!</strong>
+</p>
 <div id="rounds">
 <h2 id="judging-rounds">JUDGING ROUNDS:</h2>
 </div>
@@ -1311,9 +1598,12 @@ previous round. Thus, a submission gets at least two readings.</p>
 <h2 id="judging-readings">JUDGING READINGS:</h2>
 </div>
 <p>A reading consists of a number of actions:</p>
+<p class="leftbar">
 <ul>
-<li>reading <code>prog.c</code>, the C source<br>
-<strong><code>|</code></strong> * reviewing the <code>remarks.md</code> information</li>
+<li>reading <code>prog.c</code>, the C source, reviewing the <code>remarks.md</code> information</li>
+</ul>
+</p>
+<ul>
 <li>briefly looking any any supplied data files</li>
 <li>passing the source thru the C pre-processor
 skipping over any <code>#include</code>d files</li>
@@ -1326,7 +1616,9 @@ skipping over any <code>#include</code>d files</li>
 </ul>
 <p>In later rounds, other actions are performed including performing
 miscellaneous tests on the source and binary.</p>
-<p><strong><code>|</code></strong> This is the very <strong>guideline</strong> that goes, <strong>BING!</strong></p>
+<p class="leftbar">
+This is the very <strong>guideline</strong> that goes, <strong>BING!</strong>
+</p>
 <p>Until we reduce the stack of submissions down to about 25 submissions,
 submissions are judged on an individual basis. A submission is set aside because it
 does not, in our opinion, meet the standard established by the round.
@@ -1336,17 +1628,17 @@ A submission will often compete in several categories.</p>
 <p>The actual award category list will vary depending on the types of submissions
 we receive. A typical category list might be:</p>
 <ul>
-<li><strong>best small one line program (see above about one line programs)</strong></li>
+<li><strong>best small one line program</strong> (see above about one line programs)</li>
 <li><strong>best small program</strong></li>
 <li><strong>strangest/most creative source layout</strong></li>
 <li><strong>most useful obfuscated program</strong></li>
 <li><strong>best game that is obfuscated</strong></li>
 <li><strong>most creatively obfuscated program</strong></li>
-<li><strong>most deceptive C code (code with deceptive comments and source code)</strong></li>
+<li><strong>most deceptive C code</strong> (code with deceptive comments and source code)</li>
 <li><strong>best X program</strong> (see <a href="#likes">OUR LIKES AND DISLIKES</a>)</li>
 <li><strong>best abuse of ISO C or ANSI C standard</strong> (see above about compilers)</li>
 <li><strong>best abuse of the C preprocessor</strong></li>
-<li><strong>worst/best abuse of the rules</strong> or some variation</li>
+<li><strong>worst/best abuse of the rules</strong> (or some variation)</li>
 <li>(anything else so strange that it deserves an award)</li>
 </ul>
 <p>We do not limit ourselves to this list. For example, a few entries are so
@@ -1364,18 +1656,23 @@ similar, but slightly better submission. For this reason, it is sometimes
 worthwhile to resubmit an improved version of a submission that failed to win in
 a previous year, the next year. This assumes, of course, that the submission is
 worth improving in the first place!</p>
-<p><strong><code>|</code></strong> Over the years, more than one <a href="../judges.html">IOCCC judge</a>
+<p class="leftbar">
+Over the years, more than one <a href="../judges.html">IOCCC judge</a>
 has been known to <strong>bribe</strong> another IOCCC <a href="../judges.html">judge</a> into voting for a
 winning entry by offering a bit of high quality chocolate, or
-other fun item.</p>
-<p><strong><code>|</code></strong> One <strong>should NOT</strong> attempt to <strong>bribe</strong> an <a href="../judges.html">IOCCC
+other fun item.
+</p>
+<p class="leftbar">
+One <strong>should NOT</strong> attempt to <strong>bribe</strong> an <a href="../judges.html">IOCCC
 judge</a>, <strong>unless you are an <a href="../judges.html">IOCCC judge</a></strong>,
 because <strong>bribing</strong> an <a href="../judges.html">IOCCC judge</a> by a non-judge
 has been shown to <strong>NOT</strong> be effective when the <strong>person <em>attempting</em>
 the <em>bribe</em> is made known</strong> to the <a href="../judges.html">IOCCC judges</a>
 (i.e., they are not anonymous) AND/OR the <strong>bribe</strong> is otherwise
-associated with a submission to the <a href="../index.html">IOCCC</a>.</p>
-<p><strong><code>|</code></strong> With the previous guideline in mind: <strong>anonymous</strong> gifts
+associated with a submission to the <a href="../index.html">IOCCC</a>.
+</p>
+<p class="leftbar">
+With the previous guideline in mind: <strong>anonymous</strong> gifts
 for the <a href="../judges.html">IOCCC judges</a> that are <strong>NOT ASSOCIATED
 WITH</strong> a submission to the <a href="../index.html">IOCCC</a> may be sent to the
 <a href="../judges.html">IOCCC judges</a> via the
@@ -1383,14 +1680,19 @@ WITH</strong> a submission to the <a href="../index.html">IOCCC</a> may be sent 
 It has been shown that receiving <strong>anonymous</strong> gifts provides the
 <a href="../judges.html">IOCCC judges</a> with a nice
 <a href="https://en.wikipedia.org/wiki/Dopamine">dopamine</a> boost, and happy
-<a href="../judges.html">IOCCC judges</a> help make the <a href="../index.html">IOCCC</a> better for everyone. :-)</p>
-<p><strong><code>|</code></strong> See <a href="../faq.html#support">FAQ: How may I support the IOCCC?</a>.</p>
+<a href="../judges.html">IOCCC judges</a> help make the <a href="../index.html">IOCCC</a> better for everyone. :-)
+</p>
+<p class="leftbar">
+See <a href="../faq.html#support">FAQ: How may I support the IOCCC?</a>.
+</p>
 <p>More often than not, we select a small submission (usually one line) and a
 strange/creative layout submission. We sometimes also select a
 submission that abuses the <a href="guidelines.html">IOCCC guidelines</a> in an interesting way,
 or that stretches the contest <a href="rules.html">rules</a> that while legal, it
 nevertheless goes against the <strong>intent</strong> of the <a href="rules.html">rules</a>.</p>
-<p><strong><code>|</code></strong> Nevertheless, see <a href="rules.html#rule12">Rule 12</a>.</p>
+<p class="leftbar">
+Nevertheless, see <a href="rules.html#rule12">Rule 12</a>.
+</p>
 <p>In the end, we traditionally pick one submission as ‘<strong>best</strong>’. Sometimes such
 a submission simply far exceeds any of the other entries. More often, the
 ‘<strong>best</strong>’ is picked because it does well in a number of categories.</p>
@@ -1400,37 +1702,63 @@ Winning source is called <code>prog.c</code>. A compiled binary is called <code>
 <div id="announcements">
 <h1 id="announcement-of-winners">ANNOUNCEMENT OF WINNERS:</h1>
 </div>
-<p><strong><code>|</code></strong> The <a href="../judges.html">judges</a> will toot initial announcement of who won, the name
+<p class="leftbar">
+The <a href="../judges.html">judges</a> will toot initial announcement of who won, the name
 of their award, and a very brief description of the winning entry
-from the <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> Mastodon account</a>.</p>
-<p><strong><code>|</code></strong> We recommend that you follow us on mastodon but <strong>please make sure to
+from the <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> Mastodon account</a>.
+</p>
+<p class="leftbar">
+We recommend that you follow us on mastodon but <strong>please make sure to
 refresh the feed</strong> every so often (if not more often) because unless you are
-mentioned or someone boosts your post you will not get a push notification.</p>
+mentioned or someone boosts your post you will not get a push notification.
+</p>
 <div id="winners">
 <h2 id="how-the-new-ioccc-winners-will-be-announced">How the new IOCCC winners will be announced</h2>
 </div>
-<p><strong><code>|</code></strong> The <a href="../status.html">Current status of the IOCCC</a> will change from
-<strong><a href="../status.html#judging">judging</a></strong> to <strong><a href="../status.html#closed">closed</a></strong> .</p>
-<p><strong><code>|</code></strong> The <strong>contest_status</strong> in the <a href="../status.json">status.json</a> file will change from <strong>judging</strong> to <strong>closed</strong> as well.</p>
-<p><strong><code>|</code></strong> When the above happens, the winning entries have been selected by the <a href="../judges.html">IOCCC judges</a>.</p>
-<p><strong><code>|</code></strong> The <a href="../judges.html">IOCCC judges</a> will begin to prepare to release the source code of the new IOCCC winners.</p>
-<p><strong><code>|</code></strong> The <a href="../judges.html">IOCCC judges</a> will commit the winning source to the
-<a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> which will update the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>.</p>
-<p><strong><code>|</code></strong> The <a href="../news.html">IOCCC news</a> will also contain an announcement of the winners.</p>
+<p class="leftbar">
+The <a href="../status.html">current status of the IOCCC</a> will change from
+<strong><a href="../status.html#judging">judging</a></strong> to <strong><a href="../status.html#closed">closed</a></strong> .
+</p>
+<p class="leftbar">
+The <strong>contest_status</strong> in the <a href="../status.json">status.json</a> file will change
+from <strong>judging</strong> to <strong>closed</strong> as well.
+</p>
+<p class="leftbar">
+When the above happens, the winning entries have been selected by the <a href="../judges.html">IOCCC
+judges</a>.
+</p>
+<p class="leftbar">
+The <a href="../judges.html">IOCCC judges</a> will begin to prepare to release the source
+code of the new IOCCC winners.
+</p>
+<p class="leftbar">
+The <a href="../judges.html">IOCCC judges</a> will commit the winning source to the
+<a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> which will update the
+<a href="https://www.ioccc.org/index.html">Official IOCCC website</a>.
+</p>
+<p class="leftbar">
+The <a href="../news.html">IOCCC news</a> will also contain an announcement of the winners.
+</p>
 <div id="mastodon">
 <h2 id="an-important-update-to-how-winners-are-announced">An important update to how winners are announced</h2>
 </div>
-<p><strong><code>|</code></strong> The IOCCC no longer uses twitter. IOCCC entries will be announced by a
+<p class="leftbar">
+The IOCCC no longer uses twitter. IOCCC entries will be announced by a
 <code>git</code> commit to the <a href="https://github.com/ioccc-src/winner">IOCCC entries repo</a>
 that, in turn, updates the <a href="https://www.ioccc.org/index.html">Official IOCCC
-website</a>.</p>
-<p><strong><code>|</code></strong> In addition a note is posted to the <a href="https://fosstodon.org/@ioccc">IOCCC Mastodon account</a>.</p>
+website</a>.
+</p>
+<p class="leftbar">
+In addition a note is posted to the <a href="https://fosstodon.org/@ioccc">IOCCC Mastodon account</a>.
+</p>
 <div id="entries">
 <h2 id="back-to-announcement-of-winners">Back to announcement of winners</h2>
 </div>
-<p><strong><code>|</code></strong> It is pointless to ask the <a href="../judges.html">IOCCC judges</a> how many
+<p class="leftbar">
+It is pointless to ask the <a href="../judges.html">IOCCC judges</a> how many
 submissions we receive. See <a href="../faq.html#how_many">How many submissions do the judges receive for a
-given IOCCC?</a>.</p>
+given IOCCC?</a>.
+</p>
 <p>Often, winning entries are published in selected magazines from around the
 world. Winners have appeared in books (‘<code>The New Hackers Dictionary</code>’,
 ‘<code>Obfuscated C and Other Mysteries</code>’, ‘<code>Pointers On C</code>’, others) and on t-shirts.
@@ -1441,18 +1769,30 @@ More than one winner has been turned into a tattoo!</p>
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 </div>
 </div>
-<p><strong><code>|</code></strong> For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.</p>
-<p><strong><code>|</code></strong> Be sure to review the <a href="index.html">IOCCC Rules and Guidelines</a> as the
-<a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and often do) change from year to year.</p>
-<p><strong><code>|</code></strong> You should be sure you have the current <a href="rules.html">IOCCC rules</a> and
-<a href="guidelines.html">IOCCC guidelines</a> prior to submitting entries.</p>
-<p><strong><code>|</code></strong> See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
-<p><strong><code>|</code></strong> For the updates and breaking <a href="../news.html">IOCCC news</a>, you are encouraged to follow
+<p class="leftbar">
+For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.
+</p>
+<p class="leftbar">
+Be sure to review the <a href="index.html">IOCCC Rules and Guidelines</a> as the
+<a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and often do) change from year to year.
+</p>
+<p class="leftbar">
+You should be sure you have the current <a href="rules.html">IOCCC rules</a> and
+<a href="guidelines.html">IOCCC guidelines</a> prior to submitting entries.
+</p>
+<p class="leftbar">
+See the <a href="../news.html">Official IOCCC website news</a> for additional information.
+</p>
+<p class="change marker">
+For the updates and breaking <a href="../news.html">IOCCC news</a>, you are encouraged to follow
 the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a>. See our
 <a href="../faq.html#try_mastodon">FAQ on Mastodon</a> for more information. <strong>Please be
 aware</strong> that unless you are mentioned you most likely will <strong>NOT</strong> get a
-notification so you should make sure to check the page.</p>
-<p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a> in general.</p>
+notification so you should make sure to check the page.
+</p>
+<p class="leftbar">
+Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a> in general.
+</p>
 <p>Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) /\cc/\</p>
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -405,7 +405,9 @@ app from time to time to view IOCCC mastodon updates.</p>
 <!-- END: the next line ends content from: inc/guidelines.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 <h1 id="th-international-obfuscated-c-code-contest-official-guidelines">28th International Obfuscated C Code Contest Official Guidelines</h1>
-<p>Copyright © 2024 Leonid A. Broukhis and Landon Curt Noll.</p>
+<p class="leftbar">
+Copyright © 2024 Leonid A. Broukhis and Landon Curt Noll.
+</p>
 <p>All Rights Reserved. Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered. All other uses must receive prior permission in
@@ -426,7 +428,7 @@ previous IOCCC</strong>.
 </p>
 <p>Most lines (we sometimes make mistakes) that were modified since the previous
 IOCCC start with a solid 4 pixel black left border (or, in the case of a code
-block, just a vertical bar).</p>
+block or blockquote, just a vertical bar).</p>
 <div id="about_guidelines">
 <h1 id="about-this-file">ABOUT THIS FILE:</h1>
 </div>
@@ -1325,7 +1327,7 @@ Submitting source that uses the content of
 <a href="../authors.html#Anthony_C_Howe">Anthony C Howe</a>, might run the risk of
 violating <a href="rules.html#rule7">Rule 7</a>.</p>
 <p class="leftbar">
-The <code>txzchk</code> tool source is not an original work,
+The <code>txzchk(1)</code> tool source is not an original work,
 unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, in
 which case it is original! :-) Submitting source that uses the content of
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk.c</a>,

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -1185,7 +1185,7 @@ Submitting source that uses the content of
 [Anthony C Howe](../authors.html#Anthony_C_Howe), might run the risk of
 violating [Rule 7](rules.html#rule7).
 
-<p class="leftbar"> The `txzchk` tool source is not an original work,
+<p class="leftbar"> The `txzchk(1)` tool source is not an original work,
 unless you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), in
 which case it is original!  :-) Submitting source that uses the content of
 [txzchk.c](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c),

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -31,7 +31,9 @@ app from time to time to view IOCCC mastodon updates.
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 # 28th International Obfuscated C Code Contest Official Guidelines
 
+<p class="leftbar">
 Copyright &copy; 2024 Leonid A. Broukhis and Landon Curt Noll.
+</p>
 
 All Rights Reserved.  Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
@@ -43,7 +45,9 @@ writing by [contacting the judges](../contact.html).
 ## IOCCC Guidelines version
 </div>
 
-**`|`**   These [IOCCC guidelines](guidelines.html) are version **28.6 2024-07-06**.
+<p class="leftbar">
+These [IOCCC guidelines](guidelines.html) are version **28.7 2024-07-08**.
+</p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
 
@@ -52,10 +56,13 @@ writing by [contacting the judges](../contact.html).
 ### Change marks
 </div>
 
-**`|`**   **&larr; Lines that start with this symbol indicate a change from the previous IOCCC**
+<p class="leftbar">**&larr; Lines that start with this symbol indicate a change from the
+previous IOCCC**.
+</p>
 
 Most lines (we sometimes make mistakes) that were modified since the previous
-IOCCC start with the **`|`** symbol.
+IOCCC start with a solid 4 pixel black left border (or, in the case of a code
+block or blockquote, just a vertical bar).
 
 
 <div id="about_guidelines">
@@ -82,52 +89,79 @@ guidelines](guidelines.html)..
 # WHAT'S NEW THIS IOCCC
 </div>
 
-**`|`**   This IOCCC runs from **2024-MMM-DD HH:MM:SS UTC** to **YYYY-MMM-DD HH:MM:SS UTC**.<br>
-**`|`**   **XXX - date/time is TBD - XXX**
+<p class="leftbar">
+This IOCCC runs from **2024-MMM-DD HH:MM:SS UTC** to **YYYY-MMM-DD HH:MM:SS UTC**.<br>
+**XXX - date/time is TBD - XXX**
+</p>
 
-**`|`**   The reason for the times of day are so that key IOCCC events are **calculated**
+<p class="leftbar">
+The reason for the times of day are so that key IOCCC events are **calculated**
 to be a **fun**ctional UTC time.  :-)
+</p>
 
-**`|`**   Until the start of this IOCCC, the [IOCCC rules](rules.html),
+<p class="leftbar">
+Until the start of this IOCCC, the [IOCCC rules](rules.html),
 [IOCCC guidelines](guidelines.html) and the tools in the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry), should be
 considered provisional **BETA** versions and **may be adjusted _AT
-ANY TIME_**.
+ANY TIME_**.</p>
 
-**`|`**   The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
-**`|`**   **XXX - date/time is TBD - XXX**
+<p class="leftbar">
+The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
+**XXX - date/time is TBD - XXX**
+</p>
 
-**`|`**   The [IOCCC rules](rules.html), [IOCCC
+<p class="leftbar">
+The [IOCCC rules](rules.html), [IOCCC
 guidelines](guidelines.html) will be available on the [Official IOCCC
 website](https://www.ioccc.org) on or slightly before start of this IOCCC.  Please check
 [the IOCCC FAQ about how to submit](../faq.html#submit) to see how
 to submit entries, on or after the start of this IOCCC, to be sure
 you are using the correct versions of these items before using the
 IOCCC submission URL.
+</p>
 
-**`|`**   The [Rule 2a](rules.html#rule2a) size has **increased from 4096 to 4993** bytes.
+<p class="leftbar">
+The [Rule 2a](rules.html#rule2a) size has **increased from 4096 to 4993** bytes.
+</p>
 
-**`|`**   The [Rule 2b](rules.html#rule2b) size has **increased from 2053 to 2503** bytes.
+<p class="leftbar">
+The [Rule 2b](rules.html#rule2b) size has **increased from 2053 to 2503**
+bytes.
+</p>
 
-**`|`**   The new default way to compile submissions: `-std=gnu17 -O3 -g3
+<p class="leftbar">The new default way to compile submissions: `-std=gnu17 -O3 -g3
 -Wall -Wextra -pedantic`. See below for more details about the example Makefile
 for more help.
+</p>
 
-**`|`**   Submissions are in the form of a single xz compressed tarball.
+<p class="leftbar">
+Submissions are in the form of a single xz compressed tarball.
+</p>
 
-**`|`**   To assist in the formation of the xz compressed tarball for submission, use the
-`mkiocccentry(1)` tool as found in the  [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
+<p class="leftbar">
+To assist in the formation of the xz compressed tarball for submission, use the
+`mkiocccentry(1)` tool as found in the  [mkiocccentry
+repo](https://github.com/ioccc-src/mkiocccentry).
+</p>
 
-**`|`**   [Rule 17](rules.html#rule17) has been **significantly modified**
+<p class="leftbar">
+[Rule 17](rules.html#rule17) has been **significantly modified**
 to account for the new [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) tools.
+</p>
 
-**`|`**   An [example
+<p class="leftbar">
+An [example
 Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
 is now available from the [mkiocccentry
-repo](https://github.com/ioccc-src/mkiocccentry) and you are encouraged to use
-it.
+repo](https://github.com/ioccc-src/mkiocccentry) **and you are encouraged to use
+it**.
+</p>
 
-**`|`**   The IOCCC submission URL, [when the IOCCC is open](../status.html#open), is [submit.ioccc.org](https://submit.ioccc.org/).
+<p class="leftbar">
+The IOCCC submission URL, [when the IOCCC is open](../status.html#open), is
+[submit.ioccc.org](https://submit.ioccc.org/).
+</p>
 
 
 <div id="hints">
@@ -178,18 +212,24 @@ entries to attempt to exploit them.  We will award '**Worst abuse of the
 [rules](rules.html)**' or '**Best abuse of the [rules](rules.html)**' or some
 variation and then plug the hole next year.
 
-**`|`**   When we do need to plug a hole in the [IOCCC rules](rules.html)
-or [IOCCC guidelines](guidelines.html), we will attempt to use a very
-small plug, if not smaller.  Or, maybe not.  :-)
+<p class="leftbar">
+When we do need to plug a hole in the [IOCCC rules](rules.html) or [IOCCC
+guidelines](guidelines.html), we will attempt to use a very small plug, if not
+smaller.  Or, maybe not.  :-)
+</p>
 
-**`|`**   There may be less than 2^7+1 reasons why these [IOCCC guidelines](guidelines.html) seem obfuscated.
+<p class="leftbar">
+There may be less than 2^7+1 reasons why these [IOCCC
+guidelines](guidelines.html) seem obfuscated.
+</p>
 
 Check out your program and be sure that it works.  We sometimes make
 the effort to debug a submission that has a slight problem, particularly
 in or near the final round.  On the other hand, we have seen some
 of the best entries fall down because they didn't work.
 
-**`|`**   We tend to look down on a [prime
+<p class="leftbar">
+We tend to look down on a [prime
 number](https://en.wikipedia.org/wiki/Prime_number) printer that claims that
 16 is a prime number.  If you do have a bug, you are better off
 documenting it.  Noting "_this submission sometimes prints the 4th power
@@ -197,7 +237,7 @@ of a prime by mistake_" would save the above submission.  And sometimes,
 a strange bug/feature can even help the submission!  Of course, a correctly
 working submission is best.  Clever people will note that 16 might be prime
 under certain conditions.  Wise people, when submitting something clever
-will fully explain such cleverness in their submission's `remarks.md` file.
+will fully explain such cleverness in their submission's `remarks.md` file.</p>
 
 People who are considering to just use some complex mathematical
 function or state machine to spell out something such as "_hello,
@@ -213,25 +253,39 @@ When programs use VTxxx/ANSI sequences, they should NOT be limited to a
 specific terminal brand.  Those programs that work in a standard xterm
 are considered more portable.
 
-**`|`**   [Rule 2](rules.html#rule2) (the size rule) refers to the use of the IOCCC size tool called `iocccsize(1)`.
+<p class="leftbar">
+[Rule 2](rules.html#rule2) (the size rule) refers to the use of the IOCCC size
+tool called `iocccsize(1)`.
+</p>
 
-**`|`**   See the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) for the `iocccsize(1)` tool.
+<p class="leftbar">See the [mkiocccentry
+repo](https://github.com/ioccc-src/mkiocccentry) for the `iocccsize(1)` tool.
+</p>
 
-**`|`**   To further clarify [Rule 2](rules.html#rule2), we subdivided it into two parts, **2a** and **2b**.
+<p class="leftbar">
+To further clarify [Rule 2](rules.html#rule2), we subdivided it into two parts,
+**2a** and **2b**.
+</p>
 
-**`|`**   The overall size limit (see [Rule 2a](rules.html#rule2a)) on `prog.c` is now **4993 bytes**.
+<p class="leftbar">
+The overall size limit (see [Rule 2a](rules.html#rule2a)) on `prog.c` is now **4993 bytes**.
+</p>
 
-**`|`**   Your submission must satisfy BOTH the maximum size [Rule
+<p class="leftbar">
+Your submission must satisfy BOTH the maximum size [Rule
 2a](rules.html#rule2a) AND the IOCCC size tool [Rule 2b](rules.html#rule2b).
+</p>
 
-**`|`**   This IOCCC size tool imposes a 2nd limit on C code size (see [Rule 2a](rules.html#rule2a).  To check your
+<p class="leftbar">
+This IOCCC size tool imposes a 2nd limit on C code size (see [Rule 2a](rules.html#rule2a).  To check your
 code against [Rule 2](rules.html#rule2):
+</p>
 
 ``` <!---sh-->
     ./iocccsize prog.c
 ```
 
-**`|`**   The IOCCC size tool algorithm may be summarized as follows:
+The IOCCC size tool algorithm may be summarized as follows:
 
 > The size tool counts most C reserved words (keyword, secondary, and selected
 preprocessor keywords) as 1.  The size tool counts all other octets as 1
@@ -242,20 +296,21 @@ before the end of file.
 ASCII whitespace includes ASCII tab, ASCII space, ASCII newline,
 ASCII formfeed, and ASCII carriage return.
 
-**`|`**   When '`;`', '`{`' or '`}`' are within a C string, they may still not be<br>
-**`|`**   counted by the IOCCC size tool.  This is a feature, not a bug!
+<p class="leftbar">
+When '`;`', '`{`' or '`}`' are within a C string, they may still not be
+counted by the IOCCC size tool.  This is a feature, not a bug!</p>
 
 In cases where the above summary and the algorithm implemented by
 the IOCCC size tool source code conflict, the algorithm implemented
 by the IOCCC size tool source code is preferred by the judges.
 
-**`|`**   There are at least 2 other reasons for selecting<br>
-**`|`**   2503 as the 2nd limit besides the fact that 2503<br>
-**`|`**   is a prime. These reasons may be searched for<br>
-**`|`**   and discovered if you are ["Curios!" about 2503](https://t5k.org/curios/page.php/2503.html). :-)<br>
-**`|`**   Moreover, 2053 was the number of the kernel disk<br>
-**`|`**   pack of one of the judge's BESM-6, and 2503 is a<br>
-**`|`**   decimal anagram of 2053.
+<p class="leftbar">
+There are at least 2 other reasons for selecting 2503 as the 2nd limit besides
+the fact that 2503 is a prime. These reasons may be searched for and discovered
+if you are ["Curios!" about 2503](https://t5k.org/curios/page.php/2503.html).
+:-) Moreover, 2053 was the number of the kernel disk pack of one of the judge's
+BESM-6, and 2503 is a decimal anagram of 2053.
+</p>
 
 Take note that this secondary limit imposed by the IOCCC size tool
 obviates some of the need to `#define` C reserved words in an effort
@@ -263,48 +318,69 @@ to get around the size limits of [Rule 2](rules.html#rule2).
 
 Yes Virginia, **that is a hint**!
 
-**`|`**   The [Rule 2a](rules.html#rule2a) size was changed from
+<p class="leftbar">
+The [Rule 2a](rules.html#rule2a) size was changed from
 4096 to 4993: a change that keeps the "2b to 2a" size ratio to a
 value similar to the [2001-2012](../faq.html#size_rule2001-2012) and
 [2013-2020](../faq.html#size_rule2013-2020) IOCCC eras.
+</p>
 
-**`|`**   [Rule 17](rules.html#rule17) (the `mkiocccentry(1)` rule) states that
+<p class="leftbar">
+[Rule 17](rules.html#rule17) (the `mkiocccentry(1)` rule) states that
 you **MUST** use the `mkiocccentry(1)` tool to package your submission tarball.
+</p>
 
-**`|`**   See the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
+<p class="leftbar">
+See the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 for the `mkiocccentry(1)` tool.
+</p>
 
-**`|`**   This tool invokes a number of other tools and one, `txzchk(1)`,
+<p class="leftbar">
+This tool invokes a number of other tools and one, `txzchk(1)`,
 invokes another, `fnamchk(1)`.
+</p>
 
-**`|`**   Although the `mkiocccentry(1)` tool will verify everything for you,
+<p class="leftbar">
+Although the `mkiocccentry(1)` tool will verify everything for you,
 you may wish to validate each part individually. As the [rules](rules.html)
 state, each of these tools have a `-h` option. However, to help simplify
 matters, we give you a brief overview below.
+</p>
 
-**`|`**   The synopsis of the `mkiocccentry(1)` tool is:
+<p class="leftbar">
+The synopsis of the `mkiocccentry(1)` tool is:
+</p>
 
 ``` <!---sh-->
     ./mkiocccentry [options] work_dir prog.c \
          Makefile remarks.md [file ...]
 ```
 
-**`|`** where the `work_dir` is a directory that is used to form the
+<p class="leftbar">
+... where the `work_dir` is a directory that is used to form the
 xz compressed tarball that `txzchk(1)` validates, `prog.c` is your submission
 source code, `Makefile` is your `Makefile`, `remarks.md` is your remarks and
 `[file ...]` are any additional files you wish to provide.
+</p>
 
-**`|`**   If the `work_dir` already exists it is an error.
+<p class="leftbar">
+If the `work_dir` already exists it is an error. In the case this happens you
+will have to choose a different directory, or if it is safe to remove, you may
+do so and try again.
+</p>
 
-**`|`**   The `mkiocccentry(1)` tool will ask you for information about your
+<p class="leftbar">
+The `mkiocccentry(1)` tool will ask you for information about your
 submission as well as author details and it will run the `iocccsize(1)` tool; if
 either [Rule 2a](rules.html#rule2a) or [Rule 2b](rules.html#rule2b) are broken,
 it will give you the option to ignore them, if you are willing to risk this. The
 tool will also do a rudimentary check on the `Makefile` and run other checks as
 well. You can override warnings but doing so puts you at risk of violating
 [rules](rules.html).
+</p>
 
-**`|`**   On the other hand, some **issues are an error** and the xz compressed
+<p class="leftbar">
+On the other hand, some **issues are an error** and the xz compressed
 tarball **will not be formed**. For instance, if `chkentry(1)` fails to validate
 the `.auth.json` or `.info.json` [JSON](https://www.json.org/json-en.html) files
 that `mkiocccentry(1)` creates, it is an error and possibly a bug that you
@@ -312,83 +388,111 @@ should report at the [mkiocccentry issues
 page](https://github.com/ioccc-src/mkiocccentry/issues). **PLEASE run the
 `bug_report.sh` script to help us out here!** See the [the FAQ about reporting
 bugs in the mkiocccentry repo](../faq.html#mkiocccentry_bugs).
+</p>
 
-
-**`|`**   Assuming that `chkentry(1)` passes for both `.auth.json` and
+<p class="leftbar">
+Assuming that `chkentry(1)` passes for both `.auth.json` and
 `.info.json` then the tarball will be formed and then `txzchk(1)` will be
 executed. In this case, there should be no problems as `mkiocccentry(1)` would
 **NOT** form a tarball if there are any issues.
+</p>
 
-**`|`**  `txzchk(1)` performs a wide number of sanity checks on the xz
+<p class="leftbar">
+`txzchk(1)` performs a wide number of sanity checks on the xz
 compressed tarball and if any issues (`feathers` :-) ) are found and if you used
 `mkiocccentry(1)`, then it is very possibly a bug in one of the tools and you
 should report it at the [mkiocccentry issues
 page](https://github.com/ioccc-src/mkiocccentry/issues). **PLEASE run the
 `bug_report.sh` script to help us out here!** See [the FAQ about reporting bugs
 in the mkiocccentry repo](../faq.html#mkiocccentry_bugs).
+</p>
 
-**`|`**  As part of its sanity checks, `txzchk(1)` will run `fnamchk(1)` on the
+<p class="leftbar">
+As part of its sanity checks, `txzchk(1)` will run `fnamchk(1)` on the
 _filename_ to verify that the name is valid. If this test does not pass, then it
 is flagged by `txzchk(1)` but it is not an error if you wish to ignore it.
 Ignoring this, however, risks violating [Rule 17](rules.html#rule17) which is a
 big risk. Of course, using `mkiocccentry(1)` would prevent this from happening.
+</p>
 
-**`|`**  By default, `txzchk(1)` will show the contents of the tarball which is
+<p class="leftbar">
+By default, `txzchk(1)` will show the contents of the tarball which is
 how the `mkiocccentry(1)` shows you the tarball contents for you to review.
+</p>
 
-**`|`**  To help you with editing a submission, the `mkiocccentry(1)` tool has
+<p class="leftbar">
+To help you with editing a submission, the `mkiocccentry(1)` tool has
 some options to write _OR_ read from an answers file so you do not have to input
 the information again. To write to `answers.txt` try:
+</p>
 
 ``` <!---sh-->
     ./mkiocccentry -a answers.txt ...
 ```
 
-**`|`**  Alternatively, if you wish to overwrite a file, you can use the `-A`
+<p class="leftbar">
+Alternatively, if you wish to overwrite a file, you can use the `-A`
 flag with the same option argument. Be careful that you do not accidentally
 overwrite your `prog.c`!
+</p>
 
-**`|`**   To make use of the answers file, use the `-i answers` option like:
+<p class="leftbar">
+To make use of the answers file, use the `-i answers` option like:
+</p>
 
 ``` <!---sh-->
     ./mkiocccentry -i answers.txt ...
 ```
 
-**`|`** If you wish to manually run the commands you can do so. For instance, to
-check the validity of the tarball
+<p class="leftbar">
+If you wish to manually run the commands you can do so. For instance, to check
+the validity of the tarball
 `submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz ` you can do:
+</p>
 
 ``` <!---sh-->
     ./txzchk submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz
 ```
 
-**`|`** Assuming that the tarball exists and is valid, you should see the
+<p class="leftbar">
+Assuming that the tarball exists and is valid, you should see the
 contents of the tarball and the words:
+</p>
 
 > No feathers stuck in tarball.
 
-**`|`**  If you give the option `-q` it will not report anything unless there
+<p class="leftbar">
+If you give the option `-q` it will not report anything unless there
 are certain error conditions, for instance if `fnamchk(1)` reports there is a
 problem with the filename; if `txzchk(1)` exits 0 then there are no problems
 detected.
+</p>
 
-**`|`**  If you wish to run `fnamchk(1)` directly you can do so like:
+<p class="leftbar">
+If you wish to run `fnamchk(1)` directly you can do so like:
+</p>
 
 ``` <!---sh-->
     ./fnamchk submit.12345678-1234-4321-abcd-1234567890ab-2.1719574527.txz
 ```
 
-**`|`** Assuming everything is OK, it would show:
+<p class="leftbar">
+Assuming everything is OK, it would show:
+</p>
 
 > `12345678-1234-4321-abcd-1234567890ab-2`
 
-**`|`** ... which `txzchk(1)` uses.
+<p class="leftbar">
+... which `txzchk(1)` uses.
+</p>
 
-**`|`**  If you want to validate the `.auth.json` or `.info.json` files you
+<p class="leftbar">
+If you want to validate the `.auth.json` or `.info.json` files you
 should use `chkentry(1)`. `chkentry(1)` accepts more than one command line form.
 If you pass a single argument, it is expected to be a directory that has both
 `.auth.json` and `.info.json` in it. You can also specify a `.auth.json` and/or
 `.info.json` file. An argument of `.` will skip that file. For instance:
+</p>
 
 ``` <!---sh-->
     # test entry directory test_work:
@@ -404,114 +508,150 @@ If you pass a single argument, it is expected to be a directory that has both
     ./chkentry .info.json .auth.json
 ```
 
-**`|`**  If there is a [JSON](https://www.json.org/json-en.html) issue detected
+<p class="leftbar">
+If there is a [JSON](https://www.json.org/json-en.html) issue detected
 by `jparse(8)`, **then there is a [JSON](https://www.json.org/json-en.html)
 error and `chkentry(1)` will report it as an _error_**. If the parsing is OK **but
 there _is an issue_ in one or both of the
 [JSON](https://www.json.org/json-en.html)** files **in the context of the IOCCC**,
 _it will **report this as an error**_. Thus, if you were to package this manually
 then you would be violating [Rule 17](rules.html#rule17).
+</p>
 
-**`|`** At the risk of stating the obvious: you run **a very big risk** of having
+<p class="leftbar">
+At the risk of stating the obvious: you run **a very big risk** of having
 your submission rejected if you package your own tarball and there are **any
 problems**. For instance, if `chkentry(1)` found a problem in your `.info.json`
 file, the `mkiocccentry(1)` tool would not package it. But if you were to package
 it manually, you would be violating [Rule 17](rules.html#rule17). But even if
 everything checks out OK you should not expect that everything **IS** OK.
+</p>
 
-**`|`** As you can see, the use of `mkiocccentry(1)` is **HIGHLY RECOMMENDED**.
+<p class="leftbar">
+As you can see, the use of `mkiocccentry(1)` is **HIGHLY RECOMMENDED**.
+</p>
 
-**`|`**   We recommend that you use the
-[example Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
-from the [IOCCC mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
+<p class="leftbar">
+We recommend that you use the [example
+Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)
+from the [IOCCC mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
 renamed as `Makefile` of course, as the starting point for your submission's
-required `Makefile`.  Feel free to modify the `Makefile` to suit your obfuscated needs.
+required `Makefile`.  Feel free to modify the `Makefile` to suit your obfuscated
+needs.
 
-**`|`**   The rest of these guidelines will assume that you are using some variant of the
+<p class="leftbar">
+The rest of these guidelines will assume that you are using some variant of the
 [example Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
 renamed as `Makefile` of course.
+</p>
 
-**`|`**   We suggest that you compile your submission with a commonly available
+<p class="leftbar">
+We suggest that you compile your submission with a commonly available
 `-std=gnu17` (ISO C 2017 with GNU extensions) C compiler.
+</p>
 
-**`|`**   Unless you clearly state otherwise in your `remarks.md` file AND put into your
+<p class="leftbar">
+Unless you **clearly state** otherwise in your `remarks.md` file AND put into your
 submission's `Makefile`, we will compile using `-std=gnu17 -O3 -g3`.
+</p>
 
-**`|`**   It is **OK** to require your submission to not be compiled
+<p class="leftbar">
+It is **OK** to require your submission to not be compiled
 using the default `-std=gnu17 -O3 -g3` settings.  Simply explain why
 your submission should not be compiled using `-std=gnu17 -O3 -g3` in
 your `remarks.md` file and adjust your `Makefile` accordingly.
+</p>
 
-**`|`**   **IMPORTANT NOTE**: The use of `-std=gnu17` does **NOT** imply the use of the `gcc`
+<p class="leftbar">
+**IMPORTANT NOTE**: The use of `-std=gnu17` does **NOT** imply the use of the `gcc`
 compiler!  We often start by compiling using the **clang** C compiler instead.
+</p>
 
-**`|`**   You may change the standard under which your submission is compiled
+<p class="leftbar">
+You may change the standard under which your submission is compiled
 by modifying the `CSTD` Makefile variable.  For example, to use `c17` instead:
+</p>
+
 
 ``` <!---make-->
     CSTD= -std=c17
 ```
 
-**`|`**   For compilers, such as `clang`, that have the `-Weverything` option,
+<p class="leftbar">
+For compilers, such as `clang`, that have the `-Weverything` option,
 while you may wish to try it, you should look at [the FAQ about clang
 -Weverything](../faq.html#weverything).  We do **NOT** recommend that you put
 the use of `-Weverything` into your submission's `Makefile` for the reasons
 cited there. This goes even if your version does not trigger a warning as some
 other version might!
+</p>
 
-**`|`**   You may change the level of optimization and compiler debug level
+<p class="leftbar">
+You may change the level of optimization and compiler debug level
 that your submission is compiled with, by modifying the `OPT` Makefile variable.
 For example, to compile without optimization and debug symbols:
+</p>
 
 ``` <!---make-->
     OPT= -O0 -g3
 ```
 
-**`|`**   There is no real penalty for compiler warnings.  Sometimes
+<p class="leftbar">
+There is no real penalty for compiler warnings.  Sometimes
 compiler warnings cannot be helped: especially in the case of
 obfuscated C.  :-)  So if you cannot easily get rid of a compiler
 warning, try not fret too much.
+</p>
 
-**`|`**   We **LIKE** code that has a minimum of warnings, especially under the
+<p class="leftbar">
+We **LIKE** code that has a minimum of warnings, especially under the
 more strict ` -Wall -Wextra -pedantic` mode:
+</p>
 
 ``` <!---make-->
     CWARN= -Wall -Wextra -pedantic
 ```
 
-**`|`**   The two previous guidelines may be thought by some as being somewhat
+<p class="leftbar">
+The two previous guidelines may be thought by some as being somewhat
 contradictory.  Isn't life, and isn't trying to satisfy "contradictory customer
 requirements" all too often like that?  :-)  Try to minimize warnings if you
 can.
+</p>
 
-**`|`**   If you manage to produce very few warnings, or perhaps no warnings at
+<p class="leftbar">
+If you manage to produce very few warnings, or perhaps no warnings at
 all under the `-Wall -Wextra -pedantic` mode, then by all means brag about it in
 your `remarks.md` file **AND BE SURE TO TELL US** the OS, OS version, compiler
 and compiler version in which you observed this occurring (in case our OS and
 compiler produces a different result: so your submission won't be penalized for
 not meeting your claims).
+</p>
 
-**`|`**   If your submission issues lots of warnings but is otherwise
+<p class="leftbar">
+If your submission issues lots of warnings but is otherwise
 marvelously obfuscated in multiple levels, don't worry about it.  Nevertheless,
 be sure that the warnings do not constitute a potential "**show stopper**"
 compiler problem.  Be sure that compilers such as both `gcc` and `clang` won't
 produce a compile **error** and refuse to compile your code: unless for some
 reason that is what you intend to happen in which case document that too in your
 `remarks.md` file.  :-)
+</p>
 
 All other things being equal, a program that must turn off fewer
 warnings will be considered better, for certain values of better.
 
-
-**`|`**   To turn off a compiler warning, in your submission's `Makefile`,
+<p class="leftbar">
+To turn off a compiler warning, in your submission's `Makefile`,
 try something such as:
+</p>
 
 ``` <!---make-->
     CSILENCE= -Wno-some-thing -Wno-another-thing -Wno-unknown-warning-option
 ```
 
-**`|`**   If you do add "`-Wno-some-thing`" to your Makefile,
-consider changing:
+<p class="leftbar">
+If you do add "`-Wno-some-thing`" to your Makefile, consider changing:
 
 ``` <!---make-->
     CUNKNOWN=
@@ -523,34 +663,43 @@ to:
     CUNKNOWN= -Wno-unknown-warning-option
 ```
 
-**`|`**   Some compilers have reported this as an error, however, and if you have
+<p class="leftbar">
+Some compilers have reported this as an error, however, and if you have
 such a compiler you might want to not add it and note it in your `remarks.md`.
+</p>
 
-**`|`**   If you need to define something on the compile line, use
+<p class="leftbar">
+If you need to define something on the compile line, use
 the `CDEFINE` Makefile variable.  For example:
+</p>
 
 ``` <!---make-->
     CDEFINE= -Dfoo -Dbar=baz
 ```
 
-**`|`**   If you need to include a file on the command line, use
+<p class="leftbar">
+If you need to include a file on the command line, use
 the `CINCLUDE` Makefile variable.  For example:
+</p>
 
 ``` <!---make-->
     CINCLUDE= -include stdio.h
 ```
 
 
-**`|`**   If need to add other "**magic**" flags to your compile line,
+<p class="leftbar">
+If you need to add other "**magic**" flags to your compile line,
 use the `COTHER` Makefile variable.  For example:
+</p>
 
 ``` <!---make-->
     COTHER= -fno-math-errno
 ```
 
+<p class="leftbar">
 **NOTE**: **We only recommend using "_magic_" flags if _BOTH_ `gcc`
 _and_ `clang`** support it.
-
+</p>
 
 <div id="likes">
 <div id="dislikes">
@@ -558,11 +707,13 @@ _and_ `clang`** support it.
 </div>
 </div>
 
-**`|`**   We **LIKE** entries that use an edited variant of the
+<p class="leftbar">
+We **LIKE** entries that use an edited variant of the
 [example Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
 renamed as `Makefile` of course.  This makes it easier for the [IOCCC Judges](../judges.html)
 to test your submission. And if your submissions wins, it makes it easier to integrate it into
 the [Official IOCCC winner website](https://www.ioccc.org/index.html).
+</p>
 
 Doing masses of `#define`s to obscure the source has become 'old'.  We
 tend to 'see thru' masses of `#define`s due to our pre-processor tests
@@ -576,7 +727,9 @@ as a program that is more well rounded in confusion.
     #d foo             /* <-- don't expect this to turn into #define foo */
 ```
 
-**`|`** In other words, it is a compilation error.
+<p class="leftbar">
+In other words, it is a compilation error.
+</p>
 
 When declaring local or global variables, you should declare the type:
 
@@ -585,16 +738,22 @@ When declaring local or global variables, you should declare the type:
     this_is_not;       /* <-- Try to avoid implicit type declarations */
 ```
 
-**`|`**   We tend to **like _less_** a submission that requires either
+<p class="leftbar">
+We tend to **like _less_** a submission that requires either
 `gcc` **OR** `clang`.  **We _prefer_ submissions** that can compile
 under **BOTH** `gcc` **AND** `clang`.
+</p>
 
-**`|`**   We **RECOMMEND** that the compiler flags you use in your
+<p class="leftbar">
+We **RECOMMEND** that the compiler flags you use in your
 submission's `Makefile` are supported by **BOTH** `gcc` **AND** `clang`.
+</p>
 
-**`|`**  We **DISLIKE** the use of obscure compiler flags, especially
+<p class="leftbar">
+We **DISLIKE** the use of obscure compiler flags, especially
 if `gcc` and/or `clang` do not support it.  We **suggest**
 that you not use any really obscure compiler flags if you can help it.
+</p>
 
 One side effect of the above is that you cannot assume the use
 of nested functions such as:
@@ -608,12 +767,14 @@ of nested functions such as:
      }
 ```
 
-**`|`**  On 2012 July 20, the judges rescinded the encouragement of
+On 2012 July 20, the judges rescinded the encouragement of
 nested functions.  Such constructions, while interesting and sometimes
 amusing, will have to wait until they required by a C standard that are
 actually implemented in **BOTH** `gcc` **AND** `clang`.
 
-**`|`**  We **DISLIKE** submissions that require the use of `-fnested-functions`.
+<p class="leftbar">
+We **DISLIKE** submissions that require the use of `-fnested-functions`.
+</p>
 
 We prefer programs that do not require a fish license: crayons and
 cat detector vans not withstanding.
@@ -632,9 +793,13 @@ not portable and _must not_ be used**:
 
 In particular, do not treat `va_list` variables as if they were a `char **`s.
 
-**`|`**   We **DISLIKE** the use of `varargs.h`.  Use `stdarg.h` instead.
+<p class="leftbar">
+We **DISLIKE** the use of `varargs.h`.  Use `stdarg.h` instead.
+</p>
 
-**`|`**   We **DISLIKE** the use of `gets(3)`.  Use `fgets(3)` instead.
+<p class="leftbar">
+We **DISLIKE** the use of `gets(3)`.  Use `fgets(3)` instead.
+</p>
 
 On 28 January 2007, the Judges rescinded the requirement that the
 `#` in a C preprocessor directive must be the 1st non-whitespace octet.
@@ -642,7 +807,9 @@ On 28 January 2007, the Judges rescinded the requirement that the
 The `exit(3)` function returns `void`.  Some broken systems have `exit(3)`
 return `int`; your submission should assume that `exit(3)` returns a `void`.
 
-**`|`**   This _guideline_ has a change mark at the very start of this line.
+<p class="leftbar">
+This _guideline_ has a change mark at the very start of this line.
+</p>
 
 Small programs are best when they are short, obscure and concise.
 While such programs are not as complex as other winners, they do
@@ -650,12 +817,14 @@ serve a useful purpose: they are often the only program that people
 attempt to completely understand.  For this reason, we look for
 programs that are compact, and are instructional.
 
-**`|`** While those who are used to temperatures found on [dwarf
+<p class="leftbar">
+While those who are used to temperatures found on [dwarf
 planets](https://science.nasa.gov/dwarf-planets/)
 (**yes Virginia, dwarf planets _ARE_ planets!**), such as
 [Pluto](https://science.nasa.gov/dwarf-planets/pluto/), might be able to
 explain to the Walrus why our seas are boiling hot, the question of
 whether pigs have wings is likely to remain a debatable point to most.
+</p>
 
 One line programs should be short one line programs: say around 80 to 120
 octets long.  Going well beyond 140 octets is a bit too long to be called
@@ -664,19 +833,28 @@ a one-liner in our vague opinion.
 We tend to **DISLIKE** programs that:
 
 * are very hardware specific
-* **`|`** are very OS version specific (`index(3)`/`strchr(3)` differences are OK, but sockets/streams specific code is likely not to be)<br>
-**`|`**   * dump core or have compiler warnings (it is OK only if you warn us in your `remarks.md` file)<br>
-**`|`**   * won't compile or run in a [Single UNIX
-Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification) environment<br>
-**`|`**   * depend on a utility or application not normally found in systems that conform to the [Single UNIX Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
+* <p class="leftbar">are very OS version specific
+(`index(3)`/`strchr(3)` differences are OK, but sockets/streams specific code is
+likely not to be)</p>
+* dump core or have compiler warnings (it is OK only if
+you warn us in your `remarks.md` file)
+* <p class="leftbar">won't compile or run in a [Single UNIX
+Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
+environment</p>
+* <p class="leftbar">depend on a utility or application not normally found
+in systems that conform to the [Single UNIX
+Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)</p>
 * abuse the build file to get around the size limit<br>
-**`|`**   * obfuscate by use of ANSI trigraphs<br>
-**`|`**   * obfuscate by use of digraphs<br>
-**`|`**   * are larger than they need to be<br>
-**`|`**   * have more lines than they need to have<br>
-**`|`**   * are "blob-ier" (just a pile of unformatted C code) than they need to be
-**`|`**   * are rather similar to **[previous winners](../years.html)** :-(
-**`|`**   * are **identical** to **previous losers** :-)
+* <p class="leftbar">obfuscate by use of ANSI trigraphs</p>
+* <p class="leftbar">obfuscate by use of digraphs</p>
+* <p class="leftbar">are larger than they need to be</p>
+* <p class="leftbar">have more lines than they need to have</p>
+* <p class="leftbar">are "blob-ier" (just a pile of unformatted C code)
+than they need to be</p>
+* <p class="leftbar">are rather similar to **[previous
+winners](../years.html)** :-(</p>
+* <p class="leftbar">are **identical** to **[previous
+losers](https://en.wikipedia.org/wiki/Null_device)** :-)</p>
 * that mandate the exclusive use of a specific Integrated Development Environment (IDE)
 
 In order to encourage submission portability, we **DISLIKE** entries that
@@ -685,10 +863,12 @@ mandate that one must use Microsoft Visual Studio to compile
 your submission.  Nevertheless some of the better IDEs have command-line
 interfaces to their compilers, once one learns how to invoke a shell.
 
-**`|`**   The program must compile and link cleanly in a [Single UNIX
+<p class="leftbar">
+The program must compile and link cleanly in a [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 environment. Therefore do not assume the system has a
 [windows.h](https://en.wikipedia.org/wiki/Windows.h) include file:
+</p>
 
 
 ``` <!---c-->
@@ -714,22 +894,28 @@ many bytes of `-D`s in order to try and squeeze the source under the size limit.
 Your source code, post-pre-processing, should not exceed the size of
 [Microsoft Windows](https://en.wikipedia.org/wiki/Microsoft_Windows). :-)
 
-**`|`**   Other windows, on the other hand, might be OK: especially where "**X
+<p class="leftbar">
+Other windows, on the other hand, might be OK: especially where "**X
 marks the spot**".  Yet on the third hand, windows are best when they are
 "unseen" (i.e., not dirty).  :-)
+</p>
 
 The judges, as a group, have a history giving wide degree of latitude
 to reasonable entries.  And recently they have had as much longitudinal
 variation as it is possible to have on [Earth](https://science.nasa.gov/earth/).  :-)
 
-**`|`**   You should try to restrict commands used in the build file to
+<p class="leftbar">
+You should try to restrict commands used in the build file to
 commands found in [Single UNIX Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification) environments
 and systems that conform to the [Single UNIX Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification).
+</p>
 
-**`|`**   You may compile and use your own programs.  If you do, try to build and execute
+<p class="leftbar">
+You may compile and use your own programs.  If you do, try to build and execute
 from the current directory.  This restriction is not a hard and
 absolute one.  The intent is to ensure that the building if your
 program is reasonably portable.
+</p>
 
 We prefer programs that are portable across a wide variety of Unix-like
 operating systems (e.g., Linux, GNU Hurd, BSD, Unix, etc.).
@@ -807,8 +993,11 @@ is NOT the smallest C source file that when compiled and run, dumps core:
     main;
 ```
 
-**`|`**   Unless you specify `-fwritable-strings` (see `COTHER` in the [example
-Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)) do not assume this sort of code will work:
+<p class="leftbar">
+Unless you specify `-fwritable-strings` (see `COTHER` in the [example
+Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example))
+do not assume this sort of code will work:
+</p>
 
 ``` <!---c-->
     char *T = "So many primes, so little time!";
@@ -816,14 +1005,18 @@ Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example
     T[14] = ';';    /* modifying a string requires: -fwritable-strings */
 ```
 
-**`|`**   Initialized char arrays are OK to write over.  For instance, this is OK:
+<p class="leftbar">
+Initialized char arrays are OK to write over.  For instance, this is OK:
+</p>
 
 ``` <!---c-->
     char b[] = "Is this OK";
     b[9] = 'k';     /* modifying an initialized char array is OK */
 ```
 
-**`|`**   There are more than 1 typos in this very sentence.
+<p class="leftbar">
+There are more than 1 typos in this very sentence.
+</p>
 
 X client entries should be as portable as possible.  Submissions that
 adapt to a wide collection of environments will be favored.  For
@@ -841,11 +1034,15 @@ software that are not in wide spread use.
 This is the only _guideline_ that contains the word
 [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin).
 
-**`|`**   However, do you know how to play [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin)?
+<p class="leftbar">
+However, do you know how to play [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin)?
 You do?!?  (Except on Tuesday?)
+</p>
 
-**`|`**   OK, there are actually 3 _guidelines_ that contain the word
+<p class="leftbar">
+OK, there are actually 3 _guidelines_ that contain the word
 [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin).
+</p>
 
 We **DISLIKE** entries that use proprietary toolkits such as the `M*tif`,
 `Xv*ew`, or `OpenL*ok` toolkits, since not everyone has them.  Use an
@@ -853,18 +1050,33 @@ open source toolkit that is widely and freely available instead.
 
 **NOTE**: The previous _guideline_ in this spot has been replaced by this _guideline_:
 
-**`|`**   X client entries should try to not to depend on particular items in
+<p class="leftbar">
+X client entries should try to not to depend on particular items in
 `.Xdefaults`.  If you must do so, be sure to note the required lines
 in the your `remarks.md` file.  They should also not depend on any
 particular window manager.
+</p>
 
-**`|`**   Try to avoid entries that play music that some people believe is copyrighted music.
+<p class="leftbar">
+Try to avoid entries that play music that some people believe is copyrighted
+music.
+</p>
 
-**`|`**   While we recognize that UNIX is not a universal operating system, the contest does have a bias towards such systems.  In an effort to expand the scope of the contest, we phrase our bias to favor the [Single UNIX Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification).
+<p class="leftbar">
+While we recognize that UNIX is not a universal operating system, the contest
+does have a bias towards such systems.  In an effort to expand the scope of the
+contest, we phrase our bias to favor the [Single UNIX
+Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification).
+</p>
 
-**`|`**   You are **well advised** to submit entries that conform to the [Single UNIX Specification Version 4](https://unix.org/version4/overview.html).
+<p class="leftbar">
+You are **well advised** to submit entries that conform to the [Single UNIX
+Specification Version 4](https://unix.org/version4/overview.html).
+</p>
 
-**`|`**   To quote the [IOCCC judges](../judges.html):
+<p class="leftbar">
+To quote the [IOCCC judges](../judges.html):
+</p>
 
 > You very well might not be completely be prohibited from failing to not partly
 misunderstand this particular _guideline_, but of course, we could not possibly
@@ -891,19 +1103,25 @@ Some types of programs can't excel (anti-tm) in some areas.  Your
 program doesn't have to excel in all areas, but doing well in several
 areas really does help.
 
-**`|`**   You are better off explaining what your submission does in your
+<p class="leftbar">
+You are better off explaining what your submission does in your
 `remarks.md` file section rather than leaving it obscure for the
 [judges](../judges.html) as we might miss something and/or be too tired to
 notice.
+</p>
 
-**`|`**   Please avoid this specific individual _guideline_, if it at all possible.
+<p class="leftbar">
+Please avoid this specific individual _guideline_, if it at all possible.
+</p>
 
-**`|`**   We freely admit that interesting, creative or humorous comments in
+<p class="leftbar">
+We freely admit that interesting, creative or humorous comments in
 your `remarks.md` file help your chances of winning.  If you had to
 read so many twisted submissions, you too would enjoy a good laugh or two.
 We think the readers of the contest winners do as well.  We do read
 your `remarks.md` content during the judging process, so it is worth your
 while to write remarkable `remarks.md` file.
+</p>
 
 We **DISLIKE** C code with trailing control-M's (`\r` or `\015`) that results
 in compilation failures.  Some non-Unix/non-Linux tools such as
@@ -928,10 +1146,12 @@ Instead of unescaped octets, you should use \octal or \hex escapes:
     else printf("This code should not print this message\n");
 ```
 
-**`|`**   It is a very good idea to, in your `remarks.md` file, tell us why you
+<p class="leftbar">
+It is a very good idea to, in your `remarks.md` file, tell us why you
 think your submission is obfuscated.  This is particularly true if
 your submission has some very subtle obfuscations that we might
 otherwise overlook.  **<<-- Hint!**
+</p>
 
 Anyone can format their code into a dense blob.  A really clever
 author will try format their submission using a "normal" formatting style
@@ -946,9 +1166,11 @@ about why you think your submission is obfuscated.  On the other hand,
 if you are pushing up against the size limits, you may be forced
 into creating a dense blob. Such are the trade-offs that obfuscators face!
 
-**`|`**   We prefer code that can run on either a 64-bit or 32-bit
+<p class="leftbar">
+We prefer code that can run on either a 64-bit or 32-bit
 processor.  However, it is **UNWISE **to assume it will run on an
 some Intel-like x86 architecture.
+</p>
 
 We believe that Mark Twain's quote:
 
@@ -963,29 +1185,31 @@ Submitting source that uses the content of
 [Anthony C Howe](../authors.html#Anthony_C_Howe), might run the risk of
 violating [Rule 7](rules.html#rule7).
 
-**`|`**   The `txzchk`
-tool source is not an original work, unless you are [Cody Boone
-Ferguson](../authors.html#Cody_Boone_Ferguson), in which case it is original!  :-)
-Submitting source that uses the content of
-[txzchk.c](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c), unless you are
-[Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), might run the risk of
-violating [Rule 7](rules.html#rule7).
+<p class="leftbar"> The `txzchk` tool source is not an original work,
+unless you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), in
+which case it is original!  :-) Submitting source that uses the content of
+[txzchk.c](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c),
+unless you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), might
+run the risk of violating [Rule 7](rules.html#rule7).</p>
 
-**`|`**   Neither the [chkentry
-tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c) nor the
-[mkiocccentry
-tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c) nor
-the [fnamchk tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c) nor
-various others in the [mkiocccentry
-repo](https://github.com/ioccc-src/mkiocccentry)
-are original works, unless you are [Landon Curt
-Noll](http://www.isthe.com/chongo/index.html), in which case they are original!  :-)
-Submitting source that uses the content of these tools, unless you are
-[Landon Curt Noll](http://www.isthe.com/chongo/index.html), might run the risk of
-violating [Rule 7](rules.html#rule7).
+<p class="leftbar">
+Neither the [chkentry tool
+source](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c) nor
+the [mkiocccentry tool
+source](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c)
+nor the [fnamchk tool
+source](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c)
+nor various others in the [mkiocccentry
+repo](https://github.com/ioccc-src/mkiocccentry) are original works, unless you
+are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), in which case
+they are original!  :-) Submitting source that uses the content of these tools,
+unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), might
+run the risk of violating [Rule 7](rules.html#rule7).
+</p>
 
-**`|`**   Neither the [JSON parser and
+
+<p class="leftbar">
+Neither the [JSON parser and
 library](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
 nor [jstrencode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c)
 nor [jstrdecode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c)
@@ -996,43 +1220,52 @@ Noll](http://www.isthe.com/chongo/index.html), in which case they are original!
 :-) Submitting source that uses the code of these tools or library, unless you
 are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson) or [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), might run the risk of violating
-[Rule 7](rules.html#rule7).
+[Rule 7](rules.html#rule7).</p>
 
-**`|`** [Rule 7](rules.html#rule7) does not prohibit you from writing your own
+<p class="leftbar">
+[Rule 7](rules.html#rule7) does not prohibit you from writing your own
 obfuscated versions of these tools, unless of course you are [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), in which case you _probably_ won't
 win since judges are disqualified! :-)
 However, _**if you do** write your own version, **you might wish** to make it do something more
 interesting_ than simply implementing the [IOCCC](../index.html) tools' algorithms. On the other
 hand, writing an obfuscated version of a library runs the risk of violating
-[Rule 1](rules.html#rule1) as it is likely not a complete program.
+[Rule 1](rules.html#rule1) as it is likely not a complete program.</p>
 
 While programs that only run in a specific word size are OK, if you have
 to pick, choose a 64-bit word size.
 
-**`|`**   If [IOCCC judges](../judges.html) are feeling ornery we
+<p class="leftbar">
+If [IOCCC judges](../judges.html) are feeling ornery we
 might choose to compile your program for running on an Arduino or
 a PDP-11.  Heck, should we ever find an emulator of 60-bit CDC Cyber
 CPU, we might just try your submission on that emulator as well :-)
+</p>
 
-**`|`**   If your submission **MUST** run only on a 64-bit or 32-bit architecture,
+<p class="leftbar">
+If your submission **MUST** run only on a 64-bit or 32-bit architecture,
 then you **MUST** specify the `-arch` on your command line
 (see `ARCH` in the [example
 Makefile](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example)).  Do not assume a processor word size without specifying `-arch`.  For example:
+</p>
 
 ``` <!---make-->
     ARCH= -m64
 ```
 
-**`|`**   Note, however, that some platforms will not necessarily support some
+<p class="leftbar">
+Note, however, that some platforms will not necessarily support some
 architectures. For instance, more recent versions of `macOS` do **NOT** support
 32-bit!
+</p>
 
-**`|`**   Try to be even more creative!
+Try to be even more creative!
 
-**`|`**   If there are limitations in your submission, you are highly encouraged
+<p class="leftbar">
+If there are limitations in your submission, you are highly encouraged
 to note such limitations in your `remarks.md` file.  For example if your
 submission factors values up to a certain size, you might want to state:
+</p>
 
 >   This submission factors values up `2305567963945518424753102147331756070`.
 Attempting to factor larger values will produce unpredictable results.
@@ -1076,32 +1309,47 @@ and state:
 program is given enough time and memory.  If the value is not a proper integer,
 the program might insult a fish named Eric.
 
-**`|`**   Do not fear if you're not 100% sure of the significance of `2305567963945518424753102147331756070` as it is not of prime importance: or is it?  :-)
+<p class="leftbar">
+Do not fear if you're not 100% sure of the significance of
+`2305567963945518424753102147331756070` as it is not of prime importance: or is
+it?  :-)
+</p>
 
-**`|`**   We **DISLIKE** the use of use ASCII tab characters in markdown files, such as in the required `remarks.md` file.
+<p class="leftbar">
+We **DISLIKE** the use of use ASCII tab characters in markdown files, such as in the required `remarks.md` file.
+</p>
 
-**`|`**   We don't mind the use ASCII tab characters in your C code.  Feel free
+<p class="leftbar">
+We don't mind the use ASCII tab characters in your C code.  Feel free
 to use ASCII tab characters if that suits your obfuscation needs.  If is
 perfectly **OK** to use tab characters elsewhere in your submission, just not in
 markdown files as this tends complicate and annoy us when it comes time to
 rendering your markdown content.
+</p>
 
-**`|`**   If you do use ASCII tab characters in your non-markdown files, be
+<p class="leftbar">
+If you do use ASCII tab characters in your non-markdown files, be
 aware that some people may use tab stop that is different than the common 8
 character tab stop.
+</p>
 
-**`|`**   **PLEASE** observe our [IOCCC markdown guidelines](../markdown.html)
+<p class="leftbar">
+**PLEASE** observe our [IOCCC markdown guidelines](../markdown.html)
 when forming your submission's `remarks.md` file.  And if your submission
 contains additional markdown files, please follow those same guidelines.  See
 also [Rule 19](rules.html#rule19).
+</p>
 
-**`|`**   We **LIKE** reading `remarks.md` files, especially if they contain
+<p class="leftbar">
+We **LIKE** reading `remarks.md` files, especially if they contain
 useful, informative, and even humorous content about your submission.  Yes, this
 is a **hint**.  :-)
+</p>
 
-**`|`**   We **RECOMMEND** you put a reasonable amount effort into the content of the `remarks.md` file: it is a required for for a reason.  :-)
-
-
+<p class="leftbar">
+We **RECOMMEND** you put a reasonable amount effort into the content of the
+`remarks.md` file: it is a required for for a reason.  :-)
+</p>
 
 
 <div id="rules_abuse">
@@ -1127,7 +1375,8 @@ have a submission that might otherwise be interesting, you might want to
 submit two versions; one that does not abuse the [IOCCC rules](rules.html) and one that
 does.
 
-**`|`**   If you intend to abuse the [IOCCC rules](rules.html),
+<p class="leftbar">
+If you intend to abuse the [IOCCC rules](rules.html),
 indicate so in your `remarks.md` file.  You **MUST** try to justify
 why you consider your rule abuse to be allowed under the
 [IOCCC rules](rules.html).  That is, you must plead your case as to why
@@ -1135,11 +1384,14 @@ your submission is valid.  Humor and/or creativity help plead a case.
 As there is no guarantee that you will succeed, you might consider
 submitting an alternate version that conforms to the
 [IOCCC rules](rules.html).
+</p>
 
-**`|`**   If do bypass the `mkiocccentry(1)` warnings about [Rule
+<p class="leftbar">
+If you do bypass the `mkiocccentry(1)` warnings about [Rule
 2a](rules.html#rule2a) and/or about [Rule 2b](rules.html#rule2b)
 and submit a submission anyway, you **MUST** try to justify why the IOCCC
 judges should not reject your submission due to a rule violation.
+</p>
 
 Abusing the web submission procedure tends to annoy us more
 than amuse us.  Spend your creative energy on content of your
@@ -1208,7 +1460,7 @@ did submit to the IOCCC in the past.  In the past, Peter had denied
 submitting anything to the IOCCC.  Perhaps those entries were
 submitted by one of his students?
 
-**`|`**   Hopefully we are **VERY CLEAR** on this point!  The rules now strongly state:
+Hopefully we are **VERY CLEAR** on this point!  The rules now strongly state:
 **PLEASE _DO NOT_ put a name of an author**, in an obvious way, into your
 source code, `remarks.md`, data files, etc., the above "**Peter Honeyman is
 exempt**" notwithstanding.
@@ -1225,12 +1477,16 @@ attempts to send non-winners into oblivion.  We remove all non-winning
 files, and shred all related printouts.  By tradition, we do not even
 reveal the number of entries that we received.
 
-**`|`** During the judging process, a process that spans multiple sessions over
+<p class="leftbar">
+During the judging process, a process that spans multiple sessions over
 a few weeks, we post general updates from our [Mastodon
 account](https://fosstodon.org/@ioccc).
+</p>
 
-**`|`** **Make sure you reload the feed** every so often **because unless you
+<p class="leftbar">
+**Make sure you reload the feed** every so often **because unless you
 are mentioned you will NOT get a push notification!**
+</p>
 
 <div id="rounds">
 ## JUDGING ROUNDS:
@@ -1248,8 +1504,9 @@ previous round.  Thus, a submission gets at least two readings.
 
 A reading consists of a number of actions:
 
-* reading `prog.c`, the C source<br>
-**`|`**   * reviewing the `remarks.md` information
+<p class="leftbar">
+* reading `prog.c`, the C source, reviewing the `remarks.md` information
+</p>
 * briefly looking any any supplied data files
 * passing the source thru the C pre-processor
     skipping over any `#include`d files
@@ -1263,7 +1520,9 @@ A reading consists of a number of actions:
 In later rounds, other actions are performed including performing
 miscellaneous tests on the source and binary.
 
-**`|`**   This is the very **guideline** that goes, **BING!**
+<p class="leftbar">
+This is the very **guideline** that goes, **BING!**
+</p>
 
 Until we reduce the stack of submissions down to about 25 submissions,
 submissions are judged on an individual basis.  A submission is set aside because it
@@ -1275,17 +1534,17 @@ A submission will often compete in several categories.
 The actual award category list will vary depending on the types of submissions
 we receive.  A typical category list might be:
 
-* **best small one line program (see above about one line programs)**
+* **best small one line program** (see above about one line programs)
 * **best small program**
 * **strangest/most creative source layout**
 * **most useful obfuscated program**
 * **best game that is obfuscated**
 * **most creatively obfuscated program**
-* **most deceptive C code (code with deceptive comments and source code)**
+* **most deceptive C code** (code with deceptive comments and source code)
 * **best X program** (see [OUR LIKES AND DISLIKES](#likes))
 * **best abuse of ISO C or ANSI C standard** (see above about compilers)
 * **best abuse of the C preprocessor**
-* **worst/best abuse of the rules** or some variation
+* **worst/best abuse of the rules** (or some variation)
 * (anything else so strange that it deserves an award)
 
 We do not limit ourselves to this list.  For example, a few entries are so
@@ -1307,20 +1566,25 @@ worthwhile to resubmit an improved version of a submission that failed to win in
 a previous year, the next year.  This assumes, of course, that the submission is
 worth improving in the first place!
 
-**`|`**   Over the years, more than one [IOCCC judge](../judges.html)
+<p class="leftbar">
+Over the years, more than one [IOCCC judge](../judges.html)
 has been known to **bribe** another IOCCC [judge](../judges.html) into voting for a
 winning entry by offering a bit of high quality chocolate, or
 other fun item.
+</p>
 
-**`|`**   One **should NOT** attempt to **bribe** an [IOCCC
+<p class="leftbar">
+One **should NOT** attempt to **bribe** an [IOCCC
 judge](../judges.html), **unless you are an [IOCCC judge](../judges.html)**,
 because **bribing** an [IOCCC judge](../judges.html) by a non-judge
 has been shown to **NOT** be effective when the **person _attempting_
 the _bribe_ is made known** to the [IOCCC judges](../judges.html)
 (i.e., they are not anonymous) AND/OR the **bribe** is otherwise
 associated with a submission to the [IOCCC](../index.html).
+</p>
 
-**`|`**   With the previous guideline in mind: **anonymous** gifts
+<p class="leftbar">
+With the previous guideline in mind: **anonymous** gifts
 for the [IOCCC judges](../judges.html) that are **NOT ASSOCIATED
 WITH** a submission to the [IOCCC](../index.html) may be sent to the
 [IOCCC judges](../judges.html) via the
@@ -1329,8 +1593,11 @@ It has been shown that receiving  **anonymous** gifts provides the
 [IOCCC judges](../judges.html) with a nice
 [dopamine](https://en.wikipedia.org/wiki/Dopamine) boost, and happy
 [IOCCC judges](../judges.html) help make the [IOCCC](../index.html) better for everyone. :-)
+</p>
 
-**`|`**   See [FAQ: How may I support the IOCCC?](../faq.html#support).
+<p class="leftbar">
+See [FAQ: How may I support the IOCCC?](../faq.html#support).
+</p>
 
 More often than not, we select a small submission (usually one line) and a
 strange/creative layout submission.  We sometimes also select a
@@ -1338,7 +1605,9 @@ submission that abuses the [IOCCC guidelines](guidelines.html) in an interesting
 or that stretches the contest [rules](rules.html) that while legal, it
 nevertheless goes against the **intent** of the [rules](rules.html).
 
-**`|`**   Nevertheless, see [Rule 12](rules.html#rule12).
+<p class="leftbar">
+Nevertheless, see [Rule 12](rules.html#rule12).
+</p>
 
 In the end, we traditionally pick one submission as '**best**'.  Sometimes such
 a submission simply far exceeds any of the other entries.  More often, the
@@ -1353,53 +1622,79 @@ Winning source is called `prog.c`. A compiled binary is called `prog`.
 # ANNOUNCEMENT OF WINNERS:
 </div>
 
-**`|`** The [judges](../judges.html) will toot initial announcement of who won, the name
+<p class="leftbar">
+The [judges](../judges.html) will toot initial announcement of who won, the name
 of their award, and a very brief description of the winning entry
 from the [@IOCCC Mastodon account](https://fosstodon.org/@ioccc).
+</p>
 
-**`|`** We recommend that you follow us on mastodon but **please make sure to
+<p class="leftbar">
+We recommend that you follow us on mastodon but **please make sure to
 refresh the feed** every so often (if not more often) because unless you are
 mentioned or someone boosts your post you will not get a push notification.
+</p>
 
 
 <div id="winners">
 ## How the new IOCCC winners will be announced
 </div>
 
-**`|`**   The [Current status of the IOCCC](../status.html) will change from
+<p class="leftbar">
+The [current status of the IOCCC](../status.html) will change from
 **[judging](../status.html#judging)** to **[closed](../status.html#closed)** .
+</p>
 
-**`|`**   The **contest_status** in the [status.json](../status.json) file will change from **judging** to **closed** as well.
+<p class="leftbar">
+The **contest_status** in the [status.json](../status.json) file will change
+from **judging** to **closed** as well.
+</p>
 
-**`|`**   When the above happens, the winning entries have been selected by the [IOCCC judges](../judges.html).
+<p class="leftbar">
+When the above happens, the winning entries have been selected by the [IOCCC
+judges](../judges.html).
+</p>
 
-**`|`**   The [IOCCC judges](../judges.html) will begin to prepare to release the source code of the new IOCCC winners.
+<p class="leftbar">
+The [IOCCC judges](../judges.html) will begin to prepare to release the source
+code of the new IOCCC winners.
+</p>
 
-**`|`**   The [IOCCC judges](../judges.html) will commit the winning source to the
-[IOCCC winner repo](https://github.com/ioccc-src/winner) which will update the [Official IOCCC website](https://www.ioccc.org/index.html).
+<p class="leftbar">
+The [IOCCC judges](../judges.html) will commit the winning source to the
+[IOCCC winner repo](https://github.com/ioccc-src/winner) which will update the
+[Official IOCCC website](https://www.ioccc.org/index.html).
+</p>
 
-**`|`**   The [IOCCC news](../news.html) will also contain an announcement of the winners.
+<p class="leftbar">
+The [IOCCC news](../news.html) will also contain an announcement of the winners.
+</p>
 
 
 <div id="mastodon">
 ## An important update to how winners are announced
 </div>
 
-**`|`** The IOCCC no longer uses twitter.  IOCCC entries will be announced by a
+<p class="leftbar">
+The IOCCC no longer uses twitter.  IOCCC entries will be announced by a
 `git` commit to the [IOCCC entries repo](https://github.com/ioccc-src/winner)
 that, in turn, updates the [Official IOCCC
 website](https://www.ioccc.org/index.html).
+</p>
 
-**`|`** In addition a note is posted to the [IOCCC Mastodon account](https://fosstodon.org/@ioccc).
+<p class="leftbar">
+In addition a note is posted to the [IOCCC Mastodon account](https://fosstodon.org/@ioccc).
+</p>
 
 
 <div id="entries">
 ## Back to announcement of winners
 </div>
 
-**`|`**   It is pointless to ask the [IOCCC judges](../judges.html) how many
+<p class="leftbar">
+It is pointless to ask the [IOCCC judges](../judges.html) how many
 submissions we receive.  See [How many submissions do the judges receive for a
 given IOCCC?](../faq.html#how_many).
+</p>
 
 Often, winning entries are published in selected magazines from around the
 world.  Winners have appeared in books ('`The New Hackers Dictionary`',
@@ -1415,23 +1710,35 @@ Last, but not least, [winners](../authors.html) receive international fame and f
 </div>
 </div>
 
-**`|`**   For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
+<p class="leftbar">
+For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
+</p>
 
-**`|`**   Be sure to review the [IOCCC Rules and Guidelines](index.html) as the
+<p class="leftbar">
+Be sure to review the [IOCCC Rules and Guidelines](index.html) as the
 [IOCCC rules](rules.html) and the [IOCCC guidelines](guidelines.html) may (and often do) change from year to year.
+</p>
 
-**`|`**   You should be sure you have the current [IOCCC rules](rules.html) and
+<p class="leftbar">
+You should be sure you have the current [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) prior to submitting entries.
+</p>
 
-**`|`**   See the [Official IOCCC website news](../news.html) for additional information.
+<p class="leftbar">
+See the [Official IOCCC website news](../news.html) for additional information.
+</p>
 
-**`|`**   For the updates and breaking [IOCCC news](../news.html), you are encouraged to follow
+<p class="change marker">
+For the updates and breaking [IOCCC news](../news.html), you are encouraged to follow
 the [IOCCC on Mastodon](https://fosstodon.org/@ioccc).  See our
 [FAQ on Mastodon](../faq.html#try_mastodon) for more information. **Please be
 aware** that unless you are mentioned you most likely will **NOT** get a
 notification so you should make sure to check the page.
+</p>
 
-**`|`**   Check out the [Official IOCCC website](https://www.ioccc.org/index.html) in general.
+<p class="leftbar">
+Check out the [Official IOCCC website](https://www.ioccc.org/index.html) in general.
+</p>
 
 Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) /\\cc/\\

--- a/next/rules.html
+++ b/next/rules.html
@@ -405,7 +405,9 @@ app from time to time to view IOCCC mastodon updates.</p>
 <!-- END: the next line ends content from: inc/rules.closed.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 <h1 id="th-international-obfuscated-c-code-contest-official-rules">28th International Obfuscated C Code Contest Official Rules</h1>
-<p><strong><code>|</code></strong> Copyright © 2024 Leonid A. Broukhis and Landon Curt Noll.</p>
+<p class="leftbar">
+Copyright © 2024 Leonid A. Broukhis and Landon Curt Noll.
+</p>
 <p>All Rights Reserved. Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered. All other uses must receive prior permission in
@@ -413,14 +415,19 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <div id="rules_version">
 <h2 id="ioccc-rules-version">IOCCC Rules version</h2>
 </div>
-<p><strong><code>|</code></strong> These <a href="rules.html">IOCCC rules</a> are version <strong>28.4 2024-07-02</strong>.</p>
+<p class="leftbar">
+These <a href="rules.html">IOCCC rules</a> are version <strong>28.5 2024-07-08</strong>.
+</p>
 <p><strong>IMPORTANT</strong>: Be sure to read the <a href="guidelines.html">IOCCC guidelines</a>.</p>
 <div id="change_marks">
 <h3 id="change-marks">Change marks</h3>
 </div>
-<p><strong><code>|</code></strong> <strong>← Lines that start with this symbol indicate a change from the previous IOCCC</strong></p>
+<p class="leftbar">
+<strong>← Lines that start with this symbol indicate a change from the previous IOCCC</strong>
+</p>
 <p>Most lines (we sometimes make mistakes) that were modified since the previous
-IOCCC start with the <strong><code>|</code></strong> symbol.</p>
+IOCCC start with a solid 4 pixel black left border (or, in the case of a code
+block or blockquote, just a vertical bar).</p>
 <div id="obfuscate">
 <h1 id="obfuscate-defined">Obfuscate defined:</h1>
 </div>
@@ -446,19 +453,25 @@ IOCCC start with the <strong><code>|</code></strong> symbol.</p>
 <div id="dates">
 <h1 id="important-ioccc-dates">Important IOCCC dates</h1>
 </div>
-<p><strong><code>|</code></strong> This IOCCC runs from <strong>2024-MMM-DD HH:MM:SS UTC</strong> to <strong>202x-MMM-DD HH:MM:SS UTC</strong>.<br>
-<strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
-<p><strong><code>|</code></strong> Until the start of this IOCCC, these <a href="rules.html">IOCCC rules</a>,
+<p class="leftbar">
+This IOCCC runs from <strong>2024-MMM-DD HH:MM:SS UTC</strong> to <strong>202x-MMM-DD HH:MM:SS UTC</strong>.<br>
+<strong>XXX - date/time is TBD - XXX</strong>
+</p>
+<p class="leftbar">
+Until the start of this IOCCC, these <a href="rules.html">IOCCC rules</a>,
 <a href="guidelines.html">IOCCC guidelines</a> and the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
 toolkit</a> should be considered
-provisional <strong>BETA</strong> versions and <strong>may be adjusted <em>AT ANY TIME</em></strong>.</p>
+provisional <strong>BETA</strong> versions and <strong>may be adjusted <em>AT ANY TIME</em></strong>.
+</p>
 <p>When the IOCCC is open, the submission URL is:
 <a href="https://submit.ioccc.org">https://submit.ioccc.org</a>; at all other
 times that link is likely to be unresponsive.</p>
 <p>Please check the <a href="../faq.html#submit">How to enter FAQ</a>
 for <strong>important information</strong> on how to submit to the IOCCC.</p>
-<p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
-<strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
+<p class="leftbar">
+The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
+<strong>XXX - date/time is TBD - XXX</strong>
+</p>
 <p>Please wait to submit your entries until after that time.</p>
 <p>The official <a href="rules.html">IOCCC rules</a> and <a href="guidelines.html">IOCCC guidelines</a> will be
 available on the <a href="../index.html">official IOCCC website</a> on or slightly before
@@ -486,44 +499,66 @@ submission URL</em></strong>.</p>
 <div id="rule2a">
 <h2 id="rule-2a">Rule 2a</h2>
 </div>
-<p><strong><code>|</code></strong> The size of your program source <strong>should not exceed 4993 bytes</strong>.</p>
-<p><strong><code>|</code></strong> If you use the most recently released official IOCCC submission
+<p class="leftbar">
+The size of your program source <strong>should not exceed 4993 bytes</strong>.
+</p>
+<p class="leftbar">
+If you use the most recently released official IOCCC submission
 packaging tool (hereby referred to as <code>mkiocccentry(1)</code>), which we <strong>STRONGLY
 recommend you do</strong> (see also <a href="#rule17">Rule 17</a>), then the <code>mkiocccentry(1)</code>
-tool will warn you if there appears to be a <a href="#rule2a">Rule 2a</a> violation.</p>
-<p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2a">Rule 2a</a> warning.
+tool will warn you if there appears to be a <a href="#rule2a">Rule 2a</a> violation.
+</p>
+<p class="leftbar">
+The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2a">Rule 2a</a> warning.
 Overriding a <a href="#rule2a">Rule 2a</a> warning carries a <strong>fair amount of risk that your submission
 will be rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
-ahead of time if you plan to override the <a href="#rule2a">Rule 2a</a> warning.</p>
-<p><strong><code>|</code></strong> If you do override the <a href="#rule2a">Rule 2a</a> warning from the
+ahead of time if you plan to override the <a href="#rule2a">Rule 2a</a> warning.
+</p>
+<p class="leftbar">
+If you do override the <a href="#rule2a">Rule 2a</a> warning from the
 <code>mkiocccentry(1)</code> tool, or otherwise plan to violate <a href="#rule2a">Rule 2a</a>, then
 you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong> of why you are doing so in your
 <code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your <code>remarks.md</code> file your
-submission may still be rejected</strong>.</p>
-<p><strong><code>|</code></strong> You may check your code prior to submission by giving the filename
-as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
+submission may still be rejected</strong>.
+</p>
+<p class="leftbar">
+You may check your code prior to submission by giving the filename
+as a command like argument to the <code>iocccsize(1)</code> tool. For example:
+</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
 <div id="rule2b">
 <h2 id="rule-2b">Rule 2b</h2>
 </div>
-<p><strong><code>|</code></strong> When the filename of your program source is given as a command line argument to the latest version
+<p class="leftbar">
+When the filename of your program source is given as a command line argument to the latest version
 of the official IOCCC size tool (hereby referred to as <code>iocccsize(1)</code>), the
-value printed <strong>should NOT exceed <em>2503</em></strong>.</p>
-<p><strong><code>|</code></strong> The source to <code>iocccsize(1)</code> may be found in the
-<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p><strong><code>|</code></strong> If you use the <code>mkiocccentry(1)</code> tool, which we <strong>STRONGLY recommend
+value printed <strong>should NOT exceed <em>2503</em></strong>.
+</p>
+<p class="leftbar">
+The source to <code>iocccsize(1)</code> may be found in the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.
+</p>
+<p class="leftbar">
+If you use the <code>mkiocccentry(1)</code> tool, which we <strong>STRONGLY recommend
 you do</strong> (again, see also <a href="#rule17">Rule 17</a>),
-then <code>mkiocccentry(1)</code> will invoke <code>iocccsize(1)</code> before packaging your submission.</p>
-<p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2b">Rule 2b</a> warning.
+then <code>mkiocccentry(1)</code> will invoke <code>iocccsize(1)</code> before packaging your submission.
+</p>
+<p class="leftbar">
+The <code>mkiocccentry(1)</code> tool will give you the option of overriding the <a href="#rule2b">Rule 2b</a> warning.
 Overriding a <a href="#rule2b">Rule 2b</a> warning carries a <strong>fair amount of risk that your submission
 will be rejected</strong>. Be sure to consult the <a href="guidelines.html">IOCCC guidelines</a>
-ahead of time if you plan to override the <a href="#rule2b">Rule 2b</a> warning.</p>
-<p><strong><code>|</code></strong> If you do override the <a href="#rule2b">Rule 2b</a> warning from the <code>mkiocccentry(1)</code> tool,
+ahead of time if you plan to override the <a href="#rule2b">Rule 2b</a> warning.
+</p>
+<p class="leftbar">
+If you do override the <a href="#rule2b">Rule 2b</a> warning from the <code>mkiocccentry(1)</code> tool,
 or otherwise plan to violate <a href="#rule2b">Rule 2a</a>, then you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong>
 of why you are doing so in your <code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your <code>remarks.md</code> file
-your submission may still be rejected</strong>.</p>
-<p><strong><code>|</code></strong> You may check your code prior to submission by giving the filename
-as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
+your submission may still be rejected</strong>.
+</p>
+<p class="leftbar">
+You may check your code prior to submission by giving the filename
+as a command like argument to the <code>iocccsize(1)</code> tool. For example:
+</p>
 <pre><code>    ./iocccsize prog.c</code></pre>
 <div id="rule3">
 <h2 id="rule-3">Rule 3</h2>
@@ -533,20 +568,30 @@ the <a href="../faq.html#submit">How to enter FAQ</a>.</p>
 <p>To submit to an open IOCCC, you must use the <a href="https://submit.ioccc.org/">IOCCC submit
 server</a>. Unless the IOCCC is open, that link will
 likely be unresponsive.</p>
-<p><strong><code>|</code></strong> The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
-<strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
+<p class="leftbar">
+The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
+<strong>XXX - date/time is TBD - XXX</strong>
+</p>
 <p><strong>Please wait to submit</strong> your entries until after that time.</p>
 <div id="rule4">
 <h2 id="rule-4">Rule 4</h2>
 </div>
-<p><strong><code>|</code></strong> If your submission is selected as a winner, it may be modified in order
-to fit into the structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
-<p><strong><code>|</code></strong> For example, your submission’s <code>Makefile</code> might be modified.</p>
-<p><strong><code>|</code></strong> Your source code will be the file <code>prog.c</code>. The compiled binary
+<p class="leftbar">
+If your submission is selected as a winner, it may be modified in order
+to fit into the structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.
+</p>
+<p class="leftbar">
+For example, your submission’s <code>Makefile</code> might be modified.
+</p>
+<p class="leftbar">
+Your source code will be the file <code>prog.c</code>. The compiled binary
 will be called <code>prog</code>. If you submission requires different filenames,
 then modify your submission’s <code>Makefile</code> to <strong>COPY</strong> (<strong>NOT</strong> move)
-the files accordingly.</p>
-<p><strong><code>|</code></strong> See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
+the files accordingly.
+</p>
+<p class="leftbar">
+See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.
+</p>
 <div id="rule5">
 <h2 id="rule-5">Rule 5</h2>
 </div>
@@ -559,10 +604,14 @@ file to a new filename and then modify that copy.</p>
 <div id="rule6">
 <h2 id="rule-6">Rule 6</h2>
 </div>
-<p><strong><code>|</code></strong> I am not a rule, I am a <code>free(void *human);</code> ‼️</p>
-<p><strong><code>|</code></strong>        <code>while (!(ioccc(rule(you(are(number(6)))))) {</code><br>
-<strong><code>|</code></strong>                <code>ha_ha_ha();</code><br>
-<strong><code>|</code></strong>        <code>}</code></p>
+<p class="leftbar">
+I am not a rule, I am a <code>free(void *human);</code> ‼️
+</p>
+<p class="leftbar">
+        <code>while (!(ioccc(rule(you(are(number(6)))))) {</code><br>
+                <code>ha_ha_ha();</code><br>
+        <code>}</code>
+</p>
 <div id="rule7">
 <h2 id="rule-7">Rule 7</h2>
 </div>
@@ -570,7 +619,9 @@ file to a new filename and then modify that copy.</p>
 <p>You (the author(s)) must own the contents of your submission OR
 you must have permission from the owner(s) to submit their content
 under the following license:</p>
-<p><strong><code>|</code></strong> <strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
+<p class="leftbar">
+<strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong>
+</p>
 <p>If you submit any content that is owned by others, you <strong>MUST
 detail that ownership</strong> (i.e., who owns what) <strong><em>AND</em> document the
 permission you obtained</strong>.</p>
@@ -578,14 +629,18 @@ permission you obtained</strong>.</p>
 <div id="rule8">
 <h2 id="rule-8">Rule 8</h2>
 </div>
-<p><strong><code>|</code></strong> Entries must be received prior to the end of this IOCCC which is <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
-<strong><code>|</code></strong> <strong>XXX - date/time is TBD - XXX</strong></p>
+<p class="leftbar">
+Entries must be received prior to the end of this IOCCC which is <strong>2024-MMM-DD HH:MM:SS UTC</strong>.<br>
+<strong>XXX - date/time is TBD - XXX</strong>
+</p>
 <p>A confirmation of submission will be sent to the submitting email address
 before the close of the contest.</p>
 <div id="rule9">
 <h2 id="rule-9">Rule 9</h2>
 </div>
-<p><strong><code>|</code></strong> Each person may submit up to and including <strong>10.000000</strong> entries per contest.</p>
+<p class="leftbar">
+Each person may submit up to and including <strong>10.000000</strong> (ten) entries per contest.
+</p>
 <p><strong>Each submission <em>must be submitted separately</em></strong>.</p>
 <div id="rule10">
 <h2 id="rule-10">Rule 10</h2>
@@ -611,25 +666,33 @@ their rule abuse is legal, in the <code>remarks.md</code> file.</p>
 <div id="rule13">
 <h2 id="rule-13">Rule 13</h2>
 </div>
-<p><strong><code>|</code></strong> Any C source that fails to compile because of unescaped octets with
-the high bit set (octet value &gt;= 128) <strong><em>might</em></strong> be rejected.</p>
+<p class="leftbar">
+Any C source that fails to compile because of unescaped octets with
+the high bit set (octet value &gt;= 128) <strong><em>might</em></strong> be rejected.
+</p>
 <div id="rule14">
 <h2 id="rule-14">Rule 14</h2>
 </div>
-<p><strong><code>|</code></strong> Any C source that fails to compile because of lines with trailing
-control-M’s (i.e., lines with a tailing octet <code>015</code>) <strong><em>might</em></strong> be rejected.</p>
+<p class="leftbar">
+Any C source that fails to compile because of lines with trailing
+control-M’s (i.e., lines with a tailing octet <code>015</code>) <strong><em>might</em></strong> be rejected.
+</p>
 <p>Please do <strong>NOT</strong> put trailing control-M’s on remarks file lines.
 Please check to be sure, before submitting, that you have removed
 any control-M at the end of remark file lines.</p>
 <div id="rule15">
 <h2 id="rule-15">Rule 15</h2>
 </div>
-<p><strong><code>|</code></strong> In order to register for the IOCCC, you <strong>MUST</strong> have a valid email address.</p>
+<p class="leftbar">
+In order to register for the IOCCC, you <strong>MUST</strong> have a valid email address.
+</p>
 <p>The judges <strong>are not responsible for delays in email</strong>, please plan
 enough time for one automated exchange of email as part of your
 submission.</p>
-<p><strong><code>|</code></strong> See <a href="../faq.html#register">the FAQ on how to register for the IOCCC</a> in the
-<a href="../faq.html">FAQ</a> for details.</p>
+<p class="leftbar">
+See <a href="../faq.html#register">the FAQ on how to register for the IOCCC</a> in the
+<a href="../faq.html">FAQ</a> for details.
+</p>
 <div id="rule16">
 <h2 id="rule-16">Rule 16</h2>
 </div>
@@ -641,168 +704,323 @@ been published may be disqualified.</p>
 <h2 id="rule-17">Rule 17</h2>
 </div>
 <h3 id="tldr-rule-17---use-mkiocccentry1">TL;DR Rule 17 - Use <code>mkiocccentry(1)</code></h3>
-<p><strong><code>|</code></strong> This is a <strong>COMPLEX</strong> rule. <strong>Violating this rule will cause your submission to REJECTED</strong>!
+<p class="leftbar">
+This is a <strong>COMPLEX</strong> rule. <strong>Violating this rule will cause your submission to REJECTED</strong>!
 To help you avoid such a rejection, you are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code> tool,
 based on the latest release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>,
-to form your submission’s xz compressed tarball.</p>
-<p><strong><code>|</code></strong> The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
-contains <strong>IMPORTANT</strong> tools such as:</p>
+to form your submission’s xz compressed tarball.
+</p>
+<p class="leftbar">
+The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
+contains <strong>IMPORTANT</strong> tools such as:
+</p>
 <ul>
-<li><code>chkentry(1)</code></li>
-<li><code>iocccsize(1)</code></li>
-<li><code>mkiocccentry(1)</code></li>
-<li><code>txzchk(1)</code></li>
-<li><code>fnamchk(1)</code></li>
-<li><code>jparse(1)</code> and <code>jparse(8)</code> (which <code>chkentry(1)</code> uses)</li>
+<li><p class="leftbar">
+<code>chkentry(1)</code>
+</p></li>
+<li><p class="leftbar">
+<code>iocccsize(1)</code>
+</p></li>
+<li><p class="leftbar">
+<code>mkiocccentry(1)</code>
+</p></li>
+<li><p class="leftbar">
+<code>txzchk(1)</code>
+</p></li>
+<li><p class="leftbar">
+<code>fnamchk(1)</code>
+</p></li>
+<li><p class="leftbar">
+<code>jparse(1)</code> and <code>jparse(8)</code> (which <code>chkentry(1)</code> uses)
+</p></li>
 </ul>
-<p><strong><code>|</code></strong> The above mentioned tools will help you verify that your submission
-conforms to <a href="#rule17">Rule 17</a>.</p>
-<p><strong><code>|</code></strong> Each above mentioned tools has a <code>-h</code> option that provides command
-line help. For additional details, see the tools’ man pages.</p>
-<p><strong><code>|</code></strong> You do not explicitly need to invoke <code>jparse(1)</code> but the <code>jparse(8)</code>
-library will be used when compiling various tools.</p>
+<p class="leftbar">
+The above mentioned tools will help you verify that your submission
+conforms to <a href="#rule17">Rule 17</a>.
+</p>
+<p class="leftbar">
+Each above mentioned tools has a <code>-h</code> option that provides command
+line help. For additional details, see the tools’ man pages.
+</p>
+<p class="leftbar">
+You do not explicitly need to invoke <code>jparse(1)</code> but the <code>jparse(8)</code>
+library will be used when compiling various tools.
+</p>
+<p class="leftbar">
+Of course you <strong>can</strong> invoke <code>jparse(1)</code> if you wish to validate your own JSON
+data file or some other JSON file.
+</p>
 <h3 id="rule-17---the-complex-details">Rule 17 - The COMPLEX details</h3>
-<p><strong><code>|</code></strong> Each submission <strong>MUST</strong> be in the form of a xz compressed tarball.</p>
-<p><strong><code>|</code></strong> The xz compressed tarball filename must be of the form:</p>
+<p class="leftbar">
+Each submission <strong>MUST</strong> be in the form of a xz compressed tarball.
+The xz compressed tarball filename must be of the form:
+</p>
 <pre><code>    ^submit.username-slot_num.[1-9][0-9]{9,}.txz$</code></pre>
-<p><strong><code>|</code></strong> where <em><code>username</code></em> is your IOCCC registration username <strong>in the form of a
+<p class="leftbar">
+… where <em><code>username</code></em> is your IOCCC registration username <strong>in the form of a
 <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a></strong> (see
 <a href="https://datatracker.ietf.org/doc/html/rfc9562">RFC 9562</a> for
 details), and where <em><code>slot_num</code></em> is a single decimal digit integer
-(i.e., &gt;= <code>0</code> and &lt; <code>9</code>).</p>
-<p><strong><code>|</code></strong> In particular, <em><code>username</code></em> is in the form of:
+(i.e., &gt;= <code>0</code> and &lt; <code>9</code>).
+</p>
+<p class="leftbar">
+In particular, <em><code>username</code></em> is in the form of:
 <code>xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx</code> where <code>x</code> is a hexadecimal digit in the
 range <code>[0-9a-f]</code>. And yes, there is a 4 (UUID version 4) and an <code>a</code> (UUID variant
-1) in there.</p>
-<p><strong><code>|</code></strong> Your xz compressed tarball <strong>MUST</strong> contain, at a minimum,
-the following files:</p>
+1) in there.
+</p>
+<p class="leftbar">
+Your xz compressed tarball <strong>MUST</strong> contain, <strong>at a minimum</strong>, the following files:
+</p>
 <ul>
-<li><code>Makefile</code></li>
-<li><code>prog.c</code></li>
-<li><code>remarks.md</code></li>
-<li><code>.info.json</code></li>
-<li><code>.auth.json</code></li>
+<li><p class="leftbar">
+<code>Makefile</code>
+</p></li>
+<li><p class="leftbar">
+<code>prog.c</code>
+</p></li>
+<li><p class="leftbar">
+<code>remarks.md</code>
+</p></li>
+<li><p class="leftbar">
+<code>.info.json</code>
+</p></li>
+<li><p class="leftbar">
+<code>.auth.json</code>
+</p></li>
 </ul>
-<p><strong><code>|</code></strong> The <code>.info.json</code> must be valid JSON and pass the <code>chkentry(1)</code> tests.</p>
-<p><strong><code>|</code></strong> The <code>.auth.json</code> must be valid JSON and pass the <code>chkentry(1)</code> tests.</p>
-<p><strong><code>|</code></strong> You submission may have additional files, however the filenames of those additional files <strong>MUST</strong>:</p>
-<p><strong><code>|</code></strong> * Be less than <strong>100</strong> characters in length<br>
-<strong><code>|</code></strong> * Match the regular expression: <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code></p>
-<p><strong><code>|</code></strong> The <code>mkiocccentry(1)</code> tool will not package any files that do not meet
-those requirements.</p>
-<p><strong><code>|</code></strong> The <code>Makefile</code> must be a non-empty file in <a href="https://www.gnu.org/software/make/manual/make.html">GNU
-Makefile</a> form. See the
+<p class="leftbar">
+The <code>.info.json</code> must be valid JSON and pass the <code>chkentry(1)</code> tests.
+It is generated by the <code>mkiocccentry(1)</code> tool.
+</p>
+<p class="leftbar">
+The <code>.auth.json</code> must be valid JSON and pass the <code>chkentry(1)</code> tests.
+It is generated by the <code>mkiocccentry(1)</code> tool.
+</p>
+<p class="leftbar">
+You submission may have additional files, however the filenames of those additional files <strong>MUST</strong>:
+</p>
+<ul>
+<li><p class="leftbar">
+Be less than <strong>100</strong> characters in length.
+</p></li>
+<li><p class="leftbar">
+Match the regular expression:
+<code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code>
+</p></li>
+</ul>
+<p class="leftbar">
+The <code>mkiocccentry(1)</code> tool will not package any files that do not meet
+those requirements.
+</p>
+<p class="leftbar">
+The <code>Makefile</code> <strong>MUST</strong> be a <strong>non</strong>-empty file in <strong><a href="https://www.gnu.org/software/make/manual/make.html">GNU
+Makefile</a></strong> form. See the
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">Makefile.example</a>,
 the <a href="../faq.html#submission_makefiles">FAQ about your submission’s Makefile</a> and
-the <a href="../faq.html#make_compatibility">FAQ about IOCCC Makefile compatibility</a> for help.</p>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> must be a non-empty file in markdown form. See also
+the <a href="../faq.html#make_compatibility">FAQ about IOCCC Makefile compatibility</a> for help.
+</p>
+<p class="leftbar">
+The <code>remarks.md</code> <strong>MUST</strong> be a <strong>non</strong>-empty file in markdown form. See also
 <a href="#rule18">Rule 18</a> and our <a href="../faq.html#remarks_md">FAQ about what to put in your
-remarks.md</a>.</p>
-<p><strong><code>|</code></strong> The xz compressed tarball file <strong>MUST</strong> be less than
-or equal <strong>3999971</strong> octets in size.</p>
-<p><strong><code>|</code></strong> When your submission’s xz compressed tarball is uncompressed,
+remarks.md</a> and the <a href="../faq.html#markdown">FAQ about IOCCC best markdown
+practices</a>.
+</p>
+<p class="leftbar">
+See also the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide
+and the <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.
+</p>
+</p>
+<p class="leftbar">
+The xz compressed tarball file <strong>MUST</strong> be less than or equal <strong>3999971</strong> octets in size.
+</p>
+<p class="leftbar">
+When your submission’s xz compressed tarball is uncompressed,
 the total size of your submission: the sum of the size of the program,
 hints, comments, build and info files <strong>MUST</strong> be less than or equal
-to <strong>28314624</strong> octets (<strong>27651K</strong>) in size.</p>
-<p><strong><code>|</code></strong> Your submission’s xz compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> test.</p>
-<p><strong><code>|</code></strong> You are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code>
-tool to form your submission’s xz compressed tarball.</p>
-<p><strong><code>|</code></strong> Your entry may <strong>NOT</strong> have subdirectories.</p>
-<p><strong><code>|</code></strong> Filenames in your entry (that is, not including the files generated by
-the <code>mkiocccentry(1)</code> tool or the tools it invokes) <strong>MUST</strong>:</p>
+to <strong>28314624</strong> octets (<strong>27651K</strong>) in size.
+</p>
+<p class="leftbar">
+Your submission’s xz compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> test. See
+the <a href="guidelines.html">guidelines</a> for more details on this tool.
+</p>
+<p class="leftbar">
+You are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code> tool to form your
+submission’s xz compressed tarball. See the <a href="guidelines.html">guidelines</a> for
+more details on this tool and the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+repo</a>.
+</p>
+<p class="leftbar">
+Your entry may <strong>NOT</strong> have subdirectories. However, you can provide files that
+are in different directories as <code>mkiocccentry(1)</code> will copy them to the work
+directory (see the <a href="guidelines.html">guidelines</a> for more details).
+</p>
+<p class="leftbar">
+Filenames in your entry (that is, not including the files generated by the
+<code>mkiocccentry(1)</code> tool or the tools it or any other tool invokes) <strong>MUST</strong>:
+</p>
 <ul>
-<li>Be less than <strong>100</strong> characters in length</li>
-<li><strong>NOT</strong> have a <strong><code>/</code></strong> (excluding the entry directory that the
-<code>mkiocccentry(1)</code> tool generates).</li>
-<li><strong>NOT</strong> contain a path component of: <strong><code>.</code></strong> (that is, with the exception of
-files generated by <code>mkiocccentry(1)</code> itself, it must have <strong>NO</strong> <strong><code>.</code></strong>).</li>
-<li><strong>NOT</strong> contain a path component of: <strong><code>..</code></strong> (that is, <strong>NO</strong> <strong><code>..</code></strong>).</li>
-<li>Match the regular expression <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code> (again, excluding
-files generated by <code>mkiocccentry(1)</code>).</li>
+<li><p class="leftbar">
+Be less than <strong>100</strong> characters in length
+</p></li>
+<li><p class="leftbar">
+<strong>NOT</strong> have a <strong><code>/</code></strong> (excluding the entry directory that
+the <code>mkiocccentry(1)</code> tool generates).
+</p></li>
+<li><p class="leftbar">
+<strong>NOT</strong> contain a path component of: <strong><code>.</code></strong> (that is, with
+the exception of files generated by <code>mkiocccentry(1)</code> itself, it must have
+<strong>NO</strong> <strong><code>.</code></strong>).
+</p></li>
+<li><p class="leftbar">
+<strong>NOT</strong> contain a path component of: <strong><code>..</code></strong> (that is,
+<strong>NO</strong> <strong><code>..</code></strong>).
+</p></li>
+<li><p class="leftbar">
+Match the regular expression
+<code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code> (again, excluding files generated by
+<code>mkiocccentry(1)</code>).
+</p></li>
 </ul>
-<p><strong><code>|</code></strong> Additionally, the tarball <strong>MUST</strong> have the following files (generated
-by the <code>mkiocccentry(1)</code> tool):</p>
+<p class="leftbar">
+Additionally, the tarball <strong>MUST</strong> have the following files (generated
+by the <code>mkiocccentry(1)</code> tool):
+</p>
 <ul>
-<li><code>.auth.json</code> which contains information about the author or authors (that will
-only be looked at if the submission wins).</li>
-<li><code>.info.json</code> which contains information about the entry.</li>
+<li><p class="leftbar">
+<code>.auth.json</code> which contains information about the author or
+authors (that will only be looked at if the submission wins).
+</p></li>
+<li><p class="leftbar">
+<code>.info.json</code> which contains information about the
+entry.
+</p></li>
 </ul>
-<p><strong><code>|</code></strong> The <code>txzchk(1)</code> tool will verify these (and other things) for you and
+<p class="leftbar">
+The <code>txzchk(1)</code> tool will verify these (and other things) for you and
 the <code>chkentry(1)</code> tool will do additional checks on the contents of the
-<code>.auth.json</code> and <code>.info.json</code> files.</p>
-<p><strong><code>|</code></strong> The tarball filename <strong>MUST</strong> pass <code>fnamchk(1)</code>; the tool <code>txzchk(1)</code>
+<code>.auth.json</code> and <code>.info.json</code> files including JSON validity. If these checks
+fail it is an error and <code>mkiocccentry(1)</code> will fail. In this case it is very
+<strong>possibly</strong> a bug; please <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it at the mkiocccentry issues
+page</a>.
+</p>
+<p class="leftbar">
+The tarball filename <strong>MUST</strong> pass <code>fnamchk(1)</code>; the tool <code>txzchk(1)</code>
 will run <code>fnamchk(1)</code> as part of its algorithm. If you use <code>mkiocccentry(1)</code>
 there should be no problem but if you were to package things manually it is
-possible there could be a problem.</p>
-<p><strong><code>|</code></strong> The <code>fnamchk(1)</code>, which <code>txzchk(1)</code> executes, will verify that the
-filename is correct.</p>
-<p><strong><code>|</code></strong> These checks <strong>MUST PASS</strong>.</p>
-<p><strong><code>|</code></strong> Where <a href="#rule17">Rule 17</a> and the tools from the latest
+possible there could be a problem and this is a big risk.
+</p>
+<p class="leftbar">
+The <code>fnamchk(1)</code>, which <code>txzchk(1)</code> executes, will verify that the
+filename is correct.
+</p>
+<p class="leftbar">
+These checks <strong>MUST PASS</strong>.
+</p>
+<p class="leftbar">
+Where <a href="#rule17">Rule 17</a> and the tools from the latest
 release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 conflict, the <a href="../judges.html">IOCCC Judges</a> will use their best judgment which
-is likely to favor <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> code.</p>
-<p><strong><code>|</code></strong> This means you should <strong>MAKE SURE</strong> that you use <code>mkiocccentry(1)</code> to
+is likely to favor <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> code.
+</p>
+<p class="leftbar">
+This means you should <strong>MAKE SURE</strong> that you use <code>mkiocccentry(1)</code> to
 package your submission; <code>mkiocccentry(1)</code> will run the above mentioned tools
 (that do not act on the tarball) <strong>before</strong> creating the tarball and after the
 tarball is created it will then verify that the tarball is okay by running
-<code>txzchk(1)</code> on it.</p>
-<p><strong><code>|</code></strong> These tools will link in the <code>jparse(8)</code> library and <code>chkentry(1)</code>
-actually uses the parser to validate the
-<a href="https://www.json.org/json-en.html">JSON</a>.</p>
-<p><strong><code>|</code></strong> If you run into a problem with one or more of these tools, <strong>PLEASE</strong>
-report it at the <a href="https://github.com/ioccc-src/mkiocccentry/issues">mkiocccentry issues
-page</a>, <strong>making sure to run
-<code>bug_report.sh</code></strong>. See the <a href="guidelines.html">guidelines</a> for help here and also
-read <a href="../faq.html#mkiocccentry_bugs">the FAQ about reporting bugs in the mkiocccentry
-repo</a>.</p>
-<p><strong><code>|</code></strong> To state the obvious: submissions that violate <a href="#rule17">Rule 17</a> <strong>will be rejected</strong>,
-so be sure to use the latest release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>,
-to form and test your submission’s xz compressed tarball.</p>
+<code>txzchk(1)</code> on it.
+</p>
+<p class="leftbar">
+<strong>MAKE SURE</strong> you use the correct release of the repository; you should do this
+<strong>AFTER</strong> the contest opens (pull any changes or if you prefer download the
+repository via the download option at GitHub).
+</p>
+<p class="leftbar">
+We recommend that you run <code>make</code> and then install the tools (and man pages) via
+<code>make install</code> (as root or using <code>sudo(1)</code> to help you run these tools from your
+submission’s directory. The <code>make install</code> will install in <code>/usr/local</code>.
+</p>
+<p class="leftbar">
+These tools will link in the <code>jparse(8)</code> library; <code>chkentry(1)</code> uses the parser
+to validate the <a href="https://www.json.org/json-en.html">JSON</a> but the other tools
+use parts of the library as well.
+</p>
+<p class="leftbar">
+If you run into a problem with one or more of these tools, <strong>PLEASE</strong> <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it
+at the mkiocccentry issues
+page</a>,
+<strong>making sure to run <code>bug_report.sh</code></strong>. See the <a href="guidelines.html">guidelines</a>
+for help here and also read <a href="../faq.html#mkiocccentry_bugs">the FAQ about reporting bugs in the mkiocccentry
+repo</a>.
+</p>
+<p class="leftbar">
+At the risk of stating the obvious: submissions that violate <a href="#rule17">Rule
+17</a> <strong>will be rejected</strong>, so <strong>be sure</strong> to use the latest release of the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>, to form and test
+your submission’s xz compressed tarball. Do <strong>NOT</strong> assume you have the most
+recent release without pulling or downloading via GitHub and <strong>make sure</strong> you
+do this <strong>AFTER</strong> the <a href="../status.html">contest status</a> has changed to
+<a href="../status.html#open">open</a>.
+</p>
 <div id="rule18">
 <h2 id="rule-18">Rule 18</h2>
 </div>
 <p>The entirety of your submission must be submitted under the following license:</p>
-<p><strong><code>|</code></strong> <strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
+<p class="leftbar">
+<strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong>
+</p>
 <p>You (the author(s)) <strong>MUST</strong> own the contents of your submission <strong>OR</strong>
 you <strong>MUST HAVE PERMISSION</strong> from the owner(s) to submit their content.</p>
-<p>You must not submit anything that cannot be submitted under that license.</p>
+<p>You <strong>MUST NOT</strong> submit anything that cannot be submitted under that license.</p>
 <div id="rule19">
 <h2 id="rule-19">Rule 19</h2>
 </div>
-<p><strong><code>|</code></strong> The <code>remarks.md</code> file, a required non-empty file, must be written in
-markdown format. See the Daring Fireball <a href="http://daringfireball.net/projects/markdown/basics">Markdown:
-Basics</a>.</p>
-<p><strong><code>|</code></strong> We currently use <a href="https://pandoc.org">pandoc</a> to convert markdown to HTML.</p>
-<p><strong><code>|</code></strong> Please see our <a href="../faq.html#remarks_md">FAQ about what to put in your
+<p class="leftbar">
+The <code>remarks.md</code> file, a required non-empty file, must be written in
+markdown format. See the <a href="http://daringfireball.net/projects/markdown/basics">Daring Fireball Markdown:
+Basics</a>.
+</p>
+<p class="leftbar">
+We currently use <a href="https://pandoc.org">pandoc</a> to convert markdown to HTML.
+</p>
+<p class="leftbar">
+Please see our <a href="../faq.html#remarks_md">FAQ about what to put in your
 remarks.md</a> and the <a href="../markdown.html">IOCCC markdown
-guidelines</a> for additional markdown guidance.</p>
+guidelines</a> for additional markdown guidance.
+</p>
 <div id="rule20">
 <h2 id="rule-20">Rule 20</h2>
 </div>
 <p>The how to build instructions must be in Makefile format. See <a href="../faq.html#make_compatibility">the FAQ about
 make(1) compatibility the IOCCC
 supports</a> for more details.</p>
-<p><strong><code>|</code></strong> You are <strong>ENCOURAGED</strong> to use
+<p class="leftbar">
+You are <strong>ENCOURAGED</strong> to use
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example">Makefile.example</a>,
-renamed as <code>Makefile</code> of course, for help in constructing your Makefile.</p>
+renamed as <code>Makefile</code> of course, for help in constructing your <code>Makefile</code>.
+</p>
 <p>The target of the Makefile must be called <code>prog</code>. The original
 C source file must be called <code>prog.c</code>.</p>
-<p>To invoke the C compiler, use <code>${CC}</code>.
-To invoke the C preprocessor use <code>${CPP}</code>.</p>
-<p>Do not assume that <code>.</code> (the current directory) is in the <code>$PATH</code>.</p>
-<p><strong><code>|</code></strong> Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with bash
+<p>To invoke the C compiler, use <code>${CC}</code>. To invoke the C preprocessor use
+<code>${CPP}</code>.</p>
+<p>Do <strong>NOT</strong> assume that <code>.</code> (the current directory) is in the <code>$PATH</code>.</p>
+<p class="leftbar">
+Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with <code>bash(1)</code>
 and GNU <code>make(1)</code>. You are <strong>ENCOURAGED</strong> to use set <code>SHELL= bash</code> in
-your <code>Makefile</code>.</p>
-<p><strong><code>|</code></strong> Assume that commands commonly found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+your <code>Makefile</code>.
+</p>
+<p class="leftbar">
+Assume that commands commonly found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environments and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a> are
-available in the <code>$PATH</code> search path.</p>
+available in the <code>$PATH</code> search path.
+</p>
 <div id="rule21">
 <h2 id="rule-21">Rule 21</h2>
 </div>
-<p>Your submission <strong>must NOT</strong> create or modify files above the current directory
-with the exception of the <code>/tmp</code> and the <code>/var/tmp</code> directories. Your submission
+<p>Your submission <strong>MUST NOT</strong> create or modify files above the current directory
+<em>with the exception of</em> the <code>/tmp</code> and the <code>/var/tmp</code> directories. Your submission
 <strong>MAY</strong> create subdirectories below the current directory, or in <code>/tmp</code>,
 or in <code>/var/tmp</code> provided that <code>.</code> is <strong>NOT</strong> the first octet in any
 directory name or filename you create.</p>
@@ -810,13 +1028,13 @@ directory name or filename you create.</p>
 <h2 id="rule-22">Rule 22</h2>
 </div>
 <p>Catch 22:</p>
-<p>Your source code, data files, remarks and program output <strong>must NOT</strong>
-identify the authors of your code. The judges <strong>STRONGLY prefer</strong> to
-NOT know who is submitting entries to the IOCCC.</p>
+<p>Your source code, data files, remarks and program output <strong>MUST NOT</strong>
+identify the authors of your code. The judges <strong>STRONGLY PREFER</strong> to
+<strong>NOT</strong> know who is submitting entries to the IOCCC.</p>
 <p>Even if you are a previous IOCCC winner, catch 22 still applies.</p>
 <p>Identifying the author(s) of your submission in an obvious way anywhere
 within your code, data, remarks or program output (unless you are
-<em>Peter Honeyman</em> or pretending to be <em>Peter Honeyman</em>) will be grounds
+<strong>Peter Honeyman</strong> or pretending to be <strong>Peter Honeyman</strong>) will be grounds
 for disqualification of your submission.</p>
 <p>Yes, Virginia, <strong>WE REALLY MEAN IT!</strong></p>
 <div id="rule23">
@@ -830,43 +1048,62 @@ for disqualification of your submission.</p>
 <div id="rule25">
 <h2 id="rule-25">Rule 25</h2>
 </div>
-<p><strong><code>|</code></strong> The <a href="rules.html">IOCCC rule set</a> needs more than 5^2 rules: see <a href="#rule26">Rule 26</a>.</p>
+<p class="leftbar">
+The <a href="rules.html">IOCCC rule set</a> needs more than 5^2 rules: see <a href="#rule26">Rule 26</a>.
+</p>
 <div id="rule26">
 <h2 id="rule-26">Rule 26</h2>
 </div>
-<p><strong><code>|</code></strong> “The quick brown fox jumps over the lazy dog”.<br>
-<strong><code>|</code></strong> “Pack my box with five dozen liquor jugs.”<br>
-<strong><code>|</code></strong> “How vexingly quick daft zebras jump!”<br>
-<strong><code>|</code></strong> “Sphinx of black quartz, judge my vow.”<br>
-<strong><code>|</code></strong> “Waltz, bad nymph, for quick jigs vex.”<br>
-<strong><code>|</code></strong> “Mr. Jock, TV quiz PhD, bags few lynx.”<br>
-<strong><code>|</code></strong> “abcdefg, hijklmnop, qrstu&amp;v, wxy&amp;z.”</p>
+<blockquote>
+<p>“The quick brown fox jumps over the lazy dog”.<br>
+“Pack my box with five dozen liquor jugs.”<br>
+“How vexingly quick daft zebras jump!”<br>
+“Sphinx of black quartz, judge my vow.”<br>
+“Waltz, bad nymph, for quick jigs vex.”<br>
+“Mr. Jock, TV quiz PhD, bags few lynx.”<br>
+“abcdefg, hijklmnop, qrstu&amp;v, wxy&amp;z.”</p>
+</blockquote>
 <div id="rule27">
 <h2 id="rule-27">Rule 27</h2>
 </div>
-<p><strong><code>|</code></strong> Unless otherwise needed, <a href="#rule27">Rule 27</a> is reserved for something cubic. :-)</p>
+<p class="leftbar">
+Unless otherwise needed, <a href="#rule27">Rule 27</a> is reserved for something cubic. :-)
+</p>
 <div id="rule28">
 <h2 id="rule-28">Rule 28</h2>
 </div>
-<p><strong><code>|</code></strong> <a href="#rule28">Rule 28</a> is a perfect way end to the list of <a href="rules.html">IOCCC rules</a> as we do <strong>NOT</strong> plan to have <strong>496</strong> rules. :-)</p>
+<p class="leftbar">
+<a href="#rule28">Rule 28</a> is a perfect way end to the list of <a href="rules.html">IOCCC rules</a>
+as we do <strong>NOT</strong> plan to have <strong>496</strong> rules. :-)
+</p>
 <div id="more-information">
 <div id="information">
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 </div>
 </div>
-<p><strong><code>|</code></strong> For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.</p>
-<p><strong><code>|</code></strong> Be sure to review the <a href="index.html">IOCCC Rules and Guidelines</a> as
+<p class="leftbar">
+For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.
+</p>
+<p class="leftbar">
+<strong>Be SURE</strong> to review the <a href="index.html">IOCCC Rules and Guidelines</a> as
 <a href="rules.html">IOCCC rules</a> and the <a href="guidelines.html">IOCCC guidelines</a> may (and
-<strong>often do</strong>) change from year to year.</p>
-<p><strong><code>|</code></strong> You should be sure you have the current <a href="rules.html">IOCCC rules</a> and
-<a href="guidelines.html">IOCCC guidelines</a> prior to submitting entries.</p>
-<p><strong><code>|</code></strong> See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
-<p><strong><code>|</code></strong> For the updates and breaking IOCCC news, you are encouraged to follow
+<strong>often do</strong>) change from year to year.
+</p>
+<p class="leftbar">
+You should be sure you have the current <a href="rules.html">IOCCC rules</a> and
+<a href="guidelines.html">IOCCC guidelines</a> prior to submitting entries.
+</p>
+<p>See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
+<p class="leftbar">
+For the updates and breaking IOCCC news, you are encouraged to follow
 the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a> account. See our
 <a href="../faq.html#try_mastodon">FAQ about Mastodon</a> for more information. Please do note that unless
 you are mentioned by us you will <strong>NOT</strong> get a notification from the app <em>so you
-should refresh the page <strong>even if you do follow us</strong></em>.</p>
-<p><strong><code>|</code></strong> Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
+should refresh the page <strong>even if you do follow us</strong></em>.
+</p>
+<p class="leftbar">
+Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.
+</p>
 <p><strong>Leonid A. Broukhis</strong><br>
 <strong>chongo (Landon Curt Noll) <code>/\cc/\</code></strong></p>
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/rules.md
+++ b/next/rules.md
@@ -31,7 +31,9 @@ app from time to time to view IOCCC mastodon updates.
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 # 28th International Obfuscated C Code Contest Official Rules
 
-**`|`**   Copyright &copy; 2024 Leonid A. Broukhis and Landon Curt Noll.
+<p class="leftbar">
+Copyright &copy; 2024 Leonid A. Broukhis and Landon Curt Noll.
+</p>
 
 All Rights Reserved.  Permission for personal, education or non-profit use is
 granted provided this this copyright and notice are included in its entirety
@@ -43,7 +45,9 @@ writing by [contacting the judges](../contact.html).
 ## IOCCC Rules version
 </div>
 
-**`|`**   These [IOCCC rules](rules.html) are version **28.4 2024-07-02**.
+<p class="leftbar">
+These [IOCCC rules](rules.html) are version **28.5 2024-07-08**.
+</p>
 
 **IMPORTANT**: Be sure to read the [IOCCC guidelines](guidelines.html).
 
@@ -52,10 +56,13 @@ writing by [contacting the judges](../contact.html).
 ### Change marks
 </div>
 
-**`|`**   **&larr; Lines that start with this symbol indicate a change from the previous IOCCC**
+<p class="leftbar">
+**&larr; Lines that start with this symbol indicate a change from the previous IOCCC**
+</p>
 
 Most lines (we sometimes make mistakes) that were modified since the previous
-IOCCC start with the **`|`** symbol.
+IOCCC start with a solid 4 pixel black left border (or, in the case of a code
+block or blockquote, just a vertical bar).
 
 
 <div id="obfuscate">
@@ -89,13 +96,17 @@ The goals of the IOCCC:
 # Important IOCCC dates
 </div>
 
-**`|`**   This IOCCC runs from **2024-MMM-DD HH:MM:SS UTC** to **202x-MMM-DD HH:MM:SS UTC**.<br>
-**`|`**   **XXX - date/time is TBD - XXX**
+<p class="leftbar">
+This IOCCC runs from **2024-MMM-DD HH:MM:SS UTC** to **202x-MMM-DD HH:MM:SS UTC**.<br>
+**XXX - date/time is TBD - XXX**
+</p>
 
-**`|`**   Until the start of this IOCCC, these [IOCCC rules](rules.html),
+<p class="leftbar">
+Until the start of this IOCCC, these [IOCCC rules](rules.html),
 [IOCCC guidelines](guidelines.html) and the [mkiocccentry
 toolkit](https://github.com/ioccc-src/mkiocccentry) should be considered
 provisional **BETA** versions and **may be adjusted _AT ANY TIME_**.
+</p>
 
 When the IOCCC is open, the submission URL is:
 [https://submit.ioccc.org](https://submit.ioccc.org); at all other
@@ -104,8 +115,10 @@ times that link is likely to be unresponsive.
 Please check the [How to enter FAQ](../faq.html#submit)
 for **important information** on how to submit to the IOCCC.
 
-**`|`**   The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
-**`|`**   **XXX - date/time is TBD - XXX**
+<p class="leftbar">
+The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
+**XXX - date/time is TBD - XXX**
+</p>
 
 Please wait to submit your entries until after that time.
 
@@ -151,26 +164,36 @@ The size rule requires your submission to satisfy **BOTH** [Rule 2a](#rule2a) an
 ## Rule 2a
 </div>
 
-**`|`**   The size of your program source **should not exceed 4993 bytes**.
+<p class="leftbar">
+The size of your program source **should not exceed 4993 bytes**.
+</p>
 
-**`|`**   If you use the most recently released official IOCCC submission
+<p class="leftbar">
+If you use the most recently released official IOCCC submission
 packaging tool (hereby referred to as `mkiocccentry(1)`), which we **STRONGLY
 recommend you do** (see also [Rule 17](#rule17)), then the `mkiocccentry(1)`
 tool will warn you if there appears to be a [Rule 2a](#rule2a) violation.
+</p>
 
-**`|`**   The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2a](#rule2a) warning.
+<p class="leftbar">
+The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2a](#rule2a) warning.
 Overriding a [Rule 2a](#rule2a) warning carries a **fair amount of risk that your submission
 will be rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
 ahead of time if you plan to override the [Rule 2a](#rule2a) warning.
+</p>
 
-**`|`**   If you do override the [Rule 2a](#rule2a) warning from the
+<p class="leftbar">
+If you do override the [Rule 2a](#rule2a) warning from the
 `mkiocccentry(1)` tool, or otherwise plan to violate [Rule 2a](#rule2a), then
 you **MUST CLEARLY EXPLAIN THE RATIONALE** of why you are doing so in your
 `remarks.md` file.  **_Even if you do_ explain this in your `remarks.md` file your
 submission may still be rejected**.
+</p>
 
-**`|`**   You may check your code prior to submission by giving the filename
+<p class="leftbar">
+You may check your code prior to submission by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
+</p>
 
 ``` <!---sh-->
     ./iocccsize prog.c
@@ -181,29 +204,41 @@ as a command like argument to the `iocccsize(1)` tool. For example:
 ## Rule 2b
 </div>
 
-**`|`**   When the filename of your program source is given as a command line argument to the latest version
+<p class="leftbar">
+When the filename of your program source is given as a command line argument to the latest version
 of the official IOCCC size tool (hereby referred to as `iocccsize(1)`), the
 value printed **should NOT exceed _2503_**.
+</p>
 
-**`|`**   The source to `iocccsize(1)` may be found in the
+<p class="leftbar">
+The source to `iocccsize(1)` may be found in the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
+</p>
 
-**`|`**   If you use the `mkiocccentry(1)` tool, which we **STRONGLY recommend
+<p class="leftbar">
+If you use the `mkiocccentry(1)` tool, which we **STRONGLY recommend
 you do** (again, see also [Rule 17](#rule17)),
 then `mkiocccentry(1)` will invoke `iocccsize(1)` before packaging your submission.
+</p>
 
-**`|`**   The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2b](#rule2b) warning.
+<p class="leftbar">
+The `mkiocccentry(1)` tool will give you the option of overriding the [Rule 2b](#rule2b) warning.
 Overriding a [Rule 2b](#rule2b) warning carries a **fair amount of risk that your submission
 will be rejected**.  Be sure to consult the [IOCCC guidelines](guidelines.html)
 ahead of time if you plan to override the [Rule 2b](#rule2b) warning.
+</p>
 
-**`|`**   If you do override the [Rule 2b](#rule2b) warning from the `mkiocccentry(1)` tool,
+<p class="leftbar">
+If you do override the [Rule 2b](#rule2b) warning from the `mkiocccentry(1)` tool,
 or otherwise plan to violate [Rule 2a](#rule2b), then you **MUST CLEARLY EXPLAIN THE RATIONALE**
 of why you are doing so in your `remarks.md` file.  **_Even if you do_ explain this in your `remarks.md` file
 your submission may still be rejected**.
+</p>
 
-**`|`**   You may check your code prior to submission by giving the filename
+<p class="leftbar">
+You may check your code prior to submission by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
+</p>
 
 ``` <!---sh-->
     ./iocccsize prog.c
@@ -220,8 +255,10 @@ To submit to an open IOCCC, you must use the [IOCCC submit
 server](https://submit.ioccc.org/). Unless the IOCCC is open, that link will
 likely be unresponsive.
 
-**`|`**   The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
-**`|`**   **XXX - date/time is TBD - XXX**
+<p class="leftbar">
+The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC**.<br>
+**XXX - date/time is TBD - XXX**
+</p>
 
 **Please wait to submit** your entries until after that time.
 
@@ -230,17 +267,25 @@ likely be unresponsive.
 ## Rule 4
 </div>
 
-**`|`**   If your submission is selected as a winner, it may be modified in order
+<p class="leftbar">
+If your submission is selected as a winner, it may be modified in order
 to fit into the structure of the [Official IOCCC winner website](https://www.ioccc.org/index.html).
+</p>
 
-**`|`**   For example, your submission's `Makefile` might be modified.
+<p class="leftbar">
+For example, your submission's `Makefile` might be modified.
+</p>
 
-**`|`**   Your source code will be the file `prog.c`.  The compiled binary
+<p class="leftbar">
+Your source code will be the file `prog.c`.  The compiled binary
 will be called `prog`.  If you submission requires different filenames,
 then modify your submission's `Makefile` to **COPY** (**NOT** move)
 the files accordingly.
+</p>
 
-**`|`**   See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
+<p class="leftbar">
+See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
+</p>
 
 
 <div id="rule5">
@@ -260,11 +305,15 @@ file to a new filename and then modify that copy.
 ## Rule 6
 </div>
 
-**`|`**   I am not a rule, I am a `free(void *human);` ‼️
+<p class="leftbar">
+I am not a rule, I am a `free(void *human);` ‼️
+</p>
 
-**`|`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`while (!(ioccc(rule(you(are(number(6)))))) {`<br>
-**`|`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ha_ha_ha();`<br>
-**`|`**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`
+<p class="leftbar">
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`while (!(ioccc(rule(you(are(number(6)))))) {`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ha_ha_ha();`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`
+</p>
 
 
 <div id="rule7">
@@ -277,7 +326,9 @@ You (the author(s)) must own the contents of your submission OR
 you must have permission from the owner(s) to submit their content
 under the following license:
 
-**`|`**   **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
+<p class="leftbar">
+**[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
+</p>
 
 If you submit any content that is owned by others, you **MUST
 detail that ownership** (i.e., who owns what) **_AND_ document the
@@ -290,8 +341,10 @@ Please note that the IOCCC size tool is **NOT** an original work.
 ## Rule 8
 </div>
 
-**`|`**   Entries must be received prior to the end of this IOCCC which is **2024-MMM-DD HH:MM:SS UTC**.<br>
-**`|`**   **XXX - date/time is TBD - XXX**
+<p class="leftbar">
+Entries must be received prior to the end of this IOCCC which is **2024-MMM-DD HH:MM:SS UTC**.<br>
+**XXX - date/time is TBD - XXX**
+</p>
 
 
 A confirmation of submission will be sent to the submitting email address
@@ -302,7 +355,9 @@ before the close of the contest.
 ## Rule 9
 </div>
 
-**`|`**   Each person may submit up to and including **10.000000** entries per contest.
+<p class="leftbar">
+Each person may submit up to and including **10.000000** (ten) entries per contest.
+</p>
 
 **Each submission _must be submitted separately_**.
 
@@ -341,16 +396,20 @@ their rule abuse is legal, in the `remarks.md` file.
 ## Rule 13
 </div>
 
-**`|`**   Any C source that fails to compile because of unescaped octets with
+<p class="leftbar">
+Any C source that fails to compile because of unescaped octets with
 the high bit set (octet value >= 128) **_might_** be rejected.
+</p>
 
 
 <div id="rule14">
 ## Rule 14
 </div>
 
-**`|`**   Any C source that fails to compile because of lines with trailing
+<p class="leftbar">
+Any C source that fails to compile because of lines with trailing
 control-M's (i.e., lines with a tailing octet `015`) **_might_** be rejected.
+</p>
 
 Please do **NOT** put trailing control-M's on remarks file lines.
 Please check to be sure, before submitting, that you have removed
@@ -361,15 +420,18 @@ any control-M at the end of remark file lines.
 ## Rule 15
 </div>
 
-**`|`**   In order to register for the IOCCC, you **MUST** have a valid email address.
+<p class="leftbar">
+In order to register for the IOCCC, you **MUST** have a valid email address.
+</p>
 
 The judges **are not responsible for delays in email**, please plan
 enough time for one automated exchange of email as part of your
 submission.
 
-**`|`**  See [the FAQ on how to register for the IOCCC](../faq.html#register) in the
+<p class="leftbar">
+See [the FAQ on how to register for the IOCCC](../faq.html#register) in the
 [FAQ](../faq.html) for details.
-
+</p>
 
 <div id="rule16">
 ## Rule 16
@@ -388,156 +450,256 @@ been published may be disqualified.
 
 ### TL;DR Rule 17 - Use `mkiocccentry(1)`
 
-**`|`**   This is a **COMPLEX** rule.  **Violating this rule will cause your submission to REJECTED**!
+<p class="leftbar">
+This is a **COMPLEX** rule.  **Violating this rule will cause your submission to REJECTED**!
 To help you avoid such a rejection, you are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)` tool,
 based on the latest release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
 to form your submission's xz compressed tarball.
+</p>
 
-**`|`**   The [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
+<p class="leftbar">
+The [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 contains **IMPORTANT** tools such as:
+</p>
 
-* `chkentry(1)`
-* `iocccsize(1)`
-* `mkiocccentry(1)`
-* `txzchk(1)`
-* `fnamchk(1)`
-* `jparse(1)` and `jparse(8)` (which `chkentry(1)` uses)
+* <p class="leftbar">`chkentry(1)`</p>
+* <p class="leftbar">`iocccsize(1)`</p>
+* <p class="leftbar">`mkiocccentry(1)`</p>
+* <p class="leftbar">`txzchk(1)`</p>
+* <p class="leftbar">`fnamchk(1)`</p>
+* <p class="leftbar">`jparse(1)` and `jparse(8)` (which `chkentry(1)` uses)</p>
 
-**`|`**   The above mentioned tools will help you verify that your submission
+<p class="leftbar">
+The above mentioned tools will help you verify that your submission
 conforms to [Rule 17](#rule17).
+</p>
 
-**`|`**   Each above mentioned tools has a `-h` option that provides command
+<p class="leftbar">
+Each above mentioned tools has a `-h` option that provides command
 line help.  For additional details, see the tools' man pages.
+</p>
 
-**`|`**   You do not explicitly need to invoke `jparse(1)` but the `jparse(8)`
+<p class="leftbar">
+You do not explicitly need to invoke `jparse(1)` but the `jparse(8)`
 library will be used when compiling various tools.
+</p>
+
+<p class="leftbar">
+Of course you **can** invoke `jparse(1)` if you wish to validate your own JSON
+data file or some other JSON file.
+</p>
 
 
 ### Rule 17 - The COMPLEX details
 
-**`|`**   Each submission **MUST** be in the form of a xz compressed tarball.
-
-**`|`**   The xz compressed tarball filename must be of the form:
+<p class="leftbar">
+Each submission **MUST** be in the form of a xz compressed tarball.
+The xz compressed tarball filename must be of the form:
+</p>
 
 ``` <!---re-->
     ^submit.username-slot_num.[1-9][0-9]{9,}.txz$
 ```
 
-**`|`** where _`username`_ is your IOCCC registration username **in the form of a
+<p class="leftbar">
+... where _`username`_ is your IOCCC registration username **in the form of a
 [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)** (see
 [RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562) for
 details), and where _`slot_num`_ is a single decimal digit integer
 (i.e., >= `0` and < `9`).
+</p>
 
-**`|`** In particular, _`username`_ is in the form of:
+<p class="leftbar">
+In particular, _`username`_ is in the form of:
 `xxxxxxxx-xxxx-4xxx-axxx-xxxxxxxxxxxx` where `x` is a hexadecimal digit in the
 range `[0-9a-f]`.  And yes, there is a 4 (UUID version 4) and an `a` (UUID variant
 1) in there.
+</p>
 
-**`|`**   Your xz compressed tarball **MUST** contain, at a minimum,
-the following files:
+<p class="leftbar">
+Your xz compressed tarball **MUST** contain, **at a minimum**, the following files:
+</p>
 
-* `Makefile`
-* `prog.c`
-* `remarks.md`
-* `.info.json`
-* `.auth.json`
+* <p class="leftbar">`Makefile`</p>
+* <p class="leftbar">`prog.c`</p>
+* <p class="leftbar">`remarks.md`</p>
+* <p class="leftbar">`.info.json`</p>
+* <p class="leftbar">`.auth.json`</p>
 
-**`|`**   The `.info.json` must be valid JSON and pass the `chkentry(1)` tests.
+<p class="leftbar">
+The `.info.json` must be valid JSON and pass the `chkentry(1)` tests.
+It is generated by the `mkiocccentry(1)` tool.
+</p>
 
-**`|`**   The `.auth.json` must be valid JSON and pass the `chkentry(1)` tests.
+<p class="leftbar">
+The `.auth.json` must be valid JSON and pass the `chkentry(1)` tests.
+It is generated by the `mkiocccentry(1)` tool.
+</p>
 
-**`|`**   You submission may have additional files, however the filenames of those additional files **MUST**:
+<p class="leftbar">
+You submission may have additional files, however the filenames of those additional files **MUST**:
+</p>
 
-**`|`** * Be less than **100** characters in length<br>
-**`|`** * Match the regular expression: `^[0-9A-Za-z][0-9A-Za-z._+-]*$`
+* <p class="leftbar"> Be less than **100** characters in length.</p>
+* <p class="leftbar">Match the regular expression:
+`^[0-9A-Za-z][0-9A-Za-z._+-]*$`</p>
 
-**`|`**   The `mkiocccentry(1)` tool will not package any files that do not meet
+<p class="leftbar">
+The `mkiocccentry(1)` tool will not package any files that do not meet
 those requirements.
+</p>
 
-**`|`**   The `Makefile` must be a non-empty file in [GNU
-Makefile](https://www.gnu.org/software/make/manual/make.html) form. See the
+<p class="leftbar">
+The `Makefile` **MUST** be a **non**-empty file in **[GNU
+Makefile](https://www.gnu.org/software/make/manual/make.html)** form. See the
 [Makefile.example](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
 the [FAQ about your submission's Makefile](../faq.html#submission_makefiles) and
 the [FAQ about IOCCC Makefile compatibility](../faq.html#make_compatibility) for help.
+</p>
 
-**`|`**   The `remarks.md` must be a non-empty file in markdown form.  See also
+<p class="leftbar">
+The `remarks.md` **MUST** be a **non**-empty file in markdown form.  See also
 [Rule 18](#rule18) and our [FAQ about what to put in your
-remarks.md](../faq.html#remarks_md).
+remarks.md](../faq.html#remarks_md) and the [FAQ about IOCCC best markdown
+practices](../faq.html#markdown).
+</p>
 
-**`|`**   The xz compressed tarball file **MUST** be less than
-or equal **3999971** octets in size.
+<p class="leftbar">
+See also the [markdown syntax](https://www.markdownguide.org/basic-syntax) guide
+and the [CommonMark Spec](https://spec.commonmark.org/current/).</p>
+</p>
 
-**`|`**   When your submission's xz compressed tarball is uncompressed,
+<p class="leftbar">
+The xz compressed tarball file **MUST** be less than or equal **3999971** octets in size.
+</p>
+
+<p class="leftbar">
+When your submission's xz compressed tarball is uncompressed,
 the total size of your submission: the sum of the size of the program,
 hints, comments, build and info files **MUST** be less than or equal
 to **28314624** octets (**27651K**) in size.
+</p>
 
-**`|`**  Your submission's xz compressed tarball **MUST** pass the `txzchk(1)` test.
+<p class="leftbar">
+Your submission's xz compressed tarball **MUST** pass the `txzchk(1)` test. See
+the [guidelines](guidelines.html) for more details on this tool.
+</p>
 
-**`|`**   You are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)`
-tool to form your submission's xz compressed tarball.
+<p class="leftbar">
+You are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)` tool to form your
+submission's xz compressed tarball. See the [guidelines](guidelines.html) for
+more details on this tool and the [mkiocccentry
+repo](https://github.com/ioccc-src/mkiocccentry).
+</p>
 
-**`|`**   Your entry may **NOT** have subdirectories.
+<p class="leftbar">
+Your entry may **NOT** have subdirectories. However, you can provide files that
+are in different directories as `mkiocccentry(1)` will copy them to the work
+directory (see the [guidelines](guidelines.html) for more details).
+</p>
 
-**`|`**   Filenames in your entry (that is, not including the files generated by
-the `mkiocccentry(1)` tool or the tools it invokes) **MUST**:
+<p class="leftbar">
+Filenames in your entry (that is, not including the files generated by the
+`mkiocccentry(1)` tool or the tools it or any other tool invokes) **MUST**:
+</p>
 
-* Be less than **100** characters in length
-* **NOT** have a **`/`** (excluding the entry directory that the
-`mkiocccentry(1)` tool generates).
-* **NOT** contain a path component of: **`.`** (that is, with the exception of
-files generated by `mkiocccentry(1)` itself, it must have **NO** **`.`**).
-* **NOT** contain a path component of: **`..`** (that is, **NO** **`..`**).
-* Match the regular expression `^[0-9A-Za-z][0-9A-Za-z._+-]*$` (again, excluding
-files generated by `mkiocccentry(1)`).
+* <p class="leftbar">Be less than **100** characters in length</p>
+* <p class="leftbar">**NOT** have a **`/`** (excluding the entry directory that
+the `mkiocccentry(1)` tool generates).</p>
+* <p class="leftbar">**NOT** contain a path component of: **`.`** (that is, with
+the exception of files generated by `mkiocccentry(1)` itself, it must have
+**NO** **`.`**).</p>
+* <p class="leftbar">**NOT** contain a path component of: **`..`** (that is,
+**NO** **`..`**).</p>
+* <p class="leftbar">Match the regular expression
+`^[0-9A-Za-z][0-9A-Za-z._+-]*$` (again, excluding files generated by
+`mkiocccentry(1)`).</p>
 
-**`|`** Additionally, the tarball **MUST** have the following files (generated
+<p class="leftbar">
+Additionally, the tarball **MUST** have the following files (generated
 by the `mkiocccentry(1)` tool):
+</p>
 
-* `.auth.json` which contains information about the author or authors (that will
-only be looked at if the submission wins).
-* `.info.json` which contains information about the entry.
+* <p class="leftbar">`.auth.json` which contains information about the author or
+authors (that will only be looked at if the submission wins).</p>
+* <p class="leftbar">`.info.json` which contains information about the
+entry.</p>
 
-**`|`** The `txzchk(1)` tool will verify these (and other things) for you and
+<p class="leftbar">
+The `txzchk(1)` tool will verify these (and other things) for you and
 the `chkentry(1)` tool will do additional checks on the contents of the
-`.auth.json` and `.info.json` files.
+`.auth.json` and `.info.json` files including JSON validity. If these checks
+fail it is an error and `mkiocccentry(1)` will fail. In this case it is very
+**possibly** a bug; please [report it at the mkiocccentry issues
+page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
+</p>
 
-**`|`** The tarball filename **MUST** pass `fnamchk(1)`; the tool `txzchk(1)`
+<p class="leftbar">
+The tarball filename **MUST** pass `fnamchk(1)`; the tool `txzchk(1)`
 will run `fnamchk(1)` as part of its algorithm. If you use `mkiocccentry(1)`
 there should be no problem but if you were to package things manually it is
-possible there could be a problem.
+possible there could be a problem and this is a big risk.
+</p>
 
-**`|`** The `fnamchk(1)`, which `txzchk(1)` executes, will verify that the
+<p class="leftbar">
+The `fnamchk(1)`, which `txzchk(1)` executes, will verify that the
 filename is correct.
+</p>
 
-**`|`** These checks **MUST PASS**.
+<p class="leftbar">
+These checks **MUST PASS**.
+</p>
 
-**`|`**  Where [Rule 17](#rule17) and the tools from the latest
+<p class="leftbar">
+Where [Rule 17](#rule17) and the tools from the latest
 release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 conflict, the [IOCCC Judges](../judges.html) will use their best judgment which
 is likely to favor [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) code.
+</p>
 
-**`|`** This means you should **MAKE SURE** that you use `mkiocccentry(1)` to
+<p class="leftbar">
+This means you should **MAKE SURE** that you use `mkiocccentry(1)` to
 package your submission; `mkiocccentry(1)` will run the above mentioned tools
 (that do not act on the tarball) **before** creating the tarball and after the
 tarball is created it will then verify that the tarball is okay by running
 `txzchk(1)` on it.
+</p>
 
-**`|`** These tools will link in the `jparse(8)` library and `chkentry(1)`
-actually uses the parser to validate the
-[JSON](https://www.json.org/json-en.html).
+<p class="leftbar">
+**MAKE SURE** you use the correct release of the repository; you should do this
+**AFTER** the contest opens (pull any changes or if you prefer download the
+repository via the download option at GitHub).
+</p>
 
-**`|`** If you run into a problem with one or more of these tools, **PLEASE**
-report it at the [mkiocccentry issues
-page](https://github.com/ioccc-src/mkiocccentry/issues), **making sure to run
-`bug_report.sh`**. See the [guidelines](guidelines.html) for help here and also
-read [the FAQ about reporting bugs in the mkiocccentry
+<p class="leftbar">
+We recommend that you run `make` and then install the tools (and man pages) via
+`make install` (as root or using `sudo(1)` to help you run these tools from your
+submission's directory. The `make install` will install in `/usr/local`.
+</p>
+
+<p class="leftbar">
+These tools will link in the `jparse(8)` library; `chkentry(1)` uses the parser
+to validate the [JSON](https://www.json.org/json-en.html) but the other tools
+use parts of the library as well.
+</p>
+
+<p class="leftbar">
+If you run into a problem with one or more of these tools, **PLEASE** [report it
+at the mkiocccentry issues
+page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E),
+**making sure to run `bug_report.sh`**. See the [guidelines](guidelines.html)
+for help here and also read [the FAQ about reporting bugs in the mkiocccentry
 repo](../faq.html#mkiocccentry_bugs).
+</p>
 
-**`|`**  To state the obvious: submissions that violate [Rule 17](#rule17) **will be rejected**,
-so be sure to use the latest release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry),
-to form and test your submission's xz compressed tarball.
+<p class="leftbar">At the risk of stating the obvious: submissions that violate [Rule
+17](#rule17) **will be rejected**, so **be sure** to use the latest release of the
+[mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry), to form and test
+your submission's xz compressed tarball. Do **NOT** assume you have the most
+recent release without pulling or downloading via GitHub and **make sure** you
+do this **AFTER** the [contest status](../status.html) has changed to
+[open](../status.html#open).
+</p>
 
 
 <div id="rule18">
@@ -546,27 +708,35 @@ to form and test your submission's xz compressed tarball.
 
 The entirety of your submission must be submitted under the following license:
 
-**`|`**   **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
+<p class="leftbar">
+**[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
+</p>
 
 You (the author(s)) **MUST** own the contents of your submission **OR**
 you **MUST HAVE PERMISSION** from the owner(s) to submit their content.
 
-You must not submit anything that cannot be submitted under that license.
+You **MUST NOT** submit anything that cannot be submitted under that license.
 
 
 <div id="rule19">
 ## Rule 19
 </div>
 
-**`|`**  The `remarks.md` file, a required non-empty file, must be written in
-markdown format. See the Daring Fireball [Markdown:
+<p class="leftbar">
+The `remarks.md` file, a required non-empty file, must be written in
+markdown format. See the [Daring Fireball Markdown:
 Basics](http://daringfireball.net/projects/markdown/basics).
+</p>
 
-**`|`**   We currently use [pandoc](https://pandoc.org) to convert markdown to HTML.
+<p class="leftbar">
+We currently use [pandoc](https://pandoc.org) to convert markdown to HTML.
+</p>
 
-**`|`**   Please see our [FAQ about what to put in your
+<p class="leftbar">
+Please see our [FAQ about what to put in your
 remarks.md](../faq.html#remarks_md) and the [IOCCC markdown
 guidelines](../markdown.html) for additional markdown guidance.
+</p>
 
 
 <div id="rule20">
@@ -577,35 +747,41 @@ The how to build instructions must be in Makefile format. See [the FAQ about
 make&#x28;1&#x29; compatibility the IOCCC
 supports](../faq.html#make_compatibility) for more details.
 
-**`|`**   You are **ENCOURAGED** to use
+<p class="leftbar">
+You are **ENCOURAGED** to use
 [Makefile.example](https://github.com/ioccc-src/mkiocccentry/blob/master/Makefile.example),
-renamed as `Makefile` of course, for help in constructing your Makefile.
+renamed as `Makefile` of course, for help in constructing your `Makefile`.
+</p>
 
 The target of the Makefile must be called `prog`.  The original
 C source file must be called `prog.c`.
 
-To invoke the C compiler, use `${CC}`.
-To invoke the C preprocessor use `${CPP}`.
+To invoke the C compiler, use `${CC}`. To invoke the C preprocessor use
+`${CPP}`.
 
-Do not assume that `.` (the current directory) is in the `$PATH`.
+Do **NOT** assume that `.` (the current directory) is in the `$PATH`.
 
-**`|`**   Your `Makefile` **MUST** use a syntax that is compatible with bash
+<p class="leftbar">
+Your `Makefile` **MUST** use a syntax that is compatible with `bash(1)`
 and GNU `make(1)`.  You are **ENCOURAGED** to use set `SHELL= bash` in
 your `Makefile`.
+</p>
 
-**`|`**   Assume that commands commonly found in [Single UNIX
+<p class="leftbar">
+Assume that commands commonly found in [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 environments and systems that conform to the [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification) are
 available in the `$PATH` search path.
+</p>
 
 
 <div id="rule21">
 ## Rule 21
 </div>
 
-Your submission **must NOT** create or modify files above the current directory
-with the exception of the `/tmp` and the `/var/tmp` directories.  Your submission
+Your submission **MUST NOT** create or modify files above the current directory
+_with the exception of_ the `/tmp` and the `/var/tmp` directories.  Your submission
 **MAY** create subdirectories below the current directory, or in `/tmp`,
 or in `/var/tmp` provided that `.` is **NOT** the first octet in any
 directory name or filename you create.
@@ -617,15 +793,15 @@ directory name or filename you create.
 
 Catch 22:
 
-Your source code, data files, remarks and program output **must NOT**
-identify the authors of your code.  The judges **STRONGLY prefer** to
-NOT know who is submitting entries to the IOCCC.
+Your source code, data files, remarks and program output **MUST NOT**
+identify the authors of your code.  The judges **STRONGLY PREFER** to
+**NOT** know who is submitting entries to the IOCCC.
 
 Even if you are a previous IOCCC winner, catch 22 still applies.
 
 Identifying the author(s) of your submission in an obvious way anywhere
 within your code, data, remarks or program output (unless you are
-_Peter Honeyman_ or pretending to be _Peter Honeyman_) will be grounds
+**Peter Honeyman** or pretending to be **Peter Honeyman**) will be grounds
 for disqualification of your submission.
 
 Yes, Virginia, **WE REALLY MEAN IT!**
@@ -649,34 +825,41 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 ## Rule 25
 </div>
 
-**`|`**   The [IOCCC rule set](rules.html) needs more than 5^2 rules: see [Rule 26](#rule26).
+<p class="leftbar">
+The [IOCCC rule set](rules.html) needs more than 5^2 rules: see [Rule 26](#rule26).
+</p>
 
 
 <div id="rule26">
 ## Rule 26
 </div>
 
-**`|`**   "The quick brown fox jumps over the lazy dog".<br>
-**`|`**   "Pack my box with five dozen liquor jugs."<br>
-**`|`**   "How vexingly quick daft zebras jump!"<br>
-**`|`**   "Sphinx of black quartz, judge my vow."<br>
-**`|`**   "Waltz, bad nymph, for quick jigs vex."<br>
-**`|`**   "Mr. Jock, TV quiz PhD, bags few lynx."<br>
-**`|`**   "abcdefg, hijklmnop, qrstu&v, wxy&z."
+> "The quick brown fox jumps over the lazy dog".<br>
+> "Pack my box with five dozen liquor jugs."<br>
+> "How vexingly quick daft zebras jump!"<br>
+> "Sphinx of black quartz, judge my vow."<br>
+> "Waltz, bad nymph, for quick jigs vex."<br>
+> "Mr. Jock, TV quiz PhD, bags few lynx."<br>
+> "abcdefg, hijklmnop, qrstu&v, wxy&z."
 
 
 <div id="rule27">
 ## Rule 27
 </div>
 
-**`|`**   Unless otherwise needed, [Rule 27](#rule27) is reserved for something cubic.  :-)
+<p class="leftbar">
+Unless otherwise needed, [Rule 27](#rule27) is reserved for something cubic.  :-)
+</p>
 
 
 <div id="rule28">
 ## Rule 28
 </div>
 
-**`|`**   [Rule 28](#rule28) is a perfect way end to the list of [IOCCC rules](rules.html) as we do **NOT** plan to have **496** rules. :-)
+<p class="leftbar">
+[Rule 28](#rule28) is a perfect way end to the list of [IOCCC rules](rules.html)
+as we do **NOT** plan to have **496** rules. :-)
+</p>
 
 
 <div id="more-information">
@@ -685,24 +868,34 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 </div>
 </div>
 
-**`|`**   For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
+<p class="leftbar">
+For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
+</p>
 
-**`|`**   Be sure to review the [IOCCC Rules and Guidelines](index.html) as
+<p class="leftbar">
+**Be SURE** to review the [IOCCC Rules and Guidelines](index.html) as
 [IOCCC rules](rules.html) and the [IOCCC guidelines](guidelines.html) may (and
 **often do**) change from year to year.
+</p>
 
-**`|`**   You should be sure you have the current [IOCCC rules](rules.html) and
+<p class="leftbar">
+You should be sure you have the current [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) prior to submitting entries.
+</p>
 
-**`|`**   See the [Official IOCCC website news](../news.html) for additional information.
+See the [Official IOCCC website news](../news.html) for additional information.
 
-**`|`**   For the updates and breaking IOCCC news, you are encouraged to follow
+<p class="leftbar">
+For the updates and breaking IOCCC news, you are encouraged to follow
 the [IOCCC on Mastodon](https://fosstodon.org/@ioccc) account.  See our
 [FAQ about Mastodon](../faq.html#try_mastodon) for more information. Please do note that unless
 you are mentioned by us you will **NOT** get a notification from the app _so you
 should refresh the page **even if you do follow us**_.
+</p>
 
-**`|`**   Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
+<p class="leftbar">
+Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
+</p>
 
 
 **Leonid A. Broukhis**<br>


### PR DESCRIPTION
Rather than have a literal vertical bar (|) for lines that indicate a change from the last contest, it is now a CSS class which has a solid black left border of 4 pixels. This not only makes it easier to see but it fixes some formatting issues too (see below for tests).

This means that if a change mark is needed one can do:

    <p class="leftbar">
    ...
    </p>

A tip for vim users: in the .vimrc file add the following line (temporarily or otherwise):

    abbr leftbar <p class="leftbar">

Then you only need to type:

    leftbar

and it will automatically add the proper block.

As for testing how this looks I have checked it with Safari with:

- an iPhone 14 Pro Max
- an iPhone 8 Plus
- a MacBook Pro 16 inch (both at full width and smallest width)
- an iPad Pro 11 inch 4th generation in both portrait and landscape orientations

An important point that one needs to remember when using this CSS class in lists is that one cannot do:

    <p class="leftbar">
    * foo
    </p>
    <p class="leftbar">
    * bar
    </p>

but rather do:

    * <p class="leftbar">foo</p>
    * <p class="leftbar">bar</p>