### PR TITLE
Add mirror references back as historical note

### DIFF
--- a/2001/README.md
+++ b/2001/README.md
@@ -8,9 +8,15 @@ on how to compile it and how to run the winning program.
 Look at the winning source and try to figure how it does what it does!
 You may then wish to look at the Author's remarks for even more details.
 
+
 Some ANSI C compilers are not quite as good as they should be.  If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.
+
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.  The
+primary site can be found at [www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2001/index.html
+++ b/2001/index.html
@@ -401,6 +401,9 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors. The
+primary site can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2004/README.md
+++ b/2004/README.md
@@ -13,6 +13,12 @@ yours is lacking, you may need to compile using `gcc` instead of your
 local compiler.
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <https://www.ioccc.org/>.
+
+
 ## Remarks on some of the entries
 
 We believe you will be impressed with this year's winning entries.  The [Best of

--- a/2004/index.html
+++ b/2004/index.html
@@ -401,6 +401,9 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using <code>gcc</code> instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org/" class="uri">https://www.ioccc.org/</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries. The <a href="gavin/index.html">Best of
 Show</a> is a fine example of obfuscation. But don’t ignore the

--- a/2005/README.md
+++ b/2005/README.md
@@ -16,6 +16,12 @@ This year we included most of the information included by the submitters
 in the `README.md` files (that were used to build the `index.html` web pages).
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <https://www.ioccc.org/>.
+
+
 ## Remarks on some of the entries
 
 We believe you will be impressed with this year's winning entries.

--- a/2005/index.html
+++ b/2005/index.html
@@ -403,6 +403,9 @@ yours is lacking, you may need to compile using <code>gcc</code> instead of your
 local compiler.</p>
 <p>This year we included most of the information included by the submitters
 in the <code>README.md</code> files (that were used to build the <code>index.html</code> web pages).</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org/" class="uri">https://www.ioccc.org/</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries.</p>
 <p>In particular:</p>

--- a/2006/README.md
+++ b/2006/README.md
@@ -16,6 +16,12 @@ This year we included most of the information included by the submitters
 in the `README.md` files (that were used to build the `index.html` web pages).
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
+
+
 ## Remarks on some of the entries
 
 There were some outstanding entries that did not win.  Unfortunately

--- a/2006/index.html
+++ b/2006/index.html
@@ -403,6 +403,9 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
 <p>This year we included most of the information included by the submitters
 in the <code>README.md</code> files (that were used to build the <code>index.html</code> web pages).</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2011/README.md
+++ b/2011/README.md
@@ -14,6 +14,12 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
+
+
 ## Remarks on some of the entries
 
 There were some outstanding entries that did not win.  Unfortunately

--- a/2011/index.html
+++ b/2011/index.html
@@ -402,6 +402,9 @@ year we included most of the information by the submitters).</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2012/README.md
+++ b/2012/README.md
@@ -13,6 +13,13 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
+
+
+
 ## Remarks on some of the entries
 
 We believe you will be impressed with this year's winning entries.  We had

--- a/2012/index.html
+++ b/2012/index.html
@@ -401,6 +401,9 @@ You may then wish to look at the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries. We had
 a very difficult time picking a single best from among the other entries

--- a/2013/README.md
+++ b/2013/README.md
@@ -13,6 +13,13 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
+
+
+
 ## Remarks on some of the entries
 
 We believe you will again be impressed with this year's winning entries.

--- a/2013/index.html
+++ b/2013/index.html
@@ -401,6 +401,9 @@ the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>This year, 9 won 15 awards. For the first time in the history of the contest,

--- a/2014/README.md
+++ b/2014/README.md
@@ -13,6 +13,12 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
+
+
 ## Remarks on some of the entries
 
 We believe you will again be impressed with this year's winning entries.

--- a/2014/index.html
+++ b/2014/index.html
@@ -401,6 +401,9 @@ the Author’s remarks for even more details.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>This year, 2014:</p>

--- a/2015/README.md
+++ b/2015/README.md
@@ -14,6 +14,12 @@ yours is lacking, you may need to compile using gcc instead of your
 local compiler.
 
 
+### Historical note:
+
+The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at [www.ioccc.org](https://www.ioccc.org).
+
+
 ## Remarks on some of the winning entries
 
 We believe you will again be impressed with this year's winning entries.

--- a/2015/index.html
+++ b/2015/index.html
@@ -402,6 +402,9 @@ information included by the submitter.</p>
 <p>Some ANSI C compilers are not quite as good as they should be. If
 yours is lacking, you may need to compile using gcc instead of your
 local compiler.</p>
+<h3 id="historical-note">Historical note:</h3>
+<p>The IOCCC has a website and now has a number of international mirrors.
+The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-winning-entries">Remarks on some of the winning entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>The fraction of worthy entries was higher than usual.</p>


### PR DESCRIPTION
Instead of having the mirror note in the YYYY/index.html files completely removed it is back but as a historical note.