### PR TITLE
Fix shebang in top level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-#build authors.html if out of date with author JSON files'!/usr/bin/env make
+#!/usr/bin/env make
 #
 # IOCCC Makefile
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -652,7 +652,7 @@ XPath for JSON mechanism.  For information in XPath for JSON see:
 
 NOTE: As of 2024 Oct 08 the `jval(1)` tool has not been written,
 so [jval-wrapper.sh](%%REPO_URL%%/bin/jval-wrapper.sh) uses the
-`jsp(1)` tool from [//github.com/kjozsa/jsp](//github.com/kjozsa/jsp)
+`jsp(1)` tool from [https://github.com/kjozsa/jsp](https://github.com/kjozsa/jsp)
 or if not found, the `JSONPath.sh(1)` tool from the recently forked and modified
 [JSONPath.sh tool](https://github.com/lcn2/JSONPath.sh).
 


### PR DESCRIPTION

It had:

    #build authors.html if out of date with author JSON files'!/usr/bin/env make

so it was changed to:

    !/usr/bin/env make

It seems like this was somehow yanked pasted from make help.
