### PR TITLE
Fix sub/superscript cover text

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -117,8 +117,8 @@ small {
 }
 
 /*
- * Prevent `sub` and `sup` elements from affecting the line height in
- * all browsers.
+ * Prevent sub and sup elements from affecting the line height in
+ * all browsers (initially).
  */
 
 sub,
@@ -129,11 +129,23 @@ sup {
     vertical-align: baseline;
 }
 
+/*
+ * Fix the problem where subscript text covers part of the characters in the
+ * line below it.
+ */
 sub {
+    line-height: 190%;
+    font-size: 5%;
     bottom: -0.25em;
 }
 
+/*
+ * Fix the problem where superscript text covers part of the characters in the
+ * line above it.
+ */
 sup {
+    line-height: 190%;
+    font-size: 5%;
     top: -0.5em;
 }
 


### PR DESCRIPTION
A problem existed where in a superscript if there is a line immediately above it the superscript text would cover part of the line and in subscript the same problem occurred with the line below it.

This change can possibly be improved but it now does not cover text (though admittedly I did not test the subscript before the change, only after, but it seems highly unlikely it was not a problem).