### PR TITLE
Copy 1992/nathan.orig.c to nathan.alt.c

### DIFF
--- a/1992/nathan/.entry.json
+++ b/1992/nathan/.entry.json
@@ -26,6 +26,14 @@
 	    "entry_text" : "entry Makefile"
 	},
 	{
+	    "file_path" : "nathan.alt.c",
+	    "inventory_order" : 40,
+	    "OK_to_edit" : true,
+	    "display_as" : "c",
+	    "display_via_github" : true,
+	    "entry_text" : "alternate source code"
+	},
+	{
 	    "file_path" : "nathan.orig.c",
 	    "inventory_order" : 50,
 	    "OK_to_edit" : false,

--- a/1992/nathan/.gitignore
+++ b/1992/nathan/.gitignore
@@ -7,5 +7,6 @@ indent
 indent.c
 indent.o
 nathan
+nathan.alt
 nathan.orig
 prog.orig

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -113,8 +113,8 @@ OBJ= ${PROG}.o
 DATA=
 TARGET= ${PROG}
 #
-ALT_OBJ=
-ALT_TARGET=
+ALT_OBJ= ${PROG}.alt.o
+ALT_TARGET= ${PROG}.alt
 
 
 #################
@@ -136,6 +136,10 @@ ${PROG}: ${PROG}.c
 #
 alt: data ${ALT_TARGET}
 	@${TRUE}
+
+${PROG}.alt: ${PROG}.alt.c
+	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
+
 
 # data files
 #

--- a/1992/nathan/README.md
+++ b/1992/nathan/README.md
@@ -4,6 +4,9 @@
     make all
 ```
 
+There is an Alternate version which is what was originally published. See
+[Alternate code](#alternate-code) below for more information.
+
 
 ## To use:
 
@@ -20,6 +23,34 @@ To see some other fun uses:
 ``` <!---sh-->
     ./try.sh
 ```
+
+
+## Alternate code:
+
+At the time of publication, the judges could not publish the code due to the
+US export control over encryption. The code that was published would, if run,
+allow one to get the instructions of how to receive (via email) the actual
+entry. However, on Sat Mar 4 20:09:35 2023 UTC, the previously unseen code was
+published. This meant that the old code was not set to compile via the Makefile.
+This alternate code is that previous version.
+
+
+## Alternate build:
+
+``` <!---sh-->
+     make alt
+```
+
+
+### Alternate use:
+
+``` <!---sh-->
+    ./nathan.alt
+```
+
+**IMPORTANT NOTE**: it is unknown if the email in the code is still valid and as
+one does not need to email the author for the submitted code one should not
+email it. In other words, please do **NOT** send such an email.
 
 
 ## Judges' remarks:
@@ -41,7 +72,7 @@ should be freely re-distributable).  We suspect that the author
 may not have intended to do this, but that is the way things go
 sometimes.
 
-BTW, 'abuse of the rules' entries do not violate the rules.
+BTW, '_abuse of the rules_' entries do not violate the rules.
 Entries that violate the rules are disqualified.  Abuse of the
 rules entries are ones that tend to 'stretch' the limits and
 take the contest into unexpected territory.
@@ -88,7 +119,9 @@ is the source code is what you would have received had you
 successfully completed the above instructions.
 
 Today, the above instructions are **no longer necessary**.
-There have been reproduced above to provide historical context.
+There have been reproduced above to provide historical context. Even so, the
+[Alternate code](#alternate-code) allows you to see what the originally
+published code did.
 
 
 ### Personal note from chongo:
@@ -101,11 +134,12 @@ re-distribute a program contest entry to the network!
 
 ### Updated personal note from chongo:
 
-We removed the Email address from the above quote (although you can
-still see it in the [nathan.orig.c](%%REPO_URL%%/1992/nathan/nathan.orig.c)
-code) because sending Email to that address is not requirement today.
-The [nathan.c](%%REPO_URL%%/1992/nathan/nathan.c) file now contains
-the source you would have received in reply.
+We removed the email address from the above quote (although you can still see it
+in the [nathan.orig.c](%%REPO_URL%%/1992/nathan/nathan.orig.c) and
+[nathan.alt.c](%%REPO_URL%%/1992/nathan/nathan.alt.c) code) because sending
+email to that address is not required today and it is unknown if it is still
+valid.  The [nathan.c](%%REPO_URL%%/1992/nathan/nathan.c) file now contains the
+source you would have received in reply.
 
 Thankfully much of the ridiculous US crypto regulations has been
 amended to the extent where the above historical "_workaround_" is

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -409,12 +409,28 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <!-- BEFORE: 1st line of markdown file: 1992/nathan/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<p>There is an Alternate version which is what was originally published. See
+<a href="#alternate-code">Alternate code</a> below for more information.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./nathan
     # enter some text</code></pre>
 <h2 id="try">Try:</h2>
 <p>To see some other fun uses:</p>
 <pre><code>    ./try.sh</code></pre>
+<h2 id="alternate-code">Alternate code:</h2>
+<p>At the time of publication, the judges could not publish the code due to the
+US export control over encryption. The code that was published would, if run,
+allow one to get the instructions of how to receive (via email) the actual
+entry. However, on Sat Mar 4 20:09:35 2023 UTC, the previously unseen code was
+published. This meant that the old code was not set to compile via the Makefile.
+This alternate code is that previous version.</p>
+<h2 id="alternate-build">Alternate build:</h2>
+<pre><code>     make alt</code></pre>
+<h3 id="alternate-use">Alternate use:</h3>
+<pre><code>    ./nathan.alt</code></pre>
+<p><strong>IMPORTANT NOTE</strong>: it is unknown if the email in the code is still valid and as
+one does not need to email the author for the submitted code one should not
+email it. In other words, please do <strong>NOT</strong> send such an email.</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <h3 id="warning">WARNING:</h3>
 <p>The judges make no claim as to the strength or security
@@ -428,7 +444,7 @@ unintentionally abused the intent of rule #7 (that programs
 should be freely re-distributable). We suspect that the author
 may not have intended to do this, but that is the way things go
 sometimes.</p>
-<p>BTW, ‘abuse of the rules’ entries do not violate the rules.
+<p>BTW, ‘<em>abuse of the rules</em>’ entries do not violate the rules.
 Entries that violate the rules are disqualified. Abuse of the
 rules entries are ones that tend to ‘stretch’ the limits and
 take the contest into unexpected territory.</p>
@@ -465,18 +481,21 @@ the men in black might get you.</p>
 is the source code is what you would have received had you
 successfully completed the above instructions.</p>
 <p>Today, the above instructions are <strong>no longer necessary</strong>.
-There have been reproduced above to provide historical context.</p>
+There have been reproduced above to provide historical context. Even so, the
+<a href="#alternate-code">Alternate code</a> allows you to see what the originally
+published code did.</p>
 <h3 id="personal-note-from-chongo">Personal note from chongo:</h3>
 <p>I think the situation showed just how ridiculous US crypto regulations really
 were/are. Certain US federal officials can get away with shipping arms to
 certain nations in apparent violation of US laws, but I personally can’t
 re-distribute a program contest entry to the network!</p>
 <h3 id="updated-personal-note-from-chongo">Updated personal note from chongo:</h3>
-<p>We removed the Email address from the above quote (although you can
-still see it in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.orig.c">nathan.orig.c</a>
-code) because sending Email to that address is not requirement today.
-The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a> file now contains
-the source you would have received in reply.</p>
+<p>We removed the email address from the above quote (although you can still see it
+in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.orig.c">nathan.orig.c</a> and
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.alt.c">nathan.alt.c</a> code) because sending
+email to that address is not required today and it is unknown if it is still
+valid. The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a> file now contains the
+source you would have received in reply.</p>
 <p>Thankfully much of the ridiculous US crypto regulations has been
 amended to the extent where the above historical “<em>workaround</em>” is
 <strong>no longer required</strong>.</p>
@@ -543,6 +562,7 @@ operator, or argument separator?).</p>
 <ul>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a> - entry source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/Makefile">Makefile</a> - entry Makefile</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.alt.c">nathan.alt.c</a> - alternate source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.orig.c">nathan.orig.c</a> - original source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/try.sh">try.sh</a> - script to try entry</li>
 </ul>

--- a/1992/nathan/nathan.alt.c
+++ b/1992/nathan/nathan.alt.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+static char *text[] =
+{
+  "Export of this program from the USA is governed by the US",
+  "Munitions List from the ITAR (International Traffic in Arms",
+  "Regulations). This list gives the specific categories of",
+  "restricted exports and includes cryptographic exports. Traffic",
+  "entirely external to, entirely internal to, or into the USA is",
+  "not restricted.",
+  "To obtain a copy of the program, email to nathan@inmos.co.uk",
+  "with a subject \"IOCCC request\". If you know that your 'From'",
+  "line is incorrect, add a single line",
+  "\"replyto you@your.correct.address\" to the body of the message.",
+  "A deamon will autoreply.",
+  "WARNING: You must not re-export this out of the USA, or else",
+  "the men in black might get you.",
+  NULL
+};
+int main()
+{
+  char **ptr;
+
+  for(ptr = text; *ptr; ptr++)
+    printf("%s\n", *ptr);
+  return 0;
+}

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -1814,7 +1814,7 @@ bugs.html</a> for details.</p>
 <p><a href="#cody">Cody</a> added the original file back as it was deemed that the export
 restrictions should no longer be a cause of concern for this entry. An entry
 that referred to this previous code was updated and the originally published
-code is now also in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan.alt.c">nathan.alt.c</a>. The astute
+code is now also in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.alt.c">nathan.alt.c</a>. The astute
 viewer would note that it has the same typos as the originally published code.</p>
 <p>Cody cynically noted that if he goes quiet, for instance if he no longer
 participates in the IOCCC, that it must be our fault! :-)</p>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -1811,14 +1811,15 @@ bugs.html</a> for details.</p>
 <h2 id="winning-entry-1992nathan">Winning entry: <a href="1992/nathan/index.html">1992/nathan</a></h2>
 <h3 id="winning-entry-source-code-nathan.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added the original file back as it was deemed that the export restrictions
-should no longer be a cause of concern for this entry. Doing this did require a
-change to Cody’s <a href="2020/ferguson2/index.html">2020/ferguson2</a> entry as it’s
-referenced.</p>
+<p><a href="#cody">Cody</a> added the original file back as it was deemed that the export
+restrictions should no longer be a cause of concern for this entry. An entry
+that referred to this previous code was updated and the originally published
+code is now also in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan.alt.c">nathan.alt.c</a>. The astute
+viewer would note that it has the same typos as the originally published code.</p>
 <p>Cody cynically noted that if he goes quiet, for instance if he no longer
 participates in the IOCCC, that it must be our fault! :-)</p>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/try.sh">try.sh</a> script that runs a few commands
-that we suggested as well as one he provided.</p>
+<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/try.sh">try.sh</a> script that runs a
+few commands that we suggested as well as one he provided.</p>
 <div id="1992_vern">
 <h2 id="winning-entry-1992vern">Winning entry: <a href="1992/vern/index.html">1992/vern</a></h2>
 <h3 id="winning-entry-source-code-vern.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">vern.c</a></h3>

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2039,7 +2039,7 @@ bugs.html](bugs.html#1992_lush) for details.
 [Cody](#cody) added the original file back as it was deemed that the export
 restrictions should no longer be a cause of concern for this entry. An entry
 that referred to this previous code was updated and the originally published
-code is now also in [nathan.alt.c](%%REPO_URL%%/1992/nathan.alt.c). The astute
+code is now also in [nathan.alt.c](%%REPO_URL%%/1992/nathan/nathan.alt.c). The astute
 viewer would note that it has the same typos as the originally published code.
 
 Cody cynically noted that if he goes quiet, for instance if he no longer

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -2036,16 +2036,17 @@ bugs.html](bugs.html#1992_lush) for details.
 ### Winning entry source code: [nathan.c](%%REPO_URL%%/1992/nathan/nathan.c)
 </div>
 
-[Cody](#cody) added the original file back as it was deemed that the export restrictions
-should no longer be a cause of concern for this entry. Doing this did require a
-change to Cody's [2020/ferguson2](2020/ferguson2/index.html) entry as it's
-referenced.
+[Cody](#cody) added the original file back as it was deemed that the export
+restrictions should no longer be a cause of concern for this entry. An entry
+that referred to this previous code was updated and the originally published
+code is now also in [nathan.alt.c](%%REPO_URL%%/1992/nathan.alt.c). The astute
+viewer would note that it has the same typos as the originally published code.
 
 Cody cynically noted that if he goes quiet, for instance if he no longer
 participates in the IOCCC, that it must be our fault! :-)
 
-Cody also added the [try.sh](%%REPO_URL%%/1992/nathan/try.sh) script that runs a few commands
-that we suggested as well as one he provided.
+Cody also added the [try.sh](%%REPO_URL%%/1992/nathan/try.sh) script that runs a
+few commands that we suggested as well as one he provided.
 
 
 <div id="1992_vern">


### PR DESCRIPTION
This is so one can see what the originally published code did. The index.html has a bold important note that one should NOT send an email to the address as it is not only no longer necessary but it is not known if it is still valid. Unlike the index.html where the email was omitted/redacted the alt code still has the email as the original code as it is an exact copy thereof, including the typos in it.

Rebuilt .entry.json and index.html.

Updated .gitignore.