### PR TITLE
Link in SECURITY.html to all web pages

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1984/index.html
+++ b/1984/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1985/index.html
+++ b/1985/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/index.html
+++ b/1986/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/index.html
+++ b/1987/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/index.html
+++ b/1988/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/index.html
+++ b/1989/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/index.html
+++ b/1990/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/index.html
+++ b/1991/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/index.html
+++ b/1992/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/index.html
+++ b/1993/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/index.html
+++ b/1994/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/index.html
+++ b/1995/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/leo/secret.html
+++ b/1995/leo/secret.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/index.html
+++ b/1996/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/index.html
+++ b/1998/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/index.html
+++ b/2000/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/index.html
+++ b/2001/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/index.html
+++ b/2004/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/index.html
+++ b/2005/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/index.html
+++ b/2006/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/index.html
+++ b/2011/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/index.html
+++ b/2012/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/index.html
+++ b/2013/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/endoh1/quine-qr.html
+++ b/2014/endoh1/quine-qr.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/index.html
+++ b/2014/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/burton/obfuscation.html
+++ b/2015/burton/obfuscation.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/index.html
+++ b/2015/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/ferguson/FILES.html
+++ b/2018/ferguson/FILES.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/index.html
+++ b/2018/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/index.html
+++ b/2019/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/endoh2/obfuscation/index.html
+++ b/2020/endoh2/obfuscation/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/obfuscation.html
+++ b/2020/ferguson1/obfuscation.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/ferguson2/testing-procedure.html
+++ b/2020/ferguson2/testing-procedure.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/index.html
+++ b/2020/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/Makefile
+++ b/Makefile
@@ -253,10 +253,6 @@ indent.c:
 # the tools needed to build the website, but it does print out a friendly
 # reminder to those who understand it. For all else, there is "RTFS". :-)
 #
-# Note: there is one rule that should not be in this list. We want to make sure
-# to thank people for not adding it if they find it, perhaps with a hint right
-# here!
-#
 help:
 	@echo '# Rules for those who wish to expore the winning IOCCC entries:'
 	@echo
@@ -296,11 +292,12 @@ help:
 	@echo
 	@echo '# Rules for building specific web pages - a subset of rules mentioned above:'
 	@echo
-	@echo 'make thanks		 - generqte thanks-for-help.html'
-	@echo 'make bugs		 - generqte bugs.html'
-	@echo 'make rules		 - generqte next/rules.hmtl'
-	@echo 'make guidelines		 - generqte next/guidelines.hmtl'
-	@echo 'make faq		 - generqte faq.html'
+	@echo 'make thanks		 - generate thanks-for-help.html'
+	@echo 'make bugs		 - generate bugs.html'
+	@echo 'make rules		 - generate next/rules.hmtl'
+	@echo 'make guidelines		 - generate next/guidelines.hmtl'
+	@echo 'make faq		         - generate faq.html'
+	@echo 'make security		 - generate SECURITY.html'
 	@echo
 	@echo '# Compound make rules for building a local copy of the IOCCC website:'
 	@echo
@@ -540,6 +537,12 @@ faq: ${GEN_TOP_HTML} faq.md
 	${GEN_TOP_HTML} -v 1 faq
 	@echo "Perhaps the FAQ might help!"
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+security: ${GEN_TOP_HTML} SECURITY.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	${GEN_TOP_HTML} -v 1 SECURITY
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
 
 
 ####################################################################

--- a/README.html
+++ b/README.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/SECURITY.html
+++ b/SECURITY.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>
@@ -383,13 +389,16 @@
 <!-- BEFORE: 1st line of markdown file: SECURITY.md -->
 <h1 id="security-policy">Security Policy</h1>
 <h2 id="supported-versions">Supported Versions</h2>
-<p><strong>ALL IOCCC ENTRY CODE IS UNSUPPORTED!!</strong></p>
+<p><strong>ALL CODE IN ALL IOCCC ENTRIES IS UNSUPPORTED!!</strong></p>
 <p>Use code in this repo at your own risk! We will <strong>NOT</strong> provide security updates to any IOCCC entry code!</p>
 <h2 id="reporting-a-vulnerability">Reporting a Vulnerability</h2>
 <p>Even though <strong>ALL IOCCC ENTRY CODE IS UNSUPPORTED</strong>,
 if you wish to discuss a security concern regarding this repo then
 please <strong>send email the IOCCC judges</strong> by consulting the bottom section
 of the <a href="https://www.ioccc.org/contact.html">How to contact the IOCCC</a> web page.
+If, on the other hand, you wish to discuss a possible vulnerability in the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> then please <a href="https://github.com/ioccc-src/mkiocccentry/security/advisories/new">report it
+here</a>.
 <!-- AFTER: last line of markdown file: SECURITY.md --></p>
 
 <!-- END: this line ends content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-**ALL IOCCC ENTRY CODE IS UNSUPPORTED!!**
+**ALL CODE IN ALL IOCCC ENTRIES IS UNSUPPORTED!!**
 
 Use code in this repo at your own risk!  We will **NOT** provide security updates to any IOCCC entry code!
 
@@ -12,3 +12,6 @@ Even though **ALL IOCCC ENTRY CODE IS UNSUPPORTED**,
 if you wish to discuss a security concern regarding this repo then
 please **send email the IOCCC judges** by consulting the bottom section
 of the [How to contact the IOCCC](https://www.ioccc.org/contact.html) web page.
+If, on the other hand, you wish to discuss a possible vulnerability in the
+[mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) then please [report it
+here](https://github.com/ioccc-src/mkiocccentry/security/advisories/new).

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/authors.html
+++ b/authors.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/bin/index.html
+++ b/bin/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/bugs.html
+++ b/bugs.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/contact.html
+++ b/contact.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/faq.html
+++ b/faq.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/inc/index.html
+++ b/inc/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -131,6 +131,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/index.html
+++ b/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/judges.html
+++ b/judges.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/license.html
+++ b/license.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/location.html
+++ b/location.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/markdown.html
+++ b/markdown.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/news.html
+++ b/news.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/next/index.html
+++ b/next/index.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/next/rules.html
+++ b/next/rules.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>
@@ -409,6 +415,7 @@
 <li><a href="index.html">IOCCC Home</a></li>
 <li><a href="contact.html">The IOCCC Judges</a></li>
 <li><a href="contact.html">Contacting the IOCCC</a></li>
+<li><a href="SECURITY.html">IOCCC Security Policy</a></li>
 <li><a href="thanks-for-help.html">Thanks for the help</a></li>
 <li><a href="markdown.html">IOCCC markdown</a>
 <!-- AFTER: last line of markdown file: nojs-menu.md --></li>

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -26,5 +26,6 @@
 * [IOCCC Home](index.html)
 * [The IOCCC Judges](contact.html)
 * [Contacting the IOCCC](contact.html)
+* [IOCCC Security Policy](SECURITY.html)
 * [Thanks for the help](thanks-for-help.html)
 * [IOCCC markdown](markdown.html)

--- a/status.html
+++ b/status.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>

--- a/years.html
+++ b/years.html
@@ -175,6 +175,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>


### PR DESCRIPTION
The location of the link is in the About menu under the 'Contacting the IOCCC' and above 'Thanks for the help'. At first I had it at the very bottom, under 'IOCCC markdown guidelines', but it seemed better to have it closer to contacting the IOCCC. This is the same location in the no JavaScript menu (which, for those who do not know or forget, is not a requirement except for some screen sizes).

The top level Makefile has a new 'security' rule. Updated make help.

Typo fixes in make help.

SECURITY.html has had a few updates as well: change the wording of entry code is unsupported (it now says 'ALL CODE IN ALL IOCCC ENTRIES IS UNSUPPORTED!!') and it now links to the mkiocccentry repo and how to report a possible security vulnerability in that repo; as that IS supported - and since there was reference to discussing security concerns is in SECURITY.html - even though the entries will not receive security updates - it seemed a good idea to have a link to report such security issues in the mkiocccentry repo. Perhaps the FAQ needs to be updated for this too.