### PR TITLE
Fixes in 1998 html files

### DIFF
--- a/1998/banks/README.md
+++ b/1998/banks/README.md
@@ -46,8 +46,8 @@ because in the header file you can see that `XK_u` corresponds to `u` and `XK_d`
 corresponds to `d`:
 
 ``` <!---c-->
-    #define XK_d                             0x0064  /* U+0064 LATIN SMALL LETTER D */
-    #define XK_u                             0x0075  /* U+0075 LATIN SMALL LETTER U */
+    #define XK_d 0x0064  /* U+0064 LATIN SMALL LETTER D */
+    #define XK_u 0x0075  /* U+0075 LATIN SMALL LETTER U */
 ```
 
 Note that the [keysym.h](%%REPO_URL%%/1998/banks/keysym.h) file is not complete from X11; it's just the

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -437,8 +437,8 @@ the throttle up and down to <code>u</code> and <code>d</code>:</p>
 <pre><code>    make clobber IT=XK_u DT=XK_d all</code></pre>
 <p>because in the header file you can see that <code>XK_u</code> corresponds to <code>u</code> and <code>XK_d</code>
 corresponds to <code>d</code>:</p>
-<pre><code>    #define XK_d                             0x0064  /* U+0064 LATIN SMALL LETTER D */
-    #define XK_u                             0x0075  /* U+0075 LATIN SMALL LETTER U */</code></pre>
+<pre><code>    #define XK_d 0x0064  /* U+0064 LATIN SMALL LETTER D */
+    #define XK_u 0x0075  /* U+0075 LATIN SMALL LETTER U */</code></pre>
 <p>Note that the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/banks/keysym.h">keysym.h</a> file is not complete from X11; it’s just the
 more likely candidates (and some that are probably unlikely :-) ).</p>
 <p>The upper case letters would be <code>XK_U</code> and <code>XK_D</code> and you can search the header

--- a/1998/chaos/README.md
+++ b/1998/chaos/README.md
@@ -5,12 +5,21 @@
 ```
 
 NOTE: Some systems do not implement `halfdelay()` in their `libcurses`.
-You might try compiling with -lncurses if you have that library.
+You might try compiling with `-lncurses` if you have that library.
 Or you can build this entry without the `halfdelay()` call by:
 
 ``` <!---sh-->
     make chaos_nohalf
 ```
+
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+> **STATUS: INABIAF - please DO NOT fix**
+
+For more detailed information see [1998/chaos in bugs.html](../../bugs.html#1998_chaos).
+
 
 
 ## To use:

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -410,9 +410,15 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h2 id="to-build">To build:</h2>
 <pre><code>    make chaos</code></pre>
 <p>NOTE: Some systems do not implement <code>halfdelay()</code> in their <code>libcurses</code>.
-You might try compiling with -lncurses if you have that library.
+You might try compiling with <code>-lncurses</code> if you have that library.
 Or you can build this entry without the <code>halfdelay()</code> call by:</p>
 <pre><code>    make chaos_nohalf</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
+<p>For more detailed information see <a href="../../bugs.html#1998_chaos">1998/chaos in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./chaos</code></pre>
 <h2 id="try">Try:</h2>

--- a/1998/dlowe/README.md
+++ b/1998/dlowe/README.md
@@ -139,11 +139,8 @@ where the first one would show the text as rendered but without links, images
 etc. and the second one would write the html to `ms.html` so that you could open
 it in a browser.
 
-For an old example of it working as a CGI script see:
-
-``` <!---sh-->
-    https://web.archive.org/web/20040326083431/http://www.pootpoot.com/poot/pootify/?URL=http%3A%2F%2Fwww.ioccc.org
-```
+For an old example of it working as a CGI script see
+<https://web.archive.org/web/20040326083431/http://www.pootpoot.com/poot/pootify/?URL=http%3A%2F%2Fwww.ioccc.org>.
 
 
 ## Author's remarks:

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -487,8 +487,8 @@ can look at locally in a browser or pipe through <code>less(1)</code>. For insta
 <p>where the first one would show the text as rendered but without links, images
 etc. and the second one would write the html to <code>ms.html</code> so that you could open
 it in a browser.</p>
-<p>For an old example of it working as a CGI script see:</p>
-<pre><code>    https://web.archive.org/web/20040326083431/http://www.pootpoot.com/poot/pootify/?URL=http%3A%2F%2Fwww.ioccc.org</code></pre>
+<p>For an old example of it working as a CGI script see
+<a href="https://web.archive.org/web/20040326083431/http://www.pootpoot.com/poot/pootify/?URL=http%3A%2F%2Fwww.ioccc.org" class="uri">https://web.archive.org/web/20040326083431/http://www.pootpoot.com/poot/pootify/?URL=http%3A%2F%2Fwww.ioccc.org</a>.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>This program is a text filter, it reads <code>stdin</code> and outputs the
 “corrected” text to <code>stdout</code>.</p>

--- a/1998/dloweneil/README.md
+++ b/1998/dloweneil/README.md
@@ -60,11 +60,9 @@ clockwise `l` does as well. Instead of using `d` to drop the letter you can do
 Read the authors' remarks below to find out how to play.  We believe that your
 experience may mirror one of our experiences:
 
-```
-    Originally, I didn't appreciate the game.  Then I actually read the
-    description of the controls.  I started playing.  I struggled.
-    I spelled my first "poot".  I was hooked ...
-```
+> Originally, I didn't appreciate the game.  Then I actually read the
+description of the controls.  I started playing.  I struggled.  I spelled my
+first "poot".  I was hooked ...
 
 
 ## Author's remarks:
@@ -79,7 +77,7 @@ experience may mirror one of our experiences:
 
 The object of this game is to spell `POOT` as much as possible.  There
 is no time pressure.  You're given one letter at a time (sort of randomly
-chosen from the set 'P', 'O', and 'T') and you get to move it freely
+chosen from the set '`P`', '`O`', and '`T`') and you get to move it freely
 around the border of the playing board, and decide when and where to drop
 it into the board.  Sound easy?  Of course, there's a catch...
 

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -442,16 +442,18 @@ clockwise <code>l</code> does as well. Instead of using <code>d</code> to drop t
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>Read the authors’ remarks below to find out how to play. We believe that your
 experience may mirror one of our experiences:</p>
-<pre><code>    Originally, I didn&#39;t appreciate the game.  Then I actually read the
-    description of the controls.  I started playing.  I struggled.
-    I spelled my first &quot;poot&quot;.  I was hooked ...</code></pre>
+<blockquote>
+<p>Originally, I didn’t appreciate the game. Then I actually read the
+description of the controls. I started playing. I struggled. I spelled my
+first “poot”. I was hooked …</p>
+</blockquote>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <h3 id="usage">Usage</h3>
 <pre><code>    ./pootris [X size of board] [Y size of board]</code></pre>
 <h3 id="synopsis">Synopsis</h3>
 <p>The object of this game is to spell <code>POOT</code> as much as possible. There
 is no time pressure. You’re given one letter at a time (sort of randomly
-chosen from the set ‘P’, ‘O’, and ‘T’) and you get to move it freely
+chosen from the set ‘<code>P</code>’, ‘<code>O</code>’, and ‘<code>T</code>’) and you get to move it freely
 around the border of the playing board, and decide when and where to drop
 it into the board. Sound easy? Of course, there’s a catch…</p>
 <h3 id="controls">Controls</h3>

--- a/1998/dorssel/README.md
+++ b/1998/dorssel/README.md
@@ -116,24 +116,16 @@ is the same as
 
 **If you want a greater challenge, don't read any further**:
 just try to understand the program without running the command below.
+If you get stuck, come back and read the below.
 
-If you get stuck, come back and run the following command:
+The file [dorssel.html](dorssel.html) contains all the information needed to
+understand this program.
+
+For more information you might also try:
 
 ``` <!---sh-->
     ./dorssel < dorssel.md
 ```
-
-
-### NOTICE to those who wish for a greater challenge:
-
-**If you want a greater challenge, don't read any further**:
-just try to understand the program via the source.
-
-If you get stuck, come back and read below for additional hints and information.
-
-- The file [dorssel.html](dorssel.html) contains all the information needed to
-understand this program.  For spoiler information, try:
-
 
 <!--
 

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -423,7 +423,7 @@ counter before shifting out each symbol, such as</p>
             encoding &gt;&gt;= 1;
     } while (length--);</code></pre>
 <p>We can also use the remaining bits to <em>include</em> the counter</p>
-<pre><code>    length 1: 00000.1x     E &gt; 00000.11
+<pre><code>    length 1: 00000.1x     `E &gt; 00000.11
     length 2: 0000.1xx
     length 3: 000.1xxx
     length 4: 00.1xxxx     Z &gt; 00.11100
@@ -438,11 +438,11 @@ this is not very pleasant, as some Morse sequences will end up having
 an ASCII value &lt; 32, i.e. they will be control codes. This would make
 the initializing (encoding) string awkward. Hence I came up with the
 following</p>
-<pre><code>    length 1: 0010010x     E &gt; 00100101  (= &#39;%&#39;)
-    length 2: 001010xx
-    length 3: 00110xxx
-    length 4: 0100xxxx     Z &gt; 01001100  (= &#39;L&#39;)
-    length 5: 011xxxxx     3 &gt; 01100111  (= &#39;g&#39;)</code></pre>
+<pre><code>length 1: 0010010x     E &gt; 00100101  (= &#39;%&#39;)
+length 2: 001010xx
+length 3: 00110xxx
+length 4: 0100xxxx     Z &gt; 01001100  (= &#39;L&#39;)
+length 5: 011xxxxx     3 &gt; 01100111  (= &#39;g&#39;)</code></pre>
 <p>Notice these encodings in the initialization string. Only the coding for
 <code>5</code> needs an escape (<code>5 = ..... &gt; 01111111 = '\177'</code>). The way the length
 is encoded still allows the encoding to be its own counter:</p>
@@ -454,13 +454,14 @@ is encoded still allows the encoding to be its own counter:</p>
 Note that the calculation for the next value of <code>encoding</code> is done at <code>int</code>
 precision, so that the actual value of the <code>char</code> remains <code>&lt;= 127</code>.</p>
 <p>The character <code>'-'</code> (ASCII 45) and <code>'.'</code> (ASCII 46) are conveniently in
-sequence, so the putchar can simply be</p>
+sequence, so the <code>putchar(3)</code> can simply be</p>
 <pre><code>    putchar(45 + encoding % 2);</code></pre>
 <p>I used the modulo operator this time, because <code>+</code> takes precedence over <code>&amp;</code>.
 The assignment can be incorporated into the <code>while</code> control test, and a
 <code>do-while</code> loop with a body of a single expression statement can be written
 as a <code>while</code> loop with a comma operator in the test:</p>
-<pre><code>    while(putchar(45 + encoding % 2), encoding = encoding + 32 &gt;&gt; 1);</code></pre>
+<pre><code>    while(putchar(45 + encoding % 2),
+        encoding = encoding + 32 &gt;&gt; 1);</code></pre>
 <p>Voila.</p>
 <p>Now, the decoding of Morse codes is just the reverse. We shift in <code>0</code>s
 and <code>1</code>s as we scan the line. But: we have to scan from back to front
@@ -484,23 +485,23 @@ and letters. This is OK, since neither of these characters, or the <code>'\0'</c
 is a valid encoding ! We must, however, use <code>memchr(3)</code> instead of <code>strchr(3)</code> in
 the decoding lookup because of this <code>'\0'</code>. Since it is far more obscure
 this way, I hope you’ll forgive me.</p>
-<p>The outline of the program is roughly as follows</p>
+<p>The outline of the program is roughly as follows (pseudo C):</p>
 <pre><code>    while (more lines) {
-            if (line is in morse) {
-                    while (more characters) {
-                            skip next sequence
-                            if (&#39; &#39;)
-                                    putchar(&#39; &#39;);
-                            else
-                                    decode_sequence; /* backwards */
-                    }
-            } else {
-                    while (more characters) {
-                            if (isalnum)
-                                    encode_character;
-                            putchar(&#39; &#39;);
-                    }
-            }</code></pre>
+        if (line is in morse) {
+            while (more characters) {
+                skip next sequence
+                    if (&#39; &#39;)
+                        putchar(&#39; &#39;);
+                    else
+                        decode_sequence; /* backwards */
+            }
+        } else {
+            while (more characters) {
+                if (isalnum)
+                    encode_character;
+                    putchar(&#39; &#39;);
+            }
+        }</code></pre>
 <p>Because of the <em>two</em> <code>while(more characters)</code> loops are the same, I’ve
 exchanged the <code>if(line is in morse)</code> and the two <code>while</code> loops (so there
 is <em>single</em> <code>while</code> loop). However, we must now store the <code>if(line is in morse)</code> test for efficiency (it would be stupid to test the entire line
@@ -512,27 +513,48 @@ line of text. This does not disturb the <code>if (line is in morse)</code> test,
 as the temporary <code>l[0]</code> will remain <code>!= 0</code>.</p>
 <p>I’ve put the <code>if</code>s in the above layout into a single switch. Hope you don’t
 mind ;-)</p>
-<p>Summary of the use of l[999]:</p>
-<pre><code>    l[0]            result of &quot;is this line in morse&quot; test
-    l[0]            temporary shift during encoding
-    l[0]  - l[33]   Morse codings (letters and digits, plus garbage)
-    l[11] - l[14]   strspn argument
-    l[12] - l[14]   strspn argument
-    l[34]           terminator for backward decoding
-    l[35] - l[998]  input line</code></pre>
+<p>Summary of the use of <code>l[999]</code>:</p>
+<ul>
+<li><code>l[0]</code>
+<ul>
+<li><strong>result of “is this line in morse” test</strong></li>
+</ul></li>
+<li><code>l[0]</code>
+<ul>
+<li><strong>temporary shift during encoding</strong></li>
+</ul></li>
+<li><code>l[0]  - l[33]</code>
+<ul>
+<li><strong>Morse codings (letters and digits, plus garbage)</strong></li>
+</ul></li>
+<li><code>l[11] - l[14]</code>
+<ul>
+<li><strong><code>strspn(3)</code> argument</strong></li>
+</ul></li>
+<li><code>l[12] - l[14]</code>
+<ul>
+<li><strong><code>strspn(3)</code> argument</strong></li>
+</ul></li>
+<li><code>l[34]</code>
+<ul>
+<li><strong>terminator for backward decoding</strong></li>
+</ul></li>
+<li><code>l[35] - l[998]</code>
+<ul>
+<li><strong>input line</strong></li>
+</ul></li>
+</ul>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Selected notes:</p>
 <ul>
-<li>We don’t need to declare <code>isalnum(3)</code> (or include ctype.h) as its implicit
-declaration is correct (int argument, int result). This is not so for
+<li>We don’t need to declare <code>isalnum(3)</code> (or include <code>ctype.h</code>) as its implicit
+declaration is correct (<code>int</code> argument, <code>int</code> result). This is not so for
 <code>strlen(3)</code>, <code>strspn(3)</code>, and <code>memchr(3)</code> as they use <code>size_t</code>.</li>
 <li>During development, my gcc 2.7.2.3 had an internal compiler error (signal
-<ol start="6" type="1">
-<li>on code that was correct !</li>
-</ol></li>
+6) on code that was correct !</li>
 <li>lclint 2.4b thinks that “the observer is modified” a couple of times,
 whereas it is not. Well, it is, but there is a sequence point in between.</li>
-<li>lclint 2.4b parses line 13 as <code>&lt;error&gt;</code>, whereas it is correct code.</li>
+<li>lclint 2.4b parses <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c:L13">line 13</a> as <code>&lt;error&gt;</code>, whereas it is correct code.</li>
 <li>lclint 2.4b is positive the second <code>while</code> loop is infinite, whereas it is
 not.</li>
 </ul>

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -554,7 +554,7 @@ declaration is correct (<code>int</code> argument, <code>int</code> result). Thi
 6) on code that was correct !</li>
 <li>lclint 2.4b thinks that “the observer is modified” a couple of times,
 whereas it is not. Well, it is, but there is a sequence point in between.</li>
-<li>lclint 2.4b parses <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c:L13">line 13</a> as <code>&lt;error&gt;</code>, whereas it is correct code.</li>
+<li>lclint 2.4b parses <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c:#L13">line 13</a> as <code>&lt;error&gt;</code>, whereas it is correct code.</li>
 <li>lclint 2.4b is positive the second <code>while</code> loop is infinite, whereas it is
 not.</li>
 </ul>

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -554,7 +554,7 @@ declaration is correct (<code>int</code> argument, <code>int</code> result). Thi
 6) on code that was correct !</li>
 <li>lclint 2.4b thinks that “the observer is modified” a couple of times,
 whereas it is not. Well, it is, but there is a sequence point in between.</li>
-<li>lclint 2.4b parses <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c:#L13">line 13</a> as <code>&lt;error&gt;</code>, whereas it is correct code.</li>
+<li>lclint 2.4b parses <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c#L13">line 13</a> as <code>&lt;error&gt;</code>, whereas it is correct code.</li>
 <li>lclint 2.4b is positive the second <code>while</code> loop is infinite, whereas it is
 not.</li>
 </ul>

--- a/1998/dorssel/dorssel.md
+++ b/1998/dorssel/dorssel.md
@@ -53,7 +53,7 @@ counter before shifting out each symbol, such as
 We can also use the remaining bits to *include* the counter
 
 ```
-    length 1: 00000.1x     E > 00000.11
+    length 1: 00000.1x     `E > 00000.11
     length 2: 0000.1xx
     length 3: 000.1xxx
     length 4: 00.1xxxx     Z > 00.11100
@@ -76,11 +76,11 @@ the initializing (encoding) string awkward.  Hence I came up with the
 following
 
 ```
-    length 1: 0010010x     E > 00100101  (= '%')
-    length 2: 001010xx
-    length 3: 00110xxx
-    length 4: 0100xxxx     Z > 01001100  (= 'L')
-    length 5: 011xxxxx     3 > 01100111  (= 'g')
+length 1: 0010010x     E > 00100101  (= '%')
+length 2: 001010xx
+length 3: 00110xxx
+length 4: 0100xxxx     Z > 01001100  (= 'L')
+length 5: 011xxxxx     3 > 01100111  (= 'g')
 ```
 
 Notice these encodings in the initialization string.  Only the coding for
@@ -99,7 +99,7 @@ Note that the calculation for the next value of `encoding` is done at `int`
 precision, so that the actual value of the `char` remains `<= 127`.
 
 The character `'-'` (ASCII 45) and `'.'` (ASCII 46) are conveniently in
-sequence, so the putchar can simply be
+sequence, so the `putchar(3)` can simply be
 
 ``` <!---c-->
     putchar(45 + encoding % 2);
@@ -111,7 +111,8 @@ The assignment can be incorporated into the `while` control test, and a
 as a `while` loop with a comma operator in the test:
 
 ``` <!---c-->
-    while(putchar(45 + encoding % 2), encoding = encoding + 32 >> 1);
+    while(putchar(45 + encoding % 2),
+        encoding = encoding + 32 >> 1);
 ```
 
 Voila.
@@ -141,25 +142,25 @@ is a valid encoding !  We must, however, use `memchr(3)` instead of `strchr(3)` 
 the decoding lookup because of this `'\0'`.  Since it is far more obscure
 this way, I hope you'll forgive me.
 
-The outline of the program is roughly as follows
+The outline of the program is roughly as follows (pseudo C):
 
 ```
     while (more lines) {
-            if (line is in morse) {
-                    while (more characters) {
-                            skip next sequence
-                            if (' ')
-                                    putchar(' ');
-                            else
-                                    decode_sequence; /* backwards */
-                    }
-            } else {
-                    while (more characters) {
-                            if (isalnum)
-                                    encode_character;
-                            putchar(' ');
-                    }
+        if (line is in morse) {
+            while (more characters) {
+                skip next sequence
+                    if (' ')
+                        putchar(' ');
+                    else
+                        decode_sequence; /* backwards */
             }
+        } else {
+            while (more characters) {
+                if (isalnum)
+                    encode_character;
+                    putchar(' ');
+            }
+        }
 ```
 
 Because of the *two* `while(more characters)` loops are the same, I've
@@ -176,30 +177,41 @@ as the temporary `l[0]` will remain `!= 0`.
 I've put the `if`s in the above layout into a single switch.  Hope you don't
 mind ;-)
 
-Summary of the use of l[999]:
+Summary of the use of `l[999]`:
 
-```
-    l[0]            result of "is this line in morse" test
-    l[0]            temporary shift during encoding
-    l[0]  - l[33]   Morse codings (letters and digits, plus garbage)
-    l[11] - l[14]   strspn argument
-    l[12] - l[14]   strspn argument
-    l[34]           terminator for backward decoding
-    l[35] - l[998]  input line
-```
+- `l[0]`
+  * **result of "is this line in morse" test**
+
+- `l[0]`
+  * **temporary shift during encoding**
+
+- `l[0]  - l[33]`
+  * **Morse codings (letters and digits, plus garbage)**
+
+- `l[11] - l[14]`
+  * **`strspn(3)` argument**
+
+- `l[12] - l[14]`
+  * **`strspn(3)` argument**
+
+- `l[34]`
+  * **terminator for backward decoding**
+
+- `l[35] - l[998]`
+  * **input line**
 
 <hr style="width:10%;text-align:left;margin-left:0">
 
 Selected notes:
 
-- We don't need to declare `isalnum(3)` (or include ctype.h) as its implicit
-  declaration is correct (int argument, int result).  This is not so for
+- We don't need to declare `isalnum(3)` (or include `ctype.h`) as its implicit
+  declaration is correct (`int` argument, `int` result).  This is not so for
   `strlen(3)`, `strspn(3)`, and `memchr(3)` as they use `size_t`.
 - During development, my gcc 2.7.2.3 had an internal compiler error (signal
-  6) on code that was correct !
+  6\) on code that was correct !
 - lclint 2.4b thinks that "the observer is modified" a couple of times,
   whereas it is not.  Well, it is, but there is a sequence point in between.
-- lclint 2.4b parses line 13 as `<error>`, whereas it is correct code.
+- lclint 2.4b parses [line 13](%%REPO_URL%%/1998/dorssel/dorssel.c:L13) as `<error>`, whereas it is correct code.
 - lclint 2.4b is positive the second `while` loop is infinite, whereas it is
   not.
 

--- a/1998/dorssel/dorssel.md
+++ b/1998/dorssel/dorssel.md
@@ -211,7 +211,7 @@ Selected notes:
   6\) on code that was correct !
 - lclint 2.4b thinks that "the observer is modified" a couple of times,
   whereas it is not.  Well, it is, but there is a sequence point in between.
-- lclint 2.4b parses [line 13](%%REPO_URL%%/1998/dorssel/dorssel.c:L13) as `<error>`, whereas it is correct code.
+- lclint 2.4b parses [line 13](%%REPO_URL%%/1998/dorssel/dorssel.c:#L13) as `<error>`, whereas it is correct code.
 - lclint 2.4b is positive the second `while` loop is infinite, whereas it is
   not.
 

--- a/1998/dorssel/dorssel.md
+++ b/1998/dorssel/dorssel.md
@@ -211,7 +211,7 @@ Selected notes:
   6\) on code that was correct !
 - lclint 2.4b thinks that "the observer is modified" a couple of times,
   whereas it is not.  Well, it is, but there is a sequence point in between.
-- lclint 2.4b parses [line 13](%%REPO_URL%%/1998/dorssel/dorssel.c:#L13) as `<error>`, whereas it is correct code.
+- lclint 2.4b parses [line 13](%%REPO_URL%%/1998/dorssel/dorssel.c#L13) as `<error>`, whereas it is correct code.
 - lclint 2.4b is positive the second `while` loop is infinite, whereas it is
   not.
 

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -474,17 +474,12 @@ text that can be reversibly Morsified, i.e.</li>
 <pre><code>    ./dorssel &lt; dorssel.c | ./dorssel</code></pre>
 <h3 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge:</h3>
 <p><strong>If you want a greater challenge, don’t read any further</strong>:
-just try to understand the program without running the command below.</p>
-<p>If you get stuck, come back and run the following command:</p>
+just try to understand the program without running the command below.
+If you get stuck, come back and read the below.</p>
+<p>The file <a href="dorssel.html">dorssel.html</a> contains all the information needed to
+understand this program.</p>
+<p>For more information you might also try:</p>
 <pre><code>    ./dorssel &lt; dorssel.md</code></pre>
-<h3 id="notice-to-those-who-wish-for-a-greater-challenge-1">NOTICE to those who wish for a greater challenge:</h3>
-<p><strong>If you want a greater challenge, don’t read any further</strong>:
-just try to understand the program via the source.</p>
-<p>If you get stuck, come back and read below for additional hints and information.</p>
-<ul>
-<li>The file <a href="dorssel.html">dorssel.html</a> contains all the information needed to
-understand this program. For spoiler information, try:</li>
-</ul>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -20,8 +20,10 @@ For more detailed information see [1998/schnitzi in bugs.html](../../bugs.html#1
     ./schnitzi n > sort.c
     make sort
     ./sort
-    # enter three numbers, space separated
+    # enter three numbers, space
+    # separated
 
+    # then try:
     echo x y z | ./sort
 ```
 
@@ -41,7 +43,8 @@ program expects? For instance try:
     ./schnitzi 5 > sort.c
     make sort
 
-    # try running the next command four or five times:
+    # now try running the next
+    # command four or five times:
     echo 2 5 3 1 | ./sort
 ```
 
@@ -51,33 +54,36 @@ Why does this happen?
 ## Judges' remarks:
 
 This is a beautiful program.  How can a program with no conditional (except for
-the fixes for modern systems though still no `if`s) behavior at all have output
-which depends on anything?
+the fixes for modern systems although there are still no `if`s) behavior at all
+have output which depends on anything?
 
 For hints on deciphering this, see below past the Author's remarks;
 they're a nice summary, but they leave the mystery intact.
 
-BTW: the author notes an incredible lipogram story called
+BTW: the author notes an incredible
+[lipogram](https://en.wikipedia.org/wiki/Lipogram) story called
 [Gadsby](https://www.gutenberg.org/cache/epub/47342/pg47342.txt) which has no
-letter E in the story. He did not note this but it has over 50000 (50 thousand)
-(!!) words without the letter E which is one of the most common letters!
+letter `E` in the story. He did not note this but it has over `50000` (50
+thousand) (!!) words without the letter `E` which is one of the most common
+letters!
 
 
 ## Author's remarks:
 
-In literary circles, there is a poetic form called a "lipogram",
-which is a poem in which a specific letter has been distinctly
-avoided.  This principle can be applied in other ways.  For
-instance, in this paragraph, the vowel which immediately follows
-`t` in the alphabet is nowhere to be seen.  There is even an
-entire novel (E. V. Wright's "Gadsby") in which no word contains
-the letter `e`.
+In literary circles, there is a poetic form called a
+"[lipogram](https://en.wikipedia.org/wiki/Lipogram)", which is a poem in which a
+specific letter has been distinctly avoided.  This principle can be applied in
+other ways.  For instance, in this paragraph, the vowel which immediately
+follows `t` in the alphabet is nowhere to be seen.  There is even an entire
+novel (E. V. Wright's
+"[Gadsby](https://www.gutenberg.org/cache/epub/47342/pg47342.txt)") in which no
+word contains the letter `e`.
 
 The IOCCC has been no stranger to this concept.  Several winning entries from
 years past have accomplished interesting feats while completely avoiding the use
 of certain C constructs thought to be essential (e.g.,
-[1988/robison.c](%%REPO_URL%%/1988/robison/robison.c) file).  If you have to ask why they would
-do it this way, then this contest just isn't for you.
+[1988/robison.c](%%REPO_URL%%/1988/robison/robison.c) file).  If you have to ask
+why they would do it this way, then this contest just isn't for you.
 
 In continuing with this fine tradition, this program suggests to the ANSI
 committee some new practical simplifications for the C language.  For instance,

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -419,8 +419,10 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    ./schnitzi n &gt; sort.c
     make sort
     ./sort
-    # enter three numbers, space separated
+    # enter three numbers, space
+    # separated
 
+    # then try:
     echo x y z | ./sort</code></pre>
 <p>where <code>n</code> and <code>x</code>, <code>y</code> and <code>z</code> are numbers.</p>
 <h2 id="try">Try:</h2>
@@ -430,32 +432,36 @@ program expects? For instance try:</p>
 <pre><code>    ./schnitzi 5 &gt; sort.c
     make sort
 
-    # try running the next command four or five times:
+    # now try running the next
+    # command four or five times:
     echo 2 5 3 1 | ./sort</code></pre>
 <p>Why does this happen?</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>This is a beautiful program. How can a program with no conditional (except for
-the fixes for modern systems though still no <code>if</code>s) behavior at all have output
-which depends on anything?</p>
+the fixes for modern systems although there are still no <code>if</code>s) behavior at all
+have output which depends on anything?</p>
 <p>For hints on deciphering this, see below past the Author’s remarks;
 they’re a nice summary, but they leave the mystery intact.</p>
-<p>BTW: the author notes an incredible lipogram story called
+<p>BTW: the author notes an incredible
+<a href="https://en.wikipedia.org/wiki/Lipogram">lipogram</a> story called
 <a href="https://www.gutenberg.org/cache/epub/47342/pg47342.txt">Gadsby</a> which has no
-letter E in the story. He did not note this but it has over 50000 (50 thousand)
-(!!) words without the letter E which is one of the most common letters!</p>
+letter <code>E</code> in the story. He did not note this but it has over <code>50000</code> (50
+thousand) (!!) words without the letter <code>E</code> which is one of the most common
+letters!</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
-<p>In literary circles, there is a poetic form called a “lipogram”,
-which is a poem in which a specific letter has been distinctly
-avoided. This principle can be applied in other ways. For
-instance, in this paragraph, the vowel which immediately follows
-<code>t</code> in the alphabet is nowhere to be seen. There is even an
-entire novel (E. V. Wright’s “Gadsby”) in which no word contains
-the letter <code>e</code>.</p>
+<p>In literary circles, there is a poetic form called a
+“<a href="https://en.wikipedia.org/wiki/Lipogram">lipogram</a>”, which is a poem in which a
+specific letter has been distinctly avoided. This principle can be applied in
+other ways. For instance, in this paragraph, the vowel which immediately
+follows <code>t</code> in the alphabet is nowhere to be seen. There is even an entire
+novel (E. V. Wright’s
+“<a href="https://www.gutenberg.org/cache/epub/47342/pg47342.txt">Gadsby</a>”) in which no
+word contains the letter <code>e</code>.</p>
 <p>The IOCCC has been no stranger to this concept. Several winning entries from
 years past have accomplished interesting feats while completely avoiding the use
 of certain C constructs thought to be essential (e.g.,
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/robison/robison.c">1988/robison.c</a> file). If you have to ask why they would
-do it this way, then this contest just isn’t for you.</p>
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/robison/robison.c">1988/robison.c</a> file). If you have to ask
+why they would do it this way, then this contest just isn’t for you.</p>
 <p>In continuing with this fine tradition, this program suggests to the ANSI
 committee some new practical simplifications for the C language. For instance,
 it appears that CONDITIONAL BRANCHING isn’t really necessary. So, we can do

--- a/1998/schweikh1/README.md
+++ b/1998/schweikh1/README.md
@@ -5,9 +5,8 @@
 ```
 
 There is an alternate version of this entry that will work with macOS. See the
-[Alternate code](#alternate-code) section below. We recommend you look at it
-even if you don't have a Mac, unless you want to figure it out yourself, as it
-includes some interesting details about the entry.
+[Alternate code](#alternate-code) section below. We recommend you look at the
+code at the last, even if you don't have a Mac.
 
 
 ## To use:
@@ -22,9 +21,9 @@ includes some interesting details about the entry.
 As noted above this entry will not work as it stands for macOS and there are
 some important notes as well as a description of how the fixed version works
 (the details of which are relevant to the original entry that no longer works as
-well as the fixed version but are described in the context of the macOS
+well as the fixed version, but are described in the context of the macOS
 adjustments). For details of what had to change, see [macos.html](macos.html).
-Unless you wish to figure it out yourself, we recommend that you read this even
+**Unless you wish to figure it out yourself**, we recommend that you read this even
 if you don't have a Mac as it has some interesting details about the entry.
 
 
@@ -66,13 +65,12 @@ crufty internationalization support.
 
 #### Historical note:
 
-Some non-gcc compilers that were not fully ANSI standard did not
-compile this entry correctly.  Using cc by default was not helpful
-most of the time on this entry, because the program had a hardcoded
-gcc invocation anyway.  Anyone who uses egcs and has no plain gcc
-will need to frob the source anyway and can be expected to do the
-right thing with `${CC}`. This limitation was removed in 2023 but in the past
-one should have used gcc.
+Some non-`gcc` compilers that were not fully ANSI standard did not compile this
+entry correctly.  Using cc by default was not helpful most of the time on this
+entry, because the program had a hardcoded `gcc` invocation anyway.  Anyone who
+uses egcs and has no plain `gcc` will need to frob the source anyway and can be
+expected to do the right thing with `${CC}`. This limitation was removed in 2023
+but in the past one should have used `gcc`.
 
 
 ## Author's remarks:
@@ -109,12 +107,12 @@ itself. Just load it in your favorite editor.
 
 `gcc` (the GNU C compiler) must be available at runtime. It is assumed that your
 C implementation keeps headers as files in the `/usr/include` directory. The
-[info](%%REPO_URL%%/1998/schweikh1/info) file must be readable and reside in the current working directory.
-The current working directory must be writable in order to create a temporary
-file (which is removed upon program termination). In case you don't have gcc at
-runtime, not all is lost if your compiler or preprocessor can produce a list of
-defined macros in the format output by `gcc -dM`, i.e. lines of the form
-`#define MACRO value`.
+[info](%%REPO_URL%%/1998/schweikh1/info) file must be readable and reside in the
+current working directory.  The current working directory must be writable in
+order to create a temporary file (which is removed upon program termination). In
+case you don't have gcc at runtime, not all is lost if your compiler or
+preprocessor can produce a list of defined macros in the format output by `gcc
+-dM`, i.e. lines of the form `#define MACRO value`.
 
 Edit the source at line 55 in this case.
 
@@ -143,6 +141,12 @@ programs that may fail to compile due to syntax errors: supposing that
 is expected to compile and meet the assertion. If it does not, your
 compiler compiles some other language than ISO C.
 
+### NOTICE to those who wish for a greater challenge:
+
+**If you want a greater challenge, don't read any further**:
+just try to understand the program via the source.
+
+If you get stuck, come back and read below for additional hints and information.
 
 ### Why I think my program is obfuscated
 
@@ -271,17 +275,16 @@ To use, try:
 ```
 
 
-I have tried, as suggested in the guidelines, to let the code look
-like ordinary C code. Apart from a few long lines I think I left
-the indentation like I would in RL. You should however not try to
-use `indent` on the source. The code is extremely fragile because of the
-myriads of `__LINE__` macros -- indenting is a sure way to break
-the program. Don't even think of maintaining that beast; I've
-had my share of core dumps during development :-) A test suite
-was used after every minor change to find out if the program still
+I have tried, as suggested in the [guidelines](../guidelines.txt), to let the
+code look like ordinary C code. Apart from a few long lines I think I left the
+indentation like I would in RL. You should however not try to use `indent` on
+the source. The code is extremely fragile because of the myriads of `__LINE__`
+macros -- indenting is a sure way to break the program. Don't even think of
+maintaining that beast; I've had my share of core dumps during development :-) A
+test suite was used after every minor change to find out if the program still
 does what it should.
 
-From the goals: "To stress C compilers with unusual code."
+From the goals: "`To stress C compilers with unusual code.`"
 That describes exactly my modest attempts...
 
 

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -410,18 +410,17 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
 <p>There is an alternate version of this entry that will work with macOS. See the
-<a href="#alternate-code">Alternate code</a> section below. We recommend you look at it
-even if you don’t have a Mac, unless you want to figure it out yourself, as it
-includes some interesting details about the entry.</p>
+<a href="#alternate-code">Alternate code</a> section below. We recommend you look at the
+code at the last, even if you don’t have a Mac.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./schweikh1</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
 <p>As noted above this entry will not work as it stands for macOS and there are
 some important notes as well as a description of how the fixed version works
 (the details of which are relevant to the original entry that no longer works as
-well as the fixed version but are described in the context of the macOS
+well as the fixed version, but are described in the context of the macOS
 adjustments). For details of what had to change, see <a href="macos.html">macos.html</a>.
-Unless you wish to figure it out yourself, we recommend that you read this even
+<strong>Unless you wish to figure it out yourself</strong>, we recommend that you read this even
 if you don’t have a Mac as it has some interesting details about the entry.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
@@ -444,13 +443,12 @@ Do not read them if you want to figure this out yourself. “Amendment
 One” refers to “NA1”, the add-on to C89 which added some fairly
 crufty internationalization support.</p>
 <h4 id="historical-note">Historical note:</h4>
-<p>Some non-gcc compilers that were not fully ANSI standard did not
-compile this entry correctly. Using cc by default was not helpful
-most of the time on this entry, because the program had a hardcoded
-gcc invocation anyway. Anyone who uses egcs and has no plain gcc
-will need to frob the source anyway and can be expected to do the
-right thing with <code>${CC}</code>. This limitation was removed in 2023 but in the past
-one should have used gcc.</p>
+<p>Some non-<code>gcc</code> compilers that were not fully ANSI standard did not compile this
+entry correctly. Using cc by default was not helpful most of the time on this
+entry, because the program had a hardcoded <code>gcc</code> invocation anyway. Anyone who
+uses egcs and has no plain <code>gcc</code> will need to frob the source anyway and can be
+expected to do the right thing with <code>${CC}</code>. This limitation was removed in 2023
+but in the past one should have used <code>gcc</code>.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>Important! This program, if it compiles at all, is mis-compiled by many
 compilers due to compiler bugs. It could be the “least likely
@@ -474,12 +472,11 @@ itself. Just load it in your favorite editor.</p>
 <h3 id="requirements">Requirements</h3>
 <p><code>gcc</code> (the GNU C compiler) must be available at runtime. It is assumed that your
 C implementation keeps headers as files in the <code>/usr/include</code> directory. The
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/info">info</a> file must be readable and reside in the current working directory.
-The current working directory must be writable in order to create a temporary
-file (which is removed upon program termination). In case you don’t have gcc at
-runtime, not all is lost if your compiler or preprocessor can produce a list of
-defined macros in the format output by <code>gcc -dM</code>, i.e. lines of the form
-<code>#define MACRO value</code>.</p>
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/info">info</a> file must be readable and reside in the
+current working directory. The current working directory must be writable in
+order to create a temporary file (which is removed upon program termination). In
+case you don’t have gcc at runtime, not all is lost if your compiler or
+preprocessor can produce a list of defined macros in the format output by <code>gcc -dM</code>, i.e. lines of the form <code>#define MACRO value</code>.</p>
 <p>Edit the source at line 55 in this case.</p>
 <h3 id="background">Background</h3>
 <p>ISO C has a very strict idea of visibility of identifiers. All possible
@@ -500,6 +497,10 @@ programs that may fail to compile due to syntax errors: supposing that
     }</code></pre>
 <p>is expected to compile and meet the assertion. If it does not, your
 compiler compiles some other language than ISO C.</p>
+<h3 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge:</h3>
+<p><strong>If you want a greater challenge, don’t read any further</strong>:
+just try to understand the program via the source.</p>
+<p>If you get stuck, come back and read below for additional hints and information.</p>
 <h3 id="why-i-think-my-program-is-obfuscated">Why I think my program is obfuscated</h3>
 <p>Not only is the program’s purpose a thorough standard conformance
 test, the source itself is a beast and has uncovered bugs in many
@@ -590,16 +591,15 @@ The advantages of an independent clean room approach…</p>
     print length ($_),&quot;\n&quot;;</code></pre>
 <p>To use, try:</p>
 <pre><code>    perl ./charcount.pl schweikh1.c</code></pre>
-<p>I have tried, as suggested in the guidelines, to let the code look
-like ordinary C code. Apart from a few long lines I think I left
-the indentation like I would in RL. You should however not try to
-use <code>indent</code> on the source. The code is extremely fragile because of the
-myriads of <code>__LINE__</code> macros – indenting is a sure way to break
-the program. Don’t even think of maintaining that beast; I’ve
-had my share of core dumps during development :-) A test suite
-was used after every minor change to find out if the program still
+<p>I have tried, as suggested in the <a href="../guidelines.txt">guidelines</a>, to let the
+code look like ordinary C code. Apart from a few long lines I think I left the
+indentation like I would in RL. You should however not try to use <code>indent</code> on
+the source. The code is extremely fragile because of the myriads of <code>__LINE__</code>
+macros – indenting is a sure way to break the program. Don’t even think of
+maintaining that beast; I’ve had my share of core dumps during development :-) A
+test suite was used after every minor change to find out if the program still
 does what it should.</p>
-<p>From the goals: “To stress C compilers with unusual code.”
+<p>From the goals: “<code>To stress C compilers with unusual code.</code>”
 That describes exactly my modest attempts…</p>
 <!--
 

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -389,11 +389,18 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: 1998/schweikh1/macos.md -->
+<h1 id="introduction-to-this-document">Introduction to this document:</h1>
 <p>This document describes how this was fixed to work with macOS as well as some of
 the magic in the entry. Even if you don’t have a Mac it might be worth your time
 reading especially as some of it details some important fixes and changes in the
 original entry as well.</p>
-<h1 id="macos-changes">macOS changes</h1>
+<h2 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge:</h2>
+<p><strong>If you want a greater challenge, don’t read any further</strong>:
+just try to understand the program via the source.</p>
+<p>If you get stuck, come back and read below for additional hints and information.
+Of course, if you do not have a Mac the code might make less sense, so you might
+just wish to read this in that case, should you wish to understand it.</p>
+<h1 id="macos-aside">macOS aside:</h1>
 <p>As an aside: if you have a Mac with the Apple chip, some of the header files
 will report an unsupported architecture and unsupported compiler (error,
 warning). This will not make the program abort, however, but even with an Intel
@@ -401,20 +408,26 @@ CPU though, the original entry will not work in macOS as it stands because
 <code>/usr/include</code> is hard-coded in the code and macOS does not have it.</p>
 <p>Nevertheless, although some of it would not work in other systems where
 <code>/usr/include</code> exists, the <code>#define</code>s would still be found okay, at least until
-a file was not found (this limitation was removed in both versions in 2023). see</p>
+a file was not found (this limitation was removed in both versions in 2023).</p>
 <p>However, as noted, macOS does <strong>not</strong> have <code>/usr/include</code> so this would never
 work for macOS without some changes, described next. For macOS you will need the
 command line tools installed which can be done like:</p>
 <pre><code>    sudo xcode-select --install</code></pre>
+<h1 id="important-point-about-the-hard-coded-compiler">Important point about the hard-coded compiler:</h1>
 <p>An important point is that the original version hard-coded <code>gcc</code> but just like
 the entry, the alternate version has also removed this limitation despite <code>gcc</code>
-existing (though it’s <code>clang</code>) in macOS.</p>
+existing (though it’s <code>clang</code>) in macOS; instead it is <code>cc</code>.</p>
+<h1 id="how-this-entry-works-the-magic">How this entry works (the magic):</h1>
 <p>Now as far as how this works if you look at the code of
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c">schweikh1.c</a>, on line 55 you’ll see a funny command (this goes for
-the alternate version as well but a bit different).</p>
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c">schweikh1.c</a>, on <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c#L55">line
+55</a> you’ll see a funny command
+(this goes for the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.alt.c">alternate
+version</a>, also on <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c#L55">line
+55</a>, but the command is necessarily
+different).</p>
 <p>Now the key is two magic numbers, one (two times) on a different line shortly below the
 string and the other a couple lines further below.</p>
-<p>In the original the numbers are, respectively, <code>44</code> and <code>46</code>, but with the gcc
+<p>In the original the numbers are, respectively, <code>44</code> and <code>46</code>, but with the <code>gcc</code>
 limitation removed the numbers now are <code>43</code> and <code>45</code>. But how does this work? Well
 the command is:</p>
 <pre><code>    &quot;0gcc -ansi -E -dM -undef %s /usr/include/%s&gt;r\0 (&quot;</code></pre>

--- a/1998/schweikh1/macos.md
+++ b/1998/schweikh1/macos.md
@@ -1,9 +1,20 @@
+# Introduction to this document:
+
 This document describes how this was fixed to work with macOS as well as some of
 the magic in the entry. Even if you don't have a Mac it might be worth your time
 reading especially as some of it details some important fixes and changes in the
 original entry as well.
 
-# macOS changes
+## NOTICE to those who wish for a greater challenge:
+
+**If you want a greater challenge, don't read any further**:
+just try to understand the program via the source.
+
+If you get stuck, come back and read below for additional hints and information.
+Of course, if you do not have a Mac the code might make less sense, so you might
+just wish to read this in that case, should you wish to understand it.
+
+# macOS aside:
 
 As an aside: if you have a Mac with the Apple chip, some of the header files
 will report an unsupported architecture and unsupported compiler (error,
@@ -13,7 +24,7 @@ CPU though, the original entry will not work in macOS as it stands because
 
 Nevertheless, although some of it would not work in other systems where
 `/usr/include` exists, the `#define`s would still be found okay, at least until
-a file was not found (this limitation was removed in both versions in 2023). see
+a file was not found (this limitation was removed in both versions in 2023).
 
 However, as noted, macOS does **not** have `/usr/include` so this would never
 work for macOS without some changes, described next. For macOS you will need the
@@ -23,18 +34,26 @@ command line tools installed which can be done like:
     sudo xcode-select --install
 ```
 
+# Important point about the hard-coded compiler:
+
 An important point is that the original version hard-coded `gcc` but just like
 the entry, the alternate version has also removed this limitation despite `gcc`
-existing (though it's `clang`) in macOS.
+existing (though it's `clang`) in macOS; instead it is `cc`.
+
+# How this entry works (the magic):
 
 Now as far as how this works if you look at the code of
-[schweikh1.c](%%REPO_URL%%/1998/schweikh1/schweikh1.c), on line 55 you'll see a funny command (this goes for
-the alternate version as well but a bit different).
+[schweikh1.c](%%REPO_URL%%/1998/schweikh1/schweikh1.c), on [line
+55](%%REPO_URL%%/1998/schweikh1/schweikh1.c#L55) you'll see a funny command
+(this goes for the [alternate
+version](%%REPO_URL%%/1998/schweikh1/schweikh1.alt.c), also on [line
+55](%%REPO_URL%%/1998/schweikh1/schweikh1.c#L55), but the command is necessarily
+different).
 
 Now the key is two magic numbers, one (two times) on a different line shortly below the
 string and the other a couple lines further below.
 
-In the original the numbers are, respectively, `44` and `46`, but with the gcc
+In the original the numbers are, respectively, `44` and `46`, but with the `gcc`
 limitation removed the numbers now are `43` and `45`. But how does this work? Well
 the command is:
 

--- a/1998/schweikh2/README.md
+++ b/1998/schweikh2/README.md
@@ -137,6 +137,14 @@ and now it works with both clang and gcc.
 
 ## Author's remarks:
 
+### NOTICE to those who wish for a greater challenge:
+
+**If you want a greater challenge, don't read any further**:
+just try to understand the program via the source.
+
+If you get stuck, come back and read below for additional hints and information.
+
+
 ### What this program does
 
 My entry is a `yarng`, which stands for, you guessed it, yet another
@@ -167,7 +175,7 @@ For example:
 
 ### Why I think this is obfuscated
 
-- Ever seen a 'do for ... while' loop?
+- Ever seen a `do for ... while` loop?
 
 - I avoided `int` like the plague. Instead I used storage class specifiers
 (`register`, `auto`) to get implicit `int`. The Standard allows implicit `int` even in

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -472,6 +472,10 @@ compiler error:</p>
 <pre><code>    #line 10 ONE(O(1,1,2,6,0,6))</code></pre>
 <p>and now it works with both clang and gcc.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
+<h3 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge:</h3>
+<p><strong>If you want a greater challenge, don’t read any further</strong>:
+just try to understand the program via the source.</p>
+<p>If you get stuck, come back and read below for additional hints and information.</p>
 <h3 id="what-this-program-does">What this program does</h3>
 <p>My entry is a <code>yarng</code>, which stands for, you guessed it, yet another
 random number generator, and is pronounced ‘yawn’ due to its
@@ -496,7 +500,7 @@ different values? How long would you need for an empirical test?</p>
     10011</code></pre>
 <h3 id="why-i-think-this-is-obfuscated">Why I think this is obfuscated</h3>
 <ul>
-<li><p>Ever seen a ‘do for … while’ loop?</p></li>
+<li><p>Ever seen a <code>do for ... while</code> loop?</p></li>
 <li><p>I avoided <code>int</code> like the plague. Instead I used storage class specifiers
 (<code>register</code>, <code>auto</code>) to get implicit <code>int</code>. The Standard allows implicit <code>int</code> even in
 casts as you can see in <code>(void(*)(register))main</code>. Where implicit <code>int</code> is

--- a/1998/schweikh3/README.md
+++ b/1998/schweikh3/README.md
@@ -6,14 +6,12 @@
 
 The author stated:
 
-```
-    In the remote event that the input has more than `8192` files with
-    the same size (on systems where `sizeof (char *) == 4`, or `4096` when
-    `sizeof (char *) == 8`), increase the manifest constant 32767 on line
-    31.
-```
+> In the remote event that the input has more than `8192` files with the same
+size (on systems where `sizeof (char *) == 4`, or `4096` when `sizeof (char *)
+== 8`), increase the manifest constant 32767 on [line
+31](%%REPO_URL%%/1998/schweikh3/schweikh3.c#L31).
 
-An alternate version allows one to fix this; see [alternate
+An alternate version allows one to fix this; see [Alternate
 code](#alternate-code) below.
 
 
@@ -78,10 +76,11 @@ The source is expected to conform to IEEE Std 1003.1-1990 ("POSIX").
 Thank God the IEEE does not standardize a coding style...
 
 
-###    What this program does
+### What this program does
 
-This is best explained in the man page. The troff source for this
-man page can be found in the file [samefile.1](%%REPO_URL%%/1998/schweikh3/samefile.1). To render try:
+This is best explained in the man page. The troff source for this man page can
+be found in the file [samefile.1](%%REPO_URL%%/1998/schweikh3/samefile.1). To
+render try:
 
 ``` <!---sh-->
     `man ./samefile.1
@@ -205,6 +204,14 @@ otherwise.
 #### SEE ALSO
 
 `find(1)`, `ln(1)`, `rm(1)`
+
+
+### NOTICE to those who wish for a greater challenge
+
+**If you want a greater challenge, don't read any further**:
+just try to understand the program via the source.
+
+If you get stuck, come back and read below for additional hints and information.
 
 
 ### Why I think it is obfuscated

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -410,11 +410,12 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
 <p>The author stated:</p>
-<pre><code>    In the remote event that the input has more than `8192` files with
-    the same size (on systems where `sizeof (char *) == 4`, or `4096` when
-    `sizeof (char *) == 8`), increase the manifest constant 32767 on line
-    31.</code></pre>
-<p>An alternate version allows one to fix this; see <a href="#alternate-code">alternate
+<blockquote>
+<p>In the remote event that the input has more than <code>8192</code> files with the same
+size (on systems where <code>sizeof (char *) == 4</code>, or <code>4096</code> when <code>sizeof (char *) == 8</code>), increase the manifest constant 32767 on <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/schweikh3.c#L31">line
+31</a>.</p>
+</blockquote>
+<p>An alternate version allows one to fix this; see <a href="#alternate-code">Alternate
 code</a> below.</p>
 <h2 id="to-use">To use:</h2>
 <p>If <code>dir</code> is the directory (or a directory tree) where you keep
@@ -446,8 +447,9 @@ the tool as well at <a href="http://www.schweikhardt.net/samefile" class="uri">h
 <p>The source is expected to conform to IEEE Std 1003.1-1990 (“POSIX”).
 Thank God the IEEE does not standardize a coding style…</p>
 <h3 id="what-this-program-does">What this program does</h3>
-<p>This is best explained in the man page. The troff source for this
-man page can be found in the file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/samefile.1">samefile.1</a>. To render try:</p>
+<p>This is best explained in the man page. The troff source for this man page can
+be found in the file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/samefile.1">samefile.1</a>. To
+render try:</p>
 <pre><code>    `man ./samefile.1</code></pre>
 <p>Otherwise:</p>
 <h3 id="samefile1-user-manuals-samefile1">SAMEFILE(1) User Manuals SAMEFILE(1)</h3>
@@ -524,6 +526,10 @@ How much space is wasted below our site’s /pub directory?</p>
 otherwise.</p>
 <h4 id="see-also">SEE ALSO</h4>
 <p><code>find(1)</code>, <code>ln(1)</code>, <code>rm(1)</code></p>
+<h3 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge</h3>
+<p><strong>If you want a greater challenge, don’t read any further</strong>:
+just try to understand the program via the source.</p>
+<p>If you get stuck, come back and read below for additional hints and information.</p>
 <h3 id="why-i-think-it-is-obfuscated">Why I think it is obfuscated</h3>
 <ul>
 <li>The code is commented but this gives only an <em>extremely</em> faint clue.</li>

--- a/1998/schweikh3/samefile.1
+++ b/1998/schweikh3/samefile.1
@@ -1,7 +1,10 @@
 .\"
 .\" To format this file into a text file say
 .\"
-.\"    nroff -man samefile.1              or
+.\"    nroff -man samefile.1              
+.\"
+.\" or
+.\"
 .\"    groff -man -Tascii samefile.1
 .\"
 .TH SAMEFILE 1 "OCTOBER 1997" IOCCC "User Manuals"

--- a/1998/schweikh3/samefile.1.dupe
+++ b/1998/schweikh3/samefile.1.dupe
@@ -1,7 +1,10 @@
 .\"
 .\" To format this file into a text file say
 .\"
-.\"    nroff -man samefile.1              or
+.\"    nroff -man samefile.1              
+.\"
+.\" or
+.\"
 .\"    groff -man -Tascii samefile.1
 .\"
 .TH SAMEFILE 1 "OCTOBER 1997" IOCCC "User Manuals"

--- a/1998/tomtorfs/README.md
+++ b/1998/tomtorfs/README.md
@@ -13,14 +13,18 @@
 
 where:
 
-```
-    filename  : file to calculate the CRC of
-    bitwidth  : width of the CRC in bits (decimal)
-    polynom   : polynomial used for the CRC (hexadecimal)
-    reflected : 0 if the CRC is not reflected, 1 if it is
-    init      : initial value for the CRC (hexadecimal)
-    xor       : value to xor the final CRC with (hexadecimal)
-```
+- `filename`
+    * file to calculate the CRC of
+- `bitwidth`
+    * width of the CRC in bits (decimal)
+- `polynom`
+    * polynomial used for the CRC (hexadecimal)
+- `reflected`
+    * 0 if the CRC is not reflected, 1 if it is
+- `init`
+    * initial value for the CRC (hexadecimal)
+- `xor`
+    * value to xor the final CRC with (hexadecimal)
 
 
 ## Try:
@@ -39,17 +43,27 @@ archiver that uses the CRC-32 algorithm.
 
 ## Author's remarks:
 
-```
-    Usage:
-    ./tomtorfs filename bitwidth polynom reflected init xor
+Usage:
 
-    filename  : file to calculate the CRC of
-    bitwidth  : width of the CRC in bits (decimal)
-    polynom   : polynomial used for the CRC (hexadecimal)
-    reflected : 0 if the CRC is not reflected, 1 if it is
-    init      : initial value for the CRC (hexadecimal)
-    xor       : value to xor the final CRC with (hexadecimal)
+``` <!---sh-->
+    ./tomtorfs filename bitwidth polynom reflected init xor
 ```
+
+where:
+
+- `filename`
+    * file to calculate the CRC of
+- `bitwidth`
+    * width of the CRC in bits (decimal)
+- `polynom`
+    * polynomial used for the CRC (hexadecimal)
+- `reflected`
+    * 0 if the CRC is not reflected, 1 if it is
+- `init`
+    * initial value for the CRC (hexadecimal)
+- `xor`
+    * value to xor the final CRC with (hexadecimal)
+
 
 ### Examples
 
@@ -116,24 +130,34 @@ readable.
 The variable names are not very descriptive. They have the
 following meanings:
 
-```
-    a = argc
-    A = argv
+- `a`
+    * argc
+- `A`
+    * argv
+- `b`
+    * array of `unsigned long` variables:
+    - `b[0]`
+        * bit-width of the CRC (`argv[2]`)
+    * `b[1]`
+        - CRC polynomial (`argv[3]`)
+    * `b[2]`
+        - nonzero if CRC is reflected (argv[4])
+    * `b[3]`
+        - initial value of CRC (argv[5])
+    * `b[4]`
+        - value final CRC is XORed with (argv[6])
+    * `b[5]`
+        - CRC value
+    * `b[6]`
+        - byte from file
+    * `b[7]`
+        - counter
 
-    b = array of unsigned long variables
-        b[0] = bit-width of the CRC (argv[2])
-        b[1] = CRC polynomial (argv[3])
-        b[2] = nonzero if CRC is reflected (argv[4])
-        b[3] = initial value of CRC (argv[5])
-        b[4] = value final CRC is XORed with (argv[6])
-        b[5] = CRC value
-        b[6] = byte from file
-        b[7] = counter
+- `B`
+    * `FILE *` through which the file `argv[1]` is opened
 
-    B = FILE * through which the file argv[1] is opened
-
-    C = typedef for unsigned long
-```
+- `C`
+    - `typedef` for `unsigned long`
 
 The first `for` loop simply reads the command-line arguments
 in the `b[]` array. The third parameter to `strtoul(3)` causes

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -412,12 +412,32 @@ Location: <a href="../../location.html#BE">BE</a> - <em>Kingdom of Belgium</em> 
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./tomtorfs filename bitwidth polynom reflected init xor</code></pre>
 <p>where:</p>
-<pre><code>    filename  : file to calculate the CRC of
-    bitwidth  : width of the CRC in bits (decimal)
-    polynom   : polynomial used for the CRC (hexadecimal)
-    reflected : 0 if the CRC is not reflected, 1 if it is
-    init      : initial value for the CRC (hexadecimal)
-    xor       : value to xor the final CRC with (hexadecimal)</code></pre>
+<ul>
+<li><code>filename</code>
+<ul>
+<li>file to calculate the CRC of</li>
+</ul></li>
+<li><code>bitwidth</code>
+<ul>
+<li>width of the CRC in bits (decimal)</li>
+</ul></li>
+<li><code>polynom</code>
+<ul>
+<li>polynomial used for the CRC (hexadecimal)</li>
+</ul></li>
+<li><code>reflected</code>
+<ul>
+<li>0 if the CRC is not reflected, 1 if it is</li>
+</ul></li>
+<li><code>init</code>
+<ul>
+<li>initial value for the CRC (hexadecimal)</li>
+</ul></li>
+<li><code>xor</code>
+<ul>
+<li>value to xor the final CRC with (hexadecimal)</li>
+</ul></li>
+</ul>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
@@ -425,15 +445,35 @@ Location: <a href="../../location.html#BE">BE</a> - <em>Kingdom of Belgium</em> 
 of the program with the value of CRCs computed by PKZIP or any other
 archiver that uses the CRC-32 algorithm.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
-<pre><code>    Usage:
-    ./tomtorfs filename bitwidth polynom reflected init xor
-
-    filename  : file to calculate the CRC of
-    bitwidth  : width of the CRC in bits (decimal)
-    polynom   : polynomial used for the CRC (hexadecimal)
-    reflected : 0 if the CRC is not reflected, 1 if it is
-    init      : initial value for the CRC (hexadecimal)
-    xor       : value to xor the final CRC with (hexadecimal)</code></pre>
+<p>Usage:</p>
+<pre><code>    ./tomtorfs filename bitwidth polynom reflected init xor</code></pre>
+<p>where:</p>
+<ul>
+<li><code>filename</code>
+<ul>
+<li>file to calculate the CRC of</li>
+</ul></li>
+<li><code>bitwidth</code>
+<ul>
+<li>width of the CRC in bits (decimal)</li>
+</ul></li>
+<li><code>polynom</code>
+<ul>
+<li>polynomial used for the CRC (hexadecimal)</li>
+</ul></li>
+<li><code>reflected</code>
+<ul>
+<li>0 if the CRC is not reflected, 1 if it is</li>
+</ul></li>
+<li><code>init</code>
+<ul>
+<li>initial value for the CRC (hexadecimal)</li>
+</ul></li>
+<li><code>xor</code>
+<ul>
+<li>value to xor the final CRC with (hexadecimal)</li>
+</ul></li>
+</ul>
 <h3 id="examples">Examples</h3>
 <h4 id="crc-16">CRC-16:</h4>
 <pre><code>    ./tomtorfs filename 16 1021 0 FFFF 0000</code></pre>
@@ -461,22 +501,60 @@ the nice code shape I worked so hard on ;-) ) the code will become a bit more
 readable.</p>
 <p>The variable names are not very descriptive. They have the
 following meanings:</p>
-<pre><code>    a = argc
-    A = argv
-
-    b = array of unsigned long variables
-        b[0] = bit-width of the CRC (argv[2])
-        b[1] = CRC polynomial (argv[3])
-        b[2] = nonzero if CRC is reflected (argv[4])
-        b[3] = initial value of CRC (argv[5])
-        b[4] = value final CRC is XORed with (argv[6])
-        b[5] = CRC value
-        b[6] = byte from file
-        b[7] = counter
-
-    B = FILE * through which the file argv[1] is opened
-
-    C = typedef for unsigned long</code></pre>
+<ul>
+<li><code>a</code>
+<ul>
+<li>argc</li>
+</ul></li>
+<li><code>A</code>
+<ul>
+<li>argv</li>
+</ul></li>
+<li><code>b</code>
+<ul>
+<li>array of <code>unsigned long</code> variables:</li>
+<li><code>b[0]</code>
+<ul>
+<li>bit-width of the CRC (<code>argv[2]</code>)</li>
+</ul></li>
+<li><code>b[1]</code>
+<ul>
+<li>CRC polynomial (<code>argv[3]</code>)</li>
+</ul></li>
+<li><code>b[2]</code>
+<ul>
+<li>nonzero if CRC is reflected (argv[4])</li>
+</ul></li>
+<li><code>b[3]</code>
+<ul>
+<li>initial value of CRC (argv[5])</li>
+</ul></li>
+<li><code>b[4]</code>
+<ul>
+<li>value final CRC is XORed with (argv[6])</li>
+</ul></li>
+<li><code>b[5]</code>
+<ul>
+<li>CRC value</li>
+</ul></li>
+<li><code>b[6]</code>
+<ul>
+<li>byte from file</li>
+</ul></li>
+<li><code>b[7]</code>
+<ul>
+<li>counter</li>
+</ul></li>
+</ul></li>
+<li><code>B</code>
+<ul>
+<li><code>FILE *</code> through which the file <code>argv[1]</code> is opened</li>
+</ul></li>
+<li><code>C</code>
+<ul>
+<li><code>typedef</code> for <code>unsigned long</code></li>
+</ul></li>
+</ul>
 <p>The first <code>for</code> loop simply reads the command-line arguments
 in the <code>b[]</code> array. The third parameter to <code>strtoul(3)</code> causes
 all arguments to be in base-16 (hex) except the first one,

--- a/bugs.html
+++ b/bugs.html
@@ -1632,6 +1632,34 @@ We greatly appreciate your help here!</p>
 <h1 id="section-14">1998</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<div id="1998_chaos">
+<h2 id="chaos">1998/chaos</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-1998chaoschaos.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/chaos/chaos.c">1998/chaos/chaos.c</a></h3>
+<h3 id="information-1998chaosindex.html">Information: <a href="1998/chaos/index.html">1998/chaos/index.html</a></h3>
+<p>The author stated the following:</p>
+<blockquote>
+<p>Memory <code>malloc(3)</code>ed is never freed. This shouldn’t be a big deal, since only
+one block is ever allocated, and the OS should recover it.</p>
+<p>My local flavor of lint doesn’t seem to like the fact that I never <code>return</code>
+from <code>main()</code>. Feh, what does it know? Otherwise, ignoring lint’s over
+protectiveness (“Of course I’m not using all of the functions defined in
+<code>curses.h</code>!”), it’s lint clean.</p>
+<p>If the compiler happens to generate the byte sequence “AlWuzEre” in the
+executable by chance, the program may be unable to locate the embedded string.
+As a result, running the program without an external data file may act in
+undefined ways.
+If the compiler doesn’t store <code>char * P</code>’s data in a nice contiguous stream,
+it would be bad. As above, it would break running the program without an
+external data file.</p>
+<p>If the incoming data is corrupt, the results are undefined. (Although dumping
+core is a popular result.)</p>
+<p>When a point passes behind the camera, it is still plotted. The object will
+“bounce” off the camera, but the result (some points in front, some reflected
+from the rear) looks really odd. And it sometimes hangs. So just don’t fly
+through objects. You’ll be happier.</p>
+</blockquote>
 <div id="1998_dlowe">
 <h2 id="dlowe">1998/dlowe</h2>
 </div>
@@ -1659,7 +1687,7 @@ IOCCC fame for reviving a pootifier! :-)</p>
 <div id="1998_schnitzi">
 <h2 id="schnitzi-2">1998/schnitzi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">1998/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1998schnitziindex.html">Information: <a href="1998/schnitzi/index.html">1998/schnitzi/index.html</a></h3>
 <p>A point worth considering is that as the number passed into the program gets
@@ -1816,7 +1844,7 @@ on the stack at that point:</p>
     5</code></pre>
 <p>which might (?) suggest that the <code>+</code> operator is unimplemented. Unfortunately it
 has been many years since I have used perl and I was never a guru either.</p>
-<h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states that in perl &lt; 5.6.0 there is a bug with a core dump in what
 they said is in <code>Perl_sv_upgrade</code>. As this is documented it is not considered a
 bug to be fixed. For the curious this will crash in macOS. Cody notes that the
@@ -1858,7 +1886,7 @@ of 92 warnings! Nonetheless neither works okay and both crash.</p>
 <div id="2000_primenum">
 <h2 id="primenum">2000/primenum</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000primenumprimenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/primenum.c">2000/primenum/primenum.c</a></h3>
 <h3 id="information-2000primenumindex.html">Information: <a href="2000/primenum/index.html">2000/primenum/index.html</a></h3>
 <p>This program does not do what you might think it does! Running it like:</p>
@@ -1876,7 +1904,7 @@ make a pull request.</p>
 <div id="2000_rince">
 <h2 id="rince-1">2000/rince</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/rince.c">2000/rince/rince.c</a></h3>
 <h3 id="information-2000rinceindex.html">Information: <a href="2000/rince/index.html">2000/rince/index.html</a></h3>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash, do something strange
@@ -1890,7 +1918,7 @@ fire</a>! :-) ).</p>
 <div id="2001_anonymous">
 <h2 id="anonymous">2001/anonymous</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001anonymousanonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.c">2001/anonymous/anonymous.c</a></h3>
 <h3 id="information-2001anonymousindex.html">Information: <a href="2001/anonymous/index.html">2001/anonymous/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this so that it
@@ -1909,7 +1937,7 @@ elves of Imladris :-(</p>
 <div id="2001_bellard">
 <h2 id="bellard">2001/bellard</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
@@ -1958,14 +1986,14 @@ before the fixes there.</p>
 <div id="2001_cheong">
 <h2 id="cheong">2001/cheong</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
 <h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
 <p>This program will crash without an arg.</p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
@@ -1986,7 +2014,7 @@ appreciate your help!</p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
 <p>Sometimes when one player presses <code>q</code> it will result in broken pipe on the other
@@ -2004,7 +2032,7 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
 <div id="2001_ollinger">
 <h2 id="ollinger">2001/ollinger</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
 <h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
 <p>This program will very likely crash or do something unexpected if you do not
@@ -2020,7 +2048,7 @@ wanted to install it as a tool but this is missing.</p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
 <p>The glob pattern must match the whole string. See the author’s comments for
@@ -2188,13 +2216,13 @@ compile under clang. The following patch was applied:</p>
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
 <p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
 things that are not bugs but documented (mis)features.</p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2219,7 +2247,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2232,7 +2260,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2246,7 +2274,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2255,7 +2283,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2289,7 +2317,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2303,7 +2331,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2344,7 +2372,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2353,7 +2381,7 @@ with possibly corrupt GIF files.</p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
@@ -2372,12 +2400,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
@@ -2385,7 +2413,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2402,7 +2430,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2449,7 +2477,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2474,7 +2502,7 @@ for security in modern days!</strong>). Do you have a server with enough bandwid
 would like to set it up? We’ll gladly thank you in the <a href="thanks-for-help.html">thanks
 file</a> file and link to the page as well! You’ll also have
 IOCCC fame for reviving a pootifier! :-)</p>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2486,7 +2514,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2496,7 +2524,7 @@ remarks</a> instead.</p>
 <div id="2011_konno">
 <h2 id="konno">2011/konno</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011konnokonno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/konno.c">2011/konno/konno.c</a></h3>
 <h3 id="information-2011konnoindex.html">Information: <a href="2011/konno/index.html">2011/konno/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
@@ -2665,7 +2693,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2679,7 +2707,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2688,7 +2716,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2721,7 +2749,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2735,7 +2763,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2756,7 +2784,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2772,7 +2800,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2792,7 +2820,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2811,7 +2839,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2827,7 +2855,7 @@ used.</li>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2840,14 +2868,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2855,7 +2883,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2872,7 +2900,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2896,7 +2924,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2937,7 +2965,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -2981,7 +3009,7 @@ because it is the same thing as the other, just updated to use <code>prog.alt</c
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -2990,7 +3018,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -3023,7 +3051,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -3042,7 +3070,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -3067,7 +3095,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -3082,7 +3110,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3132,7 +3160,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3140,7 +3168,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3148,7 +3176,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3182,7 +3210,7 @@ for more information on the change to <code>fgets(3)</code>.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3211,7 +3239,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3219,7 +3247,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3249,7 +3277,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3259,7 +3287,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3279,7 +3307,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3288,7 +3316,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3303,7 +3331,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3314,7 +3342,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3328,7 +3356,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3338,7 +3366,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-95">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3347,7 +3375,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-95">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-96">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -1790,6 +1790,42 @@ There was no IOCCC in 1997.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+<div id="1998_chaos">
+## 1998/chaos
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [1998/chaos/chaos.c](%%REPO_URL%%/1998/chaos/chaos.c)
+### Information: [1998/chaos/index.html](1998/chaos/index.html)
+
+The author stated the following:
+
+> Memory `malloc(3)`ed is never freed.  This shouldn't be a big deal, since only
+one block is ever allocated, and the OS should recover it.
+>
+> My local flavor of lint doesn't seem to like the fact that I never `return`
+from `main()`.  Feh, what does it know?  Otherwise, ignoring lint's over
+protectiveness ("Of course I'm not using all of the functions defined in
+`curses.h`!"), it's lint clean.
+>
+>
+> If the compiler happens to generate the byte sequence "AlWuzEre" in the
+executable by chance, the program may be unable to locate the embedded string.
+As a result, running the program without an external data file may act in
+undefined ways.
+> If the compiler doesn't store `char * P`'s data in a nice contiguous stream,
+it would be bad.  As above, it would break running the program without an
+external data file.
+>
+> If the incoming data is corrupt, the results are undefined.  (Although dumping
+core is a popular result.)
+>
+> When a point passes behind the camera, it is still plotted.  The object will
+"bounce" off the camera, but the result (some points in front, some reflected
+from the rear) looks really odd.  And it sometimes hangs.  So just don't fly
+through objects.  You'll be happier.
+
+
 
 <div id="1998_dlowe">
 ## 1998/dlowe


### PR DESCRIPTION
This includes some notices to those who wish for a greater challenge.

In the 1998/schweikh3 the man page (and its copy to demonstrate the entry) have been updated slightly but only in comment (move 'or' from the command suggested to render it in text to its own line before the next command also in comment).

The bugs file was updated for an entry or two.