### PR TITLE
Manifest updates for 1993/ant and 2020/endoh2

### DIFF
--- a/1993/ant/.entry.json
+++ b/1993/ant/.entry.json
@@ -39,7 +39,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "text",
 	    "display_via_github" : false,
-	    "entry_text" : "ag man page"
+	    "entry_text" : "ag man page in text format"
 	},
 	{
 	    "file_path" : "try.sh",

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -477,7 +477,7 @@ more information.</p>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">ant.c</a> - entry source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/Makefile">Makefile</a> - entry Makefile</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.orig.c">ant.orig.c</a> - original source code</li>
-<li><a href="ant.txt">ant.txt</a> - ag man page</li>
+<li><a href="ant.txt">ant.txt</a> - ag man page in text format</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/try.sh">try.sh</a> - script to try entry</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.alt.c">ant.alt.c</a> - author provided unobfuscated code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/try.alt.sh">try.alt.sh</a> - script to try unobfuscated code</li>

--- a/2020/endoh2/.entry.json
+++ b/2020/endoh2/.entry.json
@@ -71,7 +71,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "c",
 	    "display_via_github" : true,
-	    "entry_text" : "debofuscated code main logic"
+	    "entry_text" : "main logic to program to obfuscate entry"
 	},
 	{
 	    "file_path" : "obfuscation/gen.rb",
@@ -87,7 +87,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "text",
 	    "display_via_github" : false,
-	    "entry_text" : "glyphs data for deobfuscation/gen.rb"
+	    "entry_text" : "glyphs data for obfuscation/gen.rb"
 	},
 	{
 	    "file_path" : "obfuscation/index.html",
@@ -95,7 +95,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "html",
 	    "display_via_github" : false,
-	    "entry_text" : "deobfuscation information web page"
+	    "entry_text" : "obfuscation information web page"
 	},
 	{
 	    "file_path" : "obfuscation/prog.c",
@@ -103,7 +103,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "c",
 	    "display_via_github" : true,
-	    "entry_text" : "unobfuscated source code"
+	    "entry_text" : "obfuscated source code"
 	},
 	{
 	    "file_path" : "obfuscation/tmpl.txt",
@@ -111,7 +111,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "text",
 	    "display_via_github" : false,
-	    "entry_text" : "template for deobfuscation/gen.rb output"
+	    "entry_text" : "template for obfuscation/gen.rb output"
 	},
 	{
 	    "file_path" : "2020_endoh2.tar.bz2",

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -461,12 +461,12 @@ render for a larger terminal window? How about adding more glyphs?</p>
 <li><a href="hello.txt">hello.txt</a> - sample input</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/try.sh">try.sh</a> - script to try entry</li>
 <li><a href="yoda.txt">yoda.txt</a> - sample input</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/obfuscation/code.c">obfuscation/code.c</a> - debofuscated code main logic</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/obfuscation/code.c">obfuscation/code.c</a> - main logic to program to obfuscate entry</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/obfuscation/gen.rb">obfuscation/gen.rb</a> - ruby code to compose items and prog.c in artistic way</li>
-<li><a href="obfuscation/glyphs.txt">obfuscation/glyphs.txt</a> - glyphs data for deobfuscation/gen.rb</li>
-<li><a href="obfuscation/index.html">obfuscation/index.html</a> - deobfuscation information web page</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/obfuscation/prog.c">obfuscation/prog.c</a> - unobfuscated source code</li>
-<li><a href="obfuscation/tmpl.txt">obfuscation/tmpl.txt</a> - template for deobfuscation/gen.rb output</li>
+<li><a href="obfuscation/glyphs.txt">obfuscation/glyphs.txt</a> - glyphs data for obfuscation/gen.rb</li>
+<li><a href="obfuscation/index.html">obfuscation/index.html</a> - obfuscation information web page</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/obfuscation/prog.c">obfuscation/prog.c</a> - obfuscated source code</li>
+<li><a href="obfuscation/tmpl.txt">obfuscation/tmpl.txt</a> - template for obfuscation/gen.rb output</li>
 </ul>
 <h2 id="secondary-files">Secondary files</h2>
 <ul>

--- a/2020/endoh2/obfuscation/index.html
+++ b/2020/endoh2/obfuscation/index.html
@@ -396,7 +396,7 @@ chunks that is a ASCII code (65-90) followed by points data: <code>x,y,ctrl</cod
 <p>If <code>ctrl</code> is 1, the point is used as control point for quadratic <a href="https://en.wikipedia.org/wiki/Bézier_curve">bézier
 curve</a>.</p>
 <p><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/obfuscation/code.c">code.c</a> is the main logic for the program, which has some placeholders
-for font data and something.</p>
+for font data and something else.</p>
 <p>It decompresses the font data and renders a given text by projection. It
 exploits <code>C99</code>’s <code>double complex</code> type to represent 2D points, but carefully
 coded so that it does not require any <code>math.h</code> functions; you don’t have to pass

--- a/2020/endoh2/obfuscation/index.md
+++ b/2020/endoh2/obfuscation/index.md
@@ -9,7 +9,7 @@ If `ctrl` is 1, the point is used as control point for quadratic [b&eacute;zier
 curve](https://en.wikipedia.org/wiki/B&eacute;zier_curve).
 
 [code.c](%%REPO_URL%%/2020/endoh2/obfuscation/code.c) is the main logic for the program, which has some placeholders
-for font data and something.
+for font data and something else.
 
 It decompresses the font data and renders a given text by projection.  It
 exploits `C99`'s `double complex` type to represent 2D points, but carefully


### PR DESCRIPTION
For 1993/ant it clarifies (even though the extension of the file probably would suggest it) that the man page is in text format.

For 2020/endoh2 there were some mistakes introduced with the renaming of spoiler to other things.

Rebuilt the .entry.json and the index.html files for both.

Rebuilt 2020/endoh2/obfuscation/index.html.