### PR TITLE
More html files of 2004 fixed

### DIFF
--- a/2004/gavare/README.md
+++ b/2004/gavare/README.md
@@ -4,7 +4,7 @@
     make
 ```
 
-There are three alternate versions; see [alternate code](#alternate-code) below
+There are three alternate versions; see [Alternate code](#alternate-code) below
 for more details.
 
 
@@ -22,6 +22,10 @@ if you have ImageMagick installed, you can convert it to a jpeg:
 ```
 
 and then view `ioccc_ray.jpg` in a graphics viewer, editor or web browser.
+
+**NOTE**: if you do not have ImageMagick installed, see the
+FAQ on "[ImageMagick](../../faq.html#imagemagick)"
+for help.
 
 
 ## Try:
@@ -43,10 +47,12 @@ image as well as the anti-alias setting, when compiling.
 The author also provided [on their web page for the
 entry](https://gavare.se/ioccc/ioccc_gavare.c.html) an unobfuscated version that
 was used during development, which we have included in the file
-[gavare.r3.c](%%REPO_URL%%/2004/gavare/gavare.r3.c).
+[gavare.r3.c](%%REPO_URL%%/2004/gavare/gavare.r3.c) (named such because that is
+what they called it).
 
 Finally, the file [gavare.alt2.c](%%REPO_URL%%/2004/gavare/gavare.alt2.c) sets binary mode
-on `stdout` which theoretically should work in Windows.
+on `stdout` which theoretically should work in Windows (if anything works in
+Windows :-) ).
 
 
 ### Alternate build:
@@ -73,7 +79,7 @@ You may of course combine the above two commands and give any combination you
 wish.
 
 This is not possible with the author's version but it is with the alt versions
-(Windows - see below - and otherwise).
+(Windows - see below).
 
 As the Windows version will not compile on most viewers' systems we do not build
 it with `make alt`; instead try:
@@ -93,7 +99,8 @@ Use `gavare.alt`, `gavare.r3` or `gavare.alt2` as you would `gavare` above.
 For users of systems that distinguish between text and binary mode
 (you know who you are), add a library call that specifies binary mode
 for `stdout` as the first statement of `main()`,
-or use `freopen("ioccc_ray.ppm", "wb", stdout);` and do not use redirection.
+or use `freopen("ioccc_ray.ppm", "wb", stdout);` and do not use redirection (or
+see [Alternate code](#alternate-code) above).
 
 A freely distributable command-line version of Microsoft Visual C
 exhibits an optimizer bug when compiling this entry. Disable `/Og` for

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -409,7 +409,7 @@ Location: <a href="../../location.html#SE">SE</a> - <em>Kingdom of Sweden</em> (
 <!-- BEFORE: 1st line of markdown file: 2004/gavare/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make</code></pre>
-<p>There are three alternate versions; see <a href="#alternate-code">alternate code</a> below
+<p>There are three alternate versions; see <a href="#alternate-code">Alternate code</a> below
 for more details.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./gavare &gt; ioccc_ray.ppm</code></pre>
@@ -417,6 +417,9 @@ for more details.</p>
 if you have ImageMagick installed, you can convert it to a jpeg:</p>
 <pre><code>    convert ioccc_ray.ppm ioccc_ray.jpg</code></pre>
 <p>and then view <code>ioccc_ray.jpg</code> in a graphics viewer, editor or web browser.</p>
+<p><strong>NOTE</strong>: if you do not have ImageMagick installed, see the
+FAQ on “<a href="../../faq.html#imagemagick">ImageMagick</a>”
+for help.</p>
 <h2 id="try">Try:</h2>
 <p>If you have <code>xv(1)</code> you can do:</p>
 <pre><code>    ./gavare | xv -</code></pre>
@@ -427,9 +430,11 @@ image as well as the anti-alias setting, when compiling.</p>
 <p>The author also provided <a href="https://gavare.se/ioccc/ioccc_gavare.c.html">on their web page for the
 entry</a> an unobfuscated version that
 was used during development, which we have included in the file
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavare/gavare.r3.c">gavare.r3.c</a>.</p>
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavare/gavare.r3.c">gavare.r3.c</a> (named such because that is
+what they called it).</p>
 <p>Finally, the file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavare/gavare.alt2.c">gavare.alt2.c</a> sets binary mode
-on <code>stdout</code> which theoretically should work in Windows.</p>
+on <code>stdout</code> which theoretically should work in Windows (if anything works in
+Windows :-) ).</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <p>To build the configurable and unobfuscated versions:</p>
 <pre><code>    make alt</code></pre>
@@ -440,7 +445,7 @@ on <code>stdout</code> which theoretically should work in Windows.</p>
 <p>You may of course combine the above two commands and give any combination you
 wish.</p>
 <p>This is not possible with the author’s version but it is with the alt versions
-(Windows - see below - and otherwise).</p>
+(Windows - see below).</p>
 <p>As the Windows version will not compile on most viewers’ systems we do not build
 it with <code>make alt</code>; instead try:</p>
 <pre><code>    make alt2</code></pre>
@@ -450,7 +455,8 @@ it with <code>make alt</code>; instead try:</p>
 <p>For users of systems that distinguish between text and binary mode
 (you know who you are), add a library call that specifies binary mode
 for <code>stdout</code> as the first statement of <code>main()</code>,
-or use <code>freopen("ioccc_ray.ppm", "wb", stdout);</code> and do not use redirection.</p>
+or use <code>freopen("ioccc_ray.ppm", "wb", stdout);</code> and do not use redirection (or
+see <a href="#alternate-code">Alternate code</a> above).</p>
 <p>A freely distributable command-line version of Microsoft Visual C
 exhibits an optimizer bug when compiling this entry. Disable <code>/Og</code> for
 best results.</p>

--- a/2004/gavin/README.md
+++ b/2004/gavin/README.md
@@ -5,17 +5,18 @@
 ```
 
 
-There is an alternate version for those who wish to use QEMU rather than having
-to reboot and rely on having a floppy drive (if you even remember what those are
-:-) ) etc. See [alternate code](#alternate-code) below.
+There is an alternate version for those who wish to use
+[QEMU](https://www.qemu.org) rather than having
+to reboot and rely on having a [floppy
+drive](https://en.wikipedia.org/wiki/Floppy_disk) ([if you even
+remember](https://en.wikipedia.org/wiki/History_of_the_floppy_disk) what those are
+:-) ) etc. See [Alternate code](#alternate-code) below.
 
 
 ### Bugs and (Mis)features:
 
 The current status of this entry is:
 
-> **STATUS: compiled executable crashes - please help us fix**<br>
-> **STATUS: doesn't work with some platforms - please help us fix it**<br>
 > **STATUS: INABIAF - please DO NOT fix**
 
 For more detailed information see [2004/gavin in bugs.html](../../bugs.html#2004_gavin).
@@ -30,8 +31,8 @@ For more detailed information see [2004/gavin in bugs.html](../../bugs.html#2004
 
 ## Try:
 
-To enjoy the results (on a Linux/x86 machine) with a floppy drive (remember
-those? We do!):
+To enjoy the results (on a Linux/x86 machine) with a floppy drive
+([remember](https://en.wikipedia.org/wiki/Old_age) those? We do!):
 
 
 ``` <!---sh-->
@@ -45,9 +46,9 @@ whatever the floppy device is!),  mount it under `/mnt/floppy` and then:
     cp kernel fs.tar lilo.conf boot.b /mnt/floppy
 ```
 
-NOTE: If the version of your lilo is not 21.4, use the appropriate boot.b file.
+**NOTE**: If the version of your lilo is not 21.4, use the appropriate `boot.b` file.
 
-NOTE: If your floppy drive is not `/dev/fd0`, edit lilo.conf appropriately.
+**NOTE**: If your floppy drive is not `/dev/fd0`, edit `lilo.conf` appropriately.
 
 ``` <!---sh-->
     lilo -C /mnt/floppy/lilo.conf
@@ -92,7 +93,7 @@ you can use it with `QEMU`.
 ### Alternate use:
 
 The use is mostly the same as `gavin` except that one initially executes `gavin.alt`
-(which `make alt` will do) and one will have to use `QEMU` instead. The files
+and one will have to use `QEMU` instead. The files
 generated are the same names. See [to use](#to-use) and [try](#try) above as
 well as the judges' remarks below plus [gavin.html](gavin.html).
 
@@ -113,9 +114,9 @@ If you do not want to mess with a floppy and you use GRUB, see
 You can put additional text files in `fs.tar` for browsing with vi.
 
 If you do not want to bother rebooting your computer at all, see
-<http://bellard.org> for QEMU ([Fabrice Bellard](../../authors.html#Fabrice_Bellard)
-is an IOCCC 2001 winning entry), but your experience will be limited; use the
-[alternate code](#alternate-code) instead. You'll have to move the mouse to
+<https://www.qemu.org> for QEMU (by [Fabrice
+Bellard](../../authors.html#Fabrice_Bellard), an IOCCC winning author) and use
+the [Alternate code](#alternate-code) instead. You'll have to move the mouse to
 trigger the initial screen update.
 
 The judges were able to write a few more programs to run in this OS.
@@ -154,7 +155,7 @@ For further usage information see [gavin.html](gavin.html).
 
 The filenames `vi` and `sh` are significant, and should not be changed.
 
-### Known 'features'
+### Known 'features':
 
 Known issues are really too plentiful to list.
 
@@ -188,16 +189,14 @@ keyboard maps, etc.  (I should also mention that it contains mini functions to
 perform an x86 `in` and `out` instruction - to allow the keyboard & mouse to be
 driven from C code).
 
-Porting to another architecture should be relatively easy\* -
+Porting to another architecture should be relatively easy[^1] -
 the string simply needs be replaced with one containing
 data & code suitable for the new target platform.
 Accesses to data in the string are made relative to the define `V`,
 so these may need updating as appropriate (`0x90200` is the address
 at which a Linux bootloader loads an x86 kernel image).
 
-```
-    \* ;-)
-```
+[^1]: \* ;-)
 
 
 <!--

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -403,28 +403,24 @@ should do no damage to your existing setup, BUT I ACCEPT NO LIABILITY FOR ANY
 DAMAGE DONE BY THIS PROGRAM. Run it at your own risk. The OS has been tested
 on half a dozen machines or so, and worked on all but one. The failure came in
 the form of the machine rebooting itself midway through loading the OS, with no
-nasty side-effects.</p></li>
-</ol>
-<pre><code>    Hardware requirements - i386 or better processor, but the GUI is
-    surprisingly power-hungry, so I would recommend a fast P3 or P4 processor
-    (has been tested on P3/P4/Athlon machines).  Minimum RAM is something like
-    32MB.  PS/2 mouse &amp; keyboard required - no USB I&#39;m afraid, and the keyboard
-    map is for a UK keyboard.  Uses VESA VBE 3.0, so should work on any modern
-    graphics card (has been tested on NVIDIA, Matrox, and SiS cards).</code></pre>
-<ol start="3" type="1">
-<li>Now you need to setup a bootloader to load the OS. If you have a system
+nasty side-effects.</p>
+<p>Hardware requirements - i386 or better processor, but the GUI is
+surprisingly power-hungry, so I would recommend a fast P3 or P4 processor
+(has been tested on P3/P4/Athlon machines). Minimum RAM is something like
+32MB. PS/2 mouse &amp; keyboard required - no USB I’m afraid, and the keyboard
+map is for a UK keyboard. Uses VESA VBE 3.0, so should work on any modern
+graphics card (has been tested on NVIDIA, Matrox, and SiS cards).</p></li>
+<li><p>Now you need to setup a bootloader to load the OS. If you have a system
 using a lilo bootloader you can simply add the OS to your boot menu. Just add
 appropriate <code>image=</code> and <code>initrd=</code> lines to your <code>/etc/lilo.conf</code>, pointing at
 <code>kernel</code> and <code>fs.tar</code> respectively (as built by make earlier), then run <code>lilo</code>.
 If you do not wish modify your lilo setup, one easy option is to get yourself a
 GRUB boot disk image, and follow the instructions for GRUB below - Debian users
-can simply run<code>apt-get install grub-disk</code> to get themselves a GRUB boot disk.</li>
-</ol>
-<pre><code>    If you run GRUB, then at the boot menu simply hit `c` to get a console, then
-    type `kernel=(hd0,0)/&lt;PATH&gt;/kernel` (substituting appropriate hard
-    drive/partition numbers &amp; path, or using `(fd0)` to load a kernel on the
-    floppy), then `initrd=(hd0,0)/&lt;PATH&gt;/fs.tar`, and finally `boot`.</code></pre>
-<ol start="4" type="1">
+can simply run<code>apt-get install grub-disk</code> to get themselves a GRUB boot disk.</p>
+<p>If you run GRUB, then at the boot menu simply hit <code>c</code> to get a console, then
+type <code>kernel=(hd0,0)/&lt;PATH&gt;/kernel</code> (substituting appropriate hard
+drive/partition numbers &amp; path, or using <code>(fd0)</code> to load a kernel on the
+floppy), then <code>initrd=(hd0,0)/&lt;PATH&gt;/fs.tar</code>, and finally <code>boot</code>.</p></li>
 <li><p>Assuming the OS has booted, what can you do now? Well, start by trying <code>sh</code>,
 to open another shell. Then, try <code>vi gavin.c</code> to open up the OS source in a
 text file viewer (up/down or PgUp/PgDn to scroll). Note that the provided

--- a/2004/gavin/gavin.md
+++ b/2004/gavin/gavin.md
@@ -15,14 +15,12 @@ on half a dozen machines or so, and worked on all but one.  The failure came in
 the form of the machine rebooting itself midway through loading the OS, with no
 nasty side-effects.
 
-```
     Hardware requirements - i386 or better processor, but the GUI is
     surprisingly power-hungry, so I would recommend a fast P3 or P4 processor
     (has been tested on P3/P4/Athlon machines).  Minimum RAM is something like
     32MB.  PS/2 mouse & keyboard required - no USB I'm afraid, and the keyboard
     map is for a UK keyboard.  Uses VESA VBE 3.0, so should work on any modern
     graphics card (has been tested on NVIDIA, Matrox, and SiS cards).
-```
 
 3. Now you need to setup a bootloader to load the OS.  If you have a system
 using a lilo bootloader you can simply add the OS to your boot menu.  Just add
@@ -32,12 +30,10 @@ If you do not wish modify your lilo setup, one easy option is to get yourself a
 GRUB boot disk image, and follow the instructions for GRUB below - Debian users
 can simply run`apt-get install grub-disk` to get themselves a GRUB boot disk.
 
-```
     If you run GRUB, then at the boot menu simply hit `c` to get a console, then
     type `kernel=(hd0,0)/<PATH>/kernel` (substituting appropriate hard
     drive/partition numbers & path, or using `(fd0)` to load a kernel on the
     floppy), then `initrd=(hd0,0)/<PATH>/fs.tar`, and finally `boot`.
-```
 
 4. Assuming the OS has booted, what can you do now?  Well, start by trying `sh`,
 to open another shell.  Then, try `vi gavin.c` to open up the OS source in a

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -409,28 +409,29 @@ Location: <a href="../../location.html#UK">UK</a> - <em>United Kingdom of Great 
 <!-- BEFORE: 1st line of markdown file: 2004/gavin/README.md -->
 <h2 id="to-build">To build:</h2>
 <pre><code>    make</code></pre>
-<p>There is an alternate version for those who wish to use QEMU rather than having
-to reboot and rely on having a floppy drive (if you even remember what those are
-:-) ) etc. See <a href="#alternate-code">alternate code</a> below.</p>
+<p>There is an alternate version for those who wish to use
+<a href="https://www.qemu.org">QEMU</a> rather than having
+to reboot and rely on having a <a href="https://en.wikipedia.org/wiki/Floppy_disk">floppy
+drive</a> (<a href="https://en.wikipedia.org/wiki/History_of_the_floppy_disk">if you even
+remember</a> what those are
+:-) ) etc. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <blockquote>
-<p><strong>STATUS: compiled executable crashes - please help us fix</strong><br>
-<strong>STATUS: doesn’t work with some platforms - please help us fix it</strong><br>
-<strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
 </blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2004_gavin">2004/gavin in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./gavin</code></pre>
 <h2 id="try">Try:</h2>
-<p>To enjoy the results (on a Linux/x86 machine) with a floppy drive (remember
-those? We do!):</p>
+<p>To enjoy the results (on a Linux/x86 machine) with a floppy drive
+(<a href="https://en.wikipedia.org/wiki/Old_age">remember</a> those? We do!):</p>
 <pre><code>    su</code></pre>
 <p>Make a floppy with an ext2 filesystem (<code>mke2fs /dev/fd0</code> replacing <code>fd0</code> with
 whatever the floppy device is!), mount it under <code>/mnt/floppy</code> and then:</p>
 <pre><code>    cp kernel fs.tar lilo.conf boot.b /mnt/floppy</code></pre>
-<p>NOTE: If the version of your lilo is not 21.4, use the appropriate boot.b file.</p>
-<p>NOTE: If your floppy drive is not <code>/dev/fd0</code>, edit lilo.conf appropriately.</p>
+<p><strong>NOTE</strong>: If the version of your lilo is not 21.4, use the appropriate <code>boot.b</code> file.</p>
+<p><strong>NOTE</strong>: If your floppy drive is not <code>/dev/fd0</code>, edit <code>lilo.conf</code> appropriately.</p>
 <pre><code>    lilo -C /mnt/floppy/lilo.conf</code></pre>
 <p>Boot from the floppy on an x86 machine with a PS/2 keyboard and mouse.
 Move the window away from the corner.</p>
@@ -448,7 +449,7 @@ you can use it with <code>QEMU</code>.</p>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>
 <p>The use is mostly the same as <code>gavin</code> except that one initially executes <code>gavin.alt</code>
-(which <code>make alt</code> will do) and one will have to use <code>QEMU</code> instead. The files
+and one will have to use <code>QEMU</code> instead. The files
 generated are the same names. See <a href="#to-use">to use</a> and <a href="#try">try</a> above as
 well as the judges’ remarks below plus <a href="gavin.html">gavin.html</a>.</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
@@ -463,9 +464,9 @@ future contests.</p>
 <a href="gavin.html">gavin.html</a>.</p>
 <p>You can put additional text files in <code>fs.tar</code> for browsing with vi.</p>
 <p>If you do not want to bother rebooting your computer at all, see
-<a href="http://bellard.org" class="uri">http://bellard.org</a> for QEMU (<a href="../../authors.html#Fabrice_Bellard">Fabrice Bellard</a>
-is an IOCCC 2001 winning entry), but your experience will be limited; use the
-<a href="#alternate-code">alternate code</a> instead. You’ll have to move the mouse to
+<a href="https://www.qemu.org" class="uri">https://www.qemu.org</a> for QEMU (by <a href="../../authors.html#Fabrice_Bellard">Fabrice
+Bellard</a>, an IOCCC winning author) and use
+the <a href="#alternate-code">Alternate code</a> instead. You’ll have to move the mouse to
 trigger the initial screen update.</p>
 <p>The judges were able to write a few more programs to run in this OS.
 What are the limitations for such programs?</p>
@@ -493,7 +494,7 @@ then building a tarball containing the resulting programs
 (the filesystem format supported by the OS is the tarball format).</p>
 <p>For further usage information see <a href="gavin.html">gavin.html</a>.</p>
 <p>The filenames <code>vi</code> and <code>sh</code> are significant, and should not be changed.</p>
-<h3 id="known-features">Known ‘features’</h3>
+<h3 id="known-features">Known ‘features’:</h3>
 <p>Known issues are really too plentiful to list.</p>
 <p>If the mouse pointer goes off the left hand side of the screen
 it will reappear on the right, and vice-versa.
@@ -519,13 +520,12 @@ Linux-esque kernel header for the bootloader, protected mode descriptor tables,
 keyboard maps, etc. (I should also mention that it contains mini functions to
 perform an x86 <code>in</code> and <code>out</code> instruction - to allow the keyboard &amp; mouse to be
 driven from C code).</p>
-<p>Porting to another architecture should be relatively easy* -
+<p>Porting to another architecture should be relatively easy<a href="#fn1" class="footnote-ref" id="fnref1" role="doc-noteref"><sup>1</sup></a> -
 the string simply needs be replaced with one containing
 data &amp; code suitable for the new target platform.
 Accesses to data in the string are made relative to the define <code>V</code>,
 so these may need updating as appropriate (<code>0x90200</code> is the address
 at which a Linux bootloader loads an x86 kernel image).</p>
-<pre><code>    \* ;-)</code></pre>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.
@@ -540,6 +540,13 @@ at which a Linux bootloader loads an x86 kernel image).</p>
 
 -->
 <!-- AFTER: last line of markdown file: 2004/gavin/README.md -->
+<hr style="width:10%;text-align:left;margin-left:0">
+<section id="footnotes" class="footnotes footnotes-end-of-document" role="doc-endnotes">
+<h5>Footnotes</h5>
+<ol>
+<li id="fn1"><p>* ;-)<a href="#fnref1" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+</ol>
+</section>
 
 <!-- END: this line ends content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 <!-- START: this line starts content for HTML phase 22 by: bin/output-index-inventory.sh via bin/md2html.sh -->

--- a/2004/hibachi/.entry.json
+++ b/2004/hibachi/.entry.json
@@ -55,7 +55,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "html",
 	    "display_via_github" : false,
-	    "entry_text" : "home page of alt HIBACHI web server"
+	    "entry_text" : "home page of alt hibachi alt web server"
 	},
 	{
 	    "file_path" : "src/configure",
@@ -71,7 +71,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "html",
 	    "display_via_github" : false,
-	    "entry_text" : "home page of alt HIBACHI web server"
+	    "entry_text" : "home page of alt hibachi web server"
 	},
 	{
 	    "file_path" : "src-alt/IOCCC-2004/mkentry.c",
@@ -103,7 +103,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "html",
 	    "display_via_github" : false,
-	    "entry_text" : "perl test page of alt HIBACHI server"
+	    "entry_text" : "perl test page of alt hibachi server"
 	},
 	{
 	    "file_path" : "src-alt/localhost/test/php/index.php",
@@ -135,7 +135,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "text",
 	    "display_via_github" : false,
-	    "entry_text" : "obfuscated changelog for code"
+	    "entry_text" : "obfuscated changelog for hibachi"
 	},
 	{
 	    "file_path" : "src/localhost/reference/rfc2616.html",
@@ -151,7 +151,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "html",
 	    "display_via_github" : false,
-	    "entry_text" : "perl test page of HIBACHI server"
+	    "entry_text" : "perl test page of hibachi server"
 	},
 	{
 	    "file_path" : "src/localhost/test/php/index.php",
@@ -239,7 +239,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "text",
 	    "display_via_github" : false,
-	    "entry_text" : "obfuscation change log for alt server"
+	    "entry_text" : "changelog for hibachi alt code"
 	},
 	{
 	    "file_path" : "src/configure.in",
@@ -263,7 +263,7 @@
 	    "OK_to_edit" : true,
 	    "display_as" : "text",
 	    "display_via_github" : false,
-	    "entry_text" : "obfuscation change log"
+	    "entry_text" : "changelog for hibachi"
 	},
 	{
 	    "file_path" : "2004_hibachi.tar.bz2",

--- a/2004/hibachi/README.md
+++ b/2004/hibachi/README.md
@@ -7,6 +7,16 @@
 There is an alternate version that is unobfuscated, provided by the author in
 2024\. See [Alternate code](#alternate-code) below.
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+> **STATUS: INABIAF - please DO NOT fix**
+
+For more detailed information see [2004/hibachi in bugs.html](../../bugs.html#2004_hibachi).
+
+
+
 
 ## To use:
 
@@ -56,7 +66,7 @@ of Mr Howe.
 This entry also has the dubious honour of being the only one to have been
 submitted with its own `configure` script.
 
-NOTE: the author states there is a tarball `hibachi.tgz` but this was extracted
+**NOTE**: the author states there is a tarball `hibachi.tgz` but this was extracted
 so the file does not exist here.
 
 
@@ -66,7 +76,7 @@ so the file does not exist here.
 
 `Hibachi` is a simple, small, and (probably) very secure web server.
 
-There is a `hibachi.tgz` file (NOTE: this file was removed by the judges after
+There is a `hibachi.tgz` file (**NOTE**: this file was removed by the judges after
 extraction) that unpacks several support files and a subdirectory tree
 containing the documentation and examples. It can be viewed by:
 
@@ -189,9 +199,9 @@ style](https://wiki.c2.com/?OneTrueBraceStyle).
 
 *  Commented obfuscation change log information available.
 
-### Known Issues
+### Known Issue
 
-*  The [links][1] text browser does not support RFC 2616 section 7.2.1
+*  The [links][1] (text) web browser does not support RFC 2616 section 7.2.1
   paragraph 3 sentence 2, and so fails to display responses from
   `hibachi`.
 
@@ -207,17 +217,10 @@ style](https://wiki.c2.com/?OneTrueBraceStyle).
 * Winner of The Far Too Much Free Time Award
 
 
-### NOTICE to those who wish for a greater challenge:
+### Changelog
 
-**If you want a greater challenge, don't read any further**:
-just try to understand the program via the source.
-
-If you get stuck, come back and read below for additional hints and information.
-
-
-### Obfuscation change log
-
-For additional hints about how the source was obfuscated, read [src/localhost/CHANGELOG.TXT](src/localhost/CHANGELOG.TXT).
+For a list of significant changes made during development, see
+[src/localhost/CHANGELOG.TXT](src/localhost/CHANGELOG.TXT).
 
 
 <!--

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -411,6 +411,12 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 <pre><code>    make</code></pre>
 <p>There is an alternate version that is unobfuscated, provided by the author in
 2024. See <a href="#alternate-code">Alternate code</a> below.</p>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
+<p>For more detailed information see <a href="../../bugs.html#2004_hibachi">2004/hibachi in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    cd build; ./hibachi-start.sh &amp;</code></pre>
 <p>Then use your web browser to visit <code>http://localhost:8008/</code>. When you’re
@@ -434,12 +440,12 @@ we are considering starting an IOCCC standards body just to reign in the likes
 of Mr Howe.</p>
 <p>This entry also has the dubious honour of being the only one to have been
 submitted with its own <code>configure</code> script.</p>
-<p>NOTE: the author states there is a tarball <code>hibachi.tgz</code> but this was extracted
+<p><strong>NOTE</strong>: the author states there is a tarball <code>hibachi.tgz</code> but this was extracted
 so the file does not exist here.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <h3 id="readme.txt-feb-2004">README.TXT (Feb 2004)</h3>
 <p><code>Hibachi</code> is a simple, small, and (probably) very secure web server.</p>
-<p>There is a <code>hibachi.tgz</code> file (NOTE: this file was removed by the judges after
+<p>There is a <code>hibachi.tgz</code> file (<strong>NOTE</strong>: this file was removed by the judges after
 extraction) that unpacks several support files and a subdirectory tree
 containing the documentation and examples. It can be viewed by:</p>
 <pre><code>    tar -zxf hibachi.tgz
@@ -506,9 +512,9 @@ style</a>.</p></li>
 <li><p><code>Hibachi</code> can serve <a href="https://www.ioccc.org">www.ioccc.org</a>.</p></li>
 <li><p>Commented obfuscation change log information available.</p></li>
 </ul>
-<h3 id="known-issues">Known Issues</h3>
+<h3 id="known-issue">Known Issue</h3>
 <ul>
-<li>The <a href="https://en.wikipedia.org/wiki/Links_(web_browser)">links</a> text browser does not support RFC 2616 section 7.2.1
+<li>The <a href="https://en.wikipedia.org/wiki/Links_(web_browser)">links</a> (text) web browser does not support RFC 2616 section 7.2.1
 paragraph 3 sentence 2, and so fails to display responses from
 <code>hibachi</code>.</li>
 </ul>
@@ -521,12 +527,9 @@ paragraph 3 sentence 2, and so fails to display responses from
 <li>Best Interpretation of RFC 2616</li>
 <li>Winner of The Far Too Much Free Time Award</li>
 </ul>
-<h3 id="notice-to-those-who-wish-for-a-greater-challenge">NOTICE to those who wish for a greater challenge:</h3>
-<p><strong>If you want a greater challenge, don’t read any further</strong>:
-just try to understand the program via the source.</p>
-<p>If you get stuck, come back and read below for additional hints and information.</p>
-<h3 id="obfuscation-change-log">Obfuscation change log</h3>
-<p>For additional hints about how the source was obfuscated, read <a href="src/localhost/CHANGELOG.TXT">src/localhost/CHANGELOG.TXT</a>.</p>
+<h3 id="changelog">Changelog</h3>
+<p>For a list of significant changes made during development, see
+<a href="src/localhost/CHANGELOG.TXT">src/localhost/CHANGELOG.TXT</a>.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.
@@ -557,19 +560,19 @@ just try to understand the program via the source.</p>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/Makefile">Makefile</a> - entry Makefile</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/hibachi.orig.c">hibachi.orig.c</a> - original source code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/configure">src-alt/configure</a> - GNU Autoconf script for alt server</li>
-<li><a href="src-alt/localhost/index.html">src-alt/localhost/index.html</a> - home page of alt HIBACHI web server</li>
+<li><a href="src-alt/localhost/index.html">src-alt/localhost/index.html</a> - home page of alt hibachi alt web server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/configure">src/configure</a> - GNU Autoconf script</li>
-<li><a href="src/localhost/index.html">src/localhost/index.html</a> - home page of alt HIBACHI web server</li>
+<li><a href="src/localhost/index.html">src/localhost/index.html</a> - home page of alt hibachi web server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/IOCCC-2004/mkentry.c">src-alt/IOCCC-2004/mkentry.c</a> - IOCCC tool of 2004 to package entries</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/ioccc.c">src-alt/ioccc.c</a> - IOCCC size tool</li>
 <li><a href="src-alt/localhost/reference/rfc2616.html">src-alt/localhost/reference/rfc2616.html</a> - RFC 2616 - Hypertext Transfer Protocol - alt server</li>
-<li><a href="src-alt/localhost/test/perl/index.html">src-alt/localhost/test/perl/index.html</a> - perl test page of alt HIBACHI server</li>
+<li><a href="src-alt/localhost/test/perl/index.html">src-alt/localhost/test/perl/index.html</a> - perl test page of alt hibachi server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/localhost/test/php/index.php">src-alt/localhost/test/php/index.php</a> - PHP making an ISO 8601:2000 calendar for alt server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/localhost/test/ruby/index.rb">src-alt/localhost/test/ruby/index.rb</a> - ruby home page for alt server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/localhost/test/shell/test0.sh">src-alt/localhost/test/shell/test0.sh</a> - POSIX shell CGI home page for alt server</li>
-<li><a href="src/localhost/CHANGES-OBFUSCATED.TXT">src/localhost/CHANGES-OBFUSCATED.TXT</a> - obfuscated changelog for code</li>
+<li><a href="src/localhost/CHANGES-OBFUSCATED.TXT">src/localhost/CHANGES-OBFUSCATED.TXT</a> - obfuscated changelog for hibachi</li>
 <li><a href="src/localhost/reference/rfc2616.html">src/localhost/reference/rfc2616.html</a> - RFC 2616 - Hypertext Transfer Protocol</li>
-<li><a href="src/localhost/test/perl/index.html">src/localhost/test/perl/index.html</a> - perl test page of HIBACHI server</li>
+<li><a href="src/localhost/test/perl/index.html">src/localhost/test/perl/index.html</a> - perl test page of hibachi server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/localhost/test/php/index.php">src/localhost/test/php/index.php</a> - PHP making an ISO 8601:2000 calendar</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/localhost/test/ruby/index.rb">src/localhost/test/ruby/index.rb</a> - ruby home page</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/localhost/test/shell/test0.sh">src/localhost/test/shell/test0.sh</a> - POSIX shell CGI home page</li>
@@ -580,10 +583,10 @@ just try to understand the program via the source.</p>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/localhost/test/perl/yahoo-ticker.pl">src/localhost/test/perl/yahoo-ticker.pl</a> - stock price fetch example in Perl</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/configure.in">src-alt/configure.in</a> - GNU Autoconf script for alt server</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src-alt/hibachi-start.sh.in">src-alt/hibachi-start.sh.in</a> - hibachi-start.sh declarations for alt server</li>
-<li><a href="src-alt/localhost/CHANGELOG.TXT">src-alt/localhost/CHANGELOG.TXT</a> - obfuscation change log for alt server</li>
+<li><a href="src-alt/localhost/CHANGELOG.TXT">src-alt/localhost/CHANGELOG.TXT</a> - changelog for hibachi alt code</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/configure.in">src/configure.in</a> - GNU Autoconf script</li>
 <li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/src/hibachi-start.sh.in">src/hibachi-start.sh.in</a> - hibachi-start.sh declarations</li>
-<li><a href="src/localhost/CHANGELOG.TXT">src/localhost/CHANGELOG.TXT</a> - obfuscation change log</li>
+<li><a href="src/localhost/CHANGELOG.TXT">src/localhost/CHANGELOG.TXT</a> - changelog for hibachi</li>
 </ul>
 <h2 id="secondary-files">Secondary files</h2>
 <ul>

--- a/author/Anders_Gavare.json
+++ b/author/Anders_Gavare.json
@@ -7,7 +7,7 @@
     "location_code" : "SE",
     "email" : "gavare@gmail.com",
     "url" : "https://gavare.se",
-    "alt_url" : "https://gavare.se/ioccc/ioccc_gavare.c.html",
+    "alt_url" : "https://gavare.se/ioccc",
     "deprecated_twitter_handle" : null,
     "mastodon" : null,
     "mastodon_url" : null,

--- a/authors.html
+++ b/authors.html
@@ -1687,7 +1687,7 @@ Location: <a class="normal" href="location.html#SE">SE</a> - <em>Sweden</em>
 <br>
 URL: <a class="normal" href="https://gavare.se">https://gavare.se</a>
 <br>
-Alternate URL: <a class="normal" href="https://gavare.se/ioccc/ioccc_gavare.c.html">https://gavare.se/ioccc/ioccc_gavare.c.html</a>
+Alternate URL: <a class="normal" href="https://gavare.se/ioccc">https://gavare.se/ioccc</a>
 <br>
 author_handle: <a class="normal" href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/author/Anders_Gavare.json">Anders_Gavare</a>
 <p>

--- a/bugs.html
+++ b/bugs.html
@@ -465,9 +465,7 @@ one that’s more than fine (and it has been done numerous times).</p>
 <p><strong>BTW</strong>: You may skip if you’re only interested in knowing about entries with known issues.</p>
 <p>Entries below have one or more of the following <em><strong>STATUS</strong></em> values. Please see
 the text below for more information. If an entry has more than one status it
-means that either they all apply or they compliment each other. For instance
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/gavin.c">2004/gavin</a> crashes but it also doesn’t even compile with
-some platforms/architectures.</p>
+means that either they all apply or they complement each other.</p>
 <h2 id="general-notes-about-the-statuses-and-making-fixes">General notes about the statuses and making fixes</h2>
 <h3 id="compiler-warnings-are-very-rarely-a-problem">Compiler warnings are very rarely a problem</h3>
 <p>In general warnings should NOT be addressed. The only time they should be
@@ -2125,12 +2123,14 @@ sleeping.</p>
 <div id="2004_gavin">
 <h2 id="gavin">2004/gavin</h2>
 </div>
-<h3 id="status-compiled-executable-crashes---please-help-us-fix">STATUS: compiled executable crashes - please help us fix</h3>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it">STATUS: doesn’t work with some platforms - please help us fix it</h3>
+<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004gavingavin.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/gavin.c">2004/gavin/gavin.c</a></h3>
 <h3 id="information-2004gavinindex.html">Information: <a href="2004/gavin//index.html">2004/gavin//index.html</a></h3>
-<p>Segmentation fault will occur in some systems. For instance on macOS with the
-arm64 chip:</p>
+<p>This program is x86 linux specific; it is extremely likely that a segmentation
+fault will occur in other systems but even if it does not it is highly unlikely
+it will work. Below we will give some examples as well as a change that was made
+to let it compile with clang.</p>
+<p>In macOS with the arm64 chip this will segfault:</p>
 <pre><code>    ./gavin &gt; kernel</code></pre>
 <p>When trying to link <code>gavin.o</code> to produce <code>sh</code>, the linker generates:</p>
 <pre><code>    Undefined symbols for architecture arm64:
@@ -2138,10 +2138,9 @@ arm64 chip:</p>
          -u command line option
          (maybe you meant: __start)
     ld: symbol(s) not found for architecture arm64</code></pre>
-<p>We believe that this simply won’t work with non x86 specific systems but perhaps
-you have a fix? We welcome your help!</p>
-<h3 id="recent-2004gavin-mods">Recent 2004/gavin mods:</h3>
-<p>Although not related some recent changes were made to 2004/gavin to let it
+<h4 id="recent-2004gavin-mods">Recent 2004/gavin mods:</h4>
+<p>Although not related some recent changes were made to
+<a href="2004/gavin/index.html">2004/gavin</a> to let it
 compile under clang. The following patch was applied:</p>
 <pre><code>    diff --git a/2004/gavin/gavin.c b/2004/gavin/gavin.c
     index c967b7e..2082b49 100644
@@ -2206,15 +2205,26 @@ compile under clang. The following patch was applied:</p>
             ${RM} -f gavin fs.tar
 
     gavin_files: boot.b lilo.conf prim gavin_install.txt</code></pre>
-<p>The current (<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
+<p>The current <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/Makefile">Makefile</a> was modified to try and
 fit into the current IOCCC build environment.</p>
-<h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
-<p>See <a href="2004/gavin/index.html#known-features">known features in the index.html</a> for
-things that are not bugs but documented (mis)features.</p>
+<p>Please also see <a href="2004/gavin/index.html#known-features">known features in the
+index.html</a> for things that are not bugs
+but documented (mis)features.</p>
+<div id="2004_hibachi">
+<h2 id="hibachi">2004/hibachi</h2>
+</div>
+<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-2004hibachihibachi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/hibachi.c">2004/hibachi/hibachi.c</a></h3>
+<h3 id="information-2004hibachiindex.html">Information: <a href="2004/hibachi//index.html">2004/hibachi//index.html</a></h3>
+<p>The author stated that:</p>
+<blockquote>
+<p>The links (text) web browser does not support RFC 2616 section 7.2.1 paragraph 3
+sentence 2, and so fails to display responses from <code>hibachi</code>.</p>
+</blockquote>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
 <p>The author stated that:</p>
@@ -2239,7 +2249,7 @@ things that are not bugs but documented (mis)features.</p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
@@ -2252,7 +2262,7 @@ given the right args. See the index.html file for the correct syntax.</p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
 <p>This program sometimes will create unsolvable puzzles :-) just to hook you.
@@ -2266,7 +2276,7 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
 <p>This entry will very likely segfault or do something strange if the source code
@@ -2275,7 +2285,7 @@ does not exist.</p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
 <p>The author states:</p>
@@ -2309,7 +2319,7 @@ for running itself.</p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> notes that, though
@@ -2323,7 +2333,7 @@ website</a> itself.</p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
 <p>The author stated the below points of interest.</p>
@@ -2364,7 +2374,7 @@ with at least <code>computer.tofu</code> input file:</p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
@@ -2373,14 +2383,14 @@ with possibly corrupt GIF files.</p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
 <div id="2006_monge">
 <h2 id="monge">2006/monge</h2>
 </div>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it-1">STATUS: doesn’t work with some platforms - please help us fix it</h3>
+<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2006mongemonge.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge/monge.c">2006/monge/monge.c</a></h3>
 <h3 id="information-2006mongeindex.html">Information: <a href="2006/monge/index.html">2006/monge/index.html</a></h3>
 <p>This program requires x86 (with an x87 FPU) or x86_64 machine and it requires
@@ -2392,12 +2402,12 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
-<h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
@@ -2405,7 +2415,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
 <p>The author stated:</p>
@@ -2422,7 +2432,7 @@ opened. The number of args is however checked.</p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed this program to
@@ -2469,7 +2479,7 @@ case-sensitive.</p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
 <p>For a great amount of data points the program will crash, depending on your
@@ -2494,7 +2504,7 @@ for security in modern days!</strong>). Do you have a server with enough bandwid
 would like to set it up? We’ll gladly thank you in the <a href="thanks-for-help.html">thanks
 file</a> file and link to the page as well! You’ll also have
 IOCCC fame for reviving a pootifier! :-)</p>
-<h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
 <li><p>Bad input (e.g. nonexistent files, non-numeric number of iterations, etc.)
@@ -2506,7 +2516,7 @@ tends to result in empty output.</p></li>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
 <p>The author stated that there are a number of features and limitations. As the
@@ -2516,14 +2526,14 @@ remarks</a> instead.</p>
 <div id="2011_konno">
 <h2 id="konno">2011/konno</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011konnokonno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/konno.c">2011/konno/konno.c</a></h3>
 <h3 id="information-2011konnoindex.html">Information: <a href="2011/konno/index.html">2011/konno/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
 <div id="2011_richards">
 <h2 id="richards">2011/richards</h2>
 </div>
-<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it-2">STATUS: doesn’t work with some platforms - please help us fix it</h3>
+<h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it-1">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2011richardsrichards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards/richards.c">2011/richards/richards.c</a></h3>
 <h3 id="information-2011richardsindex.html">Information: <a href="2011/richards/index.html">2011/richards/index.html</a></h3>
 <p>This does not appear to work with macOS, resulting in a segfault (and sometimes
@@ -2685,7 +2695,7 @@ defined.</p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2699,7 +2709,7 @@ fire</a> :-)</p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
 <p>The author stated:</p>
@@ -2708,7 +2718,7 @@ fire</a> :-)</p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
 <p>The author stated:</p>
@@ -2741,7 +2751,7 @@ fire</a> :-)</p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
 <p>The author stated:</p>
@@ -2755,7 +2765,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
 <p>The author stated:</p>
@@ -2776,7 +2786,7 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
@@ -2792,7 +2802,7 @@ fire</a> :-)</p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
 <p>The author stated:</p>
@@ -2812,7 +2822,7 @@ and endianness conversion would make the source too large for IOCCC rule 2).</li
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
 <p>This program will possibly crash or draw something strange with 0 args. Then
@@ -2831,7 +2841,7 @@ used.</li>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <p>From the author:</p>
@@ -2847,7 +2857,7 @@ used.</li>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
@@ -2860,14 +2870,14 @@ such as <code>C2E2</code>.</p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
@@ -2875,7 +2885,7 @@ Hou :-) ) yourself. This should not be fixed.</p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
 <p>The author reminds us that if you kill the program you will have to wait a short
@@ -2892,7 +2902,7 @@ it out as a known limitation it is not a bug but a feature.</p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
 <p>The author noted that in macOS the colours might be wrong. They gave a solution.
@@ -2916,7 +2926,7 @@ player become bigger, stay away from blocks!</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
@@ -2957,7 +2967,7 @@ rely on the entry as the below shows. One should be able to do:</p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
@@ -3001,7 +3011,7 @@ because it is the same thing as the other, just updated to use <code>prog.alt</c
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
@@ -3010,7 +3020,7 @@ is not compressed data it’s likely to crash.</p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
 <p>The program assumes that <code>EOF</code> is <code>-1</code>. This can be fixed but at this time it is
@@ -3043,7 +3053,7 @@ use <code>8 * sizeof(typ)</code> bits per place. It does not work when <code>CHA
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
 <p>The author wrote:</p>
@@ -3062,7 +3072,7 @@ loop printing whitespace.</li>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
 <p>When you run it on a JSON file you will see something like:</p>
@@ -3087,7 +3097,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
-<h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
 again.</p>
@@ -3102,7 +3112,7 @@ in the case of compiled code it won’t be executable).</p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
 <p>The author wrote the following:</p>
@@ -3152,7 +3162,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
@@ -3160,7 +3170,7 @@ this program has nothing to do with a hand.</p></li>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
@@ -3168,7 +3178,7 @@ values but his implementation matches that of macOS and FreeBSD.</p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
 <p><a href="authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> fixed the scripts so
@@ -3202,7 +3212,7 @@ for more information on the change to <code>fgets(3)</code>.</p>
 <div id="2019_duble">
 <h2 id="duble">2019/duble</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
 <p>There are two things to be aware of with this entry.</p>
@@ -3231,7 +3241,7 @@ in the directory:</p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
@@ -3239,7 +3249,7 @@ touched either.</p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
 <p>The author stated the following:</p>
@@ -3269,7 +3279,7 @@ touched either.</p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
 <p>The author wrote that there are a number of differences from what one might
@@ -3279,7 +3289,7 @@ remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
 <p>The author wrote that if you decide to change networks or use a different input
@@ -3299,7 +3309,7 @@ a crash.</p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
@@ -3308,7 +3318,7 @@ erroneously.</p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
 <p>The author noted that if the program runs out of memory it is likely to crash.</p>
@@ -3323,7 +3333,7 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
 <p>This entry is known to crash if no arg is specified. Although easy to fix it is
@@ -3334,7 +3344,7 @@ either. But can you figure out why this happens?</p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-95">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
 <p>The author stated that bad things happen if the entered move is outside of the
@@ -3348,7 +3358,7 @@ move.</p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-95">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-96">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
 <p>There are some things that might appear to be bugs but are actually features or
@@ -3358,7 +3368,7 @@ things that are misinterpreted as bugs. See the
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-96">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-97">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
@@ -3367,7 +3377,7 @@ audio channels.</p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
-<h3 id="status-inabiaf---please-do-not-fix-97">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-98">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
 <p>The author listed the following limitations:</p>

--- a/bugs.md
+++ b/bugs.md
@@ -102,9 +102,7 @@ Again, THANK YOU!
 
 Entries below have one or more of the following _**STATUS**_ values. Please see
 the text below for more information. If an entry has more than one status it
-means that either they all apply or they compliment each other. For instance
-[2004/gavin](%%REPO_URL%%/2004/gavin/gavin.c) crashes but it also doesn't even compile with
-some platforms/architectures.
+means that either they all apply or they complement each other.
 
 
 ## General notes about the statuses and making fixes
@@ -2542,13 +2540,16 @@ There was no IOCCC in 2003.
 ## 2004/gavin
 </div>
 
-### STATUS: compiled executable crashes - please help us fix
-### STATUS: doesn't work with some platforms - please help us fix it
+### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2004/gavin/gavin.c](%%REPO_URL%%/2004/gavin/gavin.c)
 ### Information: [2004/gavin//index.html](2004/gavin//index.html)
 
-Segmentation fault will occur in some systems. For instance on macOS with the
-arm64 chip:
+This program is x86 linux specific; it is extremely likely that a segmentation
+fault will occur in other systems but even if it does not it is highly unlikely
+it will work. Below we will give some examples as well as a change that was made
+to let it compile with clang.
+
+In macOS with the arm64 chip this will segfault:
 
 ``` <!---sh-->
     ./gavin > kernel
@@ -2564,12 +2565,11 @@ When trying to link `gavin.o` to produce `sh`, the linker generates:
     ld: symbol(s) not found for architecture arm64
 ```
 
-We believe that this simply won't work with non x86 specific systems but perhaps
-you have a fix? We welcome your help!
 
-### Recent 2004/gavin mods:
+#### Recent 2004/gavin mods:
 
-Although not related some recent changes were made to 2004/gavin to let it
+Although not related some recent changes were made to
+[2004/gavin](2004/gavin/index.html) to let it
 compile under clang. The following patch was applied:
 
 ``` <!---patch-->
@@ -2642,14 +2642,28 @@ The original Makefile from 2004 had the following to say about this entry:
     gavin_files: boot.b lilo.conf prim gavin_install.txt
 ```
 
-The current ([Makefile](%%REPO_URL%%/2004/gavin/Makefile) was modified to try and
+The current [Makefile](%%REPO_URL%%/2004/gavin/Makefile) was modified to try and
 fit into the current IOCCC build environment.
 
 
-### STATUS: INABIAF - please **DO NOT** fix
+Please also see [known features in the
+index.html](2004/gavin/index.html#known-features) for things that are not bugs
+but documented (mis)features.
 
-See [known features in the index.html](2004/gavin/index.html#known-features) for
-things that are not bugs but documented (mis)features.
+<div id="2004_hibachi">
+## 2004/hibachi
+</div>
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2004/hibachi/hibachi.c](%%REPO_URL%%/2004/hibachi/hibachi.c)
+### Information: [2004/hibachi//index.html](2004/hibachi//index.html)
+
+The author stated that:
+
+> The links (text) web browser does not support RFC 2616 section 7.2.1 paragraph 3
+sentence 2, and so fails to display responses from `hibachi`.
+
+
 
 
 <div id="2004_jdalbec">


### PR DESCRIPTION
Some bug statuses have been changed so the bugs file was also updated (some removed, some added).

The manifest of 2004/hibachi was fixed some.

The alt_url of 2004/gavare was fixed which required a rebuild of authors.html.

For 2004/gavin a proper link to QEMU was added. It strikes me as it possibly being a good idea to have an FAQ about QEMU (as it is not just 2004/gavin that might benefit from it) but I don't know and in any case I have zero experience with it.

The entries 2004/gavare, 2004/gavin and 2004/hibachi have been checked for format / display issues. This would suggest that the next entry to look at is 2004/hoyle.