### PR TITLE
Fix validation of guidelines.html

### DIFF
--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1600,12 +1600,10 @@ previous round. Thus, a submission gets at least two readings.</p>
 <h2 id="judging-readings">JUDGING READINGS:</h2>
 </div>
 <p>A reading consists of a number of actions:</p>
-<p class="leftbar">
 <ul>
-<li>reading <code>prog.c</code>, the C source, reviewing the <code>remarks.md</code> information</li>
-</ul>
-</p>
-<ul>
+<li><p class="leftbar">
+reading <code>prog.c</code>, the C source, reviewing the <code>remarks.md</code> information
+</p></li>
 <li>briefly looking any any supplied data files</li>
 <li>passing the source thru the C pre-processor
 skipping over any <code>#include</code>d files</li>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -1504,9 +1504,7 @@ previous round.  Thus, a submission gets at least two readings.
 
 A reading consists of a number of actions:
 
-<p class="leftbar">
-* reading `prog.c`, the C source, reviewing the `remarks.md` information
-</p>
+* <p class="leftbar">reading `prog.c`, the C source, reviewing the `remarks.md` information</p>
 * briefly looking any any supplied data files
 * passing the source thru the C pre-processor
     skipping over any `#include`d files

--- a/next/rules.html
+++ b/next/rules.html
@@ -830,7 +830,6 @@ practices</a>.
 See also the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide
 and the <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.
 </p>
-</p>
 <p class="leftbar">
 The xz compressed tarball file <strong>MUST</strong> be less than or equal <strong>3999971</strong> octets in size.
 </p>

--- a/next/rules.md
+++ b/next/rules.md
@@ -566,7 +566,7 @@ practices](../faq.html#markdown).
 
 <p class="leftbar">
 See also the [markdown syntax](https://www.markdownguide.org/basic-syntax) guide
-and the [CommonMark Spec](https://spec.commonmark.org/current/).</p>
+and the [CommonMark Spec](https://spec.commonmark.org/current/).
 </p>
 
 <p class="leftbar">


### PR DESCRIPTION

This was caused because I had accidentally put a leftbar class before 
the '*' rather than on the same line (after it). This commit should fix
it.