### PR TITLE
Minor fixes to FAQ wrt other repos

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -1636,9 +1636,13 @@ the tool.</p>
 <p>If you want to validate the <code>.auth.json</code> or <code>.info.json</code> files you
 should use <code>chkentry(1)</code> from the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
 repo</a>.</p>
-<p>The <code>chkentry(1)</code> tool uses the
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3">jparse API</a>
-API to perform <strong>additional</strong> checks on these two IOCCC specific JSON files.</p>
+<p>The <code>chkentry(1)</code> tool uses the IOCCC version of the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3">jparse
+API</a>
+to perform <strong>additional</strong> checks on these two IOCCC specific JSON files. It is
+<em>possible</em> that this version will at times differ from the <a href="https://github.com/xexyl/jparse/blob/master/man/man3/jparse.3">official jparse
+API</a> at the
+<a href="https://github.com/xexyl/jparse">official jparse repo</a> and this is one of the
+reasons the tools’ <code>-V</code> (version option) show the JSON parser version as well.</p>
 <p>See the
 FAQ on “<a href="#auth_json">.auth.json</a>”
 and

--- a/faq.md
+++ b/faq.md
@@ -1426,9 +1426,13 @@ If you want to validate the `.auth.json` or `.info.json` files you
 should use `chkentry(1)` from the [mkiocccentry
 repo](https://github.com/ioccc-src/mkiocccentry).
 
-The `chkentry(1)` tool uses the
-[jparse API](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3)
-API to perform **additional** checks on these two IOCCC specific JSON files.
+The `chkentry(1)` tool uses the IOCCC version of the [jparse
+API](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3)
+to perform **additional** checks on these two IOCCC specific JSON files. It is
+_possible_ that this version will at times differ from the [official jparse
+API](https://github.com/xexyl/jparse/blob/master/man/man3/jparse.3) at the
+[official jparse repo](https://github.com/xexyl/jparse) and this is one of the
+reasons the tools' `-V` (version option) show the JSON parser version as well.
 
 See the
 FAQ on "[.auth.json](#auth_json)"


### PR DESCRIPTION
The FAQ now notes that there can be times where the jparse repo (https://github.com/xexyl/jparse/) is different from the mkiocccentry repo's subdirectory jparse. This is one of the reasons the tools in the mkiocccentry and the jparse repo show the jparse API with the -V (version) option.

I believe that this is all that's needed for the jparse repo in the FAQ but time will tell on that.