### PR TITLE
Add overflow scroll bar to code blocks

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -410,9 +410,8 @@ body {
 pre, code {
     margin: 1em 0;
     hyphens: manual;
-    overflow-wrap: normal;
-    overflow: visible;
-    white-space: pre-wrap;
+    overflow-x: scroll;
+    overflow-y: scroll;
     color: DarkGreen;
 }
 
@@ -721,6 +720,7 @@ transition: all .3s ease;
     padding-top: 0;
     padding-bottom: 0;
     color: DarkGreen;
+    overflow-x: scroll;
 }
 
 /* content text */


### PR DESCRIPTION
This solves a problem with smaller screens where the code would wrap to the next line which ruins the formatting of the code on smaller devices. A downside to this is that it makes it not fit on the screen but since it technically did not fit on the screen before and this way line breaks are not added this seems a much better way. It also will mean we shouldn't need to try and fix all the other long lines in code blocks (which not only can be problematic but in some cases it can be wrong - plus it is taking too much time away from moving from entry to the next entry to the next entry).