### PR TITLE
Fixes in entries of 1994

### DIFF
--- a/1991/README.md
+++ b/1991/README.md
@@ -76,7 +76,8 @@ See [How to contact the IOCCC](../contact.html) for how to provide
 us with your comments and suggestions today.
 
 For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:
+people used to contact the IOCCC in this given year, via [Unix to Unix CoPy
+&#x28;UUCP&#x29;](https://en.wikipedia.org/wiki/UUCP#Mail_routing):
 
 >   ...!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 >   judges@toad.com

--- a/1991/index.html
+++ b/1991/index.html
@@ -455,7 +455,8 @@ Also include anything else that you would like to see in future contests.
 See <a href="../contact.html">How to contact the IOCCC</a> for how to provide
 us with your comments and suggestions today.</p>
 <p>For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:</p>
+people used to contact the IOCCC in this given year, via <a href="https://en.wikipedia.org/wiki/UUCP#Mail_routing">Unix to Unix CoPy
+(UUCP)</a>:</p>
 <blockquote>
 <p>…!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 judges@toad.com</p>

--- a/1992/README.md
+++ b/1992/README.md
@@ -66,7 +66,8 @@ See [How to contact the IOCCC](../contact.html) for how to provide
 us with your comments and suggestions today.
 
 For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:
+people used to contact the IOCCC in this given year, via [Unix to Unix CoPy
+&#x28;UUCP&#x29;](https://en.wikipedia.org/wiki/UUCP#Mail_routing):
 
 >   ...!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 >   judges@toad.com

--- a/1992/index.html
+++ b/1992/index.html
@@ -445,7 +445,8 @@ Also include anything else that you would like to see in future contests.
 See <a href="../contact.html">How to contact the IOCCC</a> for how to provide
 us with your comments and suggestions today.</p>
 <p>For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:</p>
+people used to contact the IOCCC in this given year, via <a href="https://en.wikipedia.org/wiki/UUCP#Mail_routing">Unix to Unix CoPy
+(UUCP)</a>:</p>
 <blockquote>
 <p>…!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 judges@toad.com</p>

--- a/1993/README.md
+++ b/1993/README.md
@@ -33,7 +33,8 @@ See [How to contact the IOCCC](../contact.html) for how to provide
 us with your comments and suggestions today.
 
 For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:
+people used to contact the IOCCC in this given year, via [Unix to Unix CoPy
+&#x28;UUCP&#x29;](https://en.wikipedia.org/wiki/UUCP#Mail_routing):
 
 >   ...!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 >   judges@toad.com

--- a/1993/index.html
+++ b/1993/index.html
@@ -418,7 +418,8 @@ Also include anything else that you would like to see in future contests.
 See <a href="../contact.html">How to contact the IOCCC</a> for how to provide
 us with your comments and suggestions today.</p>
 <p>For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:</p>
+people used to contact the IOCCC in this given year, via <a href="https://en.wikipedia.org/wiki/UUCP#Mail_routing">Unix to Unix CoPy
+(UUCP)</a>:</p>
 <blockquote>
 <p>…!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 judges@toad.com</p>

--- a/1994/README.md
+++ b/1994/README.md
@@ -101,7 +101,8 @@ See [How to contact the IOCCC](../contact.html) for how to provide
 us with your comments and suggestions today.
 
 For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:
+people used to contact the IOCCC in this given year, via [Unix to Unix CoPy
+&#x28;UUCP&#x29;](https://en.wikipedia.org/wiki/UUCP#Mail_routing):
 
 >   ...!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 >   judges@toad.com

--- a/1994/horton/.entry.json
+++ b/1994/horton/.entry.json
@@ -31,7 +31,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "c",
 	    "display_via_github" : true,
-	    "entry_text" : "alternate source code"
+	    "entry_text" : "author provided unobfuscated and enhanced code"
 	},
 	{
 	    "file_path" : "horton.orig.c",

--- a/1994/horton/README.md
+++ b/1994/horton/README.md
@@ -4,6 +4,9 @@
     make all
 ```
 
+There is an unobfuscated and enhanced version provided by the author. See [Alternate
+code](#alternate-code) below.
+
 
 ## To use:
 
@@ -23,8 +26,9 @@
 
 ## Alternate code:
 
-This confuses cb greatly. See [horton.alt.c](%%REPO_URL%%/1994/horton/horton.alt.c) for an unobfuscated/enhanced
-version.
+This confuses cb greatly. See
+[horton.alt.c](%%REPO_URL%%/1994/horton/horton.alt.c) for an
+unobfuscated and enhanced version.
 
 
 ### Alternate build:
@@ -40,7 +44,7 @@ version.
     ./horton.alt A B C D
 ```
 
-Where A, B, C and D are numbers like with `horton`.
+Where `A`, `B`, `C` and `D` are numbers, just like with `horton`.
 
 
 ### Alternate try:
@@ -57,8 +61,7 @@ right character.  And for extra credit, try to figure out which
 character is at the bottom of this hint file.  :-)
 
 You might be interested in the author's article that they cite towards the end
-of their remarks, included as PDF files for your convenience, the full
-newsletter and a PDF file of just the pages cited.
+of their remarks, included as a PDF file for your convenience.
 
 
 ## Author's remarks:
@@ -79,7 +82,7 @@ If you get stuck, come back and read below for additional hints and information.
 ### What this entry does:
 
 As should be obvious from 20 feet away, the program is a cubic plotter.
-It plots against certain artists, splattering their cubes with graphs
+It plots against certain arguments, splattering their cubes with graphs
 of their cubic equations.  Those dastardly arguments are mere coefficients,
 cogs in the wheels of the grand plot to overthrow the cubics!
 

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -409,19 +409,22 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 1994/horton/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<p>There is an unobfuscated and enhanced version provided by the author. See <a href="#alternate-code">Alternate
+code</a> below.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./horton A B C D</code></pre>
 <p><code>A</code>, <code>B</code>, <code>C</code> and <code>D</code> are numeric arguments.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
-<p>This confuses cb greatly. See <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.alt.c">horton.alt.c</a> for an unobfuscated/enhanced
-version.</p>
+<p>This confuses cb greatly. See
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.alt.c">horton.alt.c</a> for an
+unobfuscated and enhanced version.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>
 <pre><code>    ./horton.alt A B C D</code></pre>
-<p>Where A, B, C and D are numbers like with <code>horton</code>.</p>
+<p>Where <code>A</code>, <code>B</code>, <code>C</code> and <code>D</code> are numbers, just like with <code>horton</code>.</p>
 <h3 id="alternate-try">Alternate try:</h3>
 <pre><code>    ./try.alt.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
@@ -429,8 +432,7 @@ version.</p>
 right character. And for extra credit, try to figure out which
 character is at the bottom of this hint file. :-)</p>
 <p>You might be interested in the author’s article that they cite towards the end
-of their remarks, included as PDF files for your convenience, the full
-newsletter and a PDF file of just the pages cited.</p>
+of their remarks, included as a PDF file for your convenience.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>Run it with any 4 numeric arguments, e.g. <code>./horton 3 2 1 0</code>. Play with the
 numbers to get a pleasing result, or use it for your high school algebra
@@ -441,7 +443,7 @@ just try to understand the program via the source.</p>
 <p>If you get stuck, come back and read below for additional hints and information.</p>
 <h3 id="what-this-entry-does">What this entry does:</h3>
 <p>As should be obvious from 20 feet away, the program is a cubic plotter.
-It plots against certain artists, splattering their cubes with graphs
+It plots against certain arguments, splattering their cubes with graphs
 of their cubic equations. Those dastardly arguments are mere coefficients,
 cogs in the wheels of the grand plot to overthrow the cubics!</p>
 <p>Oh, by the way, it uses a self-contained graphtab and frame buffer.
@@ -503,7 +505,7 @@ It’s easily modified to graph <em>any</em> 96x160 bitmap on a dumb terminal.</
 <ul>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.c">horton.c</a> - entry source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/Makefile">Makefile</a> - entry Makefile</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.alt.c">horton.alt.c</a> - alternate source code</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.alt.c">horton.alt.c</a> - author provided unobfuscated and enhanced code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.orig.c">horton.orig.c</a> - original source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/gtface.c">gtface.c</a> - gtface source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/try.alt.sh">try.alt.sh</a> - script to try alternate code</li>

--- a/1994/imc/README.md
+++ b/1994/imc/README.md
@@ -8,10 +8,10 @@
 ## To use:
 
 ``` <!---sh-->
-    ./imc [NUMBER]
+    ./imc number
 ```
 
-where `[NUMBER]` is an optional number. Default is 5.
+where `number` is an optional number. Default is 5.
 
 
 ## Try:
@@ -69,9 +69,9 @@ useful the exclusive-or operator was while writing function `s()`.
 
 Here are the descriptions of the functions in the library:
 
-> o(n,a,q,d): makes a magic square of order n when n is odd and at least 3.<br>
-> s(n,a,q,d): makes a magic square of order n when n equals 4.<br>
-> e(n,a,q,d): makes a magic square of order n when n is even and at least 6.
+> `o(n,a,q,d)`: makes a magic square of order `n` when `n` is odd and at least 3.<br>
+> `s(n,a,q,d)`: makes a magic square of order `n` when `n` equals 4.<br>
+> `e(n,a,q,d)`: makes a magic square of order `n` when `n` is even and at least 6.
 
 In the above, `a` (of type `int *`) points to an area of memory in which
 the magic square will be stored and `q` (also of type `int *`) points to

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -410,8 +410,8 @@ Location: <a href="../../location.html#GB">GB</a> - <em>United Kingdom of Great 
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
 <h2 id="to-use">To use:</h2>
-<pre><code>    ./imc [NUMBER]</code></pre>
-<p>where <code>[NUMBER]</code> is an optional number. Default is 5.</p>
+<pre><code>    ./imc number</code></pre>
+<p>where <code>number</code> is an optional number. Default is 5.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
@@ -447,9 +447,9 @@ in obfuscated code! :-) Incidentally, I was surprised to find out how
 useful the exclusive-or operator was while writing function <code>s()</code>.</p>
 <p>Here are the descriptions of the functions in the library:</p>
 <blockquote>
-<p>o(n,a,q,d): makes a magic square of order n when n is odd and at least 3.<br>
-s(n,a,q,d): makes a magic square of order n when n equals 4.<br>
-e(n,a,q,d): makes a magic square of order n when n is even and at least 6.</p>
+<p><code>o(n,a,q,d)</code>: makes a magic square of order <code>n</code> when <code>n</code> is odd and at least 3.<br>
+<code>s(n,a,q,d)</code>: makes a magic square of order <code>n</code> when <code>n</code> equals 4.<br>
+<code>e(n,a,q,d)</code>: makes a magic square of order <code>n</code> when <code>n</code> is even and at least 6.</p>
 </blockquote>
 <p>In the above, <code>a</code> (of type <code>int *</code>) points to an area of memory in which
 the magic square will be stored and <code>q</code> (also of type <code>int *</code>) points to

--- a/1994/index.html
+++ b/1994/index.html
@@ -469,7 +469,8 @@ Also include anything else that you would like to see in future contests.
 See <a href="../contact.html">How to contact the IOCCC</a> for how to provide
 us with your comments and suggestions today.</p>
 <p>For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:</p>
+people used to contact the IOCCC in this given year, via <a href="https://en.wikipedia.org/wiki/UUCP#Mail_routing">Unix to Unix CoPy
+(UUCP)</a>:</p>
 <blockquote>
 <p>…!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 judges@toad.com</p>

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -6,7 +6,7 @@
 
 There are two alternate versions, one that has an increased buffer size and one
 that uses `fgets()`; neither are completely functional.  See below section [Bugs
-and (mis)features](#bugs-and-misfeatures) for details and the [Alternate
+and &#x28;mis&#x29;features](#bugs-and-misfeatures) for details and the [Alternate
 code](#alternate-code) section for how to use.
 
 

--- a/1994/schnitzi/README.md
+++ b/1994/schnitzi/README.md
@@ -5,8 +5,8 @@
 ```
 
 There are two alternate versions, one that has an increased buffer size and one
-that uses `fgets()`; neither are completely functional.
-See below section bugs and (mis)features for details and the [alternate
+that uses `fgets()`; neither are completely functional.  See below section [Bugs
+and (mis)features](#bugs-and-misfeatures) for details and the [Alternate
 code](#alternate-code) section for how to use.
 
 
@@ -35,14 +35,19 @@ For more detailed information see [1994/schnitzi in bugs.html](../../bugs.html#1
 
 ## Alternate code:
 
+These alternate versions are for those who wish to help with getting the entry
+to use `fgets(3)`. See the
+FAQ on "[gets and fgets](../../faq.html#gets)"
+for why this is desired.
+
 The first version, `schnitzi.alt.c`, uses `fgets(3)` but when fed its own code
-it will generate code that still uses `gets(3)`. What's more is it will not
-compile. Other functionality works fine.
+it will generate code that still uses `gets(3)`. What's more that code will not
+compile. Other functionality of the alt version works fine.
 
 The second version, `schnitzi.alt2.c`, has an increased buffer size but when fed
-its own source code it will generate code that can compile but with the original
-buffer size. This is due to a comment which is explained in more detail in
-[1994/schnitzi in bugs.html](../../bugs.html#1994_schnitzi).
+its own source code it will generate code that, although it can compile but, it
+has the original buffer size. This is due to a comment which is explained in
+more detail in [1994/schnitzi in bugs.html](../../bugs.html#1994_schnitzi).
 
 
 ### Alternate build:

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -410,8 +410,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
 <p>There are two alternate versions, one that has an increased buffer size and one
-that uses <code>fgets()</code>; neither are completely functional.
-See below section bugs and (mis)features for details and the <a href="#alternate-code">alternate
+that uses <code>fgets()</code>; neither are completely functional. See below section <a href="#bugs-and-misfeatures">Bugs
+and (mis)features</a> for details and the <a href="#alternate-code">Alternate
 code</a> section for how to use.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
@@ -424,13 +424,17 @@ code</a> section for how to use.</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
+<p>These alternate versions are for those who wish to help with getting the entry
+to use <code>fgets(3)</code>. See the
+FAQ on “<a href="../../faq.html#gets">gets and fgets</a>”
+for why this is desired.</p>
 <p>The first version, <code>schnitzi.alt.c</code>, uses <code>fgets(3)</code> but when fed its own code
-it will generate code that still uses <code>gets(3)</code>. What’s more is it will not
-compile. Other functionality works fine.</p>
+it will generate code that still uses <code>gets(3)</code>. What’s more that code will not
+compile. Other functionality of the alt version works fine.</p>
 <p>The second version, <code>schnitzi.alt2.c</code>, has an increased buffer size but when fed
-its own source code it will generate code that can compile but with the original
-buffer size. This is due to a comment which is explained in more detail in
-<a href="../../bugs.html#1994_schnitzi">1994/schnitzi in bugs.html</a>.</p>
+its own source code it will generate code that, although it can compile but, it
+has the original buffer size. This is due to a comment which is explained in
+more detail in <a href="../../bugs.html#1994_schnitzi">1994/schnitzi in bugs.html</a>.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>

--- a/1994/shapiro/README.md
+++ b/1994/shapiro/README.md
@@ -9,8 +9,8 @@
 
 The current status of this entry is:
 
-> **STATUS: missing file - please provide it**<br>
-> **STATUS: INABIAF - please DO NOT fix**
+> **STATUS: INABIAF - please DO NOT fix**<br>
+> **STATUS: missing file - please provide it**
 
 For more detailed information see [1994/shapiro in bugs.html](../../bugs.html#1994_shapiro).
 
@@ -48,10 +48,11 @@ source file is self documenting.  :-)
 
 From time to time, run `ps(1)` and look at the new processes.
 
-See [shapiro.html](shapiro.html) for more information in the internals of this program.
-The file `shapiro.alt.c` contains a non-obfuscated version of
-this program. Note that this alt file is currently missing. See
-[1994/shapiro in bugs.html](../../bugs.html#1994_shapiro) for details.
+If you want more information on the internals of this program, see
+[shapiro.html](shapiro.html).
+
+The missing file `shapiro.alt.c` is an unobfuscated version of this program. See
+[1994/shapiro in bugs.html](../../bugs.html#1994_shapiro).
 
 
 ## Author's remarks:
@@ -59,10 +60,15 @@ this program. Note that this alt file is currently missing. See
 The basic theme (pun) of this program is:
 
 
-```
-    "This time (everything) is not where it should be."
-          ~~~~
-```
+> "This **time** (everything) is not where it should be."
+
+
+### NOTICE to those who wish for a greater challenge:
+
+**If you want a greater challenge, don't read any further**:
+just try to understand the program via the source.
+
+If you get stuck, come back and read below for additional hints and information.
 
 
 My entry, [shapiro.c](%%REPO_URL%%/1994/shapiro/shapiro.c), is mostly comments, formatted in the shape of a

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -412,8 +412,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <blockquote>
-<p><strong>STATUS: missing file - please provide it</strong><br>
-<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong><br>
+<strong>STATUS: missing file - please provide it</strong></p>
 </blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_shapiro">1994/shapiro in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
@@ -434,14 +434,19 @@ bring it back to the foreground.</p>
 <p>This entry has many different levels of obfuscation, and yet the
 source file is self documenting. :-)</p>
 <p>From time to time, run <code>ps(1)</code> and look at the new processes.</p>
-<p>See <a href="shapiro.html">shapiro.html</a> for more information in the internals of this program.
-The file <code>shapiro.alt.c</code> contains a non-obfuscated version of
-this program. Note that this alt file is currently missing. See
-<a href="../../bugs.html#1994_shapiro">1994/shapiro in bugs.html</a> for details.</p>
+<p>If you want more information on the internals of this program, see
+<a href="shapiro.html">shapiro.html</a>.</p>
+<p>The missing file <code>shapiro.alt.c</code> is an unobfuscated version of this program. See
+<a href="../../bugs.html#1994_shapiro">1994/shapiro in bugs.html</a>.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>The basic theme (pun) of this program is:</p>
-<pre><code>    &quot;This time (everything) is not where it should be.&quot;
-          ~~~~</code></pre>
+<blockquote>
+<p>“This <strong>time</strong> (everything) is not where it should be.”</p>
+</blockquote>
+<h3 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge:</h3>
+<p><strong>If you want a greater challenge, don’t read any further</strong>:
+just try to understand the program via the source.</p>
+<p>If you get stuck, come back and read below for additional hints and information.</p>
 <p>My entry, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">shapiro.c</a>, is mostly comments, formatted in the shape of a
 clock. If you strip out the comments and look at the code you will
 quickly realize that the comments were the important part and that

--- a/1994/tvr/.entry.json
+++ b/1994/tvr/.entry.json
@@ -31,7 +31,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "c",
 	    "display_via_github" : true,
-	    "entry_text" : "alternate source code"
+	    "entry_text" : "less obfuscated source code"
 	},
 	{
 	    "file_path" : "tvr.orig.c",

--- a/1994/tvr/README.md
+++ b/1994/tvr/README.md
@@ -16,7 +16,7 @@ code](#alternate-code) below.
 
 The current status of this entry is:
 
-> **STATUS: known bug - please help us fix**
+> **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [1994/tvr in bugs.html](../../bugs.html#1994_tvr).
 
@@ -47,10 +47,10 @@ just try to understand the program without looking at the Alternate code.
 
 If you get stuck, come back and look at the Alternate code.
 
+The author provided us a less obfuscated version that might be of interest to some.
+
 
 ### Alternate build:
-
-The author provided us a less obfuscated version that might be of interest to some.
 
 ``` <!---sh-->
     make alt
@@ -152,7 +152,7 @@ and may confuse paging algorithms easily).  This means that for 512x512 windows
 you will need 4M of memory.
 
 
-### `colormapfile`
+#### colormapfile
 
 This is the file from which program reads colors for screen `colormap`. The
 first line of the file must be a number between `3..254`. This informs the

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -417,7 +417,7 @@ code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <blockquote>
-<p><strong>STATUS: known bug - please help us fix</strong></p>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
 </blockquote>
 <p>For more detailed information see <a href="../../bugs.html#1994_tvr">1994/tvr in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
@@ -431,8 +431,8 @@ code</a> below.</p>
 <p><strong>If you want a greater challenge, don’t read any further</strong>:
 just try to understand the program without looking at the Alternate code.</p>
 <p>If you get stuck, come back and look at the Alternate code.</p>
-<h3 id="alternate-build">Alternate build:</h3>
 <p>The author provided us a less obfuscated version that might be of interest to some.</p>
+<h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>
 <pre><code>    ./tvr.alt altmode screensize/2 &lt; colormapfile</code></pre>
@@ -497,7 +497,7 @@ parameter as shown above.</p>
 main memory or the machine will swap heavily (memory references are quite random
 and may confuse paging algorithms easily). This means that for 512x512 windows
 you will need 4M of memory.</p>
-<h3 id="colormapfile"><code>colormapfile</code></h3>
+<h4 id="colormapfile">colormapfile</h4>
 <p>This is the file from which program reads colors for screen <code>colormap</code>. The
 first line of the file must be a number between <code>3..254</code>. This informs the
 program how many colors there are to be expected. This is also the maximum
@@ -600,7 +600,7 @@ mono).</li>
 <ul>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.c">tvr.c</a> - entry source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/Makefile">Makefile</a> - entry Makefile</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.alt.c">tvr.alt.c</a> - alternate source code</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.alt.c">tvr.alt.c</a> - less obfuscated source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.orig.c">tvr.orig.c</a> - original source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.alt.bw.sh">try.alt.bw.sh</a> - script to try alternate code in black and white mode</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/try.alt.color.sh">try.alt.color.sh</a> - script to try alternate code in colour mode</li>

--- a/1994/weisberg/README.md
+++ b/1994/weisberg/README.md
@@ -4,8 +4,8 @@
     make all
 ```
 
-There is an alternate version that uses more memory. See [alternate
-code](#alternate-code) below for more details.
+There is an alternate build (same code, alternate build) that uses more memory.
+See [Alternate code](#alternate-code) below for more details.
 
 
 ## To use:
@@ -27,15 +27,16 @@ If you have `primes(1)` installed you might also wish to try:
     ./primes.sh number
 ```
 
-where `number` is a positive number, defaulting to 15. The [try.sh](%%REPO_URL%%/1994/weisberg/try.sh)
-script will also do this.
+where `number` is a positive number, defaulting to 15. The
+[try.sh](%%REPO_URL%%/1994/weisberg/try.sh) script will also `try` :-) and do
+this.
 
 
 ## Alternate code:
 
 If you liked what you saw from the above program, and happen to
-have some 512 Megabytes of virtual memory lying around with to do
-something with you might try this version.
+have some 512 megabytes of virtual memory lying around with to do
+something with you might try this build.
 
 
 ### Alternate build:
@@ -77,7 +78,7 @@ event of a system shutdown or reboot.
 
 ### Bugs
 
-The alternative version ([weisberg.c](%%REPO_URL%%/1994/weisberg/weisberg.c)
+The alternative build ([weisberg.c](%%REPO_URL%%/1994/weisberg/weisberg.c)
 compiled to `weisberg.alt`) has never actually run
 to completion. After running for close to a week it had reached somewhere around
 250e6, when it became necessary to test the reboot feature (which worked

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -409,20 +409,21 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 1994/weisberg/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
-<p>There is an alternate version that uses more memory. See <a href="#alternate-code">alternate
-code</a> below for more details.</p>
+<p>There is an alternate build (same code, alternate build) that uses more memory.
+See <a href="#alternate-code">Alternate code</a> below for more details.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./weisberg</code></pre>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <p>If you have <code>primes(1)</code> installed you might also wish to try:</p>
 <pre><code>    ./primes.sh number</code></pre>
-<p>where <code>number</code> is a positive number, defaulting to 15. The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/try.sh">try.sh</a>
-script will also do this.</p>
+<p>where <code>number</code> is a positive number, defaulting to 15. The
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/try.sh">try.sh</a> script will also <code>try</code> :-) and do
+this.</p>
 <h2 id="alternate-code">Alternate code:</h2>
 <p>If you liked what you saw from the above program, and happen to
-have some 512 Megabytes of virtual memory lying around with to do
-something with you might try this version.</p>
+have some 512 megabytes of virtual memory lying around with to do
+something with you might try this build.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>
@@ -443,7 +444,7 @@ run to completion, so as an added feature, it will cease execution upon
 reception of a signal (any will do equally well), as well as in the
 event of a system shutdown or reboot.</p>
 <h3 id="bugs">Bugs</h3>
-<p>The alternative version (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.c">weisberg.c</a>
+<p>The alternative build (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.c">weisberg.c</a>
 compiled to <code>weisberg.alt</code>) has never actually run
 to completion. After running for close to a week it had reached somewhere around
 250e6, when it became necessary to test the reboot feature (which worked

--- a/1995/README.md
+++ b/1995/README.md
@@ -50,7 +50,8 @@ See [How to contact the IOCCC](../contact.html) for how to provide
 us with your comments and suggestions today.
 
 For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:
+people used to contact the IOCCC in this given year, via [Unix to Unix CoPy
+&#x28;UUCP&#x29;](https://en.wikipedia.org/wiki/UUCP#Mail_routing):
 
 >   ...!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 >   judges@toad.com

--- a/1995/garry/.entry.json
+++ b/1995/garry/.entry.json
@@ -71,7 +71,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "c",
 	    "display_via_github" : true,
-	    "entry_text" : "unobfuscated and formatted source code"
+	    "entry_text" : "author provided unobfuscated and formatted source code"
 	},
 	{
 	    "file_path" : "1995_garry.tar.bz2",

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -480,7 +480,7 @@ variables by their binary representation, e.g.:</p>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/garry.data">garry.data</a> - modified README.md for input to program</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/try.alt.sh">try.alt.sh</a> - script to try alternate code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/try.sh">try.sh</a> - script to try entry</li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/garry.fmt.c">garry.fmt.c</a> - unobfuscated and formatted source code</li>
+<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/garry.fmt.c">garry.fmt.c</a> - author provided unobfuscated and formatted source code</li>
 </ul>
 <h2 id="secondary-files">Secondary files</h2>
 <ul>

--- a/1995/index.html
+++ b/1995/index.html
@@ -432,7 +432,8 @@ Also include anything else that you would like to see in future contests.
 See <a href="../contact.html">How to contact the IOCCC</a> for how to provide
 us with your comments and suggestions today.</p>
 <p>For those who appreciate a bit of Internet history, this is how
-people used to contact the IOCCC in this given year:</p>
+people used to contact the IOCCC in this given year, via <a href="https://en.wikipedia.org/wiki/UUCP#Mail_routing">Unix to Unix CoPy
+(UUCP)</a>:</p>
 <blockquote>
 <p>…!{sun,pacbell,uunet,pyramid}!hoptoad!judges<br>
 judges@toad.com</p>

--- a/bin/quick-readme2index.sh
+++ b/bin/quick-readme2index.sh
@@ -524,7 +524,7 @@ fi
 
 # determine if we need to run the tool
 #
-# If the non-empty index.html is newer than the .entry.json file,
+# Check if the non-empty index.html is newer than the .entry.json file.
 #
 if [[ $V_FLAG -ge 5 ]]; then
     echo "$0: debug[5]: listing of important files, if they exist, starts below" 1>&2

--- a/bugs.html
+++ b/bugs.html
@@ -1362,15 +1362,19 @@ there.</p>
 <h3 id="source-code-1994ldbldb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">1994/ldb/ldb.c</a></h3>
 <h3 id="information-1994ldbindex.html">Information: <a href="1994/ldb/index.html">1994/ldb/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this to compile
-with modern systems but the entry also used <code>gets()</code> which in some systems would
+with modern systems but the entry also used <code>gets(3)</code> which in some systems would
 print out a warning along with the output of the program. Naturally it could
-also overflow long lines. Cody changed it to <code>fgets()</code> to prevent the display
-problem but this introduces another problem namely that newlines can be printed
-if the line length &lt; 231.</p>
+also overflow long lines, of which there are many, though that is more
+considered a feature, not a bug, as it was documented by the author.</p>
+<p>Cody changed it to <code>fgets(3)</code> to prevent the display problem but this introduces
+another problem namely that newlines can be printed if the line length &lt; 231.</p>
 <p>This seems like a worthy compromise to not have messed up output and although it
-would be ideal for it to never print a newline unless that’s the line itself it
-might be tampering too much with the entry as it’s not a real problem and as a
-one liner it’s already quite long.</p>
+would be ideal for it to never print a newline (unless that’s the line itself)
+it might be tampering too much with the entry to fix this problem, as it’s not a
+real problem and as a one liner it’s already quite long.</p>
+<p>See the
+FAQ on “<a href="faq.html#gets">gets and fgets</a>”
+for more information on the change to <code>fgets(3)</code>.</p>
 <div id="1994_schnitzi">
 <h2 id="schnitzi-1">1994/schnitzi</h2>
 </div>
@@ -1391,16 +1395,15 @@ index.html file it might prove possible to get it to use <code>fgets(3)</code>. 
 writing this on 02 November 2023, only just noticed the author’s remarks and
 will later on look at this if nobody takes up the challenge. More important work
 like getting to a place that the next contest can run must be done first.</p>
-<p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> explains the magic of
-how this entry works, which will be necessary if this entry is to be fixed,
-below.</p>
+<p>Cody explains the magic of how this entry works, which will be necessary if this
+entry is to be fixed, below.</p>
 <p>You might wish to run the command:</p>
 <pre><code>    make diff_orig_prog</code></pre>
 <p>to see what had to change for the buffer size, when looking at the below.
 Furthermore you will want to look at:</p>
 <pre><code>    diff schnitzi.alt.c schnitzi.alt2.c</code></pre>
-<p>as the <code>fgets()</code> version can compile it just can’t generate compilable code (let
-alone using <code>fgets()</code>) when fed itself (to reiterate, just changing the call to
+<p>as the <code>fgets(3)</code> version can compile it just can’t generate compilable code (let
+alone using <code>fgets(3)</code>) when fed itself (to reiterate, just changing the call to
 <code>fgets(3)</code> does not mean it can compile and there’s a further problem in that
 <code>fgets(3)</code> retains the newline whereas <code>gets(3)</code> does not). Nevertheless looking
 at these commands will be of help to understand how it works.</p>
@@ -1413,11 +1416,12 @@ output, when changed to <code>fgets()</code> failed to compile and it also used 
 and these are the bugs here.</p>
 <p>The buffer size, when using <code>gets()</code> is still the same but as noted above the
 original code has had a buffer size increase.</p>
-<p>The real problem is with formatting the code. Take a look at the interesting
-comment as well as the <code>int r=0,x,y=0</code> at the top of the file. If you look at
-each column go down that column you can see how it spells out the code! For
-instance the first column looks like:</p>
-<pre><code>    i
+<p>The real problem is with formatting the code. Take a look at the <code>#include &lt;stdio.h&gt;</code>, <code>int r=0,x,y=0</code> and the interesting comment below it, at the top of
+the file.</p>
+<p>If you look at each column and go down that column you can see how it spells out
+the code! For instance the first column looks like:</p>
+<pre><code>    #
+    i
     n
     c
     l
@@ -1436,7 +1440,6 @@ instance the first column looks like:</p>
     &gt;</code></pre>
 <p>If you join the lines you end up with:</p>
 <pre><code>    #include &lt;stdio.h&gt;</code></pre>
-<p>(well, you get <code>include &lt;stdio.h&gt;</code> but it ends up as <code>#include &lt;stdio.h&gt;</code>.)</p>
 <p>If you look at column 25 which is the end of the word ‘mh111’ and you go down to
 the next row you’ll see a 0 and if you go one row down another 0. This is the
 buffer size, 100, for <code>u</code>! The column to the left is the same for the <code>t</code>
@@ -1446,10 +1449,10 @@ provide the correct input in comments or possibly by rearranging some of the
 code (this was actually required to make the generated code compile at all when
 changing the buffer size, see below).</p>
 <h3 id="important-points">Important points:</h3>
-<p>Getting this entry to use <code>fgets()</code> is easy but the problem is you’re supposed
+<p>Getting this entry to use <code>fgets(3)</code> is easy but the problem is you’re supposed
 to be able to feed the source to the program and the output of that will be
 compilable. It however will create compiler errors. So it’s not just changing
-the code to get it to use fgets()! I (Cody) already did this before I noticed
+the code to get it to use <code>fgets(3)</code>! I (Cody) already did this before I noticed
 the other part which is why I rolled that part back. I did increase the buffer
 size but that only works on the original source.</p>
 <p>To say just how sensitive this entry is: even a space, lack of space or a
@@ -1466,32 +1469,31 @@ compiled!</p>
 <h3 id="information-1994shapiroindex.html">Information: <a href="1994/shapiro/index.html">1994/shapiro/index.html</a></h3>
 <p>This program will likely crash if the source code file (by the name of the file
 that’s compiled) cannot be opened in the directory it is run from.</p>
-<h3 id="status-missing-file---please-provide-it">STATUS: missing file - please provide it</h3>
-<p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> noted that the
-index.html file refers to an alternative version of the code that is not
-obfuscated but it is missing from the entry directory and the archive. Do you
-have this file?</p>
-<p>We would be grateful if you could provide it to us. If you can provide this
-file you might consider removing this entry from this file as well but if not
-we’ll take care of it.</p>
 <h3 id="important-reminder-and-a-note-about-the--1-value-check-for-getc">Important reminder and a note about the <code>-1</code> value check for <code>getc()</code>:</h3>
-<p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the code to not
-use <code>-1</code> for the return value of <code>getc()</code>; this is important because <code>EOF</code> is
-<strong>NOT</strong> guaranteed to be <code>-1</code> but rather any negative value. On systems where
-<code>EOF != -1</code> the program would enter an infinite loop until the program crashed,
-by chance reads a <code>-1</code> or was killed (it is for this same reason that one should
-not use <code>EOF</code> for the <code>getopt()</code> functions as they return <code>-1</code> when all options
-are parsed (for details on the definition of <code>EOF</code> see <code>7.21 Input/output&lt;stdio.h&gt;</code> subsection 1 of the standard)).</p>
+<p>Cody fixed the code to not use <code>-1</code> for the return value of <code>getc()</code>; this is
+important because <code>EOF</code> is <strong>NOT</strong> guaranteed to be <code>-1</code> but rather any negative
+value. On systems where <code>EOF != -1</code> the program would enter an infinite loop
+until the program crashed, by chance reads a <code>-1</code> or was killed (it is for this
+same reason that one should not use <code>EOF</code> for the <code>getopt()</code> functions as they
+return <code>-1</code> when all options are parsed (for details on the definition of <code>EOF</code>
+see <code>7.21 Input/output&lt;stdio.h&gt;</code> subsection 1 of the standard)).</p>
 <p>An interesting problem occurred where changing the <code>-1</code> to <code>EOF</code> caused both
 <code>warning: illegal character encoding in string literal</code> and <code>error: source file is not valid UTF-8</code>. But since <code>EOF</code> is simply an int &lt; 0 and making the loop
 condition check that the return value is &gt;= 0 does not cause a compilation error
 and it functions correctly it will address the systems where <code>EOF != -1</code> just as
 if it checked for <code>!= EOF</code>.</p>
 <p>Since it works there is no need to fix this except for a challenge to yourself.</p>
+<h3 id="status-missing-file---please-provide-it">STATUS: missing file - please provide it</h3>
+<p>The index.html file refers to an alternate version of the code that is not
+obfuscated but it is missing from the entry directory and the archive. Do you
+have this file?</p>
+<p>We would be grateful if you could provide it to us. If you can provide this
+file you might consider removing this status from this file as well but if not
+we’ll take care of it.</p>
 <div id="1994_tvr">
 <h2 id="tvr">1994/tvr</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-5">STATUS: known bug - please help us fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994tvrtvr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.c">1994/tvr/tvr.c</a></h3>
 <h3 id="information-1994tvrindex.html">Information: <a href="1994/tvr/index.html">1994/tvr/index.html</a></h3>
 <p>The judges said the following in their remarks:</p>
@@ -1500,8 +1502,9 @@ if it checked for <code>!= EOF</code>.</p>
 Mandelbrot/Julian sets correctly. Can you find the bug? Better still, can you
 fix it without breaking something else?</p>
 </blockquote>
-<p>You are welcome to try and fix it and open a pull request, providing that it
-doesn’t break something else.</p>
+<p>However, the author stated that this is a feature so this should not be fixed.
+See also the other <a href="1994/tvr/index.html#bugs">bugs</a> the author mentioned that,
+as documented, are considered features.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1995">
 <h1 id="section-11">1995</h1>
@@ -1510,7 +1513,7 @@ doesn’t break something else.</p>
 <div id="1995_cdua">
 <h2 id="cdua">1995/cdua</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995cduacdua.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">1995/cdua/cdua.c</a></h3>
 <h3 id="information-1995cduaindex.html">Information: <a href="1995/cdua/index.html">1995/cdua/index.html</a></h3>
 <p>This did not originally compile under macOS and after it did compile under
@@ -1524,7 +1527,7 @@ it calls <code>getchar()</code> via the pointer <code>m</code>. So this is a fea
 <div id="1995_leo">
 <h2 id="leo">1995/leo</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-6">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-5">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1995leoleo.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/leo/leo.c">1995/leo/leo.c</a></h3>
 <h3 id="information-1995leoindex.html">Information: <a href="1995/leo/index.html">1995/leo/index.html</a></h3>
 <p>The judges suggested that the following commands should result in output:</p>
@@ -1542,7 +1545,7 @@ it would be good if it was fixed.</p>
 <div id="1995_savastio">
 <h2 id="savastio">1995/savastio</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995savastiosavastio.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">1995/savastio/savastio.c</a></h3>
 <h3 id="information-1995savastioindex.html">Information: <a href="1995/savastio/index.html">1995/savastio/index.html</a></h3>
 <p>This program expects a POSITIVE number. If you specify a negative number it will
@@ -1607,7 +1610,7 @@ almost be done except that some of the output of the
 <div id="1996_jonth">
 <h2 id="jonth">1996/jonth</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1996jonthjonth.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">1996/jonth/jonth.c</a></h3>
 <h3 id="information-1996jonthindex.html">Information: <a href="1996/jonth/index.html">1996/jonth/index.html</a></h3>
 <p>If X is not running this program will very likely crash or do something funny.
@@ -1650,7 +1653,7 @@ to the page as well! You’ll have IOCCC fame for reviving a pootifier! :-)</p>
 <div id="1998_schnitzi">
 <h2 id="schnitzi-2">1998/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">1998/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1998schnitziindex.html">Information: <a href="1998/schnitzi/index.html">1998/schnitzi/index.html</a></h3>
 <p>A point worth considering is that as the number passed into the program gets
@@ -1677,7 +1680,7 @@ is in the index.html file as something to try and ponder.</p>
 <div id="2000_dlowe">
 <h2 id="dlowe-1">2000/dlowe</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-7">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-6">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2000dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe/dlowe.c">2000/dlowe/dlowe.c</a></h3>
 <h3 id="information-2000dloweindex.html">Information: <a href="2000/dlowe/index.html">2000/dlowe/index.html</a></h3>
 <p>The author gives an example command:</p>
@@ -1807,7 +1810,7 @@ on the stack at that point:</p>
     5</code></pre>
 <p>which might (?) suggest that the <code>+</code> operator is unimplemented. Unfortunately it
 has been many years since I have used perl and I was never a guru either.</p>
-<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states that in perl &lt; 5.6.0 there is a bug with a core dump in what
 they said is in <code>Perl_sv_upgrade</code>. As this is documented it is not considered a
 bug to be fixed. For the curious this will crash in macOS. Cody notes that the
@@ -1849,7 +1852,7 @@ of 92 warnings! Nonetheless neither works okay and both crash.</p>
 <div id="2000_primenum">
 <h2 id="primenum">2000/primenum</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000primenumprimenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/primenum.c">2000/primenum/primenum.c</a></h3>
 <h3 id="information-2000primenumindex.html">Information: <a href="2000/primenum/index.html">2000/primenum/index.html</a></h3>
 <p>This program does not do what you might think it does! Running it like:</p>
@@ -1867,7 +1870,7 @@ make a pull request.</p>
 <div id="2000_rince">
 <h2 id="rince-1">2000/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/rince.c">2000/rince/rince.c</a></h3>
 <h3 id="information-2000rinceindex.html">Information: <a href="2000/rince/index.html">2000/rince/index.html</a></h3>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash, do something strange
@@ -1881,7 +1884,7 @@ fire</a>! :-) ).</p>
 <div id="2001_anonymous">
 <h2 id="anonymous">2001/anonymous</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001anonymousanonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.c">2001/anonymous/anonymous.c</a></h3>
 <h3 id="information-2001anonymousindex.html">Information: <a href="2001/anonymous/index.html">2001/anonymous/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this so that it
@@ -1900,7 +1903,7 @@ elves of Imladris :-(</p>
 <div id="2001_bellard">
 <h2 id="bellard">2001/bellard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
@@ -1949,14 +1952,14 @@ before the fixes there.</p>
 <div id="2001_cheong">
 <h2 id="cheong">2001/cheong</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
 <h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
 <p>This program will crash without an arg.</p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
@@ -1968,7 +1971,7 @@ before the fixes there.</p>
 <h3 id="information-2001herrmann1index.html">Information: <a href="2001/herrmann1/index.html">2001/herrmann1/index.html</a></h3>
 <p>The author referred to the file <code>herrmann1.turing</code> but it does not exist not even
 in the archive. Do you have a copy? Please provide it!</p>
-<h3 id="status-known-bug---please-help-us-fix-8">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-7">STATUS: known bug - please help us fix</h3>
 <p>There is also a bug in part. During compilation you’re supposed to see some
 animation but this does not seem to work with modern gcc versions. It appears
 that version 2.95 works but maybe others do as well. Do you have a fix? We would
@@ -1977,7 +1980,7 @@ appreciate your help!</p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
 <p>Sometimes when one player presses <code>q</code> it will result in broken pipe on the other
@@ -1995,7 +1998,7 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
 <div id="2001_ollinger">
 <h2 id="ollinger">2001/ollinger</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
 <h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
 <p>This program will very likely crash or do something unexpected if you do not
@@ -2011,7 +2014,7 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
@@ -2044,7 +2047,7 @@ it? Please provide it!</p>
 <div id="2001_williams">
 <h2 id="williams">2001/williams</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-9">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-8">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2001williamswilliams.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/williams/williams.c">2001/williams/williams.c</a></h3>
 <h3 id="information-2001williamsindex.html">Information: <a href="2001/williams/index.html">2001/williams/index.html</a></h3>
 <p>There seem to be a couple bugs at least in this entry. The first one is that
@@ -2179,13 +2182,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2210,7 +2213,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2223,7 +2226,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2237,7 +2240,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2246,7 +2249,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2280,7 +2283,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2294,7 +2297,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2335,7 +2338,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2344,7 +2347,7 @@ with possibly corrupt GIF files.</p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
@@ -2363,12 +2366,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
@@ -2376,7 +2379,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2393,7 +2396,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2440,7 +2443,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2463,7 +2466,7 @@ bins at the edges.</p>
 instead being something else entirely. The Internet Wayback Machine, although it
 archived it, did not load scripts. Do you know if the domain was moved? Do you
 have an archive or mirror? Please provide us it! Thank you.</p>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2475,7 +2478,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2485,7 +2488,7 @@ remarks</a> instead.</p>
 <div id="2011_konno">
 <h2 id="konno">2011/konno</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011konnokonno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/konno.c">2011/konno/konno.c</a></h3>
 <h3 id="information-2011konnoindex.html">Information: <a href="2011/konno/index.html">2011/konno/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
@@ -2654,7 +2657,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2668,7 +2671,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2677,7 +2680,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2710,7 +2713,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2724,7 +2727,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2745,7 +2748,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2761,7 +2764,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2781,7 +2784,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2800,7 +2803,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2816,7 +2819,7 @@ used.</li>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2829,14 +2832,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2844,7 +2847,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2861,7 +2864,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2885,14 +2888,14 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
 <div id="2014_vik">
 <h2 id="vik-2">2014/vik</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-10">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-9">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2014vikprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/prog.c">2014/vik/prog.c</a></h3>
 <h3 id="information-2014vikindex.html">Information: <a href="2014/vik/index.html">2014/vik/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> discovered a bug to do
@@ -2926,7 +2929,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2951,7 +2954,7 @@ result. Error messages become garbled, though.</p></li>
 <div id="2015_howe">
 <h2 id="howe">2015/howe</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-11">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-10">STATUS: known bug - please help us fix</h3>
 <p>The test scripts do not seem to work properly with bash but this would be ideal
 as not all systems have a compatible shell (they assume a POSIX compliant
 shell). One, with bash, might see:</p>
@@ -2970,7 +2973,7 @@ because it is the same thing as the other, just updated to use <code>prog.alt</c
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2979,7 +2982,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -3012,7 +3015,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -3031,7 +3034,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -3046,7 +3049,7 @@ fixing the syntax error in the generated <code>ioccc.json</code> file.</p>
 <div id="2018_mills">
 <h2 id="mills-1">2018/mills</h2>
 </div>
-<h3 id="status-known-bug---please-help-us-fix-12">STATUS: known bug - please help us fix</h3>
+<h3 id="status-known-bug---please-help-us-fix-11">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2018millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/mills/prog.c">2018/mills/prog.c</a></h3>
 <h3 id="information-2018millsindex.html">Information: <a href="2018/mills/index.html">2018/mills/index.html</a></h3>
 <p>After exiting the program (with ctrl-e) if you try running it again you will
@@ -3056,7 +3059,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -3071,7 +3074,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3121,7 +3124,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3129,7 +3132,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3137,7 +3140,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3169,7 +3172,7 @@ ideal if this was not the case.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3198,7 +3201,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3206,7 +3209,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3236,7 +3239,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3246,7 +3249,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3266,7 +3269,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3275,7 +3278,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3290,7 +3293,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3301,7 +3304,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3315,7 +3318,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3325,7 +3328,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3334,7 +3337,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-95">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -1395,16 +1395,22 @@ there.
 ### Information: [1994/ldb/index.html](1994/ldb/index.html)
 
 [Cody Boone Ferguson](authors.html#Cody_Boone_Ferguson) fixed this to compile
-with modern systems but the entry also used `gets()` which in some systems would
+with modern systems but the entry also used `gets(3)` which in some systems would
 print out a warning along with the output of the program. Naturally it could
-also overflow long lines.  Cody changed it to `fgets()` to prevent the display
-problem but this introduces another problem namely that newlines can be printed
-if the line length < 231.
+also overflow long lines, of which there are many, though that is more
+considered a feature, not a bug, as it was documented by the author.
+
+Cody changed it to `fgets(3)` to prevent the display problem but this introduces
+another problem namely that newlines can be printed if the line length < 231.
 
 This seems like a worthy compromise to not have messed up output and although it
-would be ideal for it to never print a newline unless that's the line itself it
-might be tampering too much with the entry as it's not a real problem and as a
-one liner it's already quite long.
+would be ideal for it to never print a newline (unless that's the line itself)
+it might be tampering too much with the entry to fix this problem, as it's not a
+real problem and as a one liner it's already quite long.
+
+See the
+FAQ on "[gets and fgets](faq.html#gets)"
+for more information on the change to `fgets(3)`.
 
 
 <div id="1994_schnitzi">
@@ -1433,9 +1439,8 @@ writing this on 02 November 2023, only just noticed the author's remarks and
 will later on look at this if nobody takes up the challenge. More important work
 like getting to a place that the next contest can run must be done first.
 
-[Cody Boone Ferguson](authors.html#Cody_Boone_Ferguson) explains the magic of
-how this entry works, which will be necessary if this entry is to be fixed,
-below.
+Cody explains the magic of how this entry works, which will be necessary if this
+entry is to be fixed, below.
 
 You might wish to run the command:
 
@@ -1451,8 +1456,8 @@ Furthermore you will want to look at:
     diff schnitzi.alt.c schnitzi.alt2.c
 ```
 
-as the `fgets()` version can compile it just can't generate compilable code (let
-alone using `fgets()`) when fed itself (to reiterate, just changing the call to
+as the `fgets(3)` version can compile it just can't generate compilable code (let
+alone using `fgets(3)`) when fed itself (to reiterate, just changing the call to
 `fgets(3)` does not mean it can compile and there's a further problem in that
 `fgets(3)` retains the newline whereas `gets(3)` does not). Nevertheless looking
 at these commands will be of help to understand how it works.
@@ -1470,13 +1475,16 @@ and these are the bugs here.
 The buffer size, when using `gets()` is still the same but as noted above the
 original code has had a buffer size increase.
 
-The real problem is with formatting the code. Take a look at the interesting
-comment as well as the `int r=0,x,y=0` at the top of the file. If you look at
-each column go down that column you can see how it spells out the code! For
-instance the first column looks like:
+The real problem is with formatting the code. Take a look at the `#include
+<stdio.h>`, `int r=0,x,y=0` and the interesting comment below it, at the top of
+the file.
+
+If you look at each column and go down that column you can see how it spells out
+the code! For instance the first column looks like:
 
 
 ```
+    #
     i
     n
     c
@@ -1503,8 +1511,6 @@ If you join the lines you end up with:
     #include <stdio.h>
 ```
 
-(well, you get `include <stdio.h>` but it ends up as `#include <stdio.h>`.)
-
 If you look at column 25 which is the end of the word 'mh111' and you go down to
 the next row you'll see a 0 and if you go one row down another 0. This is the
 buffer size, 100, for `u`! The column to the left is the same for the `t`
@@ -1517,10 +1523,10 @@ changing the buffer size, see below).
 
 ### Important points:
 
-Getting this entry to use `fgets()` is easy but the problem is you're supposed
+Getting this entry to use `fgets(3)` is easy but the problem is you're supposed
 to be able to feed the source to the program and the output of that will be
 compilable. It however will create compiler errors. So it's not just changing
-the code to get it to use fgets()! I (Cody) already did this before I noticed
+the code to get it to use `fgets(3)`! I (Cody) already did this before I noticed
 the other part which is why I rolled that part back. I did increase the buffer
 size but that only works on the original source.
 
@@ -1547,29 +1553,15 @@ compiled!
 This program will likely crash if the source code file (by the name of the file
 that's compiled) cannot be opened in the directory it is run from.
 
-
-### STATUS: missing file - please provide it
-
-[Cody Boone Ferguson](authors.html#Cody_Boone_Ferguson) noted that the
-index.html file refers to an alternative version of the code that is not
-obfuscated but it is missing from the entry directory and the archive. Do you
-have this file?
-
-We would be grateful if you could provide it to us.  If you can provide this
-file you might consider removing this entry from this file as well but if not
-we'll take care of it.
-
 ### Important reminder and a note about the `-1` value check for `getc()`:
 
-[Cody Boone Ferguson](authors.html#Cody_Boone_Ferguson) fixed the code to not
-use `-1` for the return value of `getc()`; this is important because `EOF` is
-**NOT** guaranteed to be `-1` but rather any negative value. On systems where
-`EOF != -1` the program would enter an infinite loop until the program crashed,
-by chance reads a `-1` or was killed (it is for this same reason that one should
-not use `EOF` for the `getopt()` functions as they return `-1` when all options
-are parsed (for details on the definition of `EOF` see `7.21
-Input/output<stdio.h>` subsection 1 of the standard)).
-
+Cody fixed the code to not use `-1` for the return value of `getc()`; this is
+important because `EOF` is **NOT** guaranteed to be `-1` but rather any negative
+value. On systems where `EOF != -1` the program would enter an infinite loop
+until the program crashed, by chance reads a `-1` or was killed (it is for this
+same reason that one should not use `EOF` for the `getopt()` functions as they
+return `-1` when all options are parsed (for details on the definition of `EOF`
+see `7.21 Input/output<stdio.h>` subsection 1 of the standard)).
 
 An interesting problem occurred where changing the `-1` to `EOF` caused both
 `warning: illegal character encoding in string literal` and `error: source file
@@ -1581,11 +1573,22 @@ if it checked for `!= EOF`.
 Since it works there is no need to fix this except for a challenge to yourself.
 
 
+### STATUS: missing file - please provide it
+
+The index.html file refers to an alternate version of the code that is not
+obfuscated but it is missing from the entry directory and the archive. Do you
+have this file?
+
+We would be grateful if you could provide it to us.  If you can provide this
+file you might consider removing this status from this file as well but if not
+we'll take care of it.
+
+
 <div id="1994_tvr">
 ## 1994/tvr
 </div>
 
-### STATUS: known bug - please help us fix
+### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1994/tvr/tvr.c](%%REPO_URL%%/1994/tvr/tvr.c)
 ### Information: [1994/tvr/index.html](1994/tvr/index.html)
 
@@ -1597,8 +1600,9 @@ The judges said the following in their remarks:
 Mandelbrot/Julian sets correctly.  Can you find the bug?  Better still, can you
 fix it without breaking something else?
 
-You are welcome to try and fix it and open a pull request, providing that it
-doesn't break something else.
+However, the author stated that this is a feature so this should not be fixed.
+See also the other [bugs](1994/tvr/index.html#bugs) the author mentioned that,
+as documented, are considered features.
 
 
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/markdown.html
+++ b/markdown.html
@@ -388,7 +388,9 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: markdown.md -->
+<div id="guidelines">
 <h1 id="ioccc-markdown-guidelines">IOCCC markdown guidelines</h1>
+</div>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
 For example, when submitting to the IOCCC
 we have people
@@ -406,7 +408,11 @@ Some of these relate to use of markdown directly and others relate to injecting 
 into the markdown file.</p>
 <p>In particular there are things we ask people to please <strong>NOT</strong> use in
 markdown files for the IOCCC:</p>
-<h2 id="please-do-not-use-name-attributes-in-html-a-..-hyperlink-elements">Please do NOT use name attributes in HTML <code>&lt;a ..&gt;</code> hyperlink elements</h2>
+<div id="name">
+<div id="anchor-name">
+<h2 id="please-do-not-use-the-name-attributes-in-html-a...a-hyperlink-elements">Please do NOT use the <code>name</code> attributes in HTML <code>&lt;a&gt;...&lt;/a&gt;</code> hyperlink elements</h2>
+</div>
+</div>
 <p>Please do <strong>NOT</strong> use the HTML construct:</p>
 <pre><code>    &lt;a name=&quot;string&quot;&gt;...&lt;/a&gt;                                  &lt;=== no thank you</code></pre>
 <p>as those are <strong>NOT</strong> part of the HTML 5 standard.</p>
@@ -416,43 +422,71 @@ markdown files for the IOCCC:</p>
 encapsulates the HTML you want to name: i.e., the target of some
 <code>&lt;a href="#string"&gt;</code> or some other <code>&lt;a href="URL#string"&gt;</code>
 for the given page URL.</p>
-<p>There are certain HTML Elements that cannot have internal <code>&lt;div id="string"&gt;...&lt;/div&gt;</code>.</p>
-<p>For example:</p>
+<h3 id="important-point">IMPORTANT POINT:</h3>
+<p>There are certain markdown constructs that <strong>CANNOT</strong> have an <strong>internal</strong> <code>&lt;div id="string"&gt;...&lt;/div&gt;</code> element.</p>
+<p>An example is headings (lines that start with a <code>#</code>). For example:</p>
 <pre><code>    # &lt;div id=&quot;string&quot;&gt;THIS WILL NOT WORK!&lt;/div&gt;              &lt;=== this will not work</code></pre>
-<p>For things like headings, you have to surround them, as in:</p>
+<p>For things like headings, you have to surround them with the <code>&lt;div id="string"&gt;...&lt;/div&gt;</code> element, as in:</p>
 <pre><code>    &lt;div id=&quot;string&quot;&gt;
     # This will work
     &lt;/div&gt;</code></pre>
-<p>While some browsers will still recognize the HTML construct <code>&lt;a name="string"&gt;...&lt;/a&gt;</code>, it is possible they might NOT in the future.</p>
+<p>While some browsers will still recognize the HTML construct <code>&lt;a name="string"&gt;...&lt;/a&gt;</code>, it is possible <strong>they MIGHT NOT</strong> in the future.</p>
+<div id="links">
+<h2 id="if-you-can-it-is-preferable-to-use-markdown-links-rather-than-a...a">If you can, it is PREFERABLE to use markdown links rather than <code>&lt;a&gt;...&lt;/a&gt;</code></h2>
+</div>
+<p>It is easier and preferred to use markdown links rather than HTML <code>&lt;a&gt;..&lt;/a&gt;</code>
+anchors.</p>
+<p>Instead of:</p>
+<pre><code>    Use of &lt;a href=&quot;#links&gt;HTML anchors&lt;/a&gt;
+            is one option, however ...</code></pre>
+<pre><code>    [markdown links](#links) are easier and preferred</code></pre>
+<div id="strike">
+<div id="del">
 <h2 id="please-do-not-use-the-strike-or-the-s-html-element">Please do NOT use the <code>&lt;strike&gt;</code> or the <code>&lt;s&gt;</code> HTML element</h2>
-<p>Please do NOT use the obsolete <code>&lt;strike&gt;</code> or the obsolete <code>&lt;s&gt;</code> (<del><em>strikeout</em></del>) HTML elements:</p>
+</div>
+</div>
+<p>Please do <strong>NOT</strong> use the obsolete <code>&lt;strike&gt;</code> or the obsolete <code>&lt;s&gt;</code>
+(<del><strong>strikeout</strong></del>) HTML elements:</p>
 <pre><code>    &lt;strike&gt;...&lt;/strike&gt;                                      &lt;=== no thank you
     &lt;s&gt;...&lt;/s&gt;                                                &lt;=== no thank you</code></pre>
 <p>Use instead:</p>
 <pre><code>    &lt;del&gt;...&lt;/del&gt;</code></pre>
+<div id="underline">
+<div id="ins">
 <h2 id="please-do-not-use-the-u-html-element">Please do NOT use the <code>&lt;u&gt;</code> HTML element</h2>
-<p>Please NOT use the obsolete <code>&lt;u&gt;</code> (<ins><em>underline</em></ins>) HTML element:</p>
+</div>
+</div>
+<p>Please <strong>NOT</strong> use the obsolete <code>&lt;u&gt;</code> (<ins><em>underline</em></ins>) HTML element:</p>
 <pre><code>    &lt;u&gt;...&lt;/u&gt;                                                &lt;=== no thank you</code></pre>
 <p>Use instead:</p>
 <pre><code>    &lt;ins&gt;...&lt;/ins&gt;</code></pre>
+<div id="tt">
+<div id="span">
 <h2 id="please-do-not-use-the-tt-html-element">Please do NOT use the <code>&lt;tt&gt;</code> HTML element</h2>
-<p>Please do <strong>NOT</strong> use the obsolete <code>&lt;tt&gt;</code> (<span style="font-family: monospace;"><em>teletype</em></span>) HTML element:</p>
-<pre><code>    &lt;tt&gt;The obsolete tt element is obsolete&lt;/tt&gt;              &lt;=== no thank you</code></pre>
-<p>Instead use either a monospaced span:</p>
+</div>
+</div>
+<p>Please do <strong>NOT</strong> use the obsolete <code>&lt;tt&gt;</code>
+(<span style="font-family: monospace;"><strong>teletype</strong></span>) HTML element:</p>
+<pre><code>    &lt;tt&gt;The tt element is obsolete&lt;/tt&gt;              &lt;=== no thank you</code></pre>
+<p>Instead use either a monospaced <code>&lt;span&gt;</code> or an inline markdown code block:</p>
 <pre><code>    &lt;span style=&quot;font-family: monospace;&quot;&gt;Use of a monospaced font
                                           is one option,
                                           however ... &lt;/span&gt;</code></pre>
 <p>We recommend using the inline markdown code block method instead:</p>
-<pre><code>    Using the `inline markdown code block` is easier and is `preferred`.</code></pre>
+<pre><code>    Using the `inline markdown code block` is easier and is **preferred**.</code></pre>
+<div id="unindented">
+<div id="indented">
 <h2 id="please-do-not-use-unindented-code-blocks">Please do NOT use unindented code blocks</h2>
-<p>Please do <strong>NOT</strong> start code blocks at the left-hand edge.</p>
+</div>
+</div>
+<p>Please do <strong>NOT</strong> start code blocks at the first column.</p>
 <p>For example:</p>
-<pre><code>``` &lt;!---sh--&gt;
-echo &quot;This code block is NOT indented\&quot;                       &lt;=== no thank you
+<pre class="&lt;!---markdown--&gt;"><code>``` &lt;!---sh--&gt;
+echo &quot;This code block is NOT indented&quot;                       &lt;=== no thank you
 ```</code></pre>
-<p>We request that you indent the code block by multiples of 4 ASCII spaces:</p>
-<pre><code>``` &lt;!---sh--&gt;
-    echo &quot;This code block is intended by mutiples of 4 spaces&quot;
+<p>We request that you indent the code block by multiples of 4 ASCII <strong>SPACES</strong>:</p>
+<pre class="&lt;!---markdown--&gt;"><code>``` &lt;!---sh--&gt;
+    echo &quot;This code block is indented by mutiples of 4 spaces&quot;
 
     # The top level starts with a 4 ASCII space indent.
     #
@@ -462,19 +496,23 @@ echo &quot;This code block is NOT indented\&quot;                       &lt;=== 
                 # etc.
 ```</code></pre>
 <p>Moreover:</p>
-<pre><code>```
+<pre class="&lt;!---markdown--&gt;"><code>```
     The same thing applies to any markdown block surrounded by ``` lines.
 ```</code></pre>
 <p>Please do <strong>NOT</strong> indent using ASCII tab characters in markdown files.</p>
+<div id="tabs">
+<div id="spaces">
 <h2 id="please-do-not-use-ascii-tabs-in-markdown-files">Please do NOT use ASCII tabs in markdown files</h2>
+</div>
+</div>
 <p>While we have nothing against the ASCII tab character in general,
 we have discovered that ASCII tab characters create problems when
 used as part of the leading whitespace within a markdown file.</p>
 <p>If you need to indent 2 or more levels, use multiples of 4 ASCII
-spaces. Please do <strong>NOT</strong> indent with ASCII tabs, <strong>NOR</strong> use any
+<strong>SPACES</strong>. Please do <strong>NOT</strong> indent with ASCII tabs, <strong>OR</strong> use any
 ASCII tab characters anywhere inside a markdown file:</p>
 <p>For example:</p>
-<pre><code>```
+<pre class="&lt;!---markdown--&gt;"><code>```
     Please do **NOT**   use ASCII tabs  in markdown files.      &lt;=== no thank you
         Please do **NOT** indent markdown with ASCII tabs.      &lt;=== no thank you
 
@@ -483,7 +521,7 @@ ASCII tab characters anywhere inside a markdown file:</p>
 ```</code></pre>
 <p>And to clarify, we are only talking about markdown files,
 not C code or any other non-markdown content:</p>
-<pre><code>        printf(&quot;Is is fine      to      use tabs in Obfucated C code.\n&quot;);
+<pre class="&lt;!---c--&gt;"><code>        printf(&quot;It is fine      to      use tabs in Obfuscated C code.\n&quot;);
                 /*      if      you     wish    */
 
     // We ask that you to NOT use ASCII tab characters in your remarks.md writeup,
@@ -491,35 +529,67 @@ not C code or any other non-markdown content:</p>
 <p><strong>NOTE</strong>: Again, you are <strong>perfectly welcome</strong> to use ASCII tab characters in
 your C code and other non-markdown files. We simply ask that you <strong>NOT</strong> use any
 ASCII tab characters in markdown files.</p>
-<h2 id="please-do-not-specify-a-language-for-a-code-block">Please do NOT specify a language for a code block</h2>
-<p>We request that (fenced) markdown code blocks <strong>NOT</strong> specify a language.</p>
+<div id="vim-tabs">
+<h3 id="tip-for-vim-users">Tip for <code>vim</code> users</h3>
+</div>
+<p>If you use <code>vim</code> you can put in your <code>.vimrc</code> file (usually <code>~/.vimrc</code>) the
+following settings to make sure the tabs are not put in without you noticing:</p>
+<pre><code>    set tabstop=8               &quot; a tab is 8 spaces (or whatever you wish it to be set to)
+    set softtabstop=4           &quot; ...but when inserting/backspacing use 4 spaces
+    set shiftwidth=4            &quot; ...and auto-indent 4 spaces (when autoindent is set)
+    set expandtab               &quot; ...but don&#39;t expand tab to spaces.</code></pre>
+<p>If you have file type detection enabled you can, if you prefer, have these
+settings set just for markdown files:</p>
+<pre><code>    autocmd! Filetype markdown setlocal set tabstop=8 softtabstop=4 shiftwidth=4 expandtab</code></pre>
+<p>or so.</p>
+<p>This will prevent the tab key from inserting tabs; rather it will insert 4
+spaces.</p>
+<p>To <strong>VERIFY</strong> that there are no tabs in a file you may do, in command mode:</p>
+<pre><code>    /\t</code></pre>
+<p>If you’re in insert mode hit <code>ESC</code> first.</p>
+<div id="languages">
+<div id="code">
+<h2 id="please-do-not-directly-specify-a-language-for-a-code-block">Please do NOT <em>directly</em> specify a language for a code block</h2>
+</div>
+</div>
+<p>We request that <a href="https://www.markdownguide.org/extended-syntax/#fenced-code-blocks">fenced markdown code
+blocks</a>
+<strong>NOT</strong> specify a language directly.</p>
 <p>For example:</p>
-<pre><code>```c                                                            &lt;=== no thank you
+<pre class="&lt;!---markdown--&gt;"><code>```c                                                            &lt;=== no thank you
     int main(void) {return 0;}
 ```</code></pre>
 <p>Instead, put the language inside an HTML comment, separated from the
 markdown code block starting fence by a space:</p>
-<pre><code>``` &lt;!---c--&gt;
+<pre class="&lt;!---markdown--&gt;"><code>``` &lt;!---c--&gt;
     int main(void) {return 0;}
 ```</code></pre>
-<p><strong>IMPORTANT</strong>: The <strong>initial</strong>   <strong>` ` `</strong>   must be followed by an <strong><code>ASCII space</code></strong>,
-then by an <strong>opening</strong> <strong><code>&lt;!---</code></strong>, then by the <strong>language</strong>, then by a <strong>closing</strong> <strong><code>--&gt;</code></strong>.</p>
-<h2 id="please-do-not-add-trailing-slash-to-html-elements">Please do NOT add trailing slash to HTML elements</h2>
+<p><strong>IMPORTANT</strong>: The <strong>initial</strong>   <strong>` ` `</strong>   must be followed by an <strong>ASCII SPACE</strong>,
+and <strong>THEN</strong> an <strong>opening</strong> <strong><code>&lt;!---</code></strong> (a “<code>&lt;</code>”, a “<code>!</code>” and then three “<code>-</code>”s), and
+<strong>THEN</strong> the <strong>language</strong> and <strong>FINALLY</strong> a <strong>closing</strong> “<code>--&gt;</code>” (two “<code>-</code>”s
+followed by a “<code>&gt;</code>”).</p>
+<div id="slash">
+<div id="void">
+<h2 id="please-do-not-add-trailing-slash-to-void-html-elements">Please do NOT add trailing slash to void HTML elements</h2>
+</div>
+</div>
 <p>Please do <strong>NOT</strong> use a trailing slash on <a href="https://github.com/validator/validator/wiki/Markup-»-Void-elements">void HTML
 elements</a>.</p>
 <p>See also this note on <a href="https://github.com/validator/validator/wiki/Markup-»-Void-elements#trailing-slashes-in-void-element-start-tags-do-NOT-mark-the-start-tags-as-self-closing">trailing slashes in void-element start
 tags</a>.</p>
 <p>The trailing slash on void HTML elements has no effect and interacts badly with
 unquoted attribute values.</p>
-<p>For example, please do NOT use:</p>
+<p>For example, please do <strong>NOT</strong> use:</p>
 <pre><code>    &lt;br/&gt;                                                     &lt;=== no thank you</code></pre>
 <p>Instead use just:</p>
 <pre><code>    &lt;br&gt;</code></pre>
-<p>And for example, please do NOT use:</p>
+<p>And for example, please do <strong>NOT</strong> use:</p>
 <pre><code>    &lt;hr/&gt;                                                     &lt;=== no thank you</code></pre>
 <p>Instead use just:</p>
+<pre><code>    &lt;br&gt;</code></pre>
+<p>and</p>
 <pre><code>    &lt;hr&gt;</code></pre>
-<p>And for example, please do NOT use:</p>
+<p>And for example, please do <strong>NOT</strong> use:</p>
 <pre><code>    &lt;img src=&quot;1984-anonymous-tattoo.jpg&quot;
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
      width=600 height=401 /&gt;                                  &lt;=== no thank you</code></pre>
@@ -528,7 +598,11 @@ unquoted attribute values.</p>
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
      width=600 height=401&gt;</code></pre>
 <p>etc.</p>
-<h2 id="please-do-not-use-trailing-backslash-outside-of-a-code-block">Please do NOT use trailing backslash outside of a code block</h2>
+<div id="backslash">
+<div id="br">
+<h2 id="please-do-not-use-a-trailing-backslash-outside-of-a-code-block">Please do NOT use a TRAILING backslash (<code>\</code>) outside of a code block</h2>
+</div>
+</div>
 <p>Unless the line is inside a markdown code block, please do <strong>NOT</strong>
 end a markdown line with a trailing backslash (<code>\</code>). Instead use
 a trailing <code>&lt;br&gt;</code>.</p>
@@ -542,8 +616,9 @@ a trailing <code>&lt;br&gt;</code>.</p>
     use trailing&lt;br&gt;
     br&#39;s outside of&lt;br&gt;
     a code block</code></pre>
-<p>Again, use of a trailing backslash (<code>\</code>) inside a markdown code block is fine:</p>
-<pre><code>```
+<p>Again, use of a trailing backslash (<code>\</code>) inside a markdown <a href="https://www.markdownguide.org/extended-syntax/#fenced-code-blocks"><strong>fenced code
+block</strong></a> is fine:</p>
+<pre class="&lt;!---markdown--&gt;"><code>```
     This is OK\
     inside a\
     markdown code\
@@ -551,11 +626,15 @@ a trailing <code>&lt;br&gt;</code>.</p>
 ```</code></pre>
 <p>This will prevent <code>pandoc(1)</code> from generating deprecated HTML elements such as
 <code>&lt;br /&gt;</code>.</p>
+<div id="images">
+<div id="img">
 <h2 id="please-do-not-use-markdown-style-images">Please do NOT use markdown style images</h2>
+</div>
+</div>
 <p>Please do <strong>NOT</strong> use the markdown embedded image element.</p>
 <p>Instead of using this markdown element to embed an image:</p>
 <pre><code>    ![alt text](filename.png &quot;Title&quot;)                         &lt;=== no thank you</code></pre>
-<p>Use an <code>&lt;img ..&gt;</code> HTML element with <code>alt=</code>, <code>width=</code> and <code>length=</code>
+<p>Use an <code>&lt;img&gt;</code> HTML element with <code>alt=</code>, <code>width=</code> and <code>length=</code>
 attributes:</p>
 <pre><code>    &lt;img src=&quot;filename.png&quot;
      alt=&quot;describe the filename.png image for someone who cannot view it&quot;
@@ -567,40 +646,66 @@ attributes:</p>
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
      width=600 height=401&gt;</code></pre>
 <p>The problem goes beyond the fact that <code>pandoc(1)</code> generates problematic
-HTML from the markdown image construct, the resulting HTML does NOT
+HTML from the markdown image construct, the resulting HTML does <strong>NOT</strong>
 have <code>width</code> and <code>height</code> information so browsers have to slow down
 on rendering text around the image until it can internally determine
 the image size.</p>
+<div id="hr">
+<div id="horizontal">
+<div id="lines">
 <h2 id="please-do-not-use-markdown-style-horizontal-lines">Please do NOT use markdown style horizontal lines</h2>
-<p>Please do <strong>NOT</strong> use <code>**---**</code>-style lines in markdown to create horizontal
+</div>
+</div>
+</div>
+<p>Please do <strong>NOT</strong> use <code>---</code> style lines in markdown to create horizontal
 lines or to separate sections.</p>
-<p>Unless something is inside a markdown code block, do NOT start a
-line with 3 or more dashes (<code>-</code>s).</p>
-<p>Such causes <code>pandoc(1)</code> to generate <code>&lt;hr /&gt;</code>. The <code>&lt;hr /&gt;</code> has no effect in
-standard HTML 5 and interacts badly with unquoted attribute values.</p>
+<p>Unless something is inside a markdown <strong>code block</strong>, do <strong>NOT</strong> start a
+line with 3 or more dashes (“<code>-</code>”s).</p>
+<p>Such markdown causes <code>pandoc(1)</code> to generate <code>&lt;hr /&gt;</code>. The <code>&lt;hr /&gt;</code> has no
+effect in standard HTML 5 and interacts badly with unquoted attribute values.</p>
 <p>If a horizontal line is really needed, use:</p>
 <pre><code>    &lt;hr&gt;</code></pre>
 <p>If a short line is needed, use:</p>
 <pre><code>    &lt;hr style=&quot;width:10%;text-align:left;margin-left:0&quot;&gt;</code></pre>
-<h2 id="please-do-not-end-markdown-links-in">Please do NOT end markdown links in “))”</h2>
-<p>Please do <strong>NOT</strong> end a markdown links with a double closed parenthesis “))”.</p>
-<p>Markdown links that end in “))” complicate parsing and sometimes lead
+<div id="closing-parentheses">
+<h2 id="please-do-not-end-markdown-links-with">Please do NOT end markdown links with “<code>))</code>”</h2>
+</div>
+<p>Please do <strong>NOT</strong> end a markdown links with a double closed parenthesis “<code>))</code>”.</p>
+<p>Markdown links that end in “<code>))</code>” complicate parsing and sometimes lead
 to incorrect URLs or file paths.</p>
 <p>Instead of:</p>
 <pre><code>    [some text](https://example.com/foo_(bar))                &lt;=== no thank you</code></pre>
-<p>Use:</p>
+<p>use:</p>
 <pre><code>    [some text](https://example.com/foo_&amp;#x28;bar&amp;#x29;)</code></pre>
-<p>Instead of:</p>
+<p>As another example, instead of:</p>
 <pre><code>    This thing, ([some text](some/path)), is NOT ideal.       &lt;=== no thank you</code></pre>
-<p>Use:</p>
+<p>use:</p>
 <pre><code>    This thing, [some text](some/path), is better.</code></pre>
-<h2 id="please-do-not-place-text-on-the-next-line-after-a-markdown-code-block">Please do NOT place text on the next line after a markdown code block</h2>
+<div id="parentheses">
+<h2 id="please-do-not-put-a-literal-or-in-markdown-link-titles">Please do NOT put a LITERAL “<code>(</code>” or “<code>)</code>” in markdown link titles</h2>
+</div>
+<p>Please do <strong>NOT</strong> use literal parentheses inside markdown link titles.</p>
+<p>Instead of:</p>
+<pre><code>    [some (text)](https://example.com/cyrds)                  &lt;=== no thank you</code></pre>
+<p>use:</p>
+<pre><code>    [some &amp;#x28;text&amp;#x29;](https://example.com/cyrds)</code></pre>
+<p>Instead of:</p>
+<pre><code>    [ls(1)](https://example.com/ls-man-page.1)                &lt;=== no thank you</code></pre>
+<p>use:</p>
+<pre><code>    [ls&amp;#x28;1&amp;#x29;](https://example.com/ls-man-page.1)</code></pre>
+<div id="code-text">
+<div id="code-and-text">
+<div id="text">
+<h2 id="please-do-not-place-text-on-the-immediate-very-next-line-after-a-markdown-code-block">Please do NOT place text on the IMMEDIATE (very next) line after a markdown code block</h2>
+</div>
+</div>
+</div>
 <p>Please do <strong>NOT</strong> place text on the next line after a markdown code block.
 Instead, place a blank line after the end of a markdown code block
 as this makes it easier to detect when markdown code blocks are
-NOT properly indented.</p>
+<strong>NOT</strong> properly indented.</p>
 <p>Instead of:</p>
-<pre><code>```
+<pre class="&lt;!---markdown--&gt;"><code>```
     int
     main(int foo)
     {
@@ -608,8 +713,8 @@ NOT properly indented.</p>
     }
 ```
 C compilers cannot be given a -Wno-main-arg-errors flag.      &lt;=== no thank you</code></pre>
-<p>Use:</p>
-<pre><code>```
+<p>use:</p>
+<pre class="&lt;!---markdown--&gt;"><code>```
     int
     main(int foo)
     {
@@ -619,16 +724,24 @@ C compilers cannot be given a -Wno-main-arg-errors flag.      &lt;=== no thank y
 
 C compilers cannot be given a -Wno-main-arg-errors flag.</code></pre>
 <p><strong>BTW</strong>: Please note the blank line after the code block.</p>
-<h2 id="please-do-not-put-s-or-s-in-markdown-link-titles">Please do NOT put “(”s or “)”s in markdown link titles</h2>
-<p>Please do <strong>NOT</strong> use literal parentheses inside the markdown link titles.</p>
-<p>Instead of:</p>
-<pre><code>    [some (text)](https://example.com/cyrds)                  &lt;=== no thank you</code></pre>
-<p>Use:</p>
-<pre><code>    [some &amp;#x28;text&amp;#x29;](https://example.com/cyrds)</code></pre>
-<p>Instead of:</p>
-<pre><code>    [ls(1)](https://example.com/ls-man-page.1)                &lt;=== no thank you</code></pre>
-<p>Use:</p>
-<pre><code>    [ls&amp;#x28;1&amp;#x29;](https://example.com/ls-man-page.1)</code></pre>
+<div id="italics">
+<h2 id="please-use-_-for-italics-in-markdown">Please use <code>_</code> for italics in markdown</h2>
+</div>
+<p>Please do <strong>NOT</strong> use <code>*</code> (single asterisk) for italics in markdown. Instead use
+an underscore (<code>_</code>). Using an asterisk can complicate parsing and sometimes lead
+to incorrect results. This can especially go for when it is <strong><em>bold and
+italic</em></strong>.</p>
+<p>For example, instead of:</p>
+<pre><code>     *this text is italic*        &lt;=== no thank you</code></pre>
+<p>use:</p>
+<pre><code>     _this text is italic_</code></pre>
+<p>Another example, for <strong><em>bold italic</em></strong>:</p>
+<p>Do <strong>NOT</strong> use:</p>
+<pre><code>     ***this text is bold italic***         &lt;=== no thank you</code></pre>
+<p>Instead use:</p>
+<pre><code>     **_this text is bold italic_**</code></pre>
+<p>or:</p>
+<pre><code>     _**this text is bold italic**_</code></pre>
 <!-- AFTER: last line of markdown file: markdown.md -->
 
 <!-- END: this line ends content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->

--- a/markdown.md
+++ b/markdown.md
@@ -1,4 +1,6 @@
+<div id="guidelines">
 # IOCCC markdown guidelines
+</div>
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
 For example, when submitting to the IOCCC
@@ -22,11 +24,15 @@ In particular there are things we ask people to please **NOT** use in
 markdown files for the IOCCC:
 
 
-## Please do NOT use name attributes in HTML `<a ..>` hyperlink elements
+<div id="name">
+<div id="anchor-name">
+## Please do NOT use the `name` attributes in HTML `<a>...</a>` hyperlink elements
+</div>
+</div>
 
 Please do **NOT** use the HTML construct:
 
-```
+``` <!---html-->
     <a name="string">...</a>                                  <=== no thank you
 ```
 
@@ -34,7 +40,7 @@ as those are **NOT** part of the HTML 5 standard.
 
 Instead use:
 
-```
+``` <!---html-->
     <div id="string">...</div>
 ```
 
@@ -43,69 +49,108 @@ encapsulates the HTML you want to name: i.e., the target of some
 `<a href="#string">` or some other `<a href="URL#string">`
 for the given page URL.
 
-There are certain HTML Elements that cannot have internal `<div
-id="string">...</div>`.
+### IMPORTANT POINT:
 
-For example:
+There are certain markdown constructs that **CANNOT** have an **internal** `<div
+id="string">...</div>` element.
 
-```
+An example is headings (lines that start with a `#`). For example:
+
+
+``` <!---markdown-->
     # <div id="string">THIS WILL NOT WORK!</div>              <=== this will not work
 ```
 
-For things like headings, you have to surround them, as in:
+For things like headings, you have to surround them with the `<div
+id="string">...</div>` element, as in:
 
-```
+``` <!---markdown-->
     <div id="string">
     # This will work
     </div>
 ```
 
 While some browsers will still recognize the HTML construct `<a
-name="string">...</a>`, it is possible they might NOT in the future.
+name="string">...</a>`, it is possible **they MIGHT NOT** in the future.
 
 
-## Please do NOT use the `<strike>` or the `<s>` HTML element
+<div id="links">
+## If you can, it is PREFERABLE to use markdown links rather than `<a>...</a>`
+</div>
 
-Please do NOT use the obsolete `<strike>` or the obsolete `<s>` (<del>_strikeout_</del>) HTML elements:
+It is easier and preferred to use markdown links rather than HTML `<a>..</a>`
+anchors.
 
+Instead of:
+
+
+``` <!---html-->
+    Use of <a href="#links>HTML anchors</a>
+            is one option, however ...
 ```
+
+
+``` <!---markdown-->
+    [markdown links](#links) are easier and preferred
+```
+
+
+<div id="strike">
+<div id="del">
+## Please do NOT use the `<strike>` or the `<s>` HTML element
+</div>
+</div>
+
+Please do **NOT** use the obsolete `<strike>` or the obsolete `<s>`
+(<del>**strikeout**</del>) HTML elements:
+
+``` <!---html-->
     <strike>...</strike>                                      <=== no thank you
     <s>...</s>                                                <=== no thank you
 ```
 
 Use instead:
 
-```
+``` <!---html-->
     <del>...</del>
 ```
 
 
+<div id="underline">
+<div id="ins">
 ## Please do NOT use the `<u>` HTML element
+</div>
+</div>
 
-Please NOT use the obsolete `<u>` (<ins>_underline_</ins>) HTML element:
+Please **NOT** use the obsolete `<u>` (<ins>_underline_</ins>) HTML element:
 
-```
+``` <!---html-->
     <u>...</u>                                                <=== no thank you
 ```
 
 Use instead:
 
-```
+``` <!---html-->
     <ins>...</ins>
 ```
 
 
+<div id="tt">
+<div id="span">
 ## Please do NOT use the `<tt>` HTML element
+</div>
+</div>
 
-Please do **NOT** use the obsolete `<tt>` (<span style="font-family: monospace;">_teletype_</span>) HTML element:
+Please do **NOT** use the obsolete `<tt>`
+(<span style="font-family: monospace;">**teletype**</span>) HTML element:
 
+``` <!---html-->
+    <tt>The tt element is obsolete</tt>              <=== no thank you
 ```
-    <tt>The obsolete tt element is obsolete</tt>              <=== no thank you
-```
 
-Instead use either a monospaced span:
+Instead use either a monospaced `<span>` or an inline markdown code block:
 
-```
+``` <!---html-->
     <span style="font-family: monospace;">Use of a monospaced font
                                           is one option,
                                           however ... </span>
@@ -113,28 +158,32 @@ Instead use either a monospaced span:
 
 We recommend using the inline markdown code block method instead:
 
-```
-    Using the `inline markdown code block` is easier and is `preferred`.
+``` <!---markdown-->
+    Using the `inline markdown code block` is easier and is **preferred**.
 ```
 
 
+<div id="unindented">
+<div id="indented">
 ## Please do NOT use unindented code blocks
+</div>
+</div>
 
-Please do **NOT** start code blocks at the left-hand edge.
+Please do **NOT** start code blocks at the first column.
 
 For example:
 
-````
+```` <!---markdown-->
 ``` <%%NO_COMMENT%%!---sh-->
-echo "This code block is NOT indented\"                       <=== no thank you
+echo "This code block is NOT indented"                       <=== no thank you
 ```
 ````
 
-We request that you indent the code block by multiples of 4 ASCII spaces:
+We request that you indent the code block by multiples of 4 ASCII **SPACES**:
 
-````
+```` <!---markdown-->
 ``` <%%NO_COMMENT%%!---sh-->
-    echo "This code block is intended by mutiples of 4 spaces"
+    echo "This code block is indented by mutiples of 4 spaces"
 
     # The top level starts with a 4 ASCII space indent.
     #
@@ -147,7 +196,7 @@ We request that you indent the code block by multiples of 4 ASCII spaces:
 
 Moreover:
 
-````
+```` <!---markdown-->
 ```
     The same thing applies to any markdown block surrounded by ``` lines.
 ```
@@ -156,19 +205,23 @@ Moreover:
 Please do **NOT** indent using ASCII tab characters in markdown files.
 
 
+<div id="tabs">
+<div id="spaces">
 ## Please do NOT use ASCII tabs in markdown files
+</div>
+</div>
 
 While we have nothing against the ASCII tab character in general,
 we have discovered that ASCII tab characters create problems when
 used as part of the leading whitespace within a markdown file.
 
 If you need to indent 2 or more levels, use multiples of 4 ASCII
-spaces.  Please do **NOT** indent with ASCII tabs, **NOR** use any
+**SPACES**.  Please do **NOT** indent with ASCII tabs, **OR** use any
 ASCII tab characters anywhere inside a markdown file:
 
 For example:
 
-````
+```` <!---markdown-->
 ```
     Please do **NOT**	use ASCII tabs	in markdown files.      <=== no thank you
 	Please do **NOT** indent markdown with ASCII tabs.      <=== no thank you
@@ -181,8 +234,8 @@ For example:
 And to clarify, we are only talking about markdown files,
 not C code or any other non-markdown content:
 
-````
-	printf("Is is fine	to	use tabs in Obfucated C code.\n");
+```` <!---c-->
+	printf("It is fine	to	use tabs in Obfuscated C code.\n");
 		/*	if	you	wish	*/
 
     // We ask that you to NOT use ASCII tab characters in your remarks.md writeup,
@@ -193,14 +246,54 @@ not C code or any other non-markdown content:
 your C code and other non-markdown files.  We simply ask that you **NOT** use any
 ASCII tab characters in markdown files.
 
+<div id="vim-tabs">
+### Tip for `vim` users
+</div>
 
-## Please do NOT specify a language for a code block
+If you use `vim` you can put in your `.vimrc` file (usually `~/.vimrc`) the
+following settings to make sure the tabs are not put in without you noticing:
 
-We request that (fenced) markdown code blocks **NOT** specify a language.
+``` <!---vim-->
+    set tabstop=8		" a tab is 8 spaces (or whatever you wish it to be set to)
+    set softtabstop=4		" ...but when inserting/backspacing use 4 spaces
+    set shiftwidth=4		" ...and auto-indent 4 spaces (when autoindent is set)
+    set expandtab		" ...but don't expand tab to spaces.
+```
+
+If you have file type detection enabled you can, if you prefer, have these
+settings set just for markdown files:
+
+``` <!---vim-->
+    autocmd! Filetype markdown setlocal set tabstop=8 softtabstop=4 shiftwidth=4 expandtab
+```
+
+or so.
+
+This will prevent the tab key from inserting tabs; rather it will insert 4
+spaces.
+
+To **VERIFY** that there are no tabs in a file you may do, in command mode:
+
+```
+    /\t
+```
+
+If you're in insert mode hit `ESC` first.
+
+
+<div id="languages">
+<div id="code">
+## Please do NOT _directly_ specify a language for a code block
+</div>
+</div>
+
+We request that [fenced markdown code
+blocks](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks)
+**NOT** specify a language directly.
 
 For example:
 
-````
+```` <!---markdown-->
 ```c                                                            <=== no thank you
     int main(void) {return 0;}
 ```
@@ -209,18 +302,24 @@ For example:
 Instead, put the language inside an HTML comment, separated from the
 markdown code block starting fence by a space:
 
-````
+```` <!---markdown-->
 ``` <%%NO_COMMENT%%!---c-->
     int main(void) {return 0;}
 ```
 ````
 
-**IMPORTANT**: The **initial** &nbsp; **\` \` \`** &nbsp; must be followed by an **`ASCII space`**,
-then by an **opening** **`<!---`**, then by the **language**, then by a **closing** **`-->`**.
+**IMPORTANT**: The **initial** &nbsp; **\` \` \`** &nbsp; must be followed by an **ASCII SPACE**,
+and **THEN** an **opening** **`<!---`** (a "`<`", a "`!`" and then three "`-`"s), and
+**THEN** the **language** and **FINALLY** a **closing** "`-->`" (two "`-`"s
+followed by a "`>`").
 
 
 
-## Please do NOT add trailing slash to HTML elements
+<div id="slash">
+<div id="void">
+## Please do NOT add trailing slash to void HTML elements
+</div>
+</div>
 
 Please do **NOT** use a trailing slash on [void HTML
 elements](https://github.com/validator/validator/wiki/Markup-»-Void-elements).
@@ -231,33 +330,39 @@ tags](https://github.com/validator/validator/wiki/Markup-»-Void-elements#traili
 The trailing slash on void HTML elements has no effect and interacts badly with
 unquoted attribute values.
 
-For example, please do NOT use:
+For example, please do **NOT** use:
 
-```
+``` <!---html-->
     <br/>                                                     <=== no thank you
 ```
 
 Instead use just:
 
-```
+``` <!---html-->
     <br>
 ```
 
-And for example, please do NOT use:
+And for example, please do **NOT** use:
 
-```
+``` <!---html-->
     <hr/>                                                     <=== no thank you
 ```
 
 Instead use just:
 
+``` <!---html-->
+    <br>
 ```
+
+and
+
+``` <!---html-->
     <hr>
 ```
 
-And for example, please do NOT use:
+And for example, please do **NOT** use:
 
-```
+``` <!---html-->
     <img src="1984-anonymous-tattoo.jpg"
      alt="image of a tattoo of the 1984 anonymous C code"
      width=600 height=401 />                                  <=== no thank you
@@ -265,7 +370,7 @@ And for example, please do NOT use:
 
 Instead use just:
 
-```
+``` <!---html-->
     <img src="1984-anonymous-tattoo.jpg"
      alt="image of a tattoo of the 1984 anonymous C code"
      width=600 height=401>
@@ -274,7 +379,11 @@ Instead use just:
 etc.
 
 
-## Please do NOT use trailing backslash outside of a code block
+<div id="backslash">
+<div id="br">
+## Please do NOT use a TRAILING backslash (`\`) outside of a code block
+</div>
+</div>
 
 Unless the line is inside a markdown code block, please do **NOT**
 end a markdown line with a trailing backslash (`\`).  Instead use
@@ -282,7 +391,7 @@ a trailing `<br>`.
 
 Instead of:
 
-```
+``` <!---markdown-->
     In markdown,\                                             <=== no thank you
     do NOT use trailing\
     backslashes outside of\
@@ -291,16 +400,17 @@ Instead of:
 
 use:
 
-```
+``` <!---markdown-->
     In markdown,<br>
     use trailing<br>
     br's outside of<br>
     a code block
 ```
 
-Again, use of a trailing backslash (`\`) inside a markdown code block is fine:
+Again, use of a trailing backslash (`\`) inside a markdown [**fenced code
+block**](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks) is fine:
 
-````
+```` <!---markdown-->
 ```
     This is OK\
     inside a\
@@ -313,20 +423,24 @@ This will prevent `pandoc(1)` from generating deprecated HTML elements such as
 `<br />`.
 
 
+<div id="images">
+<div id="img">
 ## Please do NOT use markdown style images
+</div>
+</div>
 
 Please do **NOT** use the markdown embedded image element.
 
 Instead of using this markdown element to embed an image:
 
-```
+``` <!---markdown-->
     ![alt text](filename.png "Title")                         <=== no thank you
 ```
 
-Use an `<img ..>` HTML element with `alt=`, `width=` and `length=`
+Use an `<img>` HTML element with `alt=`, `width=` and `length=`
 attributes:
 
-```
+``` <!---html-->
     <img src="filename.png"
      alt="describe the filename.png image for someone who cannot view it"
      width=PIXEL_WIDTH height=PIXEL_HEIGHT>
@@ -334,91 +448,136 @@ attributes:
 
 For example, instead of:
 
-```
+``` <!---markdown-->
     ![1984-anonymous-tattoo.jpg](1984-anonymous-tattoo.jpg)   <=== no thank you
 ```
 
 use this HTML:
 
-```
+``` <!---html-->
     <img src="1984-anonymous-tattoo.jpg"
      alt="image of a tattoo of the 1984 anonymous C code"
      width=600 height=401>
 ```
 
 The problem goes beyond the fact that `pandoc(1)` generates problematic
-HTML from the markdown image construct, the resulting HTML does NOT
+HTML from the markdown image construct, the resulting HTML does **NOT**
 have `width` and `height` information so browsers have to slow down
 on rendering text around the image until it can internally determine
 the image size.
 
 
+<div id="hr">
+<div id="horizontal">
+<div id="lines">
 ## Please do NOT use markdown style horizontal lines
+</div>
+</div>
+</div>
 
-Please do **NOT** use `**---**`-style lines in markdown to create horizontal
+Please do **NOT** use `---` style lines in markdown to create horizontal
 lines or to separate sections.
 
-Unless something is inside a markdown code block, do NOT start a
-line with 3 or more dashes (`-`s).
+Unless something is inside a markdown **code block**, do **NOT** start a
+line with 3 or more dashes ("`-`"s).
 
-Such causes `pandoc(1)` to generate `<hr />`.  The  `<hr />` has no effect in
-standard HTML 5 and interacts badly with unquoted attribute values.
+Such markdown causes `pandoc(1)` to generate `<hr />`.  The  `<hr />` has no
+effect in standard HTML 5 and interacts badly with unquoted attribute values.
 
 If a horizontal line is really needed, use:
 
-```
+``` <!---html-->
     <hr>
 ```
 
 If a short line is needed, use:
 
-```
+``` <!---html-->
     <hr style="width:10%;text-align:left;margin-left:0">
 ```
 
 
-## Please do NOT end markdown links in "))"
 
-Please do **NOT** end a markdown links with a double closed parenthesis "))".
+<div id="closing-parentheses">
+## Please do NOT end markdown links with "`))`"
+</div>
 
-Markdown links that end in "))" complicate parsing and sometimes lead
+Please do **NOT** end a markdown links with a double closed parenthesis "`))`".
+
+Markdown links that end in "`))`" complicate parsing and sometimes lead
 to incorrect URLs or file paths.
 
 Instead of:
 
-```
+``` <!---markdown-->
     [some text](https://example.com/foo_(bar))                <=== no thank you
 ```
 
-Use:
+use:
 
-```
+``` <!---markdown-->
     [some text](https://example.com/foo_&#x28;bar&#x29;)
 ```
 
-Instead of:
+As another example, instead of:
 
-```
+``` <!---markdown-->
     This thing, ([some text](some/path)), is NOT ideal.       <=== no thank you
 ```
 
-Use:
+use:
 
-```
+``` <!---markdown-->
     This thing, [some text](some/path), is better.
 ```
 
 
-## Please do NOT place text on the next line after a markdown code block
+<div id="parentheses">
+## Please do NOT put a LITERAL "`(`" or "`)`" in markdown link titles
+</div>
+
+Please do **NOT** use literal parentheses inside markdown link titles.
+
+Instead of:
+
+``` <!---markdown-->
+    [some (text)](https://example.com/cyrds)                  <=== no thank you
+```
+
+use:
+
+``` <!---markdown-->
+    [some &#x28;text&#x29;](https://example.com/cyrds)
+```
+
+Instead of:
+
+``` <!---markdown-->
+    [ls(1)](https://example.com/ls-man-page.1)                <=== no thank you
+```
+
+use:
+
+``` <!---markdown-->
+    [ls&#x28;1&#x29;](https://example.com/ls-man-page.1)
+```
+
+<div id="code-text">
+<div id="code-and-text">
+<div id="text">
+## Please do NOT place text on the IMMEDIATE (very next) line after a markdown code block
+</div>
+</div>
+</div>
 
 Please do **NOT** place text on the next line after a markdown code block.
 Instead, place a blank line after the end of a markdown code block
 as this makes it easier to detect when markdown code blocks are
-NOT properly indented.
+**NOT** properly indented.
 
 Instead of:
 
-````
+```` <!---markdown-->
 ```
     int
     main(int foo)
@@ -429,9 +588,9 @@ Instead of:
 C compilers cannot be given a -Wno-main-arg-errors flag.      <=== no thank you
 ````
 
-Use:
+use:
 
-````
+```` <!---markdown-->
 ```
     int
     main(int foo)
@@ -446,30 +605,45 @@ C compilers cannot be given a -Wno-main-arg-errors flag.
 **BTW**: Please note the blank line after the code block.
 
 
-## Please do NOT put "("s or ")"s in markdown link titles
+<div id="italics">
+## Please use `_` for italics in markdown
+</div>
 
-Please do **NOT** use literal parentheses inside the markdown link titles.
+Please do **NOT** use `*` (single asterisk) for italics in markdown. Instead use
+an underscore (`_`). Using an asterisk can complicate parsing and sometimes lead
+to incorrect results. This can especially go for when it is **_bold and
+italic_**.
 
-Instead of:
+For example, instead of:
 
-```
-    [some (text)](https://example.com/cyrds)                  <=== no thank you
-```
-
-Use:
-
-```
-    [some &#x28;text&#x29;](https://example.com/cyrds)
-```
-
-Instead of:
-
-```
-    [ls(1)](https://example.com/ls-man-page.1)                <=== no thank you
+``` <!---markdown-->
+     *this text is italic*        <=== no thank you
 ```
 
-Use:
+use:
 
+``` <!---markdown-->
+     _this text is italic_
 ```
-    [ls&#x28;1&#x29;](https://example.com/ls-man-page.1)
+
+Another example, for **_bold italic_**:
+
+Do **NOT** use:
+
+
+``` <!---markdown-->
+     ***this text is bold italic***         <=== no thank you
 ```
+
+Instead use:
+
+``` <!---markdown-->
+     **_this text is bold italic_**
+```
+
+or:
+
+``` <!---markdown-->
+     _**this text is bold italic**_
+```
+


### PR DESCRIPTION
 
The manifest was updated for 1994/tvr. Rebuilt .entry.json and
index.html.

Bug status changed in 1994/tvr as well. The judges noted that it has an
incorrect result in some cases but the author actually noted this as a
feature so it should not be fixed. Other fixes/updates were made in the
bugs file as well.
     
A number of other entries of 1994 had minor fixes (formatting, links and
similar things).
