### PR TITLE
Silence funny warning in 2019/adamovsky

### DIFF
--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -135,8 +135,8 @@ all: data ${TARGET}
 	sandwich supernova deep_magic magic charon pluto
 
 ${PROG}: ${PROG}.c
-	@echo "WARNING: This must be compiled as a 32-bit binary and run" \
-	      "under i386 Linux in 32-bit mode, or this entry will not work!"
+	@echo "WARNING: This must be compiled as a 32-bit binary and run"
+	@echo "under i386 Linux in 32-bit mode, or this entry will not work!"
 	@echo
 	${CC} ${CFLAGS} -m32 $< -o $@ ${LDFLAGS}
 

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-int-to-pointer-cast \
-	  -Wno-unused-value -Wno-unused-parameter
+	  -Wno-unused-value -Wno-unused-parameter -Wno-incompatible-pointer-types
 
 # Attempt to silence unknown warnings
 #

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion \
-	  -Wno-pointer-to-int-cast -Wno-deprecated-non-prototype
+	  -Wno-pointer-to-int-cast -Wno-deprecated-non-prototype -Wno-misleading-indentation
 
 # Attempt to silence unknown warnings
 #

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -40,7 +40,8 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion \
-	  -Wno-pointer-to-int-cast -Wno-deprecated-non-prototype -Wno-misleading-indentation
+	  -Wno-pointer-to-int-cast -Wno-deprecated-non-prototype -Wno-misleading-indentation \
+	  -Wno-unsafe-buffer-usage
 
 # Attempt to silence unknown warnings
 #

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-constant-conversion -Wno-format-security \
 	  -Wno-missing-braces -Wno-non-literal-null-conversion \
 	  -Wno-pointer-sign -Wno-pointer-to-int-cast -Wno-self-assign \
 	  -Wno-unused-parameter -Wno-incompatible-pointer-types -Wno-overflow \
-	  -Wno-pointer-to-int-cast -Wno-strict-aliasing
+	  -Wno-pointer-to-int-cast -Wno-strict-aliasing -Wno-reserved-identifier
 
 # Attempt to silence unknown warnings
 #

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -43,7 +43,8 @@ CSILENCE= -Wno-constant-conversion -Wno-format-security \
 	  -Wno-missing-braces -Wno-non-literal-null-conversion \
 	  -Wno-pointer-sign -Wno-pointer-to-int-cast -Wno-self-assign \
 	  -Wno-unused-parameter -Wno-incompatible-pointer-types -Wno-overflow \
-	  -Wno-pointer-to-int-cast -Wno-strict-aliasing -Wno-reserved-identifier
+	  -Wno-pointer-to-int-cast -Wno-strict-aliasing -Wno-reserved-identifier \
+	  -Wno-disabled-macro-expansion
 
 # Attempt to silence unknown warnings
 #

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -44,7 +44,8 @@ CSILENCE= -Wno-constant-conversion -Wno-format-security \
 	  -Wno-pointer-sign -Wno-pointer-to-int-cast -Wno-self-assign \
 	  -Wno-unused-parameter -Wno-incompatible-pointer-types -Wno-overflow \
 	  -Wno-pointer-to-int-cast -Wno-strict-aliasing -Wno-reserved-identifier \
-	  -Wno-disabled-macro-expansion
+	  -Wno-disabled-macro-expansion -Wno-incompatible-function-pointer-types-strict \
+	  -Wno-unsafe-buffer-usage
 
 # Attempt to silence unknown warnings
 #

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-newline-eof -Wno-strict-prototypes -Wno-maybe-uninitialized \
-	  -Wno-misleading-indentation
+	  -Wno-misleading-indentation -Wno-documentation
 
 # Attempt to silence unknown warnings
 #

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -38,7 +38,7 @@ include ../../var.mk
 
 # Common C compiler warnings to silence
 #
-CSILENCE= -Wno-trigraphs -Wno-comment -Wno-misleading-indentation
+CSILENCE= -Wno-trigraphs -Wno-comment -Wno-misleading-indentation -Wno-documentation
 
 # Attempt to silence unknown warnings
 #

--- a/Makefile
+++ b/Makefile
@@ -666,6 +666,11 @@ rules: ${GEN_TOP_HTML} next/rules.md
 	${GEN_TOP_HTML} -v 1 next/rules
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
+guidelines: ${GEN_TOP_HTML} next/guidelines.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	${GEN_TOP_HTML} -v 1 next/guidelines
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
 security: ${GEN_TOP_HTML} SECURITY.md
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	${GEN_TOP_HTML} -v 1 SECURITY

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -424,7 +424,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.11 2024-07-27</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.12 2024-08-21</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <div id="change_marks">
@@ -1041,11 +1041,8 @@ a one-liner in our vague opinion.</p>
 <p>We tend to <strong>DISLIKE</strong> programs that:</p>
 <ul>
 <li>are very hardware specific</li>
-<li><p class="leftbar">
-are very OS version specific
-(<code>index(3)</code>/<code>strchr(3)</code> differences are OK, but sockets/streams specific code is
-likely not to be)
-</p></li>
+<li>are very OS version specific (<code>index(3)</code>/<code>strchr(3)</code> differences are OK, but
+sockets/streams specific code is likely not to be)</li>
 <li>dump core or have compiler warnings (it is OK only if
 you warn us in your <code>remarks.md</code> file)</li>
 <li><p class="leftbar">
@@ -1350,22 +1347,8 @@ unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson
 run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
 </p>
 <p class="leftbar">
-Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry tool
-source</a> nor
-the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry tool
-source</a>
-nor the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c">fnamchk tool
-source</a>
-nor various others in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a> are original works, unless you
-are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, in which case
-they are original! :-) Submitting source that uses the content of these tools,
-unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might
-run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
-</p>
-<p class="leftbar">
-Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and
-library</a>
+Neither the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry tool source</a>
+nor the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">JSON parser and library</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c">jstrencode</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c">jstrdecode</a>
 nor any of the other <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse">jparse
@@ -1376,6 +1359,13 @@ Noll</a>, in which case they are original!
 are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> or <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, might run the risk of violating
 <a href="rules.html#rule7">Rule 7</a>.
+</p>
+<p class="leftbar">
+Unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, the
+remaining tools in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
+are <strong>NOT</strong> original works. Submitting source that uses the content of those tools,
+unless you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt Noll</a>, might
+run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
 </p>
 <p class="leftbar">
 <a href="rules.html#rule7">Rule 7</a> does not prohibit you from writing your own

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -48,7 +48,7 @@ writing by [contacting the judges](../contact.html).
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.11 2024-07-27**.
+These [IOCCC guidelines](guidelines.html) are version **28.12 2024-08-21**.
 </p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
@@ -847,9 +847,8 @@ a one-liner in our vague opinion.
 We tend to **DISLIKE** programs that:
 
 * are very hardware specific
-* <p class="leftbar">are very OS version specific
-(`index(3)`/`strchr(3)` differences are OK, but sockets/streams specific code is
-likely not to be)</p>
+* are very OS version specific (`index(3)`/`strchr(3)` differences are OK, but
+sockets/streams specific code is likely not to be)
 * dump core or have compiler warnings (it is OK only if
 you warn us in your `remarks.md` file)
 * <p class="leftbar">won't compile or run in a [Single UNIX
@@ -1207,24 +1206,8 @@ unless you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), might
 run the risk of violating [Rule 7](rules.html#rule7).</p>
 
 <p class="leftbar">
-Neither the [chkentry tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c) nor
-the [mkiocccentry tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c)
-nor the [fnamchk tool
-source](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c)
-nor various others in the [mkiocccentry
-repo](https://github.com/ioccc-src/mkiocccentry) are original works, unless you
-are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), in which case
-they are original!  :-) Submitting source that uses the content of these tools,
-unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), might
-run the risk of violating [Rule 7](rules.html#rule7).
-</p>
-
-
-<p class="leftbar">
-Neither the [JSON parser and
-library](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
+Neither the [chkentry tool source](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c)
+nor the [JSON parser and library](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
 nor [jstrencode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c)
 nor [jstrdecode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c)
 nor any of the other [jparse
@@ -1235,6 +1218,14 @@ Noll](http://www.isthe.com/chongo/index.html), in which case they are original!
 are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson) or [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), might run the risk of violating
 [Rule 7](rules.html#rule7).</p>
+
+<p class="leftbar">
+Unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), the
+remaining tools in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
+are **NOT** original works. Submitting source that uses the content of those tools,
+unless you are [Landon Curt Noll](http://www.isthe.com/chongo/index.html), might
+run the risk of violating [Rule 7](rules.html#rule7).
+</p>
 
 <p class="leftbar">
 [Rule 7](rules.html#rule7) does not prohibit you from writing your own


### PR DESCRIPTION

The funny warning is:

prog.c:19:515: warning: line splicing in Doxygen comments are not supported [-Wdocumentation]
   19 | void X(char*f,int r){ fputs(f,stderr);exit(r);}typedef w{w* (*t) (w*x);w* (*l) (w*x,w*y);w*a;long long p;}A;h(R) {x[N-1].p++;e x;}h(Ch) ;h(Y) ;h(fA) ;d(fD) ;d(fT) ;d(fW) ;d(fCh) ;d(rA2) ;d(fA2) ;d(rY2) ;d(Y2) ;d(rS2) ;d(fS22) ;d(rD) ;d(rE) ;d(rT) ;d(rC) ;void D(A*f) {if(f&&!--f[N-1].p) {if(u(f)!=fW&&u(f)!=fCh) D(f[1].a);if(u(f)!=fT) D(f[2].a);if(u(f)!=rE&&u(f)!=rT&&u(f)!=rC) D(f[3].a);free(f);}}int ch=EOF,c;FILE*p;A T[256][2];void U(void) {do{if(c==EOF) e;if(T[c][0].t) e;if(!T[c][1].p) E;if(T[c][1].p==4) for(/**??/
      |
                                     
           
                                                                  ^
1 warning generated.

.. obviously confused by trigraphs.
