### PR TITLE
Fix environment field in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,6 @@ body:
         - OS:
         - Device:
         - Compiler:
-    render: markdown
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yml
@@ -51,7 +51,6 @@ body:
         - OS:
         - Device:
         - Browser:
-    render: markdown
   validations:
     required: true
 


### PR DESCRIPTION
The render: markdown causes formatting problems (too long lines) in the post, at least sometimes.