### PR TITLE
Fix fa807fdb7fd1d1294b5d8e4a570c53a64f431d6d

### DIFF
--- a/1993/leo/leo.c
+++ b/1993/leo/leo.c
@@ -6,9 +6,9 @@
 #define A(x) (e^d)&i?e:(e+=i+i/15-d,d<<=4,i<<=4,x)
 #define B b+=!((e^d)&i)&&(d|=i),i<<=4,
 #define C i=15,B B B B d=d<<4|d>>12,
-#define D =(d=g,b=0,C b<<=4, C C C b)
+#define D=(d=g,b=0,C b<<=4, C C C b)
 #define E if(**y)goto
-#define F =a[rand()%c]
+#define F=a[rand()%c]
 #define G unsigned short
 #define H e^=a[z],a[z]^=e,e^=a[z],
 

--- a/1993/leo/leo.c
+++ b/1993/leo/leo.c
@@ -6,9 +6,9 @@
 #define A(x) (e^d)&i?e:(e+=i+i/15-d,d<<=4,i<<=4,x)
 #define B b+=!((e^d)&i)&&(d|=i),i<<=4,
 #define C i=15,B B B B d=d<<4|d>>12,
-#define D=(d=g,b=0,C b<<=4, C C C b)
+#define D =(d=g,b=0,C b<<=4, C C C b)
 #define E if(**y)goto
-#define F=a[rand()%c]
+#define F =a[rand()%c]
 #define G unsigned short
 #define H e^=a[z],a[z]^=e,e^=a[z],
 

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -39,7 +39,7 @@ include ../../var.mk
 # Common C compiler warnings to silence
 #
 CSILENCE= -Wno-newline-eof -Wno-strict-prototypes -Wno-maybe-uninitialized \
-	  -Wno-misleading-indentation -Wno-documentation
+	  -Wno-misleading-indentation
 
 # Attempt to silence unknown warnings
 #

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-comment -Wno-dangling-else -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-incompatible-pointer-types \
 	  -Wno-parentheses -Wno-trigraphs -Wno-newline-eof \
-	  -Wno-builtin-declaration-mismatch -Wno-sequence-point
+	  -Wno-builtin-declaration-mismatch -Wno-sequence-point -Wno-documentation
 
 # Attempt to silence unknown warnings
 #


### PR DESCRIPTION

The entry that triggered the funny warning (-Wdocumentation) was not in
2013/birken but 2014/birken. Thus the -Wno-documentation was removed 
from 2013/birken/Makefile and added to 2014/birken/Makefile.

With this commit I believe that every warning that can be disabled has 
been disabled in some way or another, though this is with an earlier
version of clang (clang version 17.0.6 but the most recent one is,
according to its website and contrary to wiki claiming 17, 18.1.8, and I
also know that fedora linux clang had more problems).
