### PR TITLE
Make thanks file MUCH MORE humble and improve FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -461,7 +461,7 @@
 <li><a class="normal" href="#faq4_3">4.3 - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?</a></li>
 <li><a class="normal" href="#faq4_4">4.4 - What is the meaning of the file ending in .orig.c in IOCCC entries?</a></li>
-<li><a class="normal" href="#faq4_5">4.5 - Why were alternate versions added to some entries when the original entry worked fine and well?</a></li>
+<li><a class="normal" href="#faq4_5">4.5 - What are alternate versions and why were alternate versions added to some entries when the original entry worked fine and well?</a></li>
 <li><a class="normal" href="#faq4_6">4.6 - Why was arg count and/or type changed in main() in some older entries?</a></li>
 <li><a class="normal" href="#faq4_7">4.7 - Why were some filenames changed?</a></li>
 <li><a class="normal" href="#faq4_8">4.8 - Why were files added or removed from some entries?</a></li>
@@ -3444,20 +3444,31 @@ we can find.</p>
 <div id="faq4_5">
 <div id="alt">
 <div id="alt_code">
-<h3 id="faq-4.5-why-were-alternate-versions-added-to-some-entries-when-the-original-entry-worked-fine-and-well">FAQ 4.5: Why were alternate versions added to some entries when the original entry worked fine and well?</h3>
+<h3 id="faq-4.5-what-are-alternate-versions-and-why-were-alternate-versions-added-to-some-entries-when-the-original-entry-worked-fine-and-well">FAQ 4.5: What are alternate versions and why were alternate versions added to some entries when the original entry worked fine and well?</h3>
 </div>
 </div>
 </div>
-<p>This was a judgement call and the reasons vary. In many cases it was simply to
-make the entry more presentable to more people but without modifying the entry
-itself, which would be tampering with the entry, and in some cases it would be
-changing it so much that it would no longer be what was submitted.</p>
+<p>The alternate versions are exactly what they sound like, versions of their
+respective entries that were not the winning source code but have additional
+features added (often by the author) or fixes, updates at the request of the
+judges (upon winning the contest), unobfuscated versions and a variety of other
+things for instance letting it work on more than one platform (where it would
+not be possible to do in the original submission).</p>
+<p>In some cases the alternate code added come directly from the author (some of
+which already were in the website) but there were other cases where alternate
+code was added that might or might not be necessary; this was a judgement call
+and the reasons vary.</p>
+<p>In many cases it was simply to make the entry more presentable to more people
+but without modifying the entry itself, which would be tampering with the entry
+(a problem that we tried to avoid as much as possible although we certainly did
+not manage to do this perfectly), and in some cases it would be changing it so
+much that it would no longer be what was submitted.</p>
 <p>In one case an alternate version was created to help locate and fix a bug that
 prevented the entry from working properly and it seemed like it should be added
-as well, for fun.</p>
-<p>In some cases it might be better to not have them but as noted this is a
+as well, for fun (it is a game).</p>
+<p>In some cases it might be better to not have them but as noted this was a
 judgement call.</p>
-<p>See the
+<p>See also the
 FAQ on “<a href="#original_source_code">original source code</a>”
 for more information.</p>
 <p>Jump to: <a href="#">top</a></p>

--- a/faq.md
+++ b/faq.md
@@ -73,7 +73,7 @@ This is FAQ version **28.0.4 2024-08-24**.
 - <a class="normal" href="#faq4_3">4.3  - Why do author remarks sometimes not match the source and/or why are there
 other inconsistencies with the original entry?</a>
 - <a class="normal" href="#faq4_4">4.4  - What is the meaning of the file ending in .orig.c in IOCCC entries?</a>
-- <a class="normal" href="#faq4_5">4.5  - Why were alternate versions added to some entries when the original entry worked fine and well?</a>
+- <a class="normal" href="#faq4_5">4.5  - What are alternate versions and why were alternate versions added to some entries when the original entry worked fine and well?</a>
 - <a class="normal" href="#faq4_6">4.6  - Why was arg count and/or type changed in main&lpar;&rpar; in some older entries?</a>
 - <a class="normal" href="#faq4_7">4.7  - Why were some filenames changed?</a>
 - <a class="normal" href="#faq4_8">4.8  - Why were files added or removed from some entries?</a>
@@ -4021,24 +4021,37 @@ Jump to: [top](#)
 <div id="faq4_5">
 <div id="alt">
 <div id="alt_code">
-### FAQ 4.5: Why were alternate versions added to some entries when the original entry worked fine and well?
+### FAQ 4.5: What are alternate versions and why were alternate versions added to some entries when the original entry worked fine and well?
 </div>
 </div>
 </div>
 
-This was a judgement call and the reasons vary. In many cases it was simply to
-make the entry more presentable to more people but without modifying the entry
-itself, which would be tampering with the entry, and in some cases it would be
-changing it so much that it would no longer be what was submitted.
+The alternate versions are exactly what they sound like, versions of their
+respective entries that were not the winning source code but have additional
+features added (often by the author) or fixes, updates at the request of the
+judges (upon winning the contest), unobfuscated versions and a variety of other
+things for instance letting it work on more than one platform (where it would
+not be possible to do in the original submission).
+
+In some cases the alternate code added come directly from the author (some of
+which already were in the website) but there were other cases where alternate
+code was added that might or might not be necessary; this was a judgement call
+and the reasons vary.
+
+In many cases it was simply to make the entry more presentable to more people
+but without modifying the entry itself, which would be tampering with the entry
+(a problem that we tried to avoid as much as possible although we certainly did
+not manage to do this perfectly), and in some cases it would be changing it so
+much that it would no longer be what was submitted.
 
 In one case an alternate version was created to help locate and fix a bug that
 prevented the entry from working properly and it seemed like it should be added
-as well, for fun.
+as well, for fun (it is a game).
 
-In some cases it might be better to not have them but as noted this is a
+In some cases it might be better to not have them but as noted this was a
 judgement call.
 
-See the
+See also the
 FAQ on "[original source code](#original_source_code)"
 for more information.
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -4609,7 +4609,7 @@ alternate code provided by the author, Yusuke.</p>
 <h2 id="winning-entry-2020ferguson1">Winning entry: <a href="2020/ferguson1/index.html">2020/ferguson1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-55">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1//prog.c">prog.c</a></h3>
 </div>
-<p>Just for awareness, here: <a href="#cody">Cody</a> made some corrections to the vital <a href="2020/ferguson1/chocolate-cake.html">Double
+<p>Just for awareness: <a href="#cody">Cody</a> made some corrections to the vital <a href="2020/ferguson1/chocolate-cake.html">Double
 layered chocolate fudge cake recipe</a> :-)
 Other fixes were made but as it’s his entry it’s not worth noting.</p>
 <div id="2020_giles">
@@ -4786,41 +4786,41 @@ helped improve the presentation of their fellow IOCCC entries.</p>
 </div>
 <p>We call out the extensive contributions of <a href="authors.html#Cody_Boone_Ferguson">Cody Boone
 Ferguson</a> who is responsible for most of the
-improvements and fixes including many <strong>EXTREMELY HARD bug fixes</strong> (for certain
-definitions of <strong><em>HARD</em></strong> :-) ) like
+improvements and fixes including <strong>fixing <em>many entries</em> that no longer worked</strong>
+(and other important bug fixes), often <strong>EXTREMELY HARD</strong> (for certain
+definitions of ‘<em>HARD</em>’ :-) ), like
 <a href="thanks-for-help.html#1988_phillipps">1988/phillipps</a>,
 <a href="thanks-for-help.html#1992_vern">1992/vern</a>,
 <a href="thanks-for-help.html#2001_anonymous">2001/anonymous</a>,
 <a href="thanks-for-help.html#2004_burley">2004/burley</a> and
-<a href="thanks-for-help.html#2005_giljade">2005/giljade</a>, making all entries such as
+<a href="thanks-for-help.html#2005_giljade">2005/giljade</a>; making all entries, such as
 <a href="thanks-for-help.html#1985_sicherman">1985/sicherman</a> and
-<a href="thanks-for-help.html#1986_wall">1986/wall</a> not need <code>-traditional-cpp</code> (all
-<strong>EXTREMELY HARD</strong>), fixing entries to work with <code>clang</code>, some <strong>EXTREMELY
-HARD</strong> like <a href="thanks-for-help.html#1991_dds">1991/dds</a>, or as much as possible
-(<a href="thanks-for-help.html#1989_westley">1989/westley</a>, a true masterpiece that is
-<strong>INCREDIBLY HARD, <em>MUCH MORE SO</em> than any other fix!</strong>), porting entries to
-macOS (some <strong>EXTREMELY HARD</strong> like
-<a href="thanks-for-help.html#1998_schweikh1">1998/schweikh1</a>, fixing code like
-<a href="thanks-for-help.html#2001_herrmann2">2001/herrmann2</a> to work in both
-32-bit/64-bit which <em>can be</em> <strong>EXTREMELY HARD</strong>, providing alternate code where
-useful/necessary, improving <strong>ALL <em>Makefiles</em></strong> and writing scripts to greatly
-simplify running many of the entries.</p>
-<p>He also wrote <a href="https://github.com/xexyl/sgit">sgit</a> to easily run
-<code>sed(1)</code> on files in the repo which we used to help build the website.</p>
+<a href="thanks-for-help.html#1986_wall">1986/wall</a>, that
+required <code>-traditional-cpp</code>, to no longer require it; fixing
+entries like <a href="thanks-for-help.html#1991_dds">1991/dds</a> (or, as in the case of
+<a href="thanks-for-help.html#1989_westley">1989/westley</a>, a true masterpiece in
+obfuscation, as much as possible) to work with <code>clang</code>; porting entries such as
+<a href="thanks-for-help.html#1998_schweikh1">1998/schweikh1</a> to macOS; fixing code like
+<a href="thanks-for-help.html#2001_herrmann2">2001/herrmann2</a> to work in both 32-bit and
+64-bit; providing <a href="faq.html#alt_code">alternate code</a> where useful/necessary;
+improving all <code>Makefiles</code>; and writing scripts to greatly simplify running many
+of the entries.</p>
+<p>Cody also wrote the feature-rich <a href="https://github.com/xexyl/sgit">sgit</a> to easily
+run <code>sed(1)</code> on files in the repo which we used to help build the website.</p>
 <p>Cody Boone Ferguson also used one of his own tools to detect many dead links.
 While the tool was not perfect it went a long way to uncover a good number of
-bad, broken or otherwise invalid links. It was a very laborious task to copy
-and paste problematic links into the <a href="https://web.archive.org">Internet Wayback
+bad, broken or otherwise invalid links. It was a very laborious task to copy and
+paste problematic links into the <a href="https://web.archive.org">Internet Wayback
 Machine</a> in an effort to try and find otherwise lost
 content. A good number of links that now refer to something in the <a href="https://web.archive.org">Internet
 Wayback Machine</a> replace bad, broken, or otherwise
 invalid links are thanks to Cody’s efforts! Another tool he wrote detected
-inconsistent award titles in the README files and CSV file (that he generated
-from the SQL file).</p>
+inconsistent award titles in the <code>README.md</code> files (used to generate the
+<code>index.html</code> files) and the CSV file that he generated from our SQL file.</p>
 <p>Additionally Cody greatly improved the manifest of the winning entries and
-checked that the generated html files, index.html and otherwise, look well and
-presentable and suggested some CSS rules for image responsiveness on smaller
-screens and other improvements.</p>
+checked that the generated html files, <code>index.html</code> and otherwise, look well and
+are presentable, and he also suggested some CSS rules for image responsiveness on smaller
+screens, as well as some other improvements.</p>
 <p><strong>THANK YOU VERY MUCH</strong> for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC entries and fixing almost all past entries for modern
 systems!</p>
@@ -4828,8 +4828,9 @@ systems!</p>
 <h3 id="yusuke-endoh">Yusuke Endoh</h3>
 </div>
 <p><a href="authors.html#Yusuke_Endoh">Yusuke Endoh</a> supplied a
-number of important bug fixes to a number of past IOCCC entries. Some of those
-fixes were <strong>EXTREMELY TECHNICALLY CHALLENGING</strong> such as
+number of important bug fixes to a number of past IOCCC entries, including
+<strong>fixing <em>numerous entries</em> that no longer worked</strong>. Some of those
+fixes were <strong>EXTREMELY TECHNICALLY CHALLENGING</strong>, such as
 <a href="thanks-for-help.html#1989_robison">1989/robison</a>,
 <a href="thanks-for-help.html#1990_cmills">1990/cmills</a>,
 <a href="thanks-for-help.html#1992_lush">1992/lush</a> and

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -5984,7 +5984,7 @@ alternate code provided by the author, Yusuke.
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2020/ferguson1//prog.c)
 </div>
 
-Just for awareness, here: [Cody](#cody) made some corrections to the vital [Double
+Just for awareness: [Cody](#cody) made some corrections to the vital [Double
 layered chocolate fudge cake recipe](2020/ferguson1/chocolate-cake.html) :-)
 Other fixes were made but as it's his entry it's not worth noting.
 
@@ -6230,44 +6230,44 @@ helped improve the presentation of their fellow IOCCC entries.
 
 We call out the extensive contributions of [Cody Boone
 Ferguson](authors.html#Cody_Boone_Ferguson) who is responsible for most of the
-improvements and fixes including many **EXTREMELY HARD bug fixes** (for certain
-definitions of **_HARD_** :-) ) like
+improvements and fixes including **fixing _many entries_ that no longer worked**
+(and other important bug fixes), often **EXTREMELY HARD** (for certain
+definitions of '_HARD_' :-) ), like
 [1988/phillipps](thanks-for-help.html#1988_phillipps),
 [1992/vern](thanks-for-help.html#1992_vern),
 [2001/anonymous](thanks-for-help.html#2001_anonymous),
 [2004/burley](thanks-for-help.html#2004_burley) and
-[2005/giljade](thanks-for-help.html#2005_giljade), making all entries such as
+[2005/giljade](thanks-for-help.html#2005_giljade); making all entries, such as
 [1985/sicherman](thanks-for-help.html#1985_sicherman) and
-[1986/wall](thanks-for-help.html#1986_wall) not need `-traditional-cpp` (all
-**EXTREMELY HARD**), fixing entries to work with `clang`, some **EXTREMELY
-HARD** like [1991/dds](thanks-for-help.html#1991_dds), or as much as possible
-([1989/westley](thanks-for-help.html#1989_westley), a true masterpiece that is
-**INCREDIBLY HARD, *MUCH MORE SO* than any other fix!**), porting entries to
-macOS (some **EXTREMELY HARD** like
-[1998/schweikh1](thanks-for-help.html#1998_schweikh1), fixing code like
-[2001/herrmann2](thanks-for-help.html#2001_herrmann2) to work in both
-32-bit/64-bit which *can be* **EXTREMELY HARD**, providing alternate code where
-useful/necessary, improving **ALL _Makefiles_** and writing scripts to greatly
-simplify running many of the entries.
+[1986/wall](thanks-for-help.html#1986_wall), that
+required `-traditional-cpp`, to no longer require it; fixing
+entries like [1991/dds](thanks-for-help.html#1991_dds) (or, as in the case of
+[1989/westley](thanks-for-help.html#1989_westley), a true masterpiece in
+obfuscation, as much as possible) to work with `clang`; porting entries such as
+[1998/schweikh1](thanks-for-help.html#1998_schweikh1) to macOS; fixing code like
+[2001/herrmann2](thanks-for-help.html#2001_herrmann2) to work in both 32-bit and
+64-bit; providing [alternate code](faq.html#alt_code) where useful/necessary;
+improving all `Makefiles`; and writing scripts to greatly simplify running many
+of the entries.
 
-He also wrote [sgit](https://github.com/xexyl/sgit) to easily run
-`sed(1)` on files in the repo which we used to help build the website.
+Cody also wrote the feature-rich [sgit](https://github.com/xexyl/sgit) to easily
+run `sed(1)` on files in the repo which we used to help build the website.
 
 Cody Boone Ferguson also used one of his own tools to detect many dead links.
 While the tool was not perfect it went a long way to uncover a good number of
-bad, broken or otherwise invalid links. It was a very laborious task to copy
-and paste problematic links into the [Internet Wayback
+bad, broken or otherwise invalid links. It was a very laborious task to copy and
+paste problematic links into the [Internet Wayback
 Machine](https://web.archive.org) in an effort to try and find otherwise lost
 content. A good number of links that now refer to something in the [Internet
 Wayback Machine](https://web.archive.org) replace bad, broken, or otherwise
 invalid links are thanks to Cody's efforts! Another tool he wrote detected
-inconsistent award titles in the README files and CSV file (that he generated
-from the SQL file).
+inconsistent award titles in the `README.md` files (used to generate the
+`index.html` files) and the CSV file that he generated from our SQL file.
 
 Additionally Cody greatly improved the manifest of the winning entries and
-checked that the generated html files, index.html and otherwise, look well and
-presentable and suggested some CSS rules for image responsiveness on smaller
-screens and other improvements.
+checked that the generated html files, `index.html` and otherwise, look well and
+are presentable, and he also suggested some CSS rules for image responsiveness on smaller
+screens, as well as some other improvements.
 
 **THANK YOU VERY MUCH** for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC entries and fixing almost all past entries for modern
@@ -6279,8 +6279,9 @@ systems!
 </div>
 
 [Yusuke Endoh](authors.html#Yusuke_Endoh) supplied a
-number of important bug fixes to a number of past IOCCC entries. Some of those
-fixes were **EXTREMELY TECHNICALLY CHALLENGING** such as
+number of important bug fixes to a number of past IOCCC entries, including
+**fixing _numerous entries_ that no longer worked**. Some of those
+fixes were **EXTREMELY TECHNICALLY CHALLENGING**, such as
 [1989/robison](thanks-for-help.html#1989_robison),
 [1990/cmills](thanks-for-help.html#1990_cmills),
 [1992/lush](thanks-for-help.html#1992_lush) and


### PR DESCRIPTION
Something that has bothered me VERY MUCH for A VERY LONG TIME is that the honour roll (under my name) was not very humble and in some respects rather redundant. I have fixed this a great deal and improved the readability of it too (grammar and so on).

I also added a point about fixing many entries that no longer worked and I also did this for Yusuke Endoh too as he was responsible for fixing numerous (at the least) entries that no longer worked (and it should be acknowledged and honoured just as much as what I did).

The FAQ I improved is related to one of the things that is in the above, to do with alternate code. It now explains some of the purposes of alternate code and why (in some cases) alt code was added when it might or might not be useful (a judgement call that invariably is not always perfect). It notes that in many cases the alternate code comes from the author directly.

With these changes a problem that I felt was a VERY BIG problem should be resolved now.