### PR TITLE
Correct comment in Makefiles for CUNKNOWN

### DIFF
--- a/1984/anonymous/Makefile
+++ b/1984/anonymous/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype -Wno-void-pointer-to-int-cast \
 	  -Wno-missing-parameter-type -Wno-pointer-to-int-cast
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1984/decot/Makefile
+++ b/1984/decot/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-array-bounds -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-pointer-to-int-cast -Wno-return-type -Wno-unused-label -Wno-implicit-int \
 	  -Wno-cast-function-type -Wno-format-extra-args
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1984/laman/Makefile
+++ b/1984/laman/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype -Wno-misleading-indentation \
 	  -Wno-builtin-declaration-mismatch -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-main -Wno-deprecated-non-prototype -Wno-missing-parameter-type \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1985/applin/Makefile
+++ b/1985/applin/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-logical-op-parenthe
 	  -Wno-deprecated-non-prototype -Wno-implicit-int -Wno-parentheses -Wno-return-type \
 	  -Wno-builtin-declaration-mismatch -Wno-format -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1985/august/Makefile
+++ b/1985/august/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-main \
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
           -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1985/lycklama/Makefile
+++ b/1985/lycklama/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-implicit-int -Wno-unused-value -Wno-parentheses -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1985/shapiro/Makefile
+++ b/1985/shapiro/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-parentheses -Wno-string-plus-int -Wno-strict-prototypes \
 	  -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1985/sicherman/Makefile
+++ b/1985/sicherman/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-comment -Wno-deprecated-non-prototype -Wno-main -Wno-pedantic \
 	  -Wno-multichar -Wno-uninitialized -Wno-unused-but-set-parameter \
 	  -Wno-parentheses -Wno-int-conversion -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/applin/Makefile
+++ b/1986/applin/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-strict-prototypes -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/august/Makefile
+++ b/1986/august/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-return-type -Wno-deprecated-non-prototype -Wno-strict-prototypes \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/bright/Makefile
+++ b/1986/bright/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-security \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/hague/Makefile
+++ b/1986/hague/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-deprecated-declarations -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/holloway/Makefile
+++ b/1986/holloway/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-format-security -Wno-implicit-int -Wno-int-to-pointer-cast \
 	  -Wno-incompatible-pointer-types -Wno-implicit-fallthrough \
 	  -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/marshall/Makefile
+++ b/1986/marshall/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-address -Wno-builtin-declaration-mismatch -Wno-sequence-point \
 	  -Wno-int-to-pointer-cast
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/pawka/Makefile
+++ b/1986/pawka/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-non-literal-null-conversion -Wno-unused-value -Wno-strict-prototypes \
 	  -Wno-implicit-int -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/stein/Makefile
+++ b/1986/stein/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-int-conversion -Wno-deprecated-non-prototype \
 	  -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1986/wall/Makefile
+++ b/1986/wall/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-pedantic \
 	  -Wno-implicit-fallthrough -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/biggar/Makefile
+++ b/1987/biggar/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-extra-semi \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-pedantic -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/heckbert/Makefile
+++ b/1987/heckbert/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration -Wno-imp
           -Wno-missing-parameter-type -Wno-parentheses -Wno-return-type \
           -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/hines/Makefile
+++ b/1987/hines/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-deprecated-non-prot
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/korn/Makefile
+++ b/1987/korn/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int -Dunix
 	  -Wno-string-plus-int -Wno-strict-prototypes -Wno-return-type \
 	  -Wno-builtin-declaration-mismatch -Wno-format-contains-nul
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/lievaart/Makefile
+++ b/1987/lievaart/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype -Wno-maybe-uninitialized -Wno-misleading-indentation \
           -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/wall/Makefile
+++ b/1987/wall/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-deprecated-non-prototype -Wno-implicit-int -Wno-incompatible-pointer-types \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1987/westley/Makefile
+++ b/1987/westley/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-for-loop-analysis -Wno-unused-value \
 	  -Wno-deprecated-non-prototype -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/applin/Makefile
+++ b/1988/applin/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-expansion-to-defined -Wno-implicit-int -Wno-strict-prototypes \
 	  -Wno-gnu-line-marker -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/dale/Makefile
+++ b/1988/dale/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-implicit-function-declaration -Wno-implicit-int -Wno-keyword-macr
 	  -Wno-deprecated-non-prototype -Wno-builtin-declaration-mismatch \
 	  -Wno-implicit-fallthrough -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/isaak/Makefile
+++ b/1988/isaak/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-comma -Wno-implicit-function-declaration -Wno-format-insufficient
 	  -Wno-unused-macros -Wno-int-conversion -Wno-macro-redefined -Wno-parentheses \
 	  -Wno-builtin-declaration-mismatch -Wno-format -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/litmaath/Makefile
+++ b/1988/litmaath/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-logical-op-parenthe
 	  -Wno-deprecated-non-prototype -Wno-implicit-int -Wno-parentheses -Wno-return-type \
 	  -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/phillipps/Makefile
+++ b/1988/phillipps/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-pedantic -Wno-logical-not-parentheses -Wno-implicit-function-decl
 	  -Wno-deprecated-non-prototype -Wno-implicit-int -Wno-missing-parameter-type \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/reddy/Makefile
+++ b/1988/reddy/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-pedantic -Wno-error -Wno-implicit-function-declaration -Wno-paren
 	  -Wno-return-type -Wno-deprecated-declarations -Wno-deprecated-non-prototype \
 	  -Wno-implicit-int -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/robison/Makefile
+++ b/1988/robison/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-deprecated-non-prot
 	  -Wno-implicit-int -Wno-misleading-indentation -Wno-missing-parameter-type \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/spinellis/Makefile
+++ b/1988/spinellis/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-everything
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1988/westley/Makefile
+++ b/1988/westley/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-return-type \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/fubar/Makefile
+++ b/1989/fubar/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-implicit-function-declaration -Wno-incompatible-library-redeclaration -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/jar.1/Makefile
+++ b/1989/jar.1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/1989/jar.2/Makefile
+++ b/1989/jar.2/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-implicit-function-declaration -Wno-missing-braces -Wno-parenthese
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/ovdluhe/Makefile
+++ b/1989/ovdluhe/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-char-subscripts -Wno-constant-conversion -Wno-empty-body \
 	  -Wno-extra-semi -Wno-non-literal-null-conversion -Wno-implicit-int \
 	  -Wno-misleading-indentation -Wno-overflow -Wno-pedantic -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/paul/Makefile
+++ b/1989/paul/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-security \
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-missing-parameter-type -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/robison/Makefile
+++ b/1989/robison/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-unused-parameter -Wno-deprecated-non-prototype -Wno-format-extra-
           -Wno-int-to-pointer-cast -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-return-type -Wno-uninitialized -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/roemer/Makefile
+++ b/1989/roemer/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-string-plus-int -Wno-unused-value -Wno-strict-prototypes \
 	  -Wno-implicit-int -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-pointer-to-int-cast -Wno-no-return-type -Wno-empty-bod
 	  -Wno-implicit-int -Wno-format -Wno-misleading-indentation \
 	  -Wno-missing-parameter-type -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/vanb/Makefile
+++ b/1989/vanb/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration -Wn
 	  -Wno-deprecated-non-prototype -Wno-implicit-int -Wno-missing-parameter-type \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1989/westley/Makefile
+++ b/1989/westley/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-comment -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-implicit-int -Wno-missing-parameter-type -Wno-pointer-to-int-cast \
 	  -Wno-conditional-type-mismatch -Wno-non-literal-null-conversion
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/baruch/Makefile
+++ b/1990/baruch/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-logical-op-parenthe
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-parentheses -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/cmills/Makefile
+++ b/1990/cmills/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-deprecated-declarations -Wno-parentheses -Wno-error \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-missing-parameter-type -Wno-multistatement-macros
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/dds/Makefile
+++ b/1990/dds/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-builtin-requires-header -Wno-char-subscripts \
 	  -Wno-return-type -Wno-strict-prototypes -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/dg/Makefile
+++ b/1990/dg/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-invalid-pp-token -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-parentheses -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/jaw/Makefile
+++ b/1990/jaw/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declarat
 	  -Wno-misleading-indentation -Wno-missing-parameter-type \
           -Wno-multistatement-macros -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/pjr/Makefile
+++ b/1990/pjr/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-implicit-int -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/scjones/Makefile
+++ b/1990/scjones/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-invalid-pp-token -Wno-trigraphs -Wno-deprecated-non-prototype \
 	  -Wno-implicit-fallthrough -Wno-misleading-indentation \
           -Wno-missing-parameter-type -Wno-return-type -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/stig/Makefile
+++ b/1990/stig/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/1990/tbr/Makefile
+++ b/1990/tbr/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-empty-body -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
           -Wno-parentheses -Wno-stringop-overflow
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/theorem/Makefile
+++ b/1990/theorem/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-deprecated-declarations -Wno-empty-body -Wno-error -Wno-unused-va
 	  -Wno-deprecated-non-prototype -Wno-int-conversion -Wno-strict-prototypes \
 	  -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1990/westley/Makefile
+++ b/1990/westley/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-builtin-declaration-mismatch -Wno-implicit-fallthrough \
           -Wno-int-in-bool-context -Wno-overflow -Wno-parentheses -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/ant/Makefile
+++ b/1991/ant/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-empty-body \
 	  -Wno-misleading-indentation -Wno-missing-parameter-type \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/brnstnd/Makefile
+++ b/1991/brnstnd/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-c99-extensions -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-unused-value -Wno-implicit-int -Wno-builtin-declaration-mismatch \
 	  -Wno-pedantic
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/buzzard/Makefile
+++ b/1991/buzzard/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-missing-parameter-type -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/cdupont/Makefile
+++ b/1991/cdupont/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-unused-label -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/davidguy/Makefile
+++ b/1991/davidguy/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declarat
 	  -Wno-missing-parameter-type -Wno-parentheses -Wno-strict-aliasing \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/dds/Makefile
+++ b/1991/dds/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-deprecated-non-prototype -Wno-unused-parameter \
 	  -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-missing-parameter-type -Wno-return-type -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/fine/Makefile
+++ b/1991/fine/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declarat
 	  -Wno-parentheses -Wno-return-type -Wno-deprecated-non-prototype \
 	  -Wno-disabled-macro-expansion -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/rince/Makefile
+++ b/1991/rince/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-unused-value -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1991/westley/Makefile
+++ b/1991/westley/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-deprecated-non-prototype -Wno-missing-braces -Wno-implicit-int \
 	  -Wno-misleading-indentation -Wno-missing-parameter-type -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/adrian/Makefile
+++ b/1992/adrian/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-comment -Wno-deprecated-declarations 
 	  -Wno-empty-translation-unit -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/albert/Makefile
+++ b/1992/albert/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-unused-parameter \
 	  -Wno-parentheses-equality -Wno-return-type \
 	  -Wno-builtin-declaration-mismatch -Wno-clobbered -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/ant/Makefile
+++ b/1992/ant/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-unsequenced \
 	  -Wno-deprecated-non-prototype -Wno-strict-prototypes \
 	  -Wno-maybe-uninitialized
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/buzzard.1/Makefile
+++ b/1992/buzzard.1/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pedantic \
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
           -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/buzzard.2/Makefile
+++ b/1992/buzzard.2/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pedantic \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts \
 	  -Wno-int-in-bool-context -Wno-misleading-indentation \
           -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/imc/Makefile
+++ b/1992/imc/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format \
 	  -Wno-deprecated-non-prototype -Wno-implicit-int -Wno-unused-value \
 	  -Wno-builtin-declaration-mismatch -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/kivinen/Makefile
+++ b/1992/kivinen/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declarat
 	  -Wno-builtin-declaration-mismatch -Wno-maybe-uninitialized \
           -Wno-misleading-indentation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/lush/Makefile
+++ b/1992/lush/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-macro-redefined \
 	  -Wno-return-type -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/marangon/Makefile
+++ b/1992/marangon/Makefile
@@ -48,7 +48,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-builtin-declaration-mismatch -Wno-sequence-point \
 	  -Wno-unused-value -Wno-unsafe-buffer-usage -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/nathan/Makefile
+++ b/1992/nathan/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/vern/Makefile
+++ b/1992/vern/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-dangling-else -Wno-error \
 	  -Wno-int-in-bool-context -Wno-missing-parameter-type -Wno-unused-value \
 	  -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1992/westley/Makefile
+++ b/1992/westley/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declarat
 	  -Wno-int-conversion -Wno-implicit-int -Wno-comma -Wno-missing-prototypes \
 	  -Wno-return-type -Wno-misleading-indentation -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/ant/Makefile
+++ b/1993/ant/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-deprecated-non-prototype -Wno-strict-prototypes \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/cmills/Makefile
+++ b/1993/cmills/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-return-type -Wno-deprecated-non-prototype -Wno-implicit-int \
 	  -Wno-missing-parameter-type -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/dgibson/Makefile
+++ b/1993/dgibson/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-int-conversion -Wno-pointer-to-int-cast \
 	  -Wno-parentheses -Wno-stringop-overflow -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/ejb/Makefile
+++ b/1993/ejb/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-pointer-sign -Wno-builtin-declaration-mismatch -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/jonth/Makefile
+++ b/1993/jonth/Makefile
@@ -47,7 +47,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-misleading-indentation -Wno-missing-parameter-type \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/leo/Makefile
+++ b/1993/leo/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/lmfjyh/Makefile
+++ b/1993/lmfjyh/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-implicit-int -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/plummer/Makefile
+++ b/1993/plummer/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-security \
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
           -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/rince/Makefile
+++ b/1993/rince/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-c99-extensions -Wno-char-subscripts -Wno-dangling-else \
 	  -Wno-incompatible-pointer-types -Wno-unused-value -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/schnitzi/Makefile
+++ b/1993/schnitzi/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-deprecated-declarations -Wno-pedantic -Wno-deprecated-non-prototy
 	  -Wno-format-overflow -Wno-misleading-indentation -Wno-implicit-int \
           -Wno-missing-parameter-type -Wno-return-type -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1993/vanb/Makefile
+++ b/1993/vanb/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-deprecated-non-prototype -Wno-unused-value -Wno-unused-parameter \
 	  -Wno-implicit-int -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/dodsond1/Makefile
+++ b/1994/dodsond1/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/dodsond2/Makefile
+++ b/1994/dodsond2/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-return-type \
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/horton/Makefile
+++ b/1994/horton/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-unused-parameter \
 	  -Wno-unused-variable -Wno-deprecated-non-prototype -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/imc/Makefile
+++ b/1994/imc/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-deprecated-non-prototype -Wno-strict-prototypes \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/ldb/Makefile
+++ b/1994/ldb/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-trigraphs -Wno-incompatible-pointer-types -Wno-int-conversion \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-int-to-pointer-cast \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/schnitzi/Makefile
+++ b/1994/schnitzi/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-deprecated-declarations -Wno-error \
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/shapiro/Makefile
+++ b/1994/shapiro/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-parentheses -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/smr/Makefile
+++ b/1994/smr/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/1994/tvr/Makefile
+++ b/1994/tvr/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-main-return-type \
 	  -Wno-maybe-uninitialized -Wno-misleading-indentation -Wno-sequence-point \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/weisberg/Makefile
+++ b/1994/weisberg/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pointer-to-int-cast
 	  -Wno-shift-op-parentheses -Wno-implicit-int -Wno-parentheses \
 	  -Wno-return-type -Wno-builtin-declaration-mismatch -Wno-int-in-bool-context
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1994/westley/Makefile
+++ b/1994/westley/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-poison-system-directories -Wno-undef -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/cdua/Makefile
+++ b/1995/cdua/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-incompatible-library-redeclaration -Wno-main \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-unused-parameter \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/dodsond1/Makefile
+++ b/1995/dodsond1/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-misleading-indentation \
 	  -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/dodsond2/Makefile
+++ b/1995/dodsond2/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
 	  -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/esde/Makefile
+++ b/1995/esde/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts -Wno-error \
 	  -Wno-implicit-int -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/garry/Makefile
+++ b/1995/garry/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-extra-semi -Wno-fortify-source -Wno-return-type \
 	  -Wno-pedantic -Wno-unused-variable -Wno-implicit-int \
 	  -Wno-stringop-overflow
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/heathbar/Makefile
+++ b/1995/heathbar/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/leo/Makefile
+++ b/1995/leo/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-main-return-type \
 	  -Wno-sign-compare -Wno-main -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/makarios/Makefile
+++ b/1995/makarios/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
 	  -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/savastio/Makefile
+++ b/1995/savastio/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-empty-body -Wno-format -Wno-incompatible-library-redeclaration \
 	  -Wno-strict-prototypes -Wno-implicit-int -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/schnitzi/Makefile
+++ b/1995/schnitzi/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-int-conversion \
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
           -Wno-parentheses -Wno-return-type -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/spinellis/Makefile
+++ b/1995/spinellis/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1995/vanschnitz/Makefile
+++ b/1995/vanschnitz/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-extra-tokens \
 	  -Wno-overlength-strings -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-endif-labels -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/august/Makefile
+++ b/1996/august/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-invalid-source-encoding -Wno-invalid-utf8 -Wno-strict-prototypes \
 	  -Wno-empty-body -Wno-maybe-uninitialized
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/dalbec/Makefile
+++ b/1996/dalbec/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-logical-not-parentheses -Wno-bool-operation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/eldby/Makefile
+++ b/1996/eldby/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-return-type -Wno-unsequenced -Wno-strict-prototypes \
 	  -Wno-implicit-int -Wno-misleading-indentation -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/gandalf/Makefile
+++ b/1996/gandalf/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-keyword-macro \
 	  -Wno-builtin-declaration-mismatch -Wno-parentheses -Wno-return-type \
           -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/huffman/Makefile
+++ b/1996/huffman/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-strict-prototypes -Wno-deprecated-declarations -Wno-implicit-int \
 	  -Wno-int-in-bool-context -Wno-misleading-indentation -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/jonth/Makefile
+++ b/1996/jonth/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
           -Wno-multistatement-macros -Wno-sequence-point -Wno-unused-value \
 	  -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/rcm/Makefile
+++ b/1996/rcm/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-empty-body -Wno-shift-op-parentheses -Wno-strict-prototypes \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-return-type \
           -Wno-unused-value -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/schweikh1/Makefile
+++ b/1996/schweikh1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/1996/schweikh2/Makefile
+++ b/1996/schweikh2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/1996/schweikh3/Makefile
+++ b/1996/schweikh3/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-language-extension-token -Wno-switch-bool
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1996/westley/Makefile
+++ b/1996/westley/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-int-to-pointer-cast -Wno-empty-body -Wno-deprecated-non-prototype\
 	  -Wno-implicit-int -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/banks/Makefile
+++ b/1998/banks/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-return-type \
 	  -Wno-sequence-point -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/bas1/Makefile
+++ b/1998/bas1/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-implicit-int -Wno-misleading-indentation -Wno-missing-parameter-type \
 	  -Wno-return-type -Wno-unused-parameter
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/bas2/Makefile
+++ b/1998/bas2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-main -Wno-deprecated-non-prototype -Wno-implicit-int \
 	  -Wno-missing-parameter-type -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/chaos/Makefile
+++ b/1998/chaos/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-c99-extensions -Wno-pedantic
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/df/Makefile
+++ b/1998/df/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts \
 	  -Wno-cast-function-type -Wno-misleading-indentation \
 	  -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/dlowe/Makefile
+++ b/1998/dlowe/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-main-return-type -Wno-strict-prototypes \
 	  -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/dloweneil/Makefile
+++ b/1998/dloweneil/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-dangling-else -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/dorssel/Makefile
+++ b/1998/dorssel/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-shift-op-parentheses -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-implicit-fallthrough -Wno-return-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/fanf/Makefile
+++ b/1998/fanf/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-pointer-bool-conversion -Wno-unused-parameter -Wno-main \
 	  -Wno-builtin-declaration-mismatch -Wno-int-conversion \
 	  -Wno-gnu-line-marker
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/schnitzi/Makefile
+++ b/1998/schnitzi/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-security \
 	  -Wno-builtin-declaration-mismatch -Wno-parentheses -Wno-return-type \
 	  -Wno-logical-op-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/schweikh1/Makefile
+++ b/1998/schweikh1/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-string-plus-int -Wno-switch-bool -Wno-array-bounds \
 	  -Wno-stringop-overread
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/schweikh2/Makefile
+++ b/1998/schweikh2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-trigraphs -Wno-sign-compare -Wno-string-plus-int -Wno-switch-bool \
 	  -Wno-implicit-int -Wno-cast-function-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/schweikh3/Makefile
+++ b/1998/schweikh3/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-trigraphs -Wno-deprecated-non-prototype -Wno-unused-parameter \
 	  -Wno-misleading-indentation -Wno-missing-parameter-type
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/1998/tomtorfs/Makefile
+++ b/1998/tomtorfs/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-misleading-indentation -Wno-sign-compare
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/anderson/Makefile
+++ b/2000/anderson/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-char-subscripts -Wno-deprecated-declarations -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype -Wno-strict-prototypes \
 	  -Wno-parentheses -Wno-sequence-point -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/bellard/Makefile
+++ b/2000/bellard/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-return-type -Wno-unsequenced -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/bmeyer/Makefile
+++ b/2000/bmeyer/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-format -Wno-parentheses -Wno-string-plus-int \
 	  -Wno-strict-prototypes -Wno-int-in-bool-context \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/briddlebane/Makefile
+++ b/2000/briddlebane/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-absolute-value -Wno-implicit-int -Wno-deprecated-non-prototype \
 	  -Wno-incompatible-pointer-types -Wno-misleading-indentation \
           -Wno-parentheses -Wno-sequence-point -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/dhyang/Makefile
+++ b/2000/dhyang/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-pedantic -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/dlowe/Makefile
+++ b/2000/dlowe/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-gnu-statement-expression -Wno-unused-parameter
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/jarijyrki/Makefile
+++ b/2000/jarijyrki/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-char-subscripts -Wno-empty-body -Wno-error \
           -Wno-misleading-indentation -Wno-unused-value \
 	  -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/natori/Makefile
+++ b/2000/natori/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-int-conversion -Wno-pointer-to-int-cast -Wno-unused-parameter \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/primenum/Makefile
+++ b/2000/primenum/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-main-return-type \
 	  -Wno-unused-parameter -Wno-int-in-bool-context
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/rince/Makefile
+++ b/2000/rince/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-maybe-uninitialized -Wno-misleading-indentation \
 	  -Wno-switch-unreachable
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/robison/Makefile
+++ b/2000/robison/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-parentheses -Wno-shift-negative-value -Wno-shift-op-parentheses \
 	  -Wno-strict-prototypes -Wno-maybe-uninitialized
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/schneiderwent/Makefile
+++ b/2000/schneiderwent/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-trigraphs -Wno-aggressive-loop-optimizations -Wno-clobbered
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/thadgavin/Makefile
+++ b/2000/thadgavin/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-empty-body -Wno-implicit-int -Wno-unsequenced \
 	  -Wno-misleading-indentation -Wno-sequence-point \
 	  -Wno-incompatible-pointer-types
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2000/tomx/Makefile
+++ b/2000/tomx/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-comment -Wno-strict-prototypes -Wno-stringop-overflow
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/anonymous/Makefile
+++ b/2001/anonymous/Makefile
@@ -47,7 +47,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-error \
 	  -Wno-deprecated-non-prototype -Wno-unused-value \
 	  -Wno-maybe-uninitialized -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/bellard/Makefile
+++ b/2001/bellard/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-int-to-pointer-cast -Wno-parentheses -Wno-return-type \
 	  -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/cheong/Makefile
+++ b/2001/cheong/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/coupard/Makefile
+++ b/2001/coupard/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-pointer-sign -Wno-deprecated-non-prototype \
 	  -Wno-implicit-int -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/ctk/Makefile
+++ b/2001/ctk/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-empty-body -Wno-logical-op-parentheses \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-unused-value \
 	  -Wno-missing-braces
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/dgbeards/Makefile
+++ b/2001/dgbeards/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-strict-prototypes -Wno-implicit-fallthrough -Wno-maybe-uninitialized \
 	  -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/herrmann1/Makefile
+++ b/2001/herrmann1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2001/herrmann2/Makefile
+++ b/2001/herrmann2/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-implicit-int -Wno-incompatible-pointer-types \
 	  -Wno-deprecated-non-prototype -Wno-address -Wno-bool-compare \
 	  -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/jason/Makefile
+++ b/2001/jason/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-char-subscripts -Wno-extra-semi -Wno-string-plus-int \
 	  -Wno-unused-parameter -Wno-deprecated-non-prototype \
 	  -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/kev/Makefile
+++ b/2001/kev/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
           -Wno-sequence-point -Wno-parentheses -Wno-pointer-bool-conversion \
 	  -Wno-unsequenced
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/ollinger/Makefile
+++ b/2001/ollinger/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-unused-parameter \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/rosten/Makefile
+++ b/2001/rosten/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-logical-op-parentheses -Wno-parentheses -Wno-unused-value \
 	  -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/schweikh/Makefile
+++ b/2001/schweikh/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-logical-op-parentheses -Wno-unused-parameter -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/westley/Makefile
+++ b/2001/westley/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-deprecated-declarations -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch -Wno-restrict
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2001/williams/Makefile
+++ b/2001/williams/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-sequence-point \
 	  -Wno-unused-value -Wno-unsequenced -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/anonymous/Makefile
+++ b/2004/anonymous/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-c99-extensions -Wno-conditional-type-mismatch -Wno-implicit-int \
 	  -Wno-logical-op-parentheses -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/arachnid/Makefile
+++ b/2004/arachnid/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-extra-semi -Wno-implicit-int \
 	  -Wno-return-type -Wno-unused-parameter -Wno-unused-value \
 	  -Wno-misleading-indentation -Wno-pedantic
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/burley/Makefile
+++ b/2004/burley/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts -Wno-error \
 	  -Wno-implicit-function-declaration -Wno-int-to-pointer-cast \
 	  -Wno-unused-value -Wno-unused-parameter -Wno-incompatible-pointer-types
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/gavare/Makefile
+++ b/2004/gavare/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-return-type -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/gavin/Makefile
+++ b/2004/gavin/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-int-to-pointer-cast -Wno-parentheses -Wno-pointer-to-int-cast \
 	  -Wno-return-type -Wno-unused-parameter -Wno-unused-variable
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/hibachi/Makefile
+++ b/2004/hibachi/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-pointer-sign -Wno-unused-parameter \
 	  -Wno-format-truncation -Wno-sign-compare -Wno-stringop-overflow
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/hoyle/Makefile
+++ b/2004/hoyle/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-absolute-value -Wno-keyword-macro -Wno-newline-eof \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/jdalbec/Makefile
+++ b/2004/jdalbec/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-int-to-pointer-cast -Wno-int-to-void-pointer-cast \
 	  -Wno-trigraphs -Wno-unused-value -Wno-gnu-line-marker
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/kopczynski/Makefile
+++ b/2004/kopczynski/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-main -Wno-parentheses -Wno-deprecated-non-prototype \
 	  -Wno-unused-parameter -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/newbern/Makefile
+++ b/2004/newbern/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-parentheses -Wno-pointer-sign -Wno-incompatible-pointer-types \
           -Wno-misleading-indentation -Wno-unused-value \
 	  -Wno-strict-prototypes -Wno-stringop-overflow
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/omoikane/Makefile
+++ b/2004/omoikane/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-int-conversion -Wno-unused-value \
 	  -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/schnitzi/Makefile
+++ b/2004/schnitzi/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-deprecated-declarations -Wno-error \
 	  -Wno-stringop-truncation -Wno-unused-value -Wno-format-extra-args \
 	  -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/sds/Makefile
+++ b/2004/sds/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-unsequenced -Wno-unused-value -Wno-strict-prototypes \
 	  -Wno-unused-parameter -Wno-implicit-int -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/vik1/Makefile
+++ b/2004/vik1/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-format-extra-args \
 	  -Wno-int-in-bool-context -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2004/vik2/Makefile
+++ b/2004/vik2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-strict-prototypes -Wno-implicit-function-declaration \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/aidan/Makefile
+++ b/2005/aidan/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-backslash-newline-escape \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/anon/Makefile
+++ b/2005/anon/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-keyword-macro -Wno-logical-op-parentheses \
 	  -Wno-shift-op-parentheses -Wno-format-truncation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/boutines/Makefile
+++ b/2005/boutines/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/chia/Makefile
+++ b/2005/chia/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-comment -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-unused-variable -Wno-deprecated-non-prototype -Wno-unused-value \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/giljade/Makefile
+++ b/2005/giljade/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-parentheses -Wno-misleading-indentation -Wno-strict-prototypes \
 	  -Wno-pedantic
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/jetro/Makefile
+++ b/2005/jetro/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-self-assign -Wno-misleading-indentation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/klausler/Makefile
+++ b/2005/klausler/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-dangling-else -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-parentheses -Wno-pointer-sign -Wno-incompatible-pointer-types \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/mikeash/Makefile
+++ b/2005/mikeash/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-unknown-escape-sequence -Wno-unused-variable -Wno-pedantic \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/mynx/Makefile
+++ b/2005/mynx/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-pedantic \
 	  -Wno-unused-parameter -Wno-restrict
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/persano/Makefile
+++ b/2005/persano/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-shift-op-parentheses -Wno-unused-parameter -Wno-unused-value \
 	  -Wno-maybe-uninitialized -Wno-misleading-indentation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/sykes/Makefile
+++ b/2005/sykes/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-empty-body -Wno-error \
 	  -Wno-pointer-sign -Wno-return-type -Wno-deprecated-non-prototype \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/timwi/Makefile
+++ b/2005/timwi/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-incompatible-pointer-types \
 	  -Wno-int-in-bool-context -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/toledo/Makefile
+++ b/2005/toledo/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-unsequenced -Wno-return-type -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/vik/Makefile
+++ b/2005/vik/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-pointer-sign -Wno-unsequenced -Wno-int-in-bool-context \
 	  -Wno-parentheses -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2005/vince/Makefile
+++ b/2005/vince/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-pointer-sign -Wno-unused-parameter -Wno-strict-prototypes \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/birken/Makefile
+++ b/2006/birken/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-deprecated-declarations -Wno-strict-prototypes -Wno-address \
 	  -Wno-maybe-uninitialized
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/borsanyi/Makefile
+++ b/2006/borsanyi/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-unused-parameter
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/grothe/Makefile
+++ b/2006/grothe/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/hamre/Makefile
+++ b/2006/hamre/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-parentheses -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/meyer/Makefile
+++ b/2006/meyer/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-format -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/monge/Makefile
+++ b/2006/monge/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-conditional-type-mismatch \
 	  -Wno-return-type -Wno-strict-prototypes -Wno-implicit-int \
 	  -Wno-misleading-indentation -Wno-pedantic -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/night/Makefile
+++ b/2006/night/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-macro-redefined \
 	  -Wno-unused-value -Wno-unused-variable -Wno-sequence-point \
 	  -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/sloane/Makefile
+++ b/2006/sloane/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-deprecated-non-prototype -Wno-main -Wno-unused-parameter \
 	  -Wno-parentheses -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/stewart/Makefile
+++ b/2006/stewart/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2006/sykes1/Makefile
+++ b/2006/sykes1/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-shift-op-parentheses \
 	  -Wno-maybe-uninitialized -Wno-misleading-indentation -Wno-parentheses \
           -Wno-stringop-truncation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/sykes2/Makefile
+++ b/2006/sykes2/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts -Wno-error \
 	  -Wno-pedantic -Wno-deprecated-non-prototype -Wno-unused-parameter \
 	  -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/toledo1/Makefile
+++ b/2006/toledo1/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-empty-body -Wno-error \
 	  -Wno-int-conversion -Wno-pedantic -Wno-deprecated-non-prototype \
 	  -Wno-misleading-indentation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/toledo2/Makefile
+++ b/2006/toledo2/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-int-conversion -Wno-pointer-type-mismatch -Wno-unsequenced \
 	  -Wno-deprecated-non-prototype -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2006/toledo3/Makefile
+++ b/2006/toledo3/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-shift-op-parentheses -Wno-main -Wno-deprecated-non-prototype \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/akari/Makefile
+++ b/2011/akari/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-empty-body -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-implicit-int -Wno-return-type -Wno-unused-parameter \
 	  -Wno-deprecated-non-prototype -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/blakely/Makefile
+++ b/2011/blakely/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-logical-op-parentheses -Wno-unused-parameter \
 	  -Wno-misleading-indentation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/borsanyi/Makefile
+++ b/2011/borsanyi/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-error \
 	  -Wno-implicit-int -Wno-main -Wno-deprecated-non-prototype \
 	  -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/dlowe/Makefile
+++ b/2011/dlowe/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/eastman/Makefile
+++ b/2011/eastman/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-implicit-int -Wno-unsequenced -Wno-strict-prototypes \
 	  -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/fredriksson/Makefile
+++ b/2011/fredriksson/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-bool-operation -Wno-char-subscripts -Wno-format-security \
 	  -Wno-logical-op-parentheses -Wno-format-overflow -Wno-parentheses \
 	  -Wno-restrict -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/goren/Makefile
+++ b/2011/goren/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-unused-value -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/hamaji/Makefile
+++ b/2011/hamaji/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-parentheses -Wno-shift-op-parentheses \
 	  -Wno-unused-value -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/hou/Makefile
+++ b/2011/hou/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bool-operation -Wno-keyword-macro -Wno-literal-conversion \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/konno/Makefile
+++ b/2011/konno/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-error \
 	  -Wno-pedantic -Wno-unsequenced -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch -Wno-sequence-point -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/richards/Makefile
+++ b/2011/richards/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-incompatible-pointer-types -Wno-implicit-fallthrough
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/toledo/Makefile
+++ b/2011/toledo/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-empty-body -Wno-error \
 	  -Wno-deprecated-non-prototype -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/vik/Makefile
+++ b/2011/vik/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2011/zucker/Makefile
+++ b/2011/zucker/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-strict-prototypes -Wno-cpp -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/blakely/Makefile
+++ b/2012/blakely/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-unused-parameter \
 	  -Wno-strict-prototypes -Wno-builtin-declaration-mismatch \
 	  -Wno-misleading-indentation -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/deckmyn/Makefile
+++ b/2012/deckmyn/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-constant-conversion -Wno-implicit-int -Wno-string-plus-char \
 	  -Wno-unused-value -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/dlowe/Makefile
+++ b/2012/dlowe/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-dangling-else -Wno-strict-prototypes -Wno-cpp -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/endoh1/Makefile
+++ b/2012/endoh1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-absolute-value -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/endoh2/Makefile
+++ b/2012/endoh2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-parentheses -Wno-empty-body -Wno-strict-prototypes \
 	  -Wno-format-overflow -Wno-int-in-bool-context -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/grothe/Makefile
+++ b/2012/grothe/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-unused-value \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/hamano/Makefile
+++ b/2012/hamano/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-empty-body -Wno-format \
 	  -Wno-parentheses -Wno-implicit-function-declaration \
 	  -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/hou/Makefile
+++ b/2012/hou/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-format-extra-args \
 	  -Wno-deprecated-non-prototype -Wno-misleading-indentation \
 	  -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/kang/Makefile
+++ b/2012/kang/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-error \
 	  -Wno-pointer-to-int-cast -Wno-deprecated-non-prototype -Wno-misleading-indentation \
 	  -Wno-unsafe-buffer-usage
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/konno/Makefile
+++ b/2012/konno/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-shift-op-parentheses -Wno-deprecated-non-prototype \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/omoikane/Makefile
+++ b/2012/omoikane/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/tromp/Makefile
+++ b/2012/tromp/Makefile
@@ -45,7 +45,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-conditional-type-mismatch -Wno-error 
 	  -Wno-builtin-declaration-mismatch -Wno-missing-parameter-type \
           -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/vik/Makefile
+++ b/2012/vik/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-pointer-sign -Wno-parentheses \
 	  -Wno-sign-compare
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2012/zeitak/Makefile
+++ b/2012/zeitak/Makefile
@@ -47,7 +47,7 @@ CSILENCE= -Wno-constant-conversion -Wno-format-security \
 	  -Wno-disabled-macro-expansion -Wno-incompatible-function-pointer-types-strict \
 	  -Wno-unsafe-buffer-usage
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/birken/Makefile
+++ b/2013/birken/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-newline-eof -Wno-strict-prototypes -Wno-maybe-uninitialized \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/cable1/Makefile
+++ b/2013/cable1/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bool-operation -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-implicit-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/cable2/Makefile
+++ b/2013/cable2/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-dollar-in-identifier-extension \
 	  -Wno-shift-op-parentheses -Wno-unsequenced -Wno-misleading-indentation \
 	  -Wno-sequence-point -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/cable3/Makefile
+++ b/2013/cable3/Makefile
@@ -48,7 +48,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-bool-operation \
 	  -Wno-pointer-type-mismatch -Wno-int-conversion -Wno-unused-value \
 	  -Wno-int-in-bool-context -Wno-sequence-point -Wno-strict-aliasing
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/dlowe/Makefile
+++ b/2013/dlowe/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-implicit-int -Wno-pedantic -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/endoh1/Makefile
+++ b/2013/endoh1/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-deprecated-non-prototype -Wno-strict-prototypes \
 	  -Wno-maybe-uninitialized
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/endoh2/Makefile
+++ b/2013/endoh2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/endoh3/Makefile
+++ b/2013/endoh3/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-main -Wno-deprecated-non-prototype -Wno-unused-parameter \
 	  -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/endoh4/Makefile
+++ b/2013/endoh4/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/hou/Makefile
+++ b/2013/hou/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-sign-compare -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/mills/Makefile
+++ b/2013/mills/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-parentheses -Wno-strict-prototypes \
 	  -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/misaka/Makefile
+++ b/2013/misaka/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-comment -Wno-empty-body -Wno-strict-prototypes \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/morgan1/Makefile
+++ b/2013/morgan1/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-absolute-value -Wno-logical-op-parentheses \
 	  -Wno-shift-op-parentheses -Wno-strict-prototypes \
 	  -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/morgan2/Makefile
+++ b/2013/morgan2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-string-plus-int -Wno-strict-prototypes \
 	  -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2013/robison/Makefile
+++ b/2013/robison/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-parentheses -Wno-unused-variable \
 	  -Wno-misleading-indentation -Wno-stringop-truncation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/birken/Makefile
+++ b/2014/birken/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-comment -Wno-dangling-else -Wno-error \
 	  -Wno-parentheses -Wno-trigraphs -Wno-newline-eof \
 	  -Wno-builtin-declaration-mismatch -Wno-sequence-point -Wno-documentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/deak/Makefile
+++ b/2014/deak/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-dollar-in-identifier-extension \
 	  -Wno-int-conversion -Wno-main -Wno-newline-eof \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/endoh1/Makefile
+++ b/2014/endoh1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/endoh2/Makefile
+++ b/2014/endoh2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-pedantic -Wno-string-plus-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/maffiodo1/Makefile
+++ b/2014/maffiodo1/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-implicit-int -Wno-deprecated-non-prototype \
 	  -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/maffiodo2/Makefile
+++ b/2014/maffiodo2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-return-type -Wno-unused-parameter -Wno-deprecated-non-prototype
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/morgan/Makefile
+++ b/2014/morgan/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-int-conversion -Wno-logical-op-parentheses \
 	  -Wno-misleading-indentation -Wno-parentheses -Wno-sign-compare
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/sinon/Makefile
+++ b/2014/sinon/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-pointer-arith -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/skeggs/Makefile
+++ b/2014/skeggs/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-format-extra-args -Wno-keyword-macro -Wno-parentheses \
 	  -Wno-unused-parameter -Wno-deprecated-non-prototype \
 	  -Wno-strict-prototypes -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/vik/Makefile
+++ b/2014/vik/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-bitwise-op-parentheses -Wno-int-in-bool-context -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2014/wiedijk/Makefile
+++ b/2014/wiedijk/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/burton/Makefile
+++ b/2015/burton/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-char-subscripts -Wno-empty-body -Wno-long-long -Wno-parentheses \
 	  -Wno-misleading-indentation -Wno-sequence-point -Wno-sign-compare \
           -Wno-unused-value -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/dogon/Makefile
+++ b/2015/dogon/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-absolute-value -Wno-char-subscripts -Wno-dangling-else \
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-sign-compare -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/duble/Makefile
+++ b/2015/duble/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-implicit-int -Wno-int-conversion \
 	  -Wno-unsequenced -Wno-unused-value -Wno-strict-prototypes \
 	  -Wno-cpp -Wno-int-in-bool-context -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/endoh1/Makefile
+++ b/2015/endoh1/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation \
 	  -Wno-multistatement-macros
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/endoh2/Makefile
+++ b/2015/endoh2/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-strict-prototypes -Wno-builtin-declaration-mismatch \
 	  -Wno-format-zero-length
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/endoh3/Makefile
+++ b/2015/endoh3/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-main -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/endoh4/Makefile
+++ b/2015/endoh4/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-main -Wno-pedantic -Wno-return-type -Wno-deprecated-non-prototype \
 	  -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/hou/Makefile
+++ b/2015/hou/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-ignored-qualifiers
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/howe/Makefile
+++ b/2015/howe/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-sign-compare -Wno-deprecated-non-prototype -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/mills1/Makefile
+++ b/2015/mills1/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-parentheses \
 	  -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/mills2/Makefile
+++ b/2015/mills2/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-shift-op-parenthese
 	  -Wno-builtin-declaration-mismatch -Wno-misleading-indentation \
           -Wno-parentheses -Wno-unused-parameter
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/muth/Makefile
+++ b/2015/muth/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-keyword-macro -Wno-strict-prototypes -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2015/schweikhardt/Makefile
+++ b/2015/schweikhardt/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2015/yang/Makefile
+++ b/2015/yang/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-dollar-in-identifier-extension -Wno-null-character \
 	  -Wno-misleading-indentation -Wno-pedantic -Wno-null-pointer-subtraction
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/algmyr/Makefile
+++ b/2018/algmyr/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-string-plus-int -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/anderson/Makefile
+++ b/2018/anderson/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-unsequenced -Wno-self-assign -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/bellard/Makefile
+++ b/2018/bellard/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-return-type -Wno-shift-op-parentheses -Wno-builtin-declaration-mismatch \
 	  -Wno-deprecated-non-prototype -Wno-unused-parameter
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/burton1/Makefile
+++ b/2018/burton1/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-char-subscripts -Wno-error -Wno-implicit-function-declaration \
 	  -Wno-implicit-int -Wno-main -Wno-deprecated-non-prototype \
 	  -Wno-builtin-declaration-mismatch -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/burton2/Makefile
+++ b/2018/burton2/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-char-subscripts -Wno-empty-body \
 	  -Wno-misleading-indentation -Wno-unused-value \
 	  -Wno-sign-compare -Wno-trigraphs
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/ciura/Makefile
+++ b/2018/ciura/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-shift-op-parentheses -Wno-unused-value -Wno-strict-prototypes \
 	  -Wno-parentheses
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/endoh1/Makefile
+++ b/2018/endoh1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/endoh2/Makefile
+++ b/2018/endoh2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/ferguson/Makefile
+++ b/2018/ferguson/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-stringop-truncation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/giles/Makefile
+++ b/2018/giles/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/hou/Makefile
+++ b/2018/hou/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-absolute-value -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/mills/Makefile
+++ b/2018/mills/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-gnu-empty-initializer -Wno-missing-field-initializers \
 	  -Wno-misleading-indentation -Wno-pedantic -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/poikola/Makefile
+++ b/2018/poikola/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-comment -Wno-dollar-in-identifier-extension -Wno-string-plus-int 
 	  -Wno-unused-parameter -Wno-deprecated-non-prototype \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/vokes/Makefile
+++ b/2018/vokes/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-deprecated-non-prototype -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2018/yang/Makefile
+++ b/2018/yang/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/adamovsky/Makefile
+++ b/2019/adamovsky/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-trigraphs -Wno-comment -Wno-misleading-indentation -Wno-documentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/burton/Makefile
+++ b/2019/burton/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-parentheses -Wno-strict-prototypes -Wno-builtin-declaration-mismatch
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/ciura/Makefile
+++ b/2019/ciura/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-parentheses -Wno-string-plus-int \
 	  -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/diels-grabsch1/Makefile
+++ b/2019/diels-grabsch1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/diels-grabsch2/Makefile
+++ b/2019/diels-grabsch2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/dogon/Makefile
+++ b/2019/dogon/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-bitwise-conditional-parentheses -Wno-bitwise-op-parentheses \
 	  -Wno-main -Wno-maybe-uninitialized -Wno-misleading-indentation \
           -Wno-shift-negative-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/duble/Makefile
+++ b/2019/duble/Makefile
@@ -44,7 +44,7 @@ CSILENCE= -Wno-bitwise-op-parentheses -Wno-dangling-else -Wno-format-security \
 	  -Wno-unused-value -Wno-misleading-indentation -Wno-parentheses \
 	  -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/endoh/Makefile
+++ b/2019/endoh/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/giles/Makefile
+++ b/2019/giles/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/karns/Makefile
+++ b/2019/karns/Makefile
@@ -46,7 +46,7 @@ CSILENCE= -Wno-error -Wno-implicit-function-declaration -Wno-implicit-int \
 	  -Wno-builtin-declaration-mismatch -Wno-incompatible-pointer-types \
           -Wno-misleading-indentation -Wno-parentheses -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/lynn/Makefile
+++ b/2019/lynn/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-comment
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/mills/Makefile
+++ b/2019/mills/Makefile
@@ -42,7 +42,7 @@ CSILENCE= -Wno-for-loop-analysis -Wno-missing-field-initializers \
 	  -Wno-strict-prototypes -Wno-misleading-indentation \
 	  -Wno-old-style-declaration -Wno-unused-value -Wno-unsafe-buffer-usage
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/poikola/Makefile
+++ b/2019/poikola/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-dollar-in-identifier-extension -Wno-empty-body \
 	  -Wno-unsequenced -Wno-misleading-indentation -Wno-pedantic \
 	  -Wno-sequence-point
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2019/yang/Makefile
+++ b/2019/yang/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/burton/Makefile
+++ b/2020/burton/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2020/carlini/Makefile
+++ b/2020/carlini/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-overlength-strings -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/endoh1/Makefile
+++ b/2020/endoh1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/endoh2/Makefile
+++ b/2020/endoh2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2020/endoh3/Makefile
+++ b/2020/endoh3/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/ferguson1/Makefile
+++ b/2020/ferguson1/Makefile
@@ -43,7 +43,7 @@ CSILENCE= -Wno-unused-value -Wno-implicit-fallthrough -Wno-parentheses \
 	  -Wno-misleading-indentation -Wno-comment -Wno-implicit-function-declaration \
           -Wno-misleading-indentation -Wno-unused-value
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/ferguson2/Makefile
+++ b/2020/ferguson2/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-comment -Wno-implicit-function-declaration \
           -Wno-misleading-indentation -Wno-unused-value -Wno-documentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/giles/Makefile
+++ b/2020/giles/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-empty-body -Wno-string-plus-char -Wno-string-plus-int
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/kurdyukov1/Makefile
+++ b/2020/kurdyukov1/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/kurdyukov2/Makefile
+++ b/2020/kurdyukov2/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2020/kurdyukov3/Makefile
+++ b/2020/kurdyukov3/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/kurdyukov4/Makefile
+++ b/2020/kurdyukov4/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/2020/otterness/Makefile
+++ b/2020/otterness/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE= -Wno-strict-prototypes
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/tsoj/Makefile
+++ b/2020/tsoj/Makefile
@@ -41,7 +41,7 @@ include ../../var.mk
 CSILENCE= -Wno-empty-body -Wno-missing-field-initializers -Wno-strict-prototypes \
 	  -Wno-misleading-indentation
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 CUNKNOWN= -Wno-unknown-warning-option
 

--- a/2020/yang/Makefile
+++ b/2020/yang/Makefile
@@ -40,7 +40,7 @@ include ../../var.mk
 #
 CSILENCE=
 
-# Attempt to silence unknown warnings
+# Attempt to silence unknown warning option
 #
 # Example: CUNKNOWN= -Wno-unknown-warning-option
 #

--- a/contact.html
+++ b/contact.html
@@ -392,7 +392,7 @@
 <p>If you are trying to:</p>
 <ul>
 <li><strong>Fix a winning IOCCC entry</strong> - See our
-FAQ on “<a href="faq.html#fix_an_entry">fix entry</a>”</li>
+FAQ on “<a href="faq.html#fix_an_entry">fixing entries</a>”</li>
 <li><strong>Update winning author information</strong> - See our
 FAQ on “<a href="faq.html#fix_author">fixing author information</a>”</li>
 <li><strong>Correct a website problem</strong> - See our
@@ -400,10 +400,11 @@ FAQ on “<a href="faq.html#fix_web_site">fixing the website</a>”
 or our
 FAQ on “<a href="faq.html#fix_link">fix URL</a>”</li>
 </ul>
-<p>Instead of sending us email, <strong>Please</strong> consider using the <a href="https://github.com/ioccc-src/winner/pulls">GitHub
+<p>Instead of sending us email, <strong>PLEASE</strong> consider using the <a href="https://github.com/ioccc-src/winner/pulls">GitHub
 pull request</a> process
 against the <a href="https://github.com/ioccc-src/winner/branches">master branch</a>
-of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>.</p>
+of the <a href="https://github.com/ioccc-src/winner">ioccc-src/winner repo</a>. See the
+FAQ on “<a href="faq.html#pull_request">submitting a pull request</a>”.</p>
 <p>If you are trying to:</p>
 <ul>
 <li><strong>Report a bug in an IOCCC winning entry</strong> - See our

--- a/contact.md
+++ b/contact.md
@@ -3,7 +3,7 @@
 If you are trying to:
 
 * **Fix a winning IOCCC entry** - See our
-FAQ on "[fix entry](faq.html#fix_an_entry)"
+FAQ on "[fixing entries](faq.html#fix_an_entry)"
 * **Update winning author information** - See our
 FAQ on "[fixing author information](faq.html#fix_author)"
 * **Correct a website problem** - See our
@@ -11,10 +11,11 @@ FAQ on "[fixing the website](faq.html#fix_web_site)"
 or our
 FAQ on "[fix URL](faq.html#fix_link)"
 
-Instead of sending us email, **Please** consider using the [GitHub
+Instead of sending us email, **PLEASE** consider using the [GitHub
 pull request](https://github.com/ioccc-src/winner/pulls) process
 against the [master branch](https://github.com/ioccc-src/winner/branches)
-of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner).
+of the [ioccc-src/winner repo](https://github.com/ioccc-src/winner). See the
+FAQ on "[submitting a pull request](faq.html#pull_request)".
 
 If you are trying to:
 


### PR DESCRIPTION

It is actually used to silence the unknown warning option, not unknown
warnings.