### PR TITLE
Fix exit code text in bin/find-missing-links.sh

### DIFF
--- a/2014/birken/README.md
+++ b/2014/birken/README.md
@@ -6,7 +6,7 @@
 
 There is alternate code that lets you redefine the port to bind to, in case
 there is a firewall issue, and also lets you redefine the timing constant,
-`STARDATE`. See [Alternate code](#alternate code) below.
+`STARDATE`. See [Alternate code](#alternate-code) below.
 
 
 ## To use:

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -417,7 +417,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <p>There is alternate code that lets you redefine the port to bind to, in case
 there is a firewall issue, and also lets you redefine the timing constant,
-<code>STARDATE</code>. See <a href="#alternate%20code">Alternate code</a> below.</p>
+<code>STARDATE</code>. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog &lt; some_secret_or_something
 

--- a/2014/maffiodo1/README.md
+++ b/2014/maffiodo1/README.md
@@ -34,8 +34,8 @@ The parameters to the program are:
 6. Sprites image height.
 7. Filename of the sprites image (raw RGBA image).
 8. Filename of the music (WAVE 8000 Hz 8bit Mono).
-9. Sky color. This number depends on the system where you run the program. See
-note on macOS.
+9. Sky color. This number depends on the system where you run the program. [See
+note on macOS](#running-under-macos).
 
 
 ## Try:
@@ -50,7 +50,7 @@ If you end up telnetting to the server (feature of [mario.sh](%%REPO_URL%%/2014/
 try:
 
 
-```
+``` <!---sh-->
     ls # show files including games
     wumpus.bas # play Hunt the Wumpus
     advent.gam # you know what this is! :-)
@@ -135,9 +135,6 @@ dies or loses its powers.
 
 ###  Running under macOS
 
-[NOTE: this seems to no longer be the case as of 2023 and most likely much
-earlier. However one can change the look of the game doing this anyway:]
-
 The color of the sky is wrong on macOS. You need to flip some bytes from the
 last parameter of the program:
 
@@ -171,8 +168,8 @@ because `while(c=getchar())` is not evil.
 6. Sprites image height.
 7. Filename of the sprites image (raw RGBA image).
 8. Filename of the music (WAVE 8000 Hz 8bit Mono).
-9. Sky color. This number depends on the system where you run the program. See
-note on macOS.
+9. Sky color. This number depends on the system where you run the program. [See
+note on macOS](#running-under-macos).
 
 ## Sprites
 
@@ -190,29 +187,45 @@ grid, sprite 8 is the first sprite of the second row of the grid etc.).
 
 Some positions of the grid have a predefined purpose:
 
-```
-    Position          | Description
-    :-----------------|:--------------
-    0                 | Player standing right
-    1                 | Player walking right frame 0
-    2                 | Player walking right frame 1
-    3                 | Player jumping right
-    4                 | Player standing left
-    5                 | Player walking left frame 0
-    6                 | Player walking left frame 1
-    7                 | Player jumping left
-    8 *(second row)*  | Super player standing right
-    9                 | Super player walking right frame 0
-    10                | Super player walking right frame 1
-    11                | Super player jumping right
-    12                | Super player standing left
-    13                | Super player walking left frame 0
-    14                | Super player walking left frame 1
-    15                | Super player jumping left
-    24                | Player dead
-    32                | Player won
-    40                | Super player won
-```
+
+- 0
+    * Player standing right
+- 1
+    * Player walking right frame 0
+- 2
+    * Player walking right frame 1
+- 3
+    * Player jumping right
+- 4
+    * Player standing left
+- 5
+    * Player walking left frame 0
+- 6
+    * Player walking left frame 1
+- 7
+    * Player jumping left
+- 8 _(second row)_
+    * Super player standing right
+- 9
+    * Super player walking right frame 0
+- 10
+    * Super player walking right frame 1
+- 11
+    * Super player jumping right
+- 12
+    * Super player standing left
+- 13
+    * Super player walking left frame 0
+- 14
+    * Super player walking left frame 1
+- 15
+    * Super player jumping left
+- 24
+    * Player dead
+- 32
+    * Player won
+- 40
+    * Super player won
 
 All the others sprites can be used as you want, depending on the game you want
 to create.
@@ -243,53 +256,43 @@ Each row has six columns:
 `CLASSFLAGS` must be a combination (bitwise OR) of some of these constants:
 
 * `ENEMY` (`1`)
-
-            An enemy. CLASSPARAM0 can be 0 if the enemies don't move, 1 if the
-            initial move direction is right, -1 if that direction is left. All
-            enemies that walk will change their direction after 20 steps. The
-            sprite of an enemy must have 2 other adjacent sprites: SPRITE-1,
-            used when the enemy dies, and SPRITE+1, used when it moves.
+    - An enemy. `CLASSPARAM0` can be 0 if the enemies don't move, 1 if the
+    initial move direction is right, -1 if that direction is left. All enemies
+    that walk will change their direction after 20 steps. The sprite of an enemy
+    must have 2 other adjacent sprites: `SPRITE-1`, used when the enemy dies, and
+    `SPRITE+1`, used when it moves.
 
 * `BLOCK` (`2`)
-
-            A wall. Player can walk over the object but can not pass through it.
+    - A wall. Player can walk over the object but can not pass through it.
 
 * `OBJECT BLOCK` (`4`)
-
-            When the player hits the object from below, a new object is created.
-            CLASSFLAGS of the new object is defined in CLASSPARAM0. The sprite
-            used for the new object is defined in CLASSPARAM1. The sprite of the
-            new object must have an adjacent sprite: SPRITE+1, used when the
-            block is hit.
+    - When the player hits the object from below, a new object is created.
+    `CLASSFLAGS` of the new object is defined in `CLASSPARAM0`. The sprite used
+    for the new object is defined in `CLASSPARAM1`. The sprite of the new object
+    must have an adjacent sprite: `SPRITE+1`, used when the block is hit.
 
 * `POWERUP` (`8`)
-
-            This is a power-up like the classic Mario mushroom. When the
-            character hits the power-up object, the character becomes the Super
-            character. If CLASSFLAGS has the bit ZOOM, the character height will
-            be doubled.  The Super character can hit the enemies without dying,
-            but when this happens, the Super character goes back to being
-            normal.
+    - This is a power-up like the classic Mario mushroom. When the character
+    hits the power-up object, the character becomes the Super character. If
+    `CLASSFLAGS` has the bit `ZOOM`, the character height will be doubled.  The
+    Super character can hit the enemies without dying, but when this happens,
+    the Super character goes back to being normal.
 
 * `END` (`16`)
-
-            When the player hits this object the level ends; the player wins.
+    - When the player hits this object the level ends; the player wins.
 
 * `ZOOM` (`32`)
-
-            This flag can be used with POWERUP to indicate a power-up that
-            will double the size of the player (like the Mario mushroom).
+    - This flag can be used with `POWERUP` to indicate a power-up that will
+    double the size of the player (like the Mario mushroom).
 
 * `DESTROY` (`64`)
-
-            When the player hits the object (e.g. the classic Mario coin) the
-            object disappears but the engine does not count the points, so,
-            from the player point of view, this object is useless.
+    - When the player hits the object (e.g. the classic Mario coin) the object
+    disappears but the engine does not count the points, so, from the player
+    point of view, this object is useless.
 
 * `DESTROYUP` (`128`)
-
-            This object is like a BLOCK but when the player hits the object
-            from below, the object disappears.
+    - This object is like a `BLOCK` but when the player hits the object from
+    below, the object disappears.
 
 If `CLASSFLAGS` is `0` the object only has an aesthetic function.
 

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -431,8 +431,8 @@ if you don’t know how to do this for your system.</p>
 <li>Sprites image height.</li>
 <li>Filename of the sprites image (raw RGBA image).</li>
 <li>Filename of the music (WAVE 8000 Hz 8bit Mono).</li>
-<li>Sky color. This number depends on the system where you run the program. See
-note on macOS.</li>
+<li>Sky color. This number depends on the system where you run the program. <a href="#running-under-macos">See
+note on macOS</a>.</li>
 </ol>
 <h2 id="try">Try:</h2>
 <pre><code>    ./giana.sh
@@ -489,8 +489,6 @@ these type of obstacles but cannot walk through them.</p></li>
 dies or loses its powers.</p></li>
 </ul>
 <h3 id="running-under-macos">Running under macOS</h3>
-<p>[NOTE: this seems to no longer be the case as of 2023 and most likely much
-earlier. However one can change the look of the game doing this anyway:]</p>
 <p>The color of the sky is wrong on macOS. You need to flip some bytes from the
 last parameter of the program:</p>
 <ul>
@@ -518,8 +516,8 @@ because <code>while(c=getchar())</code> is not evil.</li>
 <li>Sprites image height.</li>
 <li>Filename of the sprites image (raw RGBA image).</li>
 <li>Filename of the music (WAVE 8000 Hz 8bit Mono).</li>
-<li>Sky color. This number depends on the system where you run the program. See
-note on macOS.</li>
+<li>Sky color. This number depends on the system where you run the program. <a href="#running-under-macos">See
+note on macOS</a>.</li>
 </ol>
 <h2 id="sprites">Sprites</h2>
 <p>The program read a single image that contains all the game sprites. The image
@@ -530,27 +528,84 @@ program calculates the size in this way:</p>
 line, from left to right (for example sprite 0 is the top left sprite in the
 grid, sprite 8 is the first sprite of the second row of the grid etc.).</p>
 <p>Some positions of the grid have a predefined purpose:</p>
-<pre><code>    Position          | Description
-    :-----------------|:--------------
-    0                 | Player standing right
-    1                 | Player walking right frame 0
-    2                 | Player walking right frame 1
-    3                 | Player jumping right
-    4                 | Player standing left
-    5                 | Player walking left frame 0
-    6                 | Player walking left frame 1
-    7                 | Player jumping left
-    8 *(second row)*  | Super player standing right
-    9                 | Super player walking right frame 0
-    10                | Super player walking right frame 1
-    11                | Super player jumping right
-    12                | Super player standing left
-    13                | Super player walking left frame 0
-    14                | Super player walking left frame 1
-    15                | Super player jumping left
-    24                | Player dead
-    32                | Player won
-    40                | Super player won</code></pre>
+<ul>
+<li>0
+<ul>
+<li>Player standing right</li>
+</ul></li>
+<li>1
+<ul>
+<li>Player walking right frame 0</li>
+</ul></li>
+<li>2
+<ul>
+<li>Player walking right frame 1</li>
+</ul></li>
+<li>3
+<ul>
+<li>Player jumping right</li>
+</ul></li>
+<li>4
+<ul>
+<li>Player standing left</li>
+</ul></li>
+<li>5
+<ul>
+<li>Player walking left frame 0</li>
+</ul></li>
+<li>6
+<ul>
+<li>Player walking left frame 1</li>
+</ul></li>
+<li>7
+<ul>
+<li>Player jumping left</li>
+</ul></li>
+<li>8 <em>(second row)</em>
+<ul>
+<li>Super player standing right</li>
+</ul></li>
+<li>9
+<ul>
+<li>Super player walking right frame 0</li>
+</ul></li>
+<li>10
+<ul>
+<li>Super player walking right frame 1</li>
+</ul></li>
+<li>11
+<ul>
+<li>Super player jumping right</li>
+</ul></li>
+<li>12
+<ul>
+<li>Super player standing left</li>
+</ul></li>
+<li>13
+<ul>
+<li>Super player walking left frame 0</li>
+</ul></li>
+<li>14
+<ul>
+<li>Super player walking left frame 1</li>
+</ul></li>
+<li>15
+<ul>
+<li>Super player jumping left</li>
+</ul></li>
+<li>24
+<ul>
+<li>Player dead</li>
+</ul></li>
+<li>32
+<ul>
+<li>Player won</li>
+</ul></li>
+<li>40
+<ul>
+<li>Super player won</li>
+</ul></li>
+</ul>
 <p>All the others sprites can be used as you want, depending on the game you want
 to create.</p>
 <h2 id="levels">Levels</h2>
@@ -571,39 +626,53 @@ here:</p>
 </ol>
 <p><code>CLASSFLAGS</code> must be a combination (bitwise OR) of some of these constants:</p>
 <ul>
-<li><p><code>ENEMY</code> (<code>1</code>)</p>
-<pre><code>  An enemy. CLASSPARAM0 can be 0 if the enemies don&#39;t move, 1 if the
-  initial move direction is right, -1 if that direction is left. All
-  enemies that walk will change their direction after 20 steps. The
-  sprite of an enemy must have 2 other adjacent sprites: SPRITE-1,
-  used when the enemy dies, and SPRITE+1, used when it moves.</code></pre></li>
-<li><p><code>BLOCK</code> (<code>2</code>)</p>
-<pre><code>  A wall. Player can walk over the object but can not pass through it.</code></pre></li>
-<li><p><code>OBJECT BLOCK</code> (<code>4</code>)</p>
-<pre><code>  When the player hits the object from below, a new object is created.
-  CLASSFLAGS of the new object is defined in CLASSPARAM0. The sprite
-  used for the new object is defined in CLASSPARAM1. The sprite of the
-  new object must have an adjacent sprite: SPRITE+1, used when the
-  block is hit.</code></pre></li>
-<li><p><code>POWERUP</code> (<code>8</code>)</p>
-<pre><code>  This is a power-up like the classic Mario mushroom. When the
-  character hits the power-up object, the character becomes the Super
-  character. If CLASSFLAGS has the bit ZOOM, the character height will
-  be doubled.  The Super character can hit the enemies without dying,
-  but when this happens, the Super character goes back to being
-  normal.</code></pre></li>
-<li><p><code>END</code> (<code>16</code>)</p>
-<pre><code>  When the player hits this object the level ends; the player wins.</code></pre></li>
-<li><p><code>ZOOM</code> (<code>32</code>)</p>
-<pre><code>  This flag can be used with POWERUP to indicate a power-up that
-  will double the size of the player (like the Mario mushroom).</code></pre></li>
-<li><p><code>DESTROY</code> (<code>64</code>)</p>
-<pre><code>  When the player hits the object (e.g. the classic Mario coin) the
-  object disappears but the engine does not count the points, so,
-  from the player point of view, this object is useless.</code></pre></li>
-<li><p><code>DESTROYUP</code> (<code>128</code>)</p>
-<pre><code>  This object is like a BLOCK but when the player hits the object
-  from below, the object disappears.</code></pre></li>
+<li><code>ENEMY</code> (<code>1</code>)
+<ul>
+<li>An enemy. <code>CLASSPARAM0</code> can be 0 if the enemies don’t move, 1 if the
+initial move direction is right, -1 if that direction is left. All enemies
+that walk will change their direction after 20 steps. The sprite of an enemy
+must have 2 other adjacent sprites: <code>SPRITE-1</code>, used when the enemy dies, and
+<code>SPRITE+1</code>, used when it moves.</li>
+</ul></li>
+<li><code>BLOCK</code> (<code>2</code>)
+<ul>
+<li>A wall. Player can walk over the object but can not pass through it.</li>
+</ul></li>
+<li><code>OBJECT BLOCK</code> (<code>4</code>)
+<ul>
+<li>When the player hits the object from below, a new object is created.
+<code>CLASSFLAGS</code> of the new object is defined in <code>CLASSPARAM0</code>. The sprite used
+for the new object is defined in <code>CLASSPARAM1</code>. The sprite of the new object
+must have an adjacent sprite: <code>SPRITE+1</code>, used when the block is hit.</li>
+</ul></li>
+<li><code>POWERUP</code> (<code>8</code>)
+<ul>
+<li>This is a power-up like the classic Mario mushroom. When the character
+hits the power-up object, the character becomes the Super character. If
+<code>CLASSFLAGS</code> has the bit <code>ZOOM</code>, the character height will be doubled. The
+Super character can hit the enemies without dying, but when this happens,
+the Super character goes back to being normal.</li>
+</ul></li>
+<li><code>END</code> (<code>16</code>)
+<ul>
+<li>When the player hits this object the level ends; the player wins.</li>
+</ul></li>
+<li><code>ZOOM</code> (<code>32</code>)
+<ul>
+<li>This flag can be used with <code>POWERUP</code> to indicate a power-up that will
+double the size of the player (like the Mario mushroom).</li>
+</ul></li>
+<li><code>DESTROY</code> (<code>64</code>)
+<ul>
+<li>When the player hits the object (e.g. the classic Mario coin) the object
+disappears but the engine does not count the points, so, from the player
+point of view, this object is useless.</li>
+</ul></li>
+<li><code>DESTROYUP</code> (<code>128</code>)
+<ul>
+<li>This object is like a <code>BLOCK</code> but when the player hits the object from
+below, the object disappears.</li>
+</ul></li>
 </ul>
 <p>If <code>CLASSFLAGS</code> is <code>0</code> the object only has an aesthetic function.</p>
 <p>The last row of the level descriptor must have all its columns set equal to

--- a/2014/skeggs/README.md
+++ b/2014/skeggs/README.md
@@ -11,7 +11,7 @@
     ./prog
 ```
 
-HINT: Try pressing the left and right arrow keys as needed.
+**HINT**: Try pressing the left and right arrow keys as needed.
 Also try pressing space/enter to select options.
 Pressing Q or Escape may end the fun before you are ready. :-)
 
@@ -66,22 +66,22 @@ The current size is a third to a half of the original size before compression.
 
 Due to this, it does LOTS of things that subtly annoy compilers!
 
-* (10) data argument not used by format string
+* `(10)` data argument not used by format string
 
   This occurs because some of the `fprintf(3)` invocations don't use all their
   parameters. The program should still work fine!
 
-* (1) using the result of an assignment as a condition without parentheses
+* `(1)` using the result of an assignment as a condition without parentheses
 
   Somewhere, I needed to set a variable and then branch on the result. The
   shortest way was to combine them. Some self-proclaimed "EXPERTS" think this
   is a bad programming practice, but what do they know? :P
 
-* (1) implicit declaration of function 'time' is invalid in C99
+* `(1)` implicit declaration of function 'time' is invalid in C99
 
   An `#include` statement is expensive, and I'm broke.
 
-* (1) control may reach end of non-void function
+* `(1)` control may reach end of non-void function
 
   Turns out that sometimes, a `return` statement is too much. This will never
   actually occur, but some C compilers think they know more about my program

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -412,7 +412,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    make</code></pre>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
-<p>HINT: Try pressing the left and right arrow keys as needed.
+<p><strong>HINT</strong>: Try pressing the left and right arrow keys as needed.
 Also try pressing space/enter to select options.
 Pressing Q or Escape may end the fun before you are ready. :-)</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
@@ -449,24 +449,16 @@ size requirements. It’s currently at 2052 according to
 <p>The current size is a third to a half of the original size before compression.</p>
 <p>Due to this, it does LOTS of things that subtly annoy compilers!</p>
 <ul>
-<li><ol start="10" type="1">
-<li>data argument not used by format string</li>
-</ol>
+<li><p><code>(10)</code> data argument not used by format string</p>
 <p>This occurs because some of the <code>fprintf(3)</code> invocations don’t use all their
 parameters. The program should still work fine!</p></li>
-<li><ol type="1">
-<li>using the result of an assignment as a condition without parentheses</li>
-</ol>
+<li><p><code>(1)</code> using the result of an assignment as a condition without parentheses</p>
 <p>Somewhere, I needed to set a variable and then branch on the result. The
 shortest way was to combine them. Some self-proclaimed “EXPERTS” think this
 is a bad programming practice, but what do they know? :P</p></li>
-<li><ol type="1">
-<li>implicit declaration of function ‘time’ is invalid in C99</li>
-</ol>
+<li><p><code>(1)</code> implicit declaration of function ‘time’ is invalid in C99</p>
 <p>An <code>#include</code> statement is expensive, and I’m broke.</p></li>
-<li><ol type="1">
-<li>control may reach end of non-void function</li>
-</ol>
+<li><p><code>(1)</code> control may reach end of non-void function</p>
 <p>Turns out that sometimes, a <code>return</code> statement is too much. This will never
 actually occur, but some C compilers think they know more about my program
 than I do! :P</p></li>

--- a/2014/vik/README.md
+++ b/2014/vik/README.md
@@ -108,7 +108,7 @@ any code in order for the program to run correctly:
     _setmode(_fileno(stdout), 0x8000);
 ```
 
-**NOTE**: see the [alternate code](%%REPO_URL%%/2014/vik/prog.alt.c) for this.
+**NOTE**: see the [Alternate code](#alternate-code) for this.
 
 
 ### Known Issues

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -458,7 +458,7 @@ the program relies on writing binary data to <code>stdout</code>.</p>
 program with this platform, the following line can be added to <code>main()</code> before
 any code in order for the program to run correctly:</p>
 <pre><code>    _setmode(_fileno(stdout), 0x8000);</code></pre>
-<p><strong>NOTE</strong>: see the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/prog.alt.c">alternate code</a> for this.</p>
+<p><strong>NOTE</strong>: see the <a href="#alternate-code">Alternate code</a> for this.</p>
 <h3 id="known-issues">Known Issues</h3>
 <p>The program uses a quite simple algorithm for detecting tone on and off events
 in the Morse signal. Hence the program does not work well with noisy input

--- a/bin/find-missing-links.sh
+++ b/bin/find-missing-links.sh
@@ -133,14 +133,15 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir]
 	-d topdir	set topdir (def: $TOPDIR)
 
 Exit codes:
-     0         all OK
-     1	       missing links found
-     2         -h and help string printed or -V and version string printed
-     3         command line error
-     4         bash version is too old
-     6	       problems found with or in the topdir or topdir/YYYY directory
-     7	       problems found with or in the entry topdir/YYYY/dir directory
- >= 10         internal error
+     0		all OK
+     1		missing links found
+     2		-h and help string printed or -V and version string printed
+     3		command line error
+     4		bash version is too old
+     5		git not installed or not in \$PATH
+     6		problems found with or in the topdir or topdir/YYYY directory
+     7		problems found with or in the entry topdir/YYYY/dir directory
+ >= 10		internal error
 
 $NAME version: $VERSION"
 

--- a/bugs.html
+++ b/bugs.html
@@ -2843,16 +2843,17 @@ used.</li>
 <h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
-<p>From the author:</p>
-<p>–</p>
+<blockquote>
 <p>This program supports only “Combinator-calculus style notation” of Lazy K.
 “Unlambda style” and “Iota and Jot” style are not supported.</p>
+</blockquote>
+<blockquote>
 <p>Also, it requires a space between identifiers. In short, use <code>(S K)</code> instead of
-<code>(SK)</code>, “`sk”, **i<em>i</em>i<em>ii</em>i<em>i</em>ii<code>, or</code>11111100011100`.</p>
+<code>(SK)</code>, “`sk”, <code>**i*i*i*ii*i*i*ii</code>, or <code>11111100011100</code>.</p>
 <p>Huge memory may be required to compile the program (about 300 MB on my machine).</p>
 <p>In addition, there are some limitations (and workarounds) mentioned in the
 <a href="2013/endoh1/index.html#obfuscation">obfuscation section</a>.</p>
-<p>–</p>
+</blockquote>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
@@ -2860,12 +2861,12 @@ used.</li>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
 <p>From the author:</p>
-<p>–</p>
-<p>You can <em>NOT</em> write a note length immediately followed by a note <code>E</code>,
-such as <code>C2E2</code>.</p>
+<blockquote>
+<p>You can <em>NOT</em> write a note length immediately followed by a note <code>E</code>, such as
+<code>C2E2</code>.</p>
 <p>Can you figure out why?</p>
 <p>A workaround is inserting a whitespace: <code>C2 E2</code>.</p>
-<p>–</p>
+</blockquote>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
@@ -2904,24 +2905,21 @@ it out as a known limitation it is not a bug but a feature.</p>
 <h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
-<p>The author noted that in macOS the colours might be wrong. They gave a solution.
-However Cody didn’t see any problem with it and he beat the series many times.
-Of course the game here is small and he’s practically blind and it’s been a
-while since he last played so it might be wrong. Nevertheless the author does
-give a way to reconfigure the colours.</p>
+<p>The author noted that in macOS the colours might be wrong and gives a solution,
+though it is unclear if this is still true or if there was any problem at all.</p>
 <p>The author noted that the character cannot go through walls and the impression
-is that this is how it was believed but Cody ironically pointed out that there
-are known glitches where in some places you actually could go through walls.
-This might even have applied to the arcade version, Mario Bros, though that can
-no longer be confirmed by Cody. The point here is that in this game you cannot
-go through walls but it’s not a bug.</p>
+is that this is how it was believed but someone did ironically point out that
+there are known glitches where in some places you actually could go through
+walls. This might even have applied to the arcade version, Mario Bros, though
+that can no longer be confirmed by said person. The point here is that in this
+game you cannot go through walls but it’s not a bug.</p>
 <p>On the other hand, the author also stated:</p>
-<p>–</p>
+<blockquote>
 <p>When the <code>Super character</code> becomes bigger (<code>ZOOM</code> flag), the character can
 collide with blocks and get stuck inside them. This is a KNOWN BUG. When your
 player become bigger, stay away from blocks!</p>
-<p>–</p>
-<p>but since it’s documented it’s considered a feature, not a bug to fix.</p>
+</blockquote>
+<p>.. but since it’s documented it’s considered a feature, not a bug to fix.</p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>

--- a/faq.html
+++ b/faq.html
@@ -389,7 +389,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="faq-table-of-contents">FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.0.4 2024-08-24</strong>.</p>
+<p>This is FAQ version <strong>28.0.5 2024-10-14</strong>.</p>
 <h2 id="section-0---submitting-to-a-new-ioccc">Section 0 - <a href="#faq0">Submitting to a new IOCCC</a></h2>
 <ul>
 <li><a class="normal" href="#faq0_0">0.0 - How may I enter the IOCCC?</a></li>
@@ -455,6 +455,8 @@
 <li><a class="normal" href="#faq3_21">3.21 - What are <code>try.sh</code> and <code>try.alt.sh</code> scripts and why should I use them?</a></li>
 <li><a class="normal" href="#faq3_22">3.22 - Are there any compiler warnings that I should not worry about?</a></li>
 <li><a class="normal" href="#faq3_23">3.23 - How do I compile an IOCCC entry that requires zlib?</a></li>
+<li><a class="normal" href="#faq3_24">3.24 - How do I install Ruby for entries that require it?</a></li>
+<li><a class="normal" href="#faq3_25">3.25 - How do I install rake for entries that require it?</a></li>
 </ul>
 <h2 id="section-4---changes-made-to-ioccc-entries">Section 4 - <a href="#faq4">Changes made to IOCCC entries</a></h2>
 <ul>
@@ -3333,6 +3335,29 @@ packages: one for compiling and one for linking / running.</p>
 for downloading, installing and using zlib.</p>
 <p>We recommend trying a method suitable for your environment first, if possible.</p>
 <p>Jump to: <a href="#">top</a></p>
+<div id="faq3_24">
+<div id="ruby">
+<h3 id="faq-3.24-how-do-i-install-ruby-for-entries-that-require-it">FAQ 3.24: How do I install Ruby for entries that require it?</h3>
+</div>
+</div>
+<p>Please see the <a href="https://www.ruby-lang.org/en/documentation/installation/">official Ruby installation
+guide</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="faq3_25">
+<div id="rake">
+<h3 id="faq-3.25-how-do-i-install-rake-for-entries-that-require-it">FAQ 3.25: How do I install rake for entries that require it?</h3>
+</div>
+</div>
+<p>First, if <code>gem</code> is not installed, see the <a href="https://github.com/rubygems/rubygems">gem GitHub repo</a>.</p>
+<p>Assuming you have <code>git(1)</code> installed, you can do:</p>
+<pre><code>    git clone https://github.com/rubygems/rubygems
+    cd rubygems &amp;&amp; exe/gem install rake</code></pre>
+<p>Otherwise, you can download the zip file, extract it, cd to the directory and
+then run:</p>
+<pre><code>    exe/gem install rake</code></pre>
+<p>Once this is done, try as root or via <code>sudo</code>:</p>
+<pre><code>    gem install rake</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="faq4">
 <h2 id="section-4-changes-made-to-ioccc-entries">Section 4: Changes made to IOCCC entries</h2>
 </div>
@@ -3398,7 +3423,7 @@ can look almost identical.</p>
 </div>
 <p>We have set up make rules to easily do see what was changed in the winning IOCCC
 entry source. Using the <code>Makefile</code> in the entry directory, use
-one of the following <em>make(1)</em> rules:</p>
+one of the following <code>make(1)</code> rules:</p>
 <p>The following <code>make</code> rules exist to make a difference:</p>
 <ul>
 <li><code>make diff_orig_prog</code>:

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # FAQ Table of Contents
 
-This is FAQ version **28.0.4 2024-08-24**.
+This is FAQ version **28.0.5 2024-10-14**.
 
 
 ## Section  0 - [Submitting  to a new IOCCC](#faq0)


### PR DESCRIPTION

The code 5 was missing. The reason other lines changed is simply 
formatting (aligned to 4 chars).