### PR TITLE
Make all links bold

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -420,6 +420,7 @@ a {
     outline-color: transparent;
     text-decoration: none;
     padding: 2px 1px 0;
+    font-weight: bold;
 }
 
 a:link {


### PR DESCRIPTION
This does mean that in some cases there is now redundant markdown '**'s to make the links bold but those can be removed as they are discovered - or not.