### PR TITLE
Make bug statuses in index.html files quotes

### DIFF
--- a/1984/decot/README.md
+++ b/1984/decot/README.md
@@ -13,9 +13,7 @@ The original code was fixed in 2023 to not require this.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1984/decot in bugs.html](../../bugs.html#1984_decot).
 

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -414,7 +414,9 @@ you have an old enough compiler or a compiler that supports <code>-traditional-c
 The original code was fixed in 2023 to not require this.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1984_decot">1984/decot in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./decot</code></pre>

--- a/1984/laman/README.md
+++ b/1984/laman/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1984/laman in bugs.html](../../bugs.html#1984_laman).
 

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#ZZ">ZZ</a> - <em>Unknown location</em></l
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1984_laman">1984/laman in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./laman &lt;positive number&gt;</code></pre>

--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -15,9 +15,7 @@ the original version.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1984/mullender in bugs.html](../../bugs.html#1984_mullender).
 

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -421,7 +421,9 @@ to use the alt version instead. See <a href="#original-code">original code</a> b
 the original version.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1984_mullender">1984/mullender in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mullender.alt [microseconds]</code></pre>

--- a/1986/august/README.md
+++ b/1986/august/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1986/august in bugs.html](../../bugs.html#1986_august).
 

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#SE">SE</a> - <em>Kingdom of Sweden</em> (
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1986_august">1986/august in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./august</code></pre>

--- a/1988/dale/README.md
+++ b/1988/dale/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1988/dale in bugs.html](../../bugs.html#1988_dale).
 

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#AU">AU</a> - <em>Commonwealth of Australi
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1988_dale">1988/dale in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>

--- a/1989/fubar/README.md
+++ b/1989/fubar/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1989/fubar in bugs.html](../../bugs.html#1989_fubar).
 

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1989_fubar">1989/fubar in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./fubar &lt;number&gt;</code></pre>

--- a/1989/robison/README.md
+++ b/1989/robison/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1989/robison in bugs.html](../../bugs.html#1989_robison).
 

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1989_robison">1989/robison in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./robison

--- a/1989/westley/README.md
+++ b/1989/westley/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1989/westley in bugs.html](../../bugs.html#1989_westley).
 

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1989_westley">1989/westley in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <p>Try compiling and running the 4 resulting programs like:</p>

--- a/1990/baruch/README.md
+++ b/1990/baruch/README.md
@@ -12,9 +12,7 @@ code](#alternate-code) below for details.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1990/baruch in bugs.html](../../bugs.html#1990_baruch).
 

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -418,7 +418,9 @@ Location: <a href="../../location.html#IL">IL</a> - <em>State of Israel</em> (<e
 code</a> below for details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1990_baruch">1990/baruch in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo 4 | ./baruch

--- a/1990/jaw/README.md
+++ b/1990/jaw/README.md
@@ -8,9 +8,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1990/jaw in bugs.html](../../bugs.html#1990_jaw).
 

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -419,7 +419,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1990_jaw">1990/jaw in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <p>To test the official C entry, one might try:</p>

--- a/1990/tbr/README.md
+++ b/1990/tbr/README.md
@@ -12,9 +12,7 @@ version](#alternate-code) section below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1990/tbr in bugs.html](../../bugs.html#1990_tbr).
 

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -418,7 +418,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 version</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1990_tbr">1990/tbr in bugs.html</a>.</p>
 <h3 id="a-note-about-the-fixes-of-this-entry-in-2023">A note about the fixes of this entry in 2023:</h3>
 <p>In 2023 it was noticed that in some systems like macOS there was confusing

--- a/1990/theorem/README.md
+++ b/1990/theorem/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1990/theorem in bugs.html](../../bugs.html#1990_theorem).
 

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1990_theorem">1990/theorem in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./theorem expression x1 x2 h y1</code></pre>

--- a/1990/westley/README.md
+++ b/1990/westley/README.md
@@ -13,9 +13,7 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1990/westley in bugs.html](../../bugs.html#1990_westley).
 

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -414,7 +414,9 @@ who wish to see how C changed over the years. See <a href="#alternate-code">Alte
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1990_westley">1990/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./westley &lt;number&gt;</code></pre>

--- a/1991/buzzard/README.md
+++ b/1991/buzzard/README.md
@@ -12,9 +12,7 @@ for vi(m) users in navigation and which has an easy way to exit.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1991/buzzard in bugs.html](../../bugs.html#1991_buzzard).
 

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 for vi(m) users in navigation and which has an easy way to exit.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1991_buzzard">1991/buzzard in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./buzzard</code></pre>

--- a/1991/westley/README.md
+++ b/1991/westley/README.md
@@ -12,9 +12,7 @@ time.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1991/westley in bugs.html](../../bugs.html#1991_westley).
 

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 time.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1991_westley">1991/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>NOTE: we have provided a script to perform the below procedure which we include

--- a/1992/adrian/README.md
+++ b/1992/adrian/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1992/adrian in bugs.html](../../bugs.html#1992_adrian).
 

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_adrian">1992/adrian in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>

--- a/1992/albert/README.md
+++ b/1992/albert/README.md
@@ -12,9 +12,7 @@ An [alternate version](#alternate-code) exists that fixes a bug.
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1992/albert in bugs.html](../../bugs.html#1992_albert).
 

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -412,7 +412,9 @@ Location: <a href="../../location.html#NL">NL</a> - <em>Kingdom of the Netherlan
 <p>An <a href="#alternate-code">alternate version</a> exists that fixes a bug.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_albert">1992/albert in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./albert number</code></pre>

--- a/1992/gson/README.md
+++ b/1992/gson/README.md
@@ -12,10 +12,8 @@ some invocations to crash in some systems.
 
 The current status of this entry is:
 
-```
-    STATUS: uses gets() - change to fgets() if possible
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: uses gets() - change to fgets() if possible**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1992/gson in bugs.html](../../bugs.html#1992_gson).
 

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -413,8 +413,10 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 some invocations to crash in some systems.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: uses gets() - change to fgets() if possible
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: uses gets() - change to fgets() if possible</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_gson">1992/gson in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ag word word2 word3 &lt; dictionary</code></pre>

--- a/1992/kivinen/README.md
+++ b/1992/kivinen/README.md
@@ -15,9 +15,7 @@ original should you wish to see what we mean.
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1992/kivinen in bugs.html](../../bugs.html#1992_kivinen).
 

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -415,7 +415,9 @@ what this looked like back in 1992. See <a href="#original-code">original code</
 original should you wish to see what we mean.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_kivinen">1992/kivinen in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./kivinen.alt

--- a/1992/lush/README.md
+++ b/1992/lush/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers
-```
+> **STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers**
 
 For more detailed information see [1992/lush in bugs.html](../../bugs.html#1992_lush).
 

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: doesn&#39;t work with some compilers - please provide alternative code or fix for more compilers</code></pre>
+<blockquote>
+<p><strong>STATUS: doesn’t work with some compilers - please provide alternative code or fix for more compilers</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_lush">1992/lush in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./lush.sh</code></pre>

--- a/1992/vern/README.md
+++ b/1992/vern/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1992/vern in bugs.html](../../bugs.html#1992_vern).
 

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_vern">1992/vern in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vern 3    # &lt;-- default is 2</code></pre>

--- a/1992/westley/README.md
+++ b/1992/westley/README.md
@@ -9,10 +9,8 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-    STATUS: known bug - please help us fix
-```
+> **STATUS: INABIAF - please DO NOT fix**<br>
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1992/westley in bugs.html](../../bugs.html#1992_westley).
 

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -411,8 +411,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix
-    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong><br>
+<strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1992_westley">1992/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>If lost:</p>

--- a/1993/ant/README.md
+++ b/1993/ant/README.md
@@ -12,10 +12,8 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-    STATUS: missing file - please provide it
-```
+> **STATUS: INABIAF - please DO NOT fix**<br>
+> **STATUS: missing file - please provide it**
 
 For more detailed information see [1993/ant in bugs.html](../../bugs.html#1993_ant).
 

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -413,8 +413,10 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix
-    STATUS: missing file - please provide it</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong><br>
+<strong>STATUS: missing file - please provide it</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1993_ant">1993/ant in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ant &#39;ERE&#39; [file ...]</code></pre>

--- a/1993/cmills/README.md
+++ b/1993/cmills/README.md
@@ -24,9 +24,7 @@ To configure how many microseconds to sleep before updates try:
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1993/cmills in bugs.html](../../bugs.html#1993_cmills).
 

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -420,7 +420,9 @@ FAQ on “<a href="../../faq.html#X11">X11</a>”.</p>
 <pre><code>    make clobber SLEEP=200 alt</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1993_cmills">1993/cmills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    DISPLAY=&quot;your_X_server_display&quot;

--- a/1993/lmfjyh/README.md
+++ b/1993/lmfjyh/README.md
@@ -36,9 +36,7 @@ code](#alternate-code) section below for more details.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1993/lmfjyh in bugs.html](../../bugs.html#1993_lmfjyh).
 

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -428,7 +428,9 @@ for those of us with gcc &gt;= 2.3.3 or using clang. See <a href="#alternate-cod
 code</a> section below for more details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1993_lmfjyh">1993/lmfjyh in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>If you have gcc &lt; 2.3.3 (i.e. the entry can compile):</p>

--- a/1993/rince/README.md
+++ b/1993/rince/README.md
@@ -13,9 +13,7 @@ See the [Alternate code](#alternate-code) section below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [bugs report with 1993/rince](../../bugs.html#1993_rince).
 

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -414,7 +414,9 @@ slow down the game and the second one with movements more familiar to vi users.
 See the <a href="#alternate-code">Alternate code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1993_rince">bugs report with 1993/rince</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./rince [cabbage]</code></pre>

--- a/1993/schnitzi/README.md
+++ b/1993/schnitzi/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1993/schnitzi in bugs.html](../../bugs.html#1993_schnitzi).
 

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1993_schnitzi">1993/schnitzi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schnitzi file</code></pre>

--- a/1993/vanb/README.md
+++ b/1993/vanb/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1993/vanb in bugs.html](../../bugs.html#1993_vanb).
 

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1993_vanb">1993/vanb in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vanb &#39;exp&#39;</code></pre>

--- a/1994/dodsond2/README.md
+++ b/1994/dodsond2/README.md
@@ -14,9 +14,7 @@ code](#alternate-code) section below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1994/dodsond2 in bugs.html](../../bugs.html#1994_dodsond2).
 

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -414,7 +414,9 @@ amount of arrows at the start of the game. See the <a href="#alternate-code">Alt
 code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_dodsond2">1994/dodsond2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dodsond2</code></pre>

--- a/1994/ldb/README.md
+++ b/1994/ldb/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1994/ldb in bugs.html](../../bugs.html#1994_ldb).
 

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_ldb">1994/ldb in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ldb &lt; file

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -14,9 +14,7 @@ code](#alternate-code) section for how to use.
 
 The current status of this entry is:
 
-```
-    STATUS: uses gets() - change to fgets() if possible
-```
+> **STATUS: uses gets() - change to fgets() if possible**
 
 For more detailed information see [1994/schnitzi in bugs.html](../../bugs.html#1994_schnitzi).
 

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -415,7 +415,9 @@ See below section bugs and (mis)features for details and the <a href="#alternate
 code</a> section for how to use.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
+<blockquote>
+<p><strong>STATUS: uses gets() - change to fgets() if possible</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_schnitzi">1994/schnitzi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schnitzi &lt; textfile</code></pre>

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -9,10 +9,8 @@
 
 The current status of this entry is:
 
-```
-    STATUS: missing file - please provide it
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: missing file - please provide it**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1994/shapiro in bugs.html](../../bugs.html#1994_shapiro).
 

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -411,8 +411,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing file - please provide it
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: missing file - please provide it</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_shapiro">1994/shapiro in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./shapiro &amp;</code></pre>

--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -13,9 +13,7 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1994/tvr in bugs.html](../../bugs.html#1994_tvr).
 

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_tvr">1994/tvr in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./tvr mode screensize/2 &lt; colormapfile</code></pre>

--- a/1995/cdua/README.md
+++ b/1995/cdua/README.md
@@ -19,9 +19,7 @@ making it 100000 (which is actually fun :-) ).
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1995/cdua in bugs.html](../../bugs.html#1995_cdua).
 

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -419,7 +419,9 @@ it’s going too slow, too fast :-) or you’re doing some strange experiment li
 making it 100000 (which is actually fun :-) ).</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1995_cdua">1995/cdua in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./cdua.alt</code></pre>

--- a/1995/leo/README.md
+++ b/1995/leo/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [1995/leo in bugs.html](../../bugs.html#1995_leo).
 

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1995_leo">1995/leo in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./leo [ deep ] [ right ] [ Variable ] [ cycle [ freq ] ]</code></pre>

--- a/1995/savastio/README.md
+++ b/1995/savastio/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1995/savastio in bugs.html](../../bugs.html#1995_savastio).
 

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1995_savastio">1995/savastio in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./savastio

--- a/1995/vanschnitz/README.md
+++ b/1995/vanschnitz/README.md
@@ -12,9 +12,7 @@ in 2023. See [Alternate code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: missing file - please provide it
-```
+> **STATUS: missing file - please provide it**
 
 For more detailed information see [1995/vanschnitz in bugs.html](../../bugs.html#1995_vanschnitz).
 

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -418,7 +418,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 in 2023. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing file - please provide it</code></pre>
+<blockquote>
+<p><strong>STATUS: missing file - please provide it</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1995_vanschnitz">1995/vanschnitz in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vanschnitz</code></pre>

--- a/1996/gandalf/README.md
+++ b/1996/gandalf/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: missing or dead link - please provide them
-```
+> **STATUS: missing or dead link or links - please provide it or them**
 
 For more detailed information see [1996/gandalf in bugs.html](../../bugs.html#1996_gandalf).
 

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#UK">UK</a> - <em>United Kingdom of Great 
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing or dead link - please provide them</code></pre>
+<blockquote>
+<p><strong>STATUS: missing or dead link or links - please provide it or them</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1996_gandalf">1996/gandalf in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./gandalf</code></pre>

--- a/1996/huffman/README.md
+++ b/1996/huffman/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: uses gets() - change to fgets() if possible
-```
+> **STATUS: uses gets() - change to fgets() if possible**
 
 For more detailed information see [1996/huffman in bugs.html](../../bugs.html#1996_huffman).
 

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
+<blockquote>
+<p><strong>STATUS: uses gets() - change to fgets() if possible</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1996_huffman">1996/huffman in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo &#39;Huffman Decoding&#39; | ./huffman</code></pre>

--- a/1996/jonth/README.md
+++ b/1996/jonth/README.md
@@ -14,10 +14,8 @@ entry.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-    STATUS: missing or dead link - please provide them
-```
+> **STATUS: INABIAF - please DO NOT fix**<br>
+> **STATUS: missing or dead link or links - please provide it or them**
 
 For more detailed information see [1996/jonth in bugs.html](../../bugs.html#1996_jonth).
 

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -415,8 +415,10 @@ install <a href="https://www.xquartz.org">XQuartz</a> in order to compile and ru
 entry.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix
-    STATUS: missing or dead link - please provide them</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong><br>
+<strong>STATUS: missing or dead link or links - please provide it or them</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1996_jonth">1996/jonth in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./jonth :0 :0</code></pre>

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -21,9 +21,7 @@ below for more details.
 
 The current status of this entry is:
 
-```
-    STATUS: missing or dead link - please provide them
-```
+> **STATUS: missing or dead link or links - please provide it or them**
 
 For more detailed information see [1998/dlowe in bugs.html](../../bugs.html#1998_dlowe).
 

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -417,7 +417,9 @@ below for more details.</p>
     ./dlowe &lt; file</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing or dead link - please provide them</code></pre>
+<blockquote>
+<p><strong>STATUS: missing or dead link or links - please provide it or them</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1998_dlowe">1998/dlowe in bugs.html</a>.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./dlowe &lt; README.md

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -13,9 +13,7 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: missing or dead link - please provide them
-```
+> **STATUS: missing or dead link or links - please provide it or them**
 
 For more detailed information see [1998/dloweneil in bugs.html](../../bugs.html#1998_dloweneil).
 

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -419,7 +419,9 @@ be more familiar to vi(m) users and also allows one to quit. See <a href="#alter
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing or dead link - please provide them</code></pre>
+<blockquote>
+<p><strong>STATUS: missing or dead link or links - please provide it or them</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1998_dloweneil">1998/dloweneil in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./pootris [X size of board] [Y size of board]</code></pre>

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1998/schnitzi in bugs.html](../../bugs.html#1998_schnitzi).
 
@@ -53,8 +51,8 @@ Why does this happen?
 ## Judges' remarks:
 
 This is a beautiful program.  How can a program with no conditional (except for
-the fixes for modern systems) behavior at all have output which
-depends on anything?
+the fixes for modern systems though still no `if`s) behavior at all have output
+which depends on anything?
 
 For hints on deciphering this, see below past the Author's remarks;
 they're a nice summary, but they leave the mystery intact.

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1998_schnitzi">1998/schnitzi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schnitzi n &gt; sort.c
@@ -433,8 +435,8 @@ program expects? For instance try:</p>
 <p>Why does this happen?</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>This is a beautiful program. How can a program with no conditional (except for
-the fixes for modern systems) behavior at all have output which
-depends on anything?</p>
+the fixes for modern systems though still no <code>if</code>s) behavior at all have output
+which depends on anything?</p>
 <p>For hints on deciphering this, see below past the Author’s remarks;
 they’re a nice summary, but they leave the mystery intact.</p>
 <p>BTW: the author notes an incredible lipogram story called

--- a/1998/schweikh3/README.md
+++ b/1998/schweikh3/README.md
@@ -197,7 +197,7 @@ How much space is wasted below our site's /pub directory?
 ```
 
 
-#### EXIT STATUS
+#### EXIT > STATUS
 
 If  `samefile` runs out of memory the exit status is 1, zero
 otherwise.

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -519,7 +519,7 @@ more than a couple dozen files of the same size.</p>
 <p>For the ftp and WWW admins:
 How much space is wasted below our site’s /pub directory?</p>
 <pre><code>    find /pub -type f | samefile | awk &#39;{sum += $1} END {print sum}&#39;</code></pre>
-<h4 id="exit-status">EXIT STATUS</h4>
+<h4 id="exit-status">EXIT &gt; STATUS</h4>
 <p>If <code>samefile</code> runs out of memory the exit status is 1, zero
 otherwise.</p>
 <h4 id="see-also">SEE ALSO</h4>

--- a/2000/dlowe/README.md
+++ b/2000/dlowe/README.md
@@ -17,10 +17,8 @@ The following bit of perl may help determine the values you need:
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: known bug - please help us fix**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2000/dlowe in bugs.html](../../bugs.html#2000_dlowe).
 

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -414,8 +414,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>… just in case the Makefile does not figure this out for you.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2000_dlowe">2000/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe [file ...]</code></pre>

--- a/2000/primenum/README.md
+++ b/2000/primenum/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2000/primenum in bugs.html](../../bugs.html#2000_primenum).
 

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2000_primenum">2000/primenum in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo n | ./primenum n</code></pre>

--- a/2000/rince/README.md
+++ b/2000/rince/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2000/rince in bugs.html](../../bugs.html#2000_rince).
 

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2000_rince">2000/rince in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./rince number number2</code></pre>

--- a/2001/anonymous/README.md
+++ b/2001/anonymous/README.md
@@ -18,9 +18,7 @@ whatever your system will compile them as).
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2001/anonymous in bugs.html](../../bugs.html#2001_anonymous).
 

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -419,7 +419,9 @@ below for information on how to compile these programs as 64-bit binaries (or
 whatever your system will compile them as).</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_anonymous">2001/anonymous in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./anonymous x86_program</code></pre>

--- a/2001/bellard/README.md
+++ b/2001/bellard/README.md
@@ -9,10 +9,8 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-    STATUS: doesn't work with some platforms - please help us fix
-```
+> **STATUS: INABIAF - please DO NOT fix**<br>
+> **STATUS: doesn't work with some platforms - please help us fix it**
 
 For more detailed information see [2001/bellard in bugs.html](../../bugs.html#2001_bellard).
 

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -411,8 +411,10 @@ Location: <a href="../../location.html#FR">FR</a> - <em>French Republic</em> (<e
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix
-    STATUS: doesn&#39;t work with some platforms - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong><br>
+<strong>STATUS: doesn’t work with some platforms - please help us fix it</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_bellard">2001/bellard in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./bellard file</code></pre>

--- a/2001/cheong/README.md
+++ b/2001/cheong/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2001/cheong in bugs.html](../../bugs.html#2001_cheong).
 

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_cheong">2001/cheong in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./cheong digits</code></pre>

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -12,9 +12,7 @@ code](#alternate-code) below for more details.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2001/dgbeards in bugs.html](../../bugs.html#2001_dgbeards).
 

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 code</a> below for more details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_dgbeards">2001/dgbeards in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dgbeards</code></pre>

--- a/2001/herrmann1/README.md
+++ b/2001/herrmann1/README.md
@@ -9,10 +9,8 @@
 
 The current status of this entry is:
 
-```
-    STATUS: missing files - please provide them
-    STATUS: known bug - please help us fix
-```
+> **STATUS: missing files - please provide them**<br>
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [2001/herrmann1 in bugs.html](../../bugs.html#2001_herrmann1).
 

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -411,8 +411,10 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing files - please provide them
-    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: missing files - please provide them</strong><br>
+<strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_herrmann1">2001/herrmann1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./herrmann1.sh &#39;prg=file&#39;</code></pre>

--- a/2001/kev/README.md
+++ b/2001/kev/README.md
@@ -12,9 +12,7 @@ awkward `,` and `.` keys. See [alternate code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2001/kev in bugs.html](../../bugs.html#2001_kev).
 

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#AU">AU</a> - <em>Commonwealth of Australi
 awkward <code>,</code> and <code>.</code> keys. See <a href="#alternate-code">alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_kev">2001/kev in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./kev # in one terminal

--- a/2001/ollinger/README.md
+++ b/2001/ollinger/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2001/ollinger in bugs.html](../../bugs.html#2001_ollinger).
 

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#FR">FR</a> - <em>French Republic</em> (<e
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_ollinger">2001/ollinger in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./ollinger integer</code></pre>

--- a/2001/rosten/README.md
+++ b/2001/rosten/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: missing files - please provide them
-```
+> **STATUS: missing files - please provide them**
 
 For more detailed information see [2001/rosten in bugs.html](../../bugs.html#2001_rosten).
 

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing files - please provide them</code></pre>
+<blockquote>
+<p><strong>STATUS: missing files - please provide them</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_rosten">2001/rosten in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./rosten [number]</code></pre>

--- a/2001/schweikh/README.md
+++ b/2001/schweikh/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2001/schweikh in bugs.html](../../bugs.html#2001_schweikh).
 

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_schweikh">2001/schweikh in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schweikh string string2</code></pre>

--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -14,11 +14,9 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: uses gets() - change to fgets() if possible
-    STATUS: missing files - please provide them
-    STATUS: main() has only one arg - try and make it have 2 or 3
-```
+> **STATUS: uses gets() - change to fgets() if possible**<br>
+> **STATUS: missing files - please provide them**<br>
+> **STATUS: main() has only one arg - try and make it have 2 or 3**
 
 For more detailed information see [2001/westley in bugs.html](../../bugs.html#2001_westley).
 

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -415,9 +415,11 @@ code</a>, <a href="#punch-card-code">punch card code</a> and <a href="#alternate
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: uses gets() - change to fgets() if possible
-    STATUS: missing files - please provide them
-    STATUS: main() has only one arg - try and make it have 2 or 3</code></pre>
+<blockquote>
+<p><strong>STATUS: uses gets() - change to fgets() if possible</strong><br>
+<strong>STATUS: missing files - please provide them</strong><br>
+<strong>STATUS: main() has only one arg - try and make it have 2 or 3</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_westley">2001/westley in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./westley 2&gt;/dev/null

--- a/2001/williams/README.md
+++ b/2001/williams/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [2001/williams in bugs.html](../../bugs.html#2001_williams).
 

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_williams">2001/williams in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./williams</code></pre>

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -14,11 +14,9 @@ to reboot and rely on having a floppy drive (if you even remember what those are
 
 The current status of this entry is:
 
-```
-    STATUS: compiled executable crashes - please help us fix
-    STATUS: doesn't work with some platforms - please help us fix
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: compiled executable crashes - please help us fix**<br>
+> **STATUS: doesn't work with some platforms - please help us fix it**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2004/gavin in bugs.html](../../bugs.html#2004_gavin).
 

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -414,9 +414,11 @@ to reboot and rely on having a floppy drive (if you even remember what those are
 :-) ) etc. See <a href="#alternate-code">alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: compiled executable crashes - please help us fix
-    STATUS: doesn&#39;t work with some platforms - please help us fix
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: compiled executable crashes - please help us fix</strong><br>
+<strong>STATUS: doesn’t work with some platforms - please help us fix it</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2004_gavin">2004/gavin in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./gavin</code></pre>

--- a/2004/jdalbec/README.md
+++ b/2004/jdalbec/README.md
@@ -12,9 +12,7 @@ to print on a line. See [alternate code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2004/jdalbec in bugs.html](../../bugs.html#2004_jdalbec).
 

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 to print on a line. See <a href="#alternate-code">alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2004_jdalbec">2004/jdalbec in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./jdalbec number ...</code></pre>

--- a/2004/sds/README.md
+++ b/2004/sds/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2004/sds in bugs.html](../../bugs.html#2004_sds).
 

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2004_sds">2004/sds in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sds</code></pre>

--- a/2005/anon/README.md
+++ b/2005/anon/README.md
@@ -20,9 +20,7 @@ This will compile [anon.c](%%REPO_URL%%/2005/anon/anon.c) as `anon` to not use
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2005/anon in bugs.html](../../bugs.html#2005_anon).
 

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -417,7 +417,9 @@ version</a> below. If your terminal has problems with the
 <code>stty(1)</code>, with the support of an <code>#ifdef..#endif</code> added by the author.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2005_anon">2005/anon in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./anon x y [z]</code></pre>

--- a/2005/giljade/README.md
+++ b/2005/giljade/README.md
@@ -12,9 +12,7 @@ will not work with it enabled.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2005/giljade in bugs.html](../../bugs.html#2005_giljade).
 

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#IL">IL</a> - <em>State of Israel</em> (<e
 will not work with it enabled.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2005_giljade">2005/giljade in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./giljade</code></pre>

--- a/2005/mikeash/README.md
+++ b/2005/mikeash/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2005/mikeash in bugs.html](../../bugs.html#2005_mikeash).
 

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2005_mikeash">2005/mikeash in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mikeash</code></pre>

--- a/2005/mynx/README.md
+++ b/2005/mynx/README.md
@@ -15,9 +15,7 @@ below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2005/mynx in bugs.html](../../bugs.html#2005_mynx).
 

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -416,7 +416,9 @@ websites no longer work with <code>http</code>. See <a href="#alternate-code">al
 below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2005_mynx">2005/mynx in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mynx http://&lt;domain&gt;</code></pre>

--- a/2005/sykes/README.md
+++ b/2005/sykes/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2005/sykes in bugs.html](../../bugs.html#2005_sykes).
 

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2005_sykes">2005/sykes in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sykes binary_file</code></pre>

--- a/2006/birken/README.md
+++ b/2006/birken/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: uses gets() - change to fgets() if possible
-```
+> **STATUS: uses gets() - change to fgets() if possible**
 
 For more detailed information see [2006/birken in bugs.html](../../bugs.html#2006_birken).
 

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
+<blockquote>
+<p><strong>STATUS: uses gets() - change to fgets() if possible</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_birken">2006/birken in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./birken &lt; file.tofu</code></pre>

--- a/2006/borsanyi/README.md
+++ b/2006/borsanyi/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2006/borsanyi in bugs.html](../../bugs.html#2006_borsanyi).
 
@@ -29,9 +27,11 @@ For more detailed information see [2006/borsanyi in bugs.html](../../bugs.html#2
     ./try.sh
 ```
 
-We recommend you input for the filename `example.gif` and for the string
-`ioccc@example.com`. The script will not overwrite files. It runs the program in
-a loop until you answer that you do not wish to make another.
+We recommend you first try inputting for the filename `example.gif` and for the
+string `ioccc@example.com`. Of course you could also provide a different
+filename and even include your own email address or something else entirely.
+The script will not overwrite files. It runs the program in a loop until you
+answer that you do not wish to make another.
 
 
 ## Judges' remarks:

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -411,15 +411,19 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_borsanyi">2006/borsanyi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./borsanyi string &gt; file.gif</code></pre>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
-<p>We recommend you input for the filename <code>example.gif</code> and for the string
-<code>ioccc@example.com</code>. The script will not overwrite files. It runs the program in
-a loop until you answer that you do not wish to make another.</p>
+<p>We recommend you first try inputting for the filename <code>example.gif</code> and for the
+string <code>ioccc@example.com</code>. Of course you could also provide a different
+filename and even include your own email address or something else entirely.
+The script will not overwrite files. It runs the program in a loop until you
+answer that you do not wish to make another.</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>This entry uses a very user-friendly representation of the font
 it uses (with a few exceptions). Check out the source and see

--- a/2006/hamre/README.md
+++ b/2006/hamre/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2006/hamre in bugs.html](../../bugs.html#2006_hamre).
 

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#NO">NO</a> - <em>Kingdom of Norway</em> (
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_hamre">2006/hamre in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./hamre math_expression_string</code></pre>

--- a/2006/monge/README.md
+++ b/2006/monge/README.md
@@ -14,10 +14,8 @@ of iterations to use. See [Alternate code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: doesn't work with some platforms - please help us fix
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: doesn't work with some platforms - please help us fix it**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2006/monge in bugs.html](../../bugs.html#2006_monge).
 

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -414,8 +414,10 @@ Location: <a href="../../location.html#IT">IT</a> - <em>Italian Republic</em> (<
 of iterations to use. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: doesn&#39;t work with some platforms - please help us fix
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: doesn’t work with some platforms - please help us fix it</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_monge">2006/monge in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./monge expression ...</code></pre>

--- a/2006/stewart/README.md
+++ b/2006/stewart/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2006/stewart in bugs.html](../../bugs.html#2006_stewart).
 
@@ -26,13 +24,14 @@ For more detailed information see [2006/stewart in bugs.html](../../bugs.html#20
 
 where `file` is one of:
 
-```
-    altar box box2 box3 build carpet circles cross cross2 cross3
-    crystal curve diamonds diamonds2 dragon dragon2 dragon3
-    fern gasket gasket_mod gasket_mod2 ioccc maze octagon
-    pentagon pentagons rings rings2 spirals spirals2 spirals3
-    spirals4 squares stars stars2 tree tree2 tree3 tree4 triangle
-```
+> altar box box2 box3 build carpet<br>
+> circles cross cross2 cross3 crystal<br>
+> curve diamonds diamonds2 dragon<br>
+> dragon2 dragon3 fern gasket gasket_mod<br>
+> gasket_mod2 ioccc maze octagon pentagon<br>
+> pentagons rings rings2 spirals spirals2<br>
+> spirals3 spirals4 squares stars stars2<br>
+> tree tree2 tree3 tree4 triangle
 
 NOTE: you cannot specify a different width from height; it's one number.
 

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -411,17 +411,24 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_stewart">2006/stewart in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./stewart width_and_height iterations file &gt; file.xbm
     convert file.xbm file.png</code></pre>
 <p>where <code>file</code> is one of:</p>
-<pre><code>    altar box box2 box3 build carpet circles cross cross2 cross3
-    crystal curve diamonds diamonds2 dragon dragon2 dragon3
-    fern gasket gasket_mod gasket_mod2 ioccc maze octagon
-    pentagon pentagons rings rings2 spirals spirals2 spirals3
-    spirals4 squares stars stars2 tree tree2 tree3 tree4 triangle</code></pre>
+<blockquote>
+<p>altar box box2 box3 build carpet<br>
+circles cross cross2 cross3 crystal<br>
+curve diamonds diamonds2 dragon<br>
+dragon2 dragon3 fern gasket gasket_mod<br>
+gasket_mod2 ioccc maze octagon pentagon<br>
+pentagons rings rings2 spirals spirals2<br>
+spirals3 spirals4 squares stars stars2<br>
+tree tree2 tree3 tree4 triangle</p>
+</blockquote>
 <p>NOTE: you cannot specify a different width from height; it’s one number.</p>
 <p>NOTE: <code>convert(1)</code> belongs to <a href="https://imagemagick.org/index.php">ImageMagick</a>.</p>
 <h2 id="try">Try:</h2>

--- a/2006/sykes1/README.md
+++ b/2006/sykes1/README.md
@@ -13,9 +13,7 @@ specifically see the [Alternate code](#alternate-code) section below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2006/sykes1 in bugs.html](../../bugs.html#2006_sykes1).
 

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -414,7 +414,9 @@ script will compile and use both but if you wish to see the alternate version
 specifically see the <a href="#alternate-code">Alternate code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_sykes1">2006/sykes1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./sykes1</code></pre>

--- a/2006/toledo2/README.md
+++ b/2006/toledo2/README.md
@@ -13,9 +13,7 @@ that it should be fine, after the proper header files were added.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2006/toledo2 in bugs.html](../../bugs.html#2006_toledo2).
 

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -414,7 +414,9 @@ for DOS/Windows. This cannot be tested by us, not even to compile, but it appear
 that it should be fine, after the proper header files were added.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2006_toledo2">2006/toledo2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./toledo2</code></pre>

--- a/2011/borsanyi/README.md
+++ b/2011/borsanyi/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2011/borsanyi in bugs.html](../../bugs.html#2011_borsanyi).
 

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2011_borsanyi">2011/borsanyi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./borsanyi &lt; some_data_file</code></pre>

--- a/2011/dlowe/README.md
+++ b/2011/dlowe/README.md
@@ -9,10 +9,8 @@
 
 The current status of this entry is:
 
-```
-    STATUS: missing or dead link - please provide them
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: missing or dead link or links - please provide it or them**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2011/dlowe in bugs.html](../../bugs.html#2011_dlowe).
 

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -411,8 +411,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: missing or dead link - please provide them
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: missing or dead link or links - please provide it or them</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2011_dlowe">2011/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe -&lt;n_iterations&gt; corpus1/ [...] corpus0/ &lt; start.net &gt; trained.net</code></pre>

--- a/2011/fredriksson/README.md
+++ b/2011/fredriksson/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2011/fredriksson in bugs.html](../../bugs.html#2011_fredriksson).
 

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#FI">FI</a> - <em>Republic of Finland </em
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2011_fredriksson">2011/fredriksson in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./fredriksson [-icvtnk#] regexp &lt; file</code></pre>

--- a/2011/konno/README.md
+++ b/2011/konno/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2011/konno in bugs.html](../../bugs.html#2011_konno).
 

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2011_konno">2011/konno in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./konno lower_case_word</code></pre>

--- a/2011/richards/README.md
+++ b/2011/richards/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: doesn't work with some platforms - please help us fix
-```
+> **STATUS: doesn't work with some platforms - please help us fix it**
 
 For more detailed information see [2011/richards in bugs.html](../../bugs.html#2011_richards).
 

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: doesn&#39;t work with some platforms - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: doesn’t work with some platforms - please help us fix it</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2011_richards">2011/richards in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo expression | ./richards</code></pre>

--- a/2011/vik/README.md
+++ b/2011/vik/README.md
@@ -12,9 +12,7 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2011/vik in bugs.html](../../bugs.html#2011_vik).
 

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2011_vik">2011/vik in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./vik file.mod &gt; audio_file.raw</code></pre>

--- a/2012/blakely/README.md
+++ b/2012/blakely/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2012/blakely in bugs.html](../../bugs.html#2012_blakely).
 

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2012_blakely">2012/blakely in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./blakely &quot;RPN formula&quot; resolution &gt; output.gif</code></pre>

--- a/2012/deckmyn/README.md
+++ b/2012/deckmyn/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2012/deckmyn in bugs.html](../../bugs.html#2012_deckmyn).
 

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#BE">BE</a> - <em>Kingdom of Belgium</em> 
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2012_deckmyn">2012/deckmyn in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./deckmyn &quot;$(cat deckmyn.c)&quot; &quot;$(cat musicfile.txt)&quot; &gt; sheetmusic.pbm</code></pre>

--- a/2012/dlowe/README.md
+++ b/2012/dlowe/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2012/dlowe in bugs.html](../../bugs.html#2012_dlowe).
 

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2012_dlowe">2012/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe</code></pre>

--- a/2012/tromp/README.md
+++ b/2012/tromp/README.md
@@ -11,9 +11,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2012/tromp in bugs.html](../../bugs.html#2012_tromp).
 

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
     make tromp32                # On a 32-bit machine</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2012_tromp">2012/tromp in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./tromp [-b]</code></pre>

--- a/2012/vik/README.md
+++ b/2012/vik/README.md
@@ -14,9 +14,7 @@ code](#alternate-code) section below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2012/vik in bugs.html](../../bugs.html#2012_vik).
 

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -414,7 +414,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2012_vik">2012/vik in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <p>To embed text (from file or command line):</p>

--- a/2013/cable2/README.md
+++ b/2013/cable2/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/cable2 in bugs.html](../../bugs.html#2013_cable2).
 

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_cable2">2013/cable2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./cable2 file.bmp [color]</code></pre>

--- a/2013/dlowe/README.md
+++ b/2013/dlowe/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/dlowe in bugs.html](../../bugs.html#2013_dlowe).
 

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_dlowe">2013/dlowe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./dlowe [number...]</code></pre>

--- a/2013/endoh1/README.md
+++ b/2013/endoh1/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/endoh1 in bugs.html](../../bugs.html#2013_endoh1).
 

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_endoh1">2013/endoh1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./endoh1 [file.lazy]</code></pre>

--- a/2013/endoh3/README.md
+++ b/2013/endoh3/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/endoh3 in bugs.html](../../bugs.html#2013_endoh3).
 

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_endoh3">2013/endoh3 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./endoh3</code></pre>

--- a/2013/endoh4/README.md
+++ b/2013/endoh4/README.md
@@ -20,9 +20,7 @@ described below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/endoh4 in bugs.html](../../bugs.html#2013_endoh4).
 

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -416,7 +416,9 @@ below) you can do so with the <code>SIZE</code> variable. For instance you can d
 described below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_endoh4">2013/endoh4 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./endoh4 &lt; file

--- a/2013/hou/README.md
+++ b/2013/hou/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/hou in bugs.html](../../bugs.html#2013_hou).
 

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#CN">CN</a> - <em>People’s Republic of C
 <pre><code>    make all</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_hou">2013/hou in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./hou [scene-file-name] [options]</code></pre>

--- a/2013/mills/README.md
+++ b/2013/mills/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2013/mills in bugs.html](../../bugs.html#2013_mills).
 

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2013_mills">2013/mills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./mills</code></pre>

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -13,9 +13,7 @@ if you don't know how to do this for your system.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2014/maffiodo1 in bugs.html](../../bugs.html#2014_maffiodo1).
 

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -414,7 +414,9 @@ if you don’t know how to do this for your system.</p>
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2014_maffiodo1">2014/maffiodo1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    cat game.level | ./prog 320 200 800 300 128 144 game.rgba game.wav 10343679</code></pre>

--- a/2014/maffiodo2/README.md
+++ b/2014/maffiodo2/README.md
@@ -12,9 +12,7 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2014/maffiodo2 in bugs.html](../../bugs.html#2014_maffiodo2).
 

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#IT">IT</a> - <em>Italian Republic</em> (<
 code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2014_maffiodo2">2014/maffiodo2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog arg</code></pre>

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -13,9 +13,7 @@ code](#alternate-code) section below.
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [2014/vik in bugs.html](../../bugs.html#2014_vik).
 

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -414,7 +414,9 @@ compilers (if anything in Windows works :-) ). See the <a href="#alternate-code"
 code</a> section below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2014_vik">2014/vik in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo foo | ./prog &gt; audio_file.raw

--- a/2015/hou/README.md
+++ b/2015/hou/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2015/hou in bugs.html](../../bugs.html#2015_hou).
 

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#CN">CN</a> - <em>People’s Republic of C
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2015_hou">2015/hou in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    echo something | ./prog

--- a/2015/howe/README.md
+++ b/2015/howe/README.md
@@ -12,9 +12,7 @@ code](#alternate-code) and the author's remarks below for more details.
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-```
+> **STATUS: known bug - please help us fix**
 
 For more detailed information see [2015/howe in bugs.html](../../bugs.html#2015_howe).
 

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 code</a> and the author’s remarks below for more details.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2015_howe">2015/howe in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog file1 file2

--- a/2015/mills2/README.md
+++ b/2015/mills2/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2015/mills2 in bugs.html](../../bugs.html#2015_mills2).
 

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2015_mills2">2015/mills2 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog compressed_file.Z</code></pre>

--- a/2015/schweikhardt/README.md
+++ b/2015/schweikhardt/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2015/schweikhardt in bugs.html](../../bugs.html#2015_schweikhardt).
 
@@ -22,7 +20,7 @@ For more detailed information see [2015/schweikhardt in bugs.html](../../bugs.ht
     ./prog n
 ```
 
-where n is a base 16 number of any size.
+where `n` is a base 16 number of any size.
 
 NOTE: although it's supposed to be a base 16 number nothing will stop you from
 doing something else. The author explains this in more details.

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -411,11 +411,13 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2015_schweikhardt">2015/schweikhardt in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog n</code></pre>
-<p>where n is a base 16 number of any size.</p>
+<p>where <code>n</code> is a base 16 number of any size.</p>
 <p>NOTE: although it’s supposed to be a base 16 number nothing will stop you from
 doing something else. The author explains this in more details.</p>
 <h2 id="try">Try:</h2>

--- a/2018/algmyr/README.md
+++ b/2018/algmyr/README.md
@@ -13,9 +13,7 @@ FAQ on "[SDL1 and SDL2](../../faq.html#sox)".
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2018/algmyr in bugs.html](../../bugs.html#2018_algmyr).
 

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -414,7 +414,9 @@ This can be ALSA or SoX but we recommend the latter. See
 FAQ on “<a href="../../faq.html#sox">SDL1 and SDL2</a>”.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2018_algmyr">2018/algmyr in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; prog.c                     # Print garbage: might mess up your terminal

--- a/2018/hou/README.md
+++ b/2018/hou/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2018/hou in bugs.html](../../bugs.html#2018_hou).
 

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#CN">CN</a> - <em>People’s Republic of C
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2018_hou">2018/hou in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; input.json &gt; output.html</code></pre>

--- a/2018/mills/README.md
+++ b/2018/mills/README.md
@@ -21,10 +21,8 @@ will be corrupt if it does.
 
 The current status of this entry is:
 
-```
-    STATUS: known bug - please help us fix
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: known bug - please help us fix**<br>
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2018/mills in bugs.html](../../bugs.html#2018_mills).
 

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -418,8 +418,10 @@ you exit (ctrl-e) you type in <code>sync</code>! Otherwise the file might not ex
 will be corrupt if it does.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: known bug - please help us fix
-    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: known bug - please help us fix</strong><br>
+<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2018_mills">2018/mills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>

--- a/2018/vokes/README.md
+++ b/2018/vokes/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2018/vokes in bugs.html](../../bugs.html#2018_vokes).
 

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2018_vokes">2018/vokes in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; file.txt</code></pre>

--- a/2019/adamovsky/README.md
+++ b/2019/adamovsky/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/adamovsky in bugs.html](../../bugs.html#2019_adamovsky).
 

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#CZ">CZ</a> - <em>Czech Republic</em> (<em
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_adamovsky">2019/adamovsky in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog file.unl</code></pre>

--- a/2019/burton/README.md
+++ b/2019/burton/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/burton in bugs.html](../../bugs.html#2019_burton).
 

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_burton">2019/burton in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; file

--- a/2019/ciura/README.md
+++ b/2019/ciura/README.md
@@ -13,9 +13,7 @@ below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/ciura in bugs.html](../../bugs.html#2019_ciura).
 

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#PL">PL</a> - <em>Republic of Poland</em> 
 below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_ciura">2019/ciura in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./getwords.sh en | grep .. | ./prog string</code></pre>

--- a/2019/dogon/README.md
+++ b/2019/dogon/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: uses gets() - change to fgets() if possible
-```
+> **STATUS: uses gets() - change to fgets() if possible**
 
 For more detailed information see [2019/dogon in bugs.html](../../bugs.html#2019_dogon).
 

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#IL">IL</a> - <em>State of Israel</em> (<e
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: uses gets() - change to fgets() if possible</code></pre>
+<blockquote>
+<p><strong>STATUS: uses gets() - change to fgets() if possible</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_dogon">2019/dogon in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; pattern.mc</code></pre>

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -12,9 +12,7 @@ See [Alternate code](#alternate-code) below if you are curious.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/duble in bugs.html](../../bugs.html#2019_duble).
 

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#FR">FR</a> - <em>French Republic</em> (<e
 See <a href="#alternate-code">Alternate code</a> below if you are curious.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_duble">2019/duble in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog file</code></pre>

--- a/2019/endoh/README.md
+++ b/2019/endoh/README.md
@@ -12,9 +12,7 @@ this entry because it is SUPPOSED to crash and it needs debugging symbols.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/endoh in bugs.html](../../bugs.html#2019_endoh).
 

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 this entry because it is SUPPOSED to crash and it needs debugging symbols.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_endoh">2019/endoh in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>

--- a/2019/karns/README.md
+++ b/2019/karns/README.md
@@ -12,9 +12,7 @@ enabled.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/karns in bugs.html](../../bugs.html#2019_karns).
 

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 enabled.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_karns">2019/karns in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; textfile_that_fits_on_the_screen</code></pre>

--- a/2019/lynn/README.md
+++ b/2019/lynn/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/lynn in bugs.html](../../bugs.html#2019_lynn).
 

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_lynn">2019/lynn in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>

--- a/2019/mills/README.md
+++ b/2019/mills/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/mills in bugs.html](../../bugs.html#2019_mills).
 

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_mills">2019/mills in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    make cpclean

--- a/2019/poikola/README.md
+++ b/2019/poikola/README.md
@@ -17,9 +17,7 @@ forcing `-std=gnu11`.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/poikola in bugs.html](../../bugs.html#2019_poikola).
 

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -417,7 +417,9 @@ might or might not work with GCC. Likewise, we do similar for the standard,
 forcing <code>-std=gnu11</code>.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_poikola">2019/poikola in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog 512 ./prog

--- a/2019/yang/README.md
+++ b/2019/yang/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2019/yang in bugs.html](../../bugs.html#2019_yang).
 

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2019_yang">2019/yang in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog sample_input.txt a b c d

--- a/2020/burton/README.md
+++ b/2020/burton/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2020/burton in bugs.html](../../bugs.html#2020_burton).
 

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2020_burton">2020/burton in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog arg ...</code></pre>

--- a/2020/carlini/README.md
+++ b/2020/carlini/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2020/carlini in bugs.html](../../bugs.html#2020_carlini).
 

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2020_carlini">2020/carlini in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>

--- a/2020/ferguson1/README.md
+++ b/2020/ferguson1/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2020/ferguson1 in bugs.html](../../bugs.html#2020_ferguson1).
 

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2020_ferguson1">2020/ferguson1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    WAIT=N WALLS=[01] EVADE=N SIZE=N MAXSIZE=N GROW=N SHEDS=N SHED=N CANNIBAL=[01] ./prog

--- a/2020/giles/README.md
+++ b/2020/giles/README.md
@@ -9,9 +9,7 @@
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2020/giles in bugs.html](../../bugs.html#2020_giles).
 

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -411,7 +411,9 @@ Location: <a href="../../location.html#AU">AU</a> - <em>Commonwealth of Australi
 <pre><code>    make</code></pre>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2020_giles">2020/giles in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; dtmf.wav

--- a/2020/otterness/README.md
+++ b/2020/otterness/README.md
@@ -12,9 +12,7 @@ prior to obfuscation. See [Alternate code](#alternate-code) below.
 
 The current status of this entry is:
 
-```
-    STATUS: INABIAF - please DO NOT fix
-```
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2020/otterness in bugs.html](../../bugs.html#2020_otterness).
 

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -413,7 +413,9 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 prior to obfuscation. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
-<pre><code>    STATUS: INABIAF - please DO NOT fix</code></pre>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2020_otterness">2020/otterness in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>

--- a/bugs.html
+++ b/bugs.html
@@ -1580,7 +1580,7 @@ compilers to use the program but this file is missing. Can you provide it?</p>
 <div id="1996_gandalf">
 <h2 id="gandalf">1996/gandalf</h2>
 </div>
-<h3 id="status-missing-or-dead-link---please-provide-them">STATUS: missing or dead link - please provide them</h3>
+<h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-1996gandalfgandalf.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/gandalf/gandalf.c">1996/gandalf/gandalf.c</a></h3>
 <h3 id="information-1996gandalfindex.html">Information: <a href="1996/gandalf/index.html">1996/gandalf/index.html</a></h3>
 <p>The link was http://www.tc3.co.uk/~gandalf/G.HTML but this no longer exists as
@@ -1630,7 +1630,7 @@ almost be done except that some of the output of the
 This should NOT be fixed.</p>
 <p>NOTE: the two boards will be on top of each other so you will have to drag one
 off the other so that you can properly play.</p>
-<h3 id="status-missing-or-dead-link---please-provide-them-1">STATUS: missing or dead link - please provide them</h3>
+<h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-1">STATUS: missing or dead link or links - please provide it or them</h3>
 <p>As well: the link which was http://www.uio.no/~jonth is no longer valid and
 there’s no archive on the Internet Wayback Machine. Do you know of a proper URL?
 We greatly appreciate your help here!</p>
@@ -1648,7 +1648,7 @@ We greatly appreciate your help here!</p>
 <div id="1998_dlowe">
 <h2 id="dlowe">1998/dlowe</h2>
 </div>
-<h3 id="status-missing-or-dead-link---please-provide-them-2">STATUS: missing or dead link - please provide them</h3>
+<h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-2">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-1998dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dlowe/dlowe.c">1998/dlowe/dlowe.c</a></h3>
 <h3 id="information-1998dloweindex.html">Information: <a href="1998/dlowe/index.html">1998/dlowe/index.html</a></h3>
 <p>The domain http://pootpoot.com no longer exists as it once did. The judges have
@@ -1659,7 +1659,7 @@ to the page as well! You’ll have IOCCC fame for reviving a pootifier! :-)</p>
 <div id="1998_dloweneil">
 <h2 id="dloweneil">1998/dloweneil</h2>
 </div>
-<h3 id="status-missing-or-dead-link---please-provide-them-3">STATUS: missing or dead link - please provide them</h3>
+<h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-3">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-1998dloweneildloweneil.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.c">1998/dloweneil/dloweneil.c</a></h3>
 <h3 id="information-1998dloweneilindex.html">Information: <a href="1998/dloweneil/index.html">1998/dloweneil/index.html</a></h3>
 <p>See above entry <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dlowe/dlowe.c">1998/dlowe</a>.</p>
@@ -1917,7 +1917,7 @@ elves of Imladris :-(</p>
 <h2 id="bellard">2001/bellard</h2>
 </div>
 <h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix">STATUS: doesn’t work with some platforms - please help us fix</h3>
+<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
 <p>The two statuses might seem contradictory but that is a complicated question.
@@ -2113,7 +2113,7 @@ sleeping.</p>
 <h2 id="gavin">2004/gavin</h2>
 </div>
 <h3 id="status-compiled-executable-crashes---please-help-us-fix">STATUS: compiled executable crashes - please help us fix</h3>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-1">STATUS: doesn’t work with some platforms - please help us fix</h3>
+<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it-1">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2004gavingavin.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/gavin.c">2004/gavin/gavin.c</a></h3>
 <h3 id="information-2004gavinindex.html">Information: <a href="2004/gavin//index.html">2004/gavin//index.html</a></h3>
 <p>Segmentation fault will occur in some systems. For instance on macOS with the
@@ -2367,7 +2367,7 @@ with possibly corrupt GIF files.</p>
 <div id="2006_monge">
 <h2 id="monge">2006/monge</h2>
 </div>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-2">STATUS: doesn’t work with some platforms - please help us fix</h3>
+<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it-2">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2006mongemonge.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge/monge.c">2006/monge/monge.c</a></h3>
 <h3 id="information-2006mongeindex.html">Information: <a href="2006/monge/index.html">2006/monge/index.html</a></h3>
 <p>This program requires x86 (with an x87 FPU) or x86_64 machine and it requires
@@ -2472,7 +2472,7 @@ bins at the edges.</p>
 <div id="2011_dlowe">
 <h2 id="dlowe-2">2011/dlowe</h2>
 </div>
-<h3 id="status-missing-or-dead-link---please-provide-them-4">STATUS: missing or dead link - please provide them</h3>
+<h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-4">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-2011dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/dlowe/dlowe.c">2011/dlowe/dlowe.c</a></h3>
 <h3 id="information-2011dloweindex.html">Information: <a href="2011/dlowe/index.html">2011/dlowe/index.html</a></h3>
 <p>The author’s website, http://www.pootpoot.net, no longer exists as it once did,
@@ -2509,7 +2509,7 @@ remarks</a> instead.</p>
 <div id="2011_richards">
 <h2 id="richards">2011/richards</h2>
 </div>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-3">STATUS: doesn’t work with some platforms - please help us fix</h3>
+<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it-3">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2011richardsrichards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards/richards.c">2011/richards/richards.c</a></h3>
 <h3 id="information-2011richardsindex.html">Information: <a href="2011/richards/index.html">2011/richards/index.html</a></h3>
 <p>This does not appear to work with macOS, resulting in a segfault (and sometimes

--- a/bugs.md
+++ b/bugs.md
@@ -1724,7 +1724,7 @@ We would appreciate anyone who has it or even just knows the name! Thank you.
 ## 1996/gandalf
 </div>
 
-### STATUS: missing or dead link - please provide them
+### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [1996/gandalf/gandalf.c](%%REPO_URL%%/1996/gandalf/gandalf.c)
 ### Information: [1996/gandalf/index.html](1996/gandalf/index.html)
 
@@ -1792,7 +1792,7 @@ NOTE: the two boards will be on top of each other so you will have to drag one
 off the other so that you can properly play.
 
 
-### STATUS: missing or dead link - please provide them
+### STATUS: missing or dead link or links - please provide it or them
 
 As well: the link which was http://www.uio.no/~jonth is no longer valid and
 there's no archive on the Internet Wayback Machine. Do you know of a proper URL?
@@ -1819,7 +1819,7 @@ There was no IOCCC in 1997.
 ## 1998/dlowe
 </div>
 
-### STATUS: missing or dead link - please provide them
+### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [1998/dlowe/dlowe.c](%%REPO_URL%%/1998/dlowe/dlowe.c)
 ### Information: [1998/dlowe/index.html](1998/dlowe/index.html)
 
@@ -1834,7 +1834,7 @@ to the page as well!  You'll have IOCCC fame for reviving a pootifier! :-)
 ## 1998/dloweneil
 </div>
 
-### STATUS: missing or dead link - please provide them
+### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [1998/dloweneil/dloweneil.c](%%REPO_URL%%/1998/dloweneil/dloweneil.c)
 ### Information: [1998/dloweneil/index.html](1998/dloweneil/index.html)
 
@@ -2228,7 +2228,7 @@ elves of Imladris :-(
 </div>
 
 ### STATUS: INABIAF - please **DO NOT** fix
-### STATUS: doesn't work with some platforms - please help us fix
+### STATUS: doesn't work with some platforms - please help us fix it
 ### Source code: [2001/bellard/bellard.c](%%REPO_URL%%/2001/bellard/bellard.c)
 ### Information: [2001/bellard/index.html](2001/bellard/index.html)
 
@@ -2528,7 +2528,7 @@ There was no IOCCC in 2003.
 </div>
 
 ### STATUS: compiled executable crashes - please help us fix
-### STATUS: doesn't work with some platforms - please help us fix
+### STATUS: doesn't work with some platforms - please help us fix it
 ### Source code: [2004/gavin/gavin.c](%%REPO_URL%%/2004/gavin/gavin.c)
 ### Information: [2004/gavin//index.html](2004/gavin//index.html)
 
@@ -2874,7 +2874,7 @@ This program will likely crash or do something funny without an arg.
 ## 2006/monge
 </div>
 
-### STATUS: doesn't work with some platforms - please help us fix
+### STATUS: doesn't work with some platforms - please help us fix it
 ### Source code: [2006/monge/monge.c](%%REPO_URL%%/2006/monge/monge.c)
 ### Information: [2006/monge/index.html](2006/monge/index.html)
 
@@ -3033,7 +3033,7 @@ bins at the edges.
 ## 2011/dlowe
 </div>
 
-### STATUS: missing or dead link - please provide them
+### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [2011/dlowe/dlowe.c](%%REPO_URL%%/2011/dlowe/dlowe.c)
 ### Information: [2011/dlowe/index.html](2011/dlowe/index.html)
 
@@ -3089,7 +3089,7 @@ This program will very likely crash or do something funny without an arg.
 ## 2011/richards
 </div>
 
-### STATUS: doesn't work with some platforms - please help us fix
+### STATUS: doesn't work with some platforms - please help us fix it
 ### Source code: [2011/richards/richards.c](%%REPO_URL%%/2011/richards/richards.c)
 ### Information: [2011/richards/index.html](2011/richards/index.html)
 

--- a/faq.html
+++ b/faq.html
@@ -1864,7 +1864,7 @@ entries that do not win on their web page for everyone to see.</p>
 <div id="faq2_3">
 <h3 id="faq-2.3-how-much-time-does-it-take-to-judge-the-contest">FAQ 2.3: How much time does it take to judge the contest?</h3>
 </div>
-<p>It takes a fair amount of time to setup, run, answer email, process entries,
+<p>It takes a fair amount of time to setup, run, respond to messages, process entries,
 review entries, trim down the set entries to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
@@ -3189,15 +3189,14 @@ for information on opening up an IOCCC issue.</p>
 <h2 id="faq-5.5-how-may-i-correct-or-update-ioccc-author-information">FAQ 5.5: How may I correct or update IOCCC author information?</h2>
 </div>
 </div>
-<h4 id="please-help-us-identify-proper-locations-for-ioccc-authors">PLEASE HELP us identify proper locations for IOCCC authors</h4>
-<p>If you know the location of an author listed under:</p>
-<p>      <strong><a href="location.html#ZZ">ZZ - Unknown location</a></strong></p>
-<p>or if you find IOCCC author location that is incorrect,
-then <strong>please submit a pull request</strong>,
-or at least <a href="contact.html">inform the IOCCC judges</a>.</p>
-<p>See the
-FAQ on “<a href="#pull_request">GitHub pull request</a>”
-for more information.</p>
+<p>You may correct or update IOCCC author information by submitting a
+GitHub pull request that modifies an author’s <code>author_handle.json</code> file.</p>
+<p>For example, if a given <code>author_handle.json</code> file contained:</p>
+<pre><code>    &quot;url&quot; : &quot;https://www.example.com/employee/username&quot;,</code></pre>
+<p>and you knew that the author has long ago left the <code>www.example.com</code> company,
+and that they have a new faculty web page at <code>www.example.edu</code>, then you should
+submit a GitHub pull request to change the above line to:</p>
+<pre><code>    &quot;url&quot; : &quot;https://www.example.edu/faculty/department/user.name&quot;,</code></pre>
 <p>Authors of IOCCC winning entries are kept in JSON files of the form:</p>
 <pre><code>    author/author_handle.json</code></pre>
 <p>where <code>author_handle</code> is an author handle.</p>
@@ -3206,60 +3205,57 @@ FAQ on “<a href="#author_handle_faq">author handle</a>”
 for more information about author handles.</p>
 <p>See the
 FAQ on “<a href="#author_json">author_handle.json</a>”
-for information about the contents of these JSON file and how they are used.</p>
+for information about the contents of these JSON files and how they are used.</p>
 <p>See the
 FAQ on “<a href="#find_author_handle">finding author handles</a>”
-for how to find your own <em>author_handle</em>.</p>
-<p>The contents of these JSON files contain the best known information
-about authors of IOCCC entries. See
-FAQ on “<a href="#author_json">author_handle.json</a>”
-for information about the contents of these JSON file and how they are used.</p>
+for how to find an <em>author_handle</em>.</p>
 <p>You may update IOCCC author information in a <code>author_handle.json</code> file
 by <a href="#pull_request">submitting a pull request</a>
 against the <a href="https://github.com/ioccc-src/winner/branches">master branch</a>
 of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>.</p>
-<p>As these files are JSON you should verify that they are validly formed (e.g. you
-didn’t make a typo).</p>
-<p>Please make sure that you run <code>make www</code> after updating the file or files. This unfortunately
-takes quite a while but it is the safest way to do it. There are other ways to go
-about this that can speed things up. Here is one such way which was done when
-fixing two authors in 1995 (in one commit as they were the authors of the same
-two entries):</p>
-<p>First, the two files, <a href="author/Heather_Downs.json">author/Heather_Downs.json</a> and
-<a href="author/Selene_Makarios.json">author/Selene_Makarios.json</a> were fixed (the
-location was set as <code>ZZ</code> but Cody Boone Ferguson knew from the archive that it
-was the US for both of them and he also noticed that the URL, the same for
-both, was no longer valid and it was also known that the email was no longer
-valid as it referred to the same domain). Thus the <code>location_code</code>, <code>url</code> (it was on the Internet Wayback Machine) and
-in one case the <code>email</code> lines to look like:</p>
-<pre class="&lt;--json--&gt;"><code>    &quot;location_code&quot; : &quot;US&quot;,
-    &quot;email&quot; : null,
-    &quot;url&quot; : &quot;https://web.archive.org/web/19961019045145/http://www.bungalow.com/&quot;,</code></pre>
-<p>Now since only two entries (the same entries) were won by these two individuals
-it means that only two index.html files had to be updated, besides the
-<a href="authors.html">authors.html</a> and <a href="location.html">location.html</a> files. These
-are: <a href="1995/heathbar/index.html">1995/heathbar/index.html</a> and
-<a href="1995/makarios/index.html">1995/makarios/index.html</a>. Thus the following
-procedure was done:</p>
-<pre class="&lt;!--sh--&gt;"><code>        touch 1995/heathbar/README.md 1995/makarios/README.md
-        make quick_www</code></pre>
-<p>That works because the <code>quick_www</code> rule will update the <code>authors.html</code> and
+<p>See the
+FAQ on “<a href="#pull_request">GitHub pull request</a>”
+for more information.</p>
+<p><strong>IMPORTANT NOTE</strong>: As these files are JSON you should verify that
+they are validly formed (e.g., you didn’t make a typo).</p>
+<p>Before you form your GitHub pull request that modifies a
+<code>author_handle.json</code> file, please run the <code>make www</code> command. This
+unfortunately takes quite a while but it is the safest way to do
+it. So you may wish to test your edits by running the somewhat
+quicker <code>make quick_www</code> as this can speed up your testing.</p>
+<p>The <code>make quick_www</code> rule will update the <code>authors.html</code> and
 <code>location.html</code> pages and it will also check the timestamps of the <code>index.html</code>
 files versus the <code>README.md</code> files. Since they were touched and thus the
 timestamp was updated, the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/quick-readme2index.sh">bin/quick-readme2index.sh</a> tool would
-only worry about those two files. This greatly speeds things along.</p>
-<p>Once that command finishes a proper <code>git status</code> and <code>git diff</code> shows that
-everything is in order. In the end the safest way is to run <code>make www</code>, however.</p>
+only worry about those two files. This greatly speeds things along while testing.
+Nevertheless, doing a final <code>make www</code> is still recommended best practice
+before you form your pull request.</p>
 <p>Please see
 FAQ on “<a href="#fix_an_entry">fixing an entry</a>”.</p>
 <p>See also the
 FAQ on “<a href="#pull_request">GitHub pull request</a>”
 for more information about pull requests.</p>
+<h4 id="please-help-us-identify-proper-locations-for-ioccc-authors">PLEASE HELP us identify proper locations for IOCCC authors</h4>
+<p>If you know the location of an author listed under:</p>
+<p>      <strong><a href="location.html#ZZ">ZZ - Unknown location</a></strong></p>
+<p>or if you find IOCCC author location that is incorrect,
+then <strong>please submit a pull request</strong>,
+or at least <a href="contact.html">inform the IOCCC judges</a>.</p>
 <p><strong>FYI</strong>: The <a href="location.html#ZZ">ZZ - Unknown location</a> is used for
 historic winning authors whose location or country is not known,
 whereas the <a href="location.html#XX">XX - Anonymous location</a> is used when the
 winning author does <strong>not wish to disclose their location</strong>.</p>
+<p>The contents of these JSON files contain the best known information
+about authors of IOCCC entries. See
+FAQ on “<a href="#author_json">author_handle.json</a>”
+for information about the contents of these JSON files and how they are used.</p>
+<p>For example, if a given <code>author_handle.json</code> file contained:</p>
+<pre><code>    &quot;location_code&quot; : &quot;ZZ&quot;,</code></pre>
+<p>and you knew that the author was located in <a href="location.html#AU">Australia</a>
+(location code <strong>AU</strong>), we encourage you to submit a <strong>GitHub pull
+request</strong> to change that line to:</p>
+<pre><code>    &quot;location_code&quot; : &quot;AU&quot;,</code></pre>
 <h3 id="important-note-about-xx---anonymous-location">Important note about <strong>XX - Anonymous location</strong>:</h3>
 <p>Unless you are the author who originally selected the <strong>XX - Anonymous
 location</strong>, please do not attempt to change an <strong>XX - Anonymous
@@ -3485,7 +3481,7 @@ for information about how to update
 and/or correct IOCCC author information.</p>
 <p>See the
 FAQ on “<a href="#auth_json">.auth.json</a>”
-for information about the contents of these JSON file and
+for information about the contents of these JSON files and
 how they are used.</p>
 <p>See the
 FAQ on “<a href="#find_author_handle">finding author handle</a>”
@@ -4274,19 +4270,13 @@ information in the <a href="authors.html">authors.html</a> page.</p>
 <p>There you will find various information including a link to their
 <a href="authors.html">authors.html</a> information which includes various things like
 their GitHub account (if known), a URL or alternate UL, mastodon handle,
-location (if known and not anonymous location) and a link to their JSON author
-file which has more information like email (if known).</p>
+location (if known and not anonymous location) and a link to their JSON author file.</p>
 <p><strong>NOTE</strong>: you might wish to search google (or some other search engine) by their
 name as sometimes you can find out their GitHub account even if it’s not in our
 JSON files.</p>
 <p>Of course if you know the author’s name you can go directly to
 <a href="authors.html">authors.html</a> and click on their surname’s/last name’s/second
 name’s initial and then scroll down (if necessary) to the author in question.</p>
-<p><strong>NOTE</strong>: previously we included email in the <a href="authors.html">authors.html</a> page
-but we have decided against this. Nevertheless, the <code>author_handle</code> link under
-the author links to a JSON file which has the email address if it is known,
-which you might wish to consult. You might also wish to look at their URL or
-alternate URL for more information.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a></p>
 <!--

--- a/faq.md
+++ b/faq.md
@@ -1707,7 +1707,7 @@ entries that do not win on their web page for everyone to see.
 ### FAQ 2.3: How much time does it take to judge the contest?
 </div>
 
-It takes a fair amount of time to setup, run, answer email, process entries,
+It takes a fair amount of time to setup, run, respond to messages, process entries,
 review entries, trim down the set entries to a set of winning entries, doing the
 write-up of the entries, announcing the entries, reviewing final edits of the
 winning entry set, posting the winning entries, being flamed :-), tell folks who send in
@@ -3708,19 +3708,22 @@ for information on opening up an IOCCC issue.
 </div>
 </div>
 
-#### PLEASE HELP us identify proper locations for IOCCC authors
+You may correct or update IOCCC author information by submitting a
+GitHub pull request that modifies an author's `author_handle.json` file.
 
-If you know the location of an author listed under:
+For example, if a given `author_handle.json` file contained:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[ZZ - Unknown location](location.html#ZZ)**
+``` <!---json-->
+    "url" : "https://www.example.com/employee/username",
+```
 
-or if you find IOCCC author location that is incorrect,
-then **please submit a pull request**,
-or at least [inform the IOCCC judges](contact.html).
+and you knew that the author has long ago left the `www.example.com` company,
+and that they have a new faculty web page at `www.example.edu`, then you should
+submit a GitHub pull request to change the above line to:
 
-See the
-FAQ on "[GitHub pull request](#pull_request)"
-for more information.
+``` <!---json-->
+    "url" : "https://www.example.edu/faculty/department/user.name",
+```
 
 Authors of IOCCC winning entries are kept in JSON files of the form:
 
@@ -3736,66 +3739,38 @@ for more information about author handles.
 
 See the
 FAQ on "[author_handle.json](#author_json)"
-for information about the contents of these JSON file and how they are used.
+for information about the contents of these JSON files and how they are used.
 
 See the
 FAQ on "[finding author handles](#find_author_handle)"
-for how to find your own _author_handle_.
-
-The contents of these JSON files contain the best known information
-about authors of IOCCC entries.  See
-FAQ on "[author_handle.json](#author_json)"
-for information about the contents of these JSON file and how they are used.
+for how to find an _author_handle_.
 
 You may update IOCCC author information in a `author_handle.json` file
 by [submitting  a pull request](#pull_request)
 against the [master branch](https://github.com/ioccc-src/winner/branches)
 of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner).
 
-As these files are JSON you should verify that they are validly formed (e.g. you
-didn't make a typo).
+See the
+FAQ on "[GitHub pull request](#pull_request)"
+for more information.
 
-Please make sure that you run `make www` after updating the file or files. This unfortunately
-takes quite a while but it is the safest way to do it. There are other ways to go
-about this that can speed things up. Here is one such way which was done when
-fixing two authors in 1995 (in one commit as they were the authors of the same
-two entries):
+**IMPORTANT NOTE**: As these files are JSON you should verify that
+they are validly formed (e.g., you didn't make a typo).
 
-First, the two files, [author/Heather_Downs.json](author/Heather_Downs.json) and
-[author/Selene_Makarios.json](author/Selene_Makarios.json) were fixed (the
-location was set as `ZZ` but Cody Boone Ferguson knew from the archive that it
-was the US for both of them and he also noticed that the URL, the same for
-both, was no longer valid and it was also known that the email was no longer
-valid as it referred to the same domain). Thus the `location_code`, `url` (it was on the Internet Wayback Machine) and
-in one case the `email` lines to look like:
+Before you form your GitHub pull request that modifies a
+`author_handle.json` file, please run the `make www` command.  This
+unfortunately takes quite a while but it is the safest way to do
+it.  So you may wish to test your edits by running the somewhat
+quicker `make quick_www` as this can speed up your testing.
 
-``` <--json-->
-    "location_code" : "US",
-    "email" : null,
-    "url" : "https://web.archive.org/web/19961019045145/http://www.bungalow.com/",
-```
-
-Now since only two entries (the same entries) were won by these two individuals
-it means that only two index.html files had to be updated, besides the
-[authors.html](authors.html) and [location.html](location.html) files. These
-are: [1995/heathbar/index.html](1995/heathbar/index.html) and
-[1995/makarios/index.html](1995/makarios/index.html). Thus the following
-procedure was done:
-
-``` <!--sh-->
-        touch 1995/heathbar/README.md 1995/makarios/README.md
-        make quick_www
-```
-
-That works because the `quick_www` rule will update the `authors.html` and
+The `make quick_www` rule will update the `authors.html` and
 `location.html` pages and it will also check the timestamps of the `index.html`
 files versus the `README.md` files. Since they were touched and thus the
 timestamp was updated, the
 [bin/quick-readme2index.sh](%%REPO_URL%%/bin/quick-readme2index.sh) tool would
-only worry about those two files. This greatly speeds things along.
-
-Once that command finishes a proper `git status` and `git diff` shows that
-everything is in order. In the end the safest way is to run `make www`, however.
+only worry about those two files. This greatly speeds things along while testing.
+Nevertheless, doing a final `make www` is still recommended best practice
+before you form your pull request.
 
 Please see
 FAQ on "[fixing an entry](#fix_an_entry)".
@@ -3804,10 +3779,39 @@ See also the
 FAQ on "[GitHub pull request](#pull_request)"
 for more information about pull requests.
 
+#### PLEASE HELP us identify proper locations for IOCCC authors
+
+If you know the location of an author listed under:
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[ZZ - Unknown location](location.html#ZZ)**
+
+or if you find IOCCC author location that is incorrect,
+then **please submit a pull request**,
+or at least [inform the IOCCC judges](contact.html).
+
 **FYI**: The [ZZ - Unknown location](location.html#ZZ) is used for
 historic winning authors whose location or country is not known,
 whereas the [XX - Anonymous location](location.html#XX) is used when the
 winning author does **not wish to disclose their location**.
+
+The contents of these JSON files contain the best known information
+about authors of IOCCC entries.  See
+FAQ on "[author_handle.json](#author_json)"
+for information about the contents of these JSON files and how they are used.
+
+For example, if a given `author_handle.json` file contained:
+
+``` <!---json-->
+    "location_code" : "ZZ",
+```
+
+and you knew that the author was located in [Australia](location.html#AU)
+(location code **AU**), we encourage you to submit a **GitHub pull
+request** to change that line to:
+
+``` <!---json-->
+    "location_code" : "AU",
+```
 
 ### Important note about **XX - Anonymous location**:
 
@@ -4108,7 +4112,7 @@ and/or correct IOCCC author information.
 
 See the
 FAQ on "[.auth.json](#auth_json)"
-for information about the contents of these JSON file and
+for information about the contents of these JSON files and
 how they are used.
 
 See the
@@ -5346,8 +5350,7 @@ information in the [authors.html](authors.html) page.
 There you will find various information including a link to their
 [authors.html](authors.html) information which includes various things like
 their GitHub account (if known), a URL or alternate UL, mastodon handle,
-location (if known and not anonymous location) and a link to their JSON author
-file which has more information like email (if known).
+location (if known and not anonymous location) and a link to their JSON author file.
 
 **NOTE**: you might wish to search google (or some other search engine) by their
 name as sometimes you can find out their GitHub account even if it's not in our
@@ -5356,12 +5359,6 @@ JSON files.
 Of course if you know the author's name you can go directly to
 [authors.html](authors.html) and click on their surname's/last name's/second
 name's initial and then scroll down (if necessary) to the author in question.
-
-**NOTE**: previously we included email in the [authors.html](authors.html) page
-but we have decided against this. Nevertheless, the `author_handle` link under
-the author links to a JSON file which has the email address if it is known,
-which you might wish to consult. You might also wish to look at their URL or
-alternate URL for more information.
 
 
 <hr style="width:10%;text-align:left;margin-left:0">


### PR DESCRIPTION

Instead of code blocks the bug / (mis)features statuses are quoted 
rather than in a code block. In the case that there is more than one a 
line break was added at the end of all but the last one.

A bug status was renamed to be slightly more correct (maybe more than 
one was renamed for the same purpose but at least one was).

The bug statuses in the quotes are now bold to let them stand out 
better.
