### PR TITLE
Make 2004/burley fix more like original

### DIFF
--- a/2001/README.md
+++ b/2001/README.md
@@ -8,9 +8,6 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
-The IOCCC has a website and now has a number of international mirrors.  The
-primary site can be found at [www.ioccc.org](https://www.ioccc.org).
-
 Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.

--- a/2001/index.html
+++ b/2001/index.html
@@ -398,8 +398,6 @@
 on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author’s remarks for even more details.</p>
-<p>The IOCCC has a website and now has a number of international mirrors. The
-primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>

--- a/2004/README.md
+++ b/2004/README.md
@@ -12,9 +12,6 @@ Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using `gcc` instead of your
 local compiler.
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <https://www.ioccc.org/>.
-
 
 ## Remarks on some of the entries
 

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-int-to-pointer-cast \
-	  -Wno-unused-value -Wno-unused-parameter
+	  -Wno-unused-value -Wno-unused-parameter -Wno-incompatible-pointer-types
 
 # Attempt to silence unknown warnings
 #

--- a/2004/burley/README.md
+++ b/2004/burley/README.md
@@ -4,7 +4,7 @@
     make
 ```
 
-NOTE: We FORCE the use of -O0 even if someone overrides it because this entry
+**NOTE**: We FORCE the use of `-O0` even if someone overrides it because this entry
 will not work with it enabled.
 
 
@@ -14,7 +14,7 @@ will not work with it enabled.
     ./burley
 ```
 
-NOTE: you need to input a number first. See judges' remarks below for
+**NOTE**: you need to input a number first. See judges' remarks below for
 information on how to play.
 
 
@@ -22,32 +22,57 @@ information on how to play.
 
 This is a [draw poker](https://en.wikipedia.org/wiki/Draw_poker) program.  You
 start with $100.  Input alternates between your bet and which cards to keep.
-Example:
 
-```
-    5           <== you enter a bet of $5 (defaults to $1)
-    J Q J 9 5   <== your hand is Jack of Clubs, Queen of Hearts,
-    C H D S C       Jack of Diamonds, 9 of Spades, 5 of Clubs
-    123         <== you enter which cards you want to keep
-                    (enter 0 to 5 digits between 1 and 5)
-    J Q J J Q   <== your new hand is Jack of Clubs, Queen of Hearts,
-    C H D S C       Jack of Diamonds, Jack of Spaces, Queen of clubs
-    $145 (45)   <== Your new balance is now $145.  You had a Full House
-                    so your payoff is 9 times your bet == 45
-```
+### Example:
+
+Here is an example.
+
+First, enter your bet (say `5`) (for $5, defaults to $1). You might then see
+something like:
+
+> J Q J 9 5<br>
+> C H D S C
+
+That indicates your hand is Jack of Clubs, Queen of Hearts, Jack of Diamonds, 9
+of Spades and 5 of Clubs.
+
+Now enter what cards you want to keep (enter 0 to 5 digits between 1 and 5).
+Let's say you want to keep 1, 2 and 3 so you enter `123`. You should see
+something like the following after you hit enter:
+
+> J Q J J Q<br>
+> C H D S C
+
+which tells you that your new hand is Jack of Clubs, Queen of Hearts, Jack of
+Diamonds, Jack of Spaces and Queen of clubs. You might now see something like:
+
+> $145 (45)
+
+which tells you that your new balance is now $145. You had a Full House so your
+payoff is 9 times your bet == 45.
+
+#### Payout:
 
 The payout is according to "Vegas rules":
 
-```
-    Straight Flush     50 times your bet
-    Four of a Kind     25 times your bet
-    Full House          9 times your bet
-    Flush               6 times your bet
-    Straight            4 times your bet
-    3 of a Kind         3 times your bet
-    2 Pair              2 times your bet
-    Jacks or Better     1 times your bet
-```
+- **Straight Flush**
+    * 50 times your bet
+- **Four of a Kind**
+    * 25 times your bet
+- **Full House**
+    * 9 times your bet
+- **Flush**
+    * 6 times your bet
+- **Straight**
+    * 4 times your bet
+- **3 of a Kind**
+    * 3 times your bet)
+- **2 Pair**
+    * 2 times your bet
+- **Jacks or Better**
+    * 1 times your bet
+
+### Other things:
 
 The program allows you to go into debt.  However I'm sure you would never
 control-C to kill the program just because you got behind, right?  On the other
@@ -60,9 +85,10 @@ the program so this "strategy" no longer works?
 Notice the clever use of `setjmp(3)` and `longjmp(3)` calls.  Can you keep track
 of what state is being saved and restored?
 
-NOTE: the author talks about how it is a single statement. This might not be
+**NOTE**: the author talks about how it is a single statement. This might not be
 strictly true in 2023 for the fixes for it to work so you can look at the
-original file [burley.orig.c](%%REPO_URL%%/2004/burley/burley.orig.c) to see what is meant.
+original file [burley.orig.c](%%REPO_URL%%/2004/burley/burley.orig.c) to see
+what is meant.
 
 
 ## Author's remarks:

--- a/2004/burley/burley.c
+++ b/2004/burley/burley.c
@@ -1,8 +1,9 @@
 char a[80];
 int e[4],g[5],c=100,h,i,j,k,b,f,s,t;
 jmp_buf p[4];
-int pain(char *d){
-return pain((char*)((srand(time((time_t*)&h)),
+int main(int argc,char**D){
+char*d=(char*)D;
+return main(argc,(char*)((srand(time((time_t*)&h)),
 setjmp(p[2]),
 (k=atoi((fgets(a,sizeof a, stdin),
 a+strspn(a," -"))))
@@ -89,5 +90,3 @@ i+=i+1,
 longjmp(p[0],0)),0),
 longjmp(p[2],3)),0));
 }
-int main(int argc,char**d){
-return pain((char*)d);}

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -409,34 +409,76 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <!-- BEFORE: 1st line of markdown file: 2004/burley/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make</code></pre>
-<p>NOTE: We FORCE the use of -O0 even if someone overrides it because this entry
+<p><strong>NOTE</strong>: We FORCE the use of <code>-O0</code> even if someone overrides it because this entry
 will not work with it enabled.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./burley</code></pre>
-<p>NOTE: you need to input a number first. See judges’ remarks below for
+<p><strong>NOTE</strong>: you need to input a number first. See judges’ remarks below for
 information on how to play.</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>This is a <a href="https://en.wikipedia.org/wiki/Draw_poker">draw poker</a> program. You
-start with $100. Input alternates between your bet and which cards to keep.
-Example:</p>
-<pre><code>    5           &lt;== you enter a bet of $5 (defaults to $1)
-    J Q J 9 5   &lt;== your hand is Jack of Clubs, Queen of Hearts,
-    C H D S C       Jack of Diamonds, 9 of Spades, 5 of Clubs
-    123         &lt;== you enter which cards you want to keep
-                    (enter 0 to 5 digits between 1 and 5)
-    J Q J J Q   &lt;== your new hand is Jack of Clubs, Queen of Hearts,
-    C H D S C       Jack of Diamonds, Jack of Spaces, Queen of clubs
-    $145 (45)   &lt;== Your new balance is now $145.  You had a Full House
-                    so your payoff is 9 times your bet == 45</code></pre>
+start with $100. Input alternates between your bet and which cards to keep.</p>
+<h3 id="example">Example:</h3>
+<p>Here is an example.</p>
+<p>First, enter your bet (say <code>5</code>) (for $5, defaults to $1). You might then see
+something like:</p>
+<blockquote>
+<p>J Q J 9 5<br>
+C H D S C</p>
+</blockquote>
+<p>That indicates your hand is Jack of Clubs, Queen of Hearts, Jack of Diamonds, 9
+of Spades and 5 of Clubs.</p>
+<p>Now enter what cards you want to keep (enter 0 to 5 digits between 1 and 5).
+Let’s say you want to keep 1, 2 and 3 so you enter <code>123</code>. You should see
+something like the following after you hit enter:</p>
+<blockquote>
+<p>J Q J J Q<br>
+C H D S C</p>
+</blockquote>
+<p>which tells you that your new hand is Jack of Clubs, Queen of Hearts, Jack of
+Diamonds, Jack of Spaces and Queen of clubs. You might now see something like:</p>
+<blockquote>
+<p>$145 (45)</p>
+</blockquote>
+<p>which tells you that your new balance is now $145. You had a Full House so your
+payoff is 9 times your bet == 45.</p>
+<h4 id="payout">Payout:</h4>
 <p>The payout is according to “Vegas rules”:</p>
-<pre><code>    Straight Flush     50 times your bet
-    Four of a Kind     25 times your bet
-    Full House          9 times your bet
-    Flush               6 times your bet
-    Straight            4 times your bet
-    3 of a Kind         3 times your bet
-    2 Pair              2 times your bet
-    Jacks or Better     1 times your bet</code></pre>
+<ul>
+<li><strong>Straight Flush</strong>
+<ul>
+<li>50 times your bet</li>
+</ul></li>
+<li><strong>Four of a Kind</strong>
+<ul>
+<li>25 times your bet</li>
+</ul></li>
+<li><strong>Full House</strong>
+<ul>
+<li>9 times your bet</li>
+</ul></li>
+<li><strong>Flush</strong>
+<ul>
+<li>6 times your bet</li>
+</ul></li>
+<li><strong>Straight</strong>
+<ul>
+<li>4 times your bet</li>
+</ul></li>
+<li><strong>3 of a Kind</strong>
+<ul>
+<li>3 times your bet)</li>
+</ul></li>
+<li><strong>2 Pair</strong>
+<ul>
+<li>2 times your bet</li>
+</ul></li>
+<li><strong>Jacks or Better</strong>
+<ul>
+<li>1 times your bet</li>
+</ul></li>
+</ul>
+<h3 id="other-things">Other things:</h3>
 <p>The program allows you to go into debt. However I’m sure you would never
 control-C to kill the program just because you got behind, right? On the other
 hand the program never willingly exits, so you have to leave even when you are
@@ -445,9 +487,10 @@ ahead. :-)</p>
 the program so this “strategy” no longer works?</p>
 <p>Notice the clever use of <code>setjmp(3)</code> and <code>longjmp(3)</code> calls. Can you keep track
 of what state is being saved and restored?</p>
-<p>NOTE: the author talks about how it is a single statement. This might not be
+<p><strong>NOTE</strong>: the author talks about how it is a single statement. This might not be
 strictly true in 2023 for the fixes for it to work so you can look at the
-original file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/burley/burley.orig.c">burley.orig.c</a> to see what is meant.</p>
+original file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/burley/burley.orig.c">burley.orig.c</a> to see
+what is meant.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <p>This program plays draw poker. What is unusual about it is that it
 is written as a single statement – count the semicolons! (OK, there

--- a/2004/index.html
+++ b/2004/index.html
@@ -401,8 +401,6 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using <code>gcc</code> instead of your
 local compiler.</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org/" class="uri">https://www.ioccc.org/</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries. The <a href="gavin/index.html">Best of
 Show</a> is a fine example of obfuscation. But don’t ignore the

--- a/2005/README.md
+++ b/2005/README.md
@@ -15,9 +15,6 @@ local compiler.
 This year we included most of the information included by the submitters
 in the `README.md` files (that were used to build the `index.html` web pages).
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <https://www.ioccc.org/>.
-
 
 ## Remarks on some of the entries
 

--- a/2005/index.html
+++ b/2005/index.html
@@ -403,8 +403,6 @@ yours is lacking, you may need to compile using <code>gcc</code> instead of your
 local compiler.</p>
 <p>This year we included most of the information included by the submitters
 in the <code>README.md</code> files (that were used to build the <code>index.html</code> web pages).</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org/" class="uri">https://www.ioccc.org/</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries.</p>
 <p>In particular:</p>

--- a/2006/README.md
+++ b/2006/README.md
@@ -15,9 +15,6 @@ local compiler.
 This year we included most of the information included by the submitters
 in the `README.md` files (that were used to build the `index.html` web pages).
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
-
 
 ## Remarks on some of the entries
 

--- a/2006/index.html
+++ b/2006/index.html
@@ -403,8 +403,6 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
 <p>This year we included most of the information included by the submitters
 in the <code>README.md</code> files (that were used to build the <code>index.html</code> web pages).</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2011/README.md
+++ b/2011/README.md
@@ -13,9 +13,6 @@ Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
-
 
 ## Remarks on some of the entries
 

--- a/2011/index.html
+++ b/2011/index.html
@@ -402,8 +402,6 @@ year we included most of the information by the submitters).</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2012/README.md
+++ b/2012/README.md
@@ -12,10 +12,6 @@ Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
-
-
 
 ## Remarks on some of the entries
 

--- a/2012/index.html
+++ b/2012/index.html
@@ -401,8 +401,6 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries. We had
 a very difficult time picking a single best from among the other entries

--- a/2013/README.md
+++ b/2013/README.md
@@ -12,10 +12,6 @@ Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
-
-
 
 ## Remarks on some of the entries
 

--- a/2013/index.html
+++ b/2013/index.html
@@ -401,8 +401,6 @@ the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>This year, 9 won 15 awards. For the first time in the history of the contest,

--- a/2014/README.md
+++ b/2014/README.md
@@ -12,9 +12,6 @@ Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
-
 
 ## Remarks on some of the entries
 

--- a/2014/index.html
+++ b/2014/index.html
@@ -401,8 +401,6 @@ the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>This year, 2014:</p>

--- a/2015/README.md
+++ b/2015/README.md
@@ -13,9 +13,6 @@ Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
-The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
-
 
 ## Remarks on some of the winning entries
 

--- a/2015/index.html
+++ b/2015/index.html
@@ -402,8 +402,6 @@ information included by the submitter.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
-<p>The IOCCC has a website and now has a number of international mirrors.
-The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-winning-entries">Remarks on some of the winning entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>The fraction of worthy entries was higher than usual.</p>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -3005,10 +3005,6 @@ expression with <code>void</code> or if it is for some other reason).</p>
 <p><code>longjmp(3)</code> was being called with one arg which was an element
 of an <code>int[4][1000]</code> which had to be changed to a <code>jmp_buf p[4]</code> (this due to
 the prototype being included).</p>
-<p><code>main()</code> also called itself but this was a problem so it now calls another
-function <code>poke()</code> which calls itself instead (this is sometimes necessary
-nowadays and other entries had to have this same kind of change,
-<a href="2001/anonymous/index.html">2001/anonymous</a> being a good example).</p>
 <p>Finally the optimiser cannot be enabled so the compiler flags were changed for
 this, forcing <code>-O0</code>.</p>
 <div id="2004_gavare">

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -3710,11 +3710,6 @@ expression with `void` or if it is for some other reason).
 of an `int[4][1000]` which had to be changed to a `jmp_buf p[4]` (this due to
 the prototype being included).
 
-`main()` also called itself but this was a problem so it now calls another
-function `poke()` which calls itself instead (this is sometimes necessary
-nowadays and other entries had to have this same kind of change,
-[2001/anonymous](2001/anonymous/index.html) being a good example).
-
 Finally the optimiser cannot be enabled so the compiler flags were changed for
 this, forcing `-O0`.
 


### PR DESCRIPTION

The code can recursively call main() as long by changing the name of the
argv and by a cast in the call.

Updated Makefile to disable a new warning.

Improved index.html file.
