### PR TITLE
Fix title and link to SDL FAQ in var.mk

### DIFF
--- a/var.mk
+++ b/var.mk
@@ -286,10 +286,10 @@ X11_INCDIR= /opt/X11/include
 # SD1 and SDL2 libraries #
 ##########################
 #
-# For details on how to install SDL/SDL2 see FAQ 3.8  - How do I compile an
-# IOCCC entry that requires SDL1 or SDL2? which can be found at:
+# For details on how to install SDL/SDL2 see the FAQ on how to compile and use
+# IOCCC entries that require SDL1 or SDL1:
 #
-#   https://www.ioccc.org/faq.html#SDL
+#   https://ioccc-src.github.io/temp-test-ioccc/faq.html#SDL
 #
 # SDL2_INCLUDE_ROOT is the directory under which include/SDL/ and/or
 # include/SDL2/ may be found.


### PR DESCRIPTION
The link, for now, refers to the GitHub repo html file (https://ioccc-src.github.io/temp-test-ioccc/faq.html#SDL) instead of what it will be later, https://www.ioccc.org/faq.html#SDL.

The title has been changed to not refer to which FAQ (number) it is, instead saying 'the FAQ on how to compile and use IOCCC entries that require SDL1 or SDL1'.