### PR TITLE
Fix warning in 2001/bellard/Makefile

### DIFF
--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -135,8 +135,8 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "WARNING: This must be compiled as a 32-bit binary and run" \
-	      "under i386 Linux in 32-bit mode, or this entry will not work!"
+	@echo "WARNING: This must be compiled as a 32-bit binary and run"
+	@echo "under i386 Linux in 32-bit mode, or this entry will not work!"
 	@echo
 	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS}
 

--- a/Makefile
+++ b/Makefile
@@ -666,6 +666,11 @@ rules: ${GEN_TOP_HTML} next/rules.md
 	${GEN_TOP_HTML} -v 1 next/rules
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
+guidelines: ${GEN_TOP_HTML} next/guidelines.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	${GEN_TOP_HTML} -v 1 next/guidelines
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
 security: ${GEN_TOP_HTML} SECURITY.md
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	${GEN_TOP_HTML} -v 1 SECURITY

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -424,7 +424,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.11 2024-07-27</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.12 2024-08-21</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <div id="change_marks">
@@ -1041,11 +1041,8 @@ a one-liner in our vague opinion.</p>
 <p>We tend to <strong>DISLIKE</strong> programs that:</p>
 <ul>
 <li>are very hardware specific</li>
-<li><p class="leftbar">
-are very OS version specific
-(<code>index(3)</code>/<code>strchr(3)</code> differences are OK, but sockets/streams specific code is
-likely not to be)
-</p></li>
+<li>are very OS version specific (<code>index(3)</code>/<code>strchr(3)</code> differences are OK, but
+sockets/streams specific code is likely not to be)</li>
 <li>dump core or have compiler warnings (it is OK only if
 you warn us in your <code>remarks.md</code> file)</li>
 <li><p class="leftbar">
@@ -1350,22 +1347,8 @@ unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson
 run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
 </p>
 <p class="leftbar">
-Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry tool
-source</a> nor
-the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry tool
-source</a>
-nor the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c">fnamchk tool
-source</a>
-nor various others in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a> are original works, unless you
-are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, in which case
-they are original! :-) Submitting source that uses the content of these tools,
-unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might
-run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
-</p>
-<p class="leftbar">
-Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and
-library</a>
+Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry tool source</a>
+nor the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and library</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c">jstrencode</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c">jstrdecode</a>
 nor any of the other <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse">jparse
@@ -1376,6 +1359,13 @@ Noll</a>, in which case they are original!
 are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> or <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, might run the risk of violating
 <a href="rules.html#rule7">Rule 7</a>.
+</p>
+<p class="leftbar">
+Unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, the
+remaining tools in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
+are <strong>NOT</strong> original works. Submitting source that uses the content of those tools,
+unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might
+run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
 </p>
 <p class="leftbar">
 <a href="rules.html#rule7">Rule 7</a> does not prohibit you from writing your own

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -48,7 +48,7 @@ writing by [contacting the judges](../contact.html).
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.11 2024-07-27**.
+These [IOCCC guidelines](guidelines.html) are version **28.12 2024-08-21**.
 </p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
@@ -847,9 +847,8 @@ a one-liner in our vague opinion.
 We tend to **DISLIKE** programs that:
 
 * are very hardware specific
-* <p class="leftbar">are very OS version specific
-(`index(3)`/`strchr(3)` differences are OK, but sockets/streams specific code is
-likely not to be)</p>
+* are very OS version specific (`index(3)`/`strchr(3)` differences are OK, but
+sockets/streams specific code is likely not to be)
 * dump core or have compiler warnings (it is OK only if
 you warn us in your `remarks.md` file)
 * <p class="leftbar">won't compile or run in a [Single UNIX
@@ -1207,24 +1206,8 @@ unless you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), might
 run the risk of violating [Rule 7](rules.html#rule7).</p>
 
 <p class="leftbar">
-Neither the [chkentry tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c) nor
-the [mkiocccentry tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c)
-nor the [fnamchk tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c)
-nor various others in the [mkiocccentry
-repo](https://github.com/ioccc-src/mkiocccentry) are original works, unless you
-are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), in which case
-they are original!  :-) Submitting source that uses the content of these tools,
-unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), might
-run the risk of violating [Rule 7](rules.html#rule7).
-</p>
-
-
-<p class="leftbar">
-Neither the [JSON parser and
-library](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
+Neither the [chkentry tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c)
+nor the [JSON parser and library](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
 nor [jstrencode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c)
 nor [jstrdecode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c)
 nor any of the other [jparse
@@ -1235,6 +1218,14 @@ Noll](http://www.isthe.com/chongo/index.html), in which case they are original!
 are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson) or [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), might run the risk of violating
 [Rule 7](rules.html#rule7).</p>
+
+<p class="leftbar">
+Unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), the
+remaining tools in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
+are **NOT** original works. Submitting source that uses the content of those tools,
+unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), might
+run the risk of violating [Rule 7](rules.html#rule7).
+</p>
 
 <p class="leftbar">
 [Rule 7](rules.html#rule7) does not prohibit you from writing your own


### PR DESCRIPTION

Having a '\' at the EOL of an echo followed by the rest of the string on
the next line will obviously not work as the '\' doesn't start a new 
command but continues it (scripts notwithstanding). I am not sure how 
this even got there but it resulted in a very long line of output.