### PR TITLE
Add jparse repo to guidelines

### DIFF
--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -424,7 +424,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.14 2024-08-24</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.14 2024-08-30</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <div id="change_marks">
@@ -1374,7 +1374,9 @@ nor the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/RE
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c">jstrencode</a>
 nor <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c">jstrdecode</a>
 nor any of the other <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse">jparse
-tools</a> are original works, unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody
+tools</a>
+are original works (see the <a href="https://github.com/xexyl/jparse/">jparse repo</a> for
+the original), unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody
 Boone Ferguson</a> or <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, in which case they are original!
 :-) Submitting source that uses the code of these tools or library, unless you

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -48,7 +48,7 @@ writing by [contacting the judges](../contact.html).
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.14 2024-08-24**.
+These [IOCCC guidelines](guidelines.html) are version **28.14 2024-08-30**.
 </p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
@@ -1236,7 +1236,9 @@ nor the [JSON parser and library](https://github.com/ioccc-src/mkiocccentry/blob
 nor [jstrencode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrencode.c)
 nor [jstrdecode](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jstrdecode.c)
 nor any of the other [jparse
-tools](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse) are original works, unless you are [Cody
+tools](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse)
+are original works (see the [jparse repo](https://github.com/xexyl/jparse/) for
+the original), unless you are [Cody
 Boone Ferguson](../authors.html#Cody_Boone_Ferguson) or [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), in which case they are original!
 :-) Submitting source that uses the code of these tools or library, unless you


### PR DESCRIPTION
The jparse/ subdirectory in the mkiocccentry repo is self-contained but it was suggested to put in parentheses the original source and this has been done now.