### PR TITLE
Remove <ul>/</ul> in FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -395,7 +395,6 @@
     NOTE: lists to make it easier to add entries in the middle of a section,
     NOTE: without having to update all the entries after that entry.
 -->
-<ul>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><a class="normal" href="#submit">How can I enter the IOCCC?</a></li>
@@ -527,10 +526,8 @@ other inconsistencies with the original entry?</a></li>
 <li><a class="normal" href="#bof">What is an IOCCC BOF?</a></li>
 <li><a class="normal" href="#explain_IOCCC">I do not understand the IOCCC, can you explain it to me?</a></li>
 </ul>
-</ul>
 <p>Jump to: <a href="#">top</a></p>
 <h1 id="the-ioccc-faq">The IOCCC FAQ</h1>
-<ul>
 <div id="enter_questions">
 <h2 id="section-0-entering-the-ioccc-the-bare-minimum-you-need-to-know">Section 0: Entering the IOCCC: the bare minimum you need to know</h2>
 </div>
@@ -1530,8 +1527,6 @@ it will report this as an <strong>error</strong>. Thus, if you were to package y
 submission manually then you would be violating <a href="next/rules.html#rule17">Rule
 17</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="submitting_help">
 <h2 id="section-1-entering-the-ioccc-more-help-and-details">Section 1: Entering the IOCCC: more help and details</h2>
 </div>
@@ -1623,8 +1618,6 @@ page</a>.</p>
 FAQ on “<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md#bugs">reporting bugs and other issues in the mkiocccentry repo</a>”
 in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="judging">
 <h2 id="section-2-ioccc-judging-process">Section 2: IOCCC Judging process</h2>
 </div>
@@ -1915,8 +1908,6 @@ winning entries page</a>. This is done by updating this repo.</p></li>
 <li><p>Update the <a href="news.html">IOCCC news</a> page, also by updating this repo.</p></li>
 </ul>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="mkiocccentry_details">
 <h2 id="section-3-the-mkiocccentry-toolkit-finer-details">Section 3: The mkiocccentry toolkit: finer details</h2>
 </div>
@@ -2049,8 +2040,6 @@ you can do so. For instance:</p>
 FAQ on “<a href="#txzchk">validating your submission tarball</a>”
 for more information.</p>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="compiling">
 <h2 id="section-4-compiling-ioccc-entries">Section 4: Compiling IOCCC entries</h2>
 </div>
@@ -2300,7 +2289,8 @@ the <a href="thanks-for-help.html">thanks-for-help.html</a> file.</p>
 <p>First, see the
 FAQ on “<a href="#X11_general">general X11</a>”.</p>
 <p>Install Xorg and related packages:</p>
-<pre><code>    sudo dnf install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
+<pre><code>    sudo dnf install --skip-broken --best --exclude xorgxrdp \
+    --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
 <p>See also:</p>
 <ul>
 <li><a href="https://www.wikihow.com/Configure-X11-in-Linux">How to Configure X11 in Linux</a></li>
@@ -2366,9 +2356,11 @@ may be helpful:</p>
 <li><a href="https://www.wikihow.com/Configure-X11-in-Linux">How to Configure X11 in Linux</a></li>
 </ul>
 <p>For systems that have the <code>dnf(1)</code> command:</p>
-<pre><code>    sudo dnf install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
+<pre><code>    sudo dnf install --skip-broken --best --exclude xorgxrdp \
+    --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
 <p>For systems that have the <code>yum(1)</code> command:</p>
-<pre><code>    sudo yum install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
+<pre><code>    sudo yum install --skip-broken --best --exclude xorgxrdp\
+    --exclude xorgxrdp-glamor &#39;*xorg*&#39; &#39;libx*&#39; &#39;libX*&#39; &#39;fontconfig*&#39;</code></pre>
 <p><strong>IMPORTANT NOTE</strong>: The X.org server has been deprecated.
 See the
 FAQ on “<a href="#Xorg_deprecated">X.org deprecated</a>”
@@ -2991,27 +2983,19 @@ then run:</p>
 <pre><code>    exe/gem install rake</code></pre>
 <p>Once this is done, try as root or via <code>sudo</code>:</p>
 <pre><code>    gem install rake</code></pre>
-Jump to: <a href="#">top</a>
-</ul>
-<ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="dependencies">
 <h2 id="section-5-dependencies-for-some-ioccc-entries">Section 5: Dependencies for some IOCCC entries</h2>
 </div>
-Jump to: <a href="#">top</a>
-</ul>
-<ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="compile_problems">
 <h2 id="section-6-problems-compiling-ioccc-entries">Section 6: Problems compiling IOCCC entries</h2>
 </div>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="running_entries">
 <h2 id="section-7-running-ioccc-entries">Section 7: Running IOCCC entries</h2>
 </div>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="changes">
 <h2 id="section-8-changes-made-to-ioccc-entries">Section 8: Changes made to IOCCC entries</h2>
 </div>
@@ -3310,8 +3294,6 @@ the source code as it is now now, try:</p>
 FAQ on “<a href="#what_changed">what changed</a>”
 for more information and make rules relating to “<strong>original source file</strong>” differences.</p>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="help">
 <h2 id="section-9-helping-the-ioccc">Section 9: Helping the IOCCC</h2>
 </div>
@@ -3699,8 +3681,6 @@ happy to include any whatever notes and/or comments from your new discussion
 that be prove helpful.</p>
 <p><strong>THANK YOU</strong> in advance for your willingness to assist!</p>
 <p>Jump to: <a href="#">top</a></p>
-</ul>
-<ul>
 <div id="misc">
 <h2 id="section-10-miscellaneous-ioccc">Section 10: Miscellaneous IOCCC</h2>
 </div>
@@ -5083,8 +5063,6 @@ and inexplicable.</p>
 <a href="#great_fork_merge">already happened</a>.” 😜</p>
 </blockquote>
 <p>Share and enjoy! ☺️</p>
-</ul>
-<ul>
 <div id="history">
 <div id="ioccc_history">
 <h2 id="section-11-history-of-the-ioccc">Section 11: History of the IOCCC</h2>
@@ -5408,9 +5386,7 @@ Contest Birds Of a Feather</strong>. It was a special session held at the
 general <a href="https://www.usenix.org/conferences">USENIX conference</a>, usually
 immediately after the BSD BOF, where the winners of a new IOCCC were
 announced in the early years of the IOCCC.</p>
-Jump to: <a href="#">top</a>
-</ul>
-</ul>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <!--
 

--- a/faq.md
+++ b/faq.md
@@ -8,7 +8,7 @@ This is FAQ version **28.0.9 2024-10-19**.
     NOTE: without having to update all the entries after that entry.
 -->
 
-<ul>
+
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
 - <a class="normal" href="#submit">How can I enter the IOCCC?</a>
 - <a class="normal" href="#mkiocccentry">What is the `mkiocccentry` tool and how do I use it?</a>
@@ -127,7 +127,7 @@ other inconsistencies with the original entry?</a>
 - <a class="normal" href="#great_fork_merge">What is the **Great Fork Merge**?</a>
 - <a class="normal" href="#bof">What is an IOCCC BOF?</a>
 - <a class="normal" href="#explain_IOCCC">I do not understand the IOCCC, can you explain it to me?</a>
-</ul>
+
 
 
 Jump to: [top](#)
@@ -135,7 +135,7 @@ Jump to: [top](#)
 
 # The IOCCC FAQ
 
-<ul>
+
 <div id="enter_questions">
 ## Section 0: Entering the IOCCC: the bare minimum you need to know
 </div>
@@ -1280,9 +1280,9 @@ submission manually then you would be violating [Rule
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="submitting_help">
 ## Section 1: Entering the IOCCC: more help and details
 </div>
@@ -1409,9 +1409,9 @@ in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="judging">
 ## Section 2: IOCCC Judging process
 </div>
@@ -1785,9 +1785,9 @@ winning entries page](years.html). This is done by updating this repo.
 Jump to: [top](#)
 
 
-</ul>
 
-<ul>
+
+
 <div id="mkiocccentry_details">
 ## Section 3: The mkiocccentry toolkit: finer details
 </div>
@@ -1946,9 +1946,9 @@ for more information.
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="compiling">
 ## Section 4: Compiling IOCCC entries
 </div>
@@ -2276,7 +2276,8 @@ FAQ on "[general X11](#X11_general)".
 Install Xorg and related packages:
 
 ``` <!---sh-->
-    sudo dnf install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
+    sudo dnf install --skip-broken --best --exclude xorgxrdp \
+    --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
 ```
 
 See also:
@@ -2374,13 +2375,15 @@ See also:
 For systems that have the `dnf(1)` command:
 
 ``` <!---sh-->
-    sudo dnf install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
+    sudo dnf install --skip-broken --best --exclude xorgxrdp \
+    --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
 ```
 
 For systems that have the `yum(1)` command:
 
 ``` <!---sh-->
-    sudo yum install --skip-broken --best --exclude xorgxrdp --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
+    sudo yum install --skip-broken --best --exclude xorgxrdp\
+    --exclude xorgxrdp-glamor '*xorg*' 'libx*' 'libX*' 'fontconfig*'
 ```
 
 **IMPORTANT NOTE**: The X.org server has been deprecated.
@@ -3477,35 +3480,34 @@ Once this is done, try as root or via `sudo`:
 ```
 
 Jump to: [top](#)
-</ul>
 
-<ul>
+
 <div id="dependencies">
 ## Section 5: Dependencies for some IOCCC entries
 </div>
 
 Jump to: [top](#)
-</ul>
 
-<ul>
+
+
 <div id="compile_problems">
 ## Section 6: Problems compiling IOCCC entries
 </div>
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="running_entries">
 ## Section 7: Running IOCCC entries
 </div>
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="changes">
 ## Section 8: Changes made to IOCCC entries
 </div>
@@ -3902,9 +3904,9 @@ for more information and make rules relating to "**original source file**" diffe
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="help">
 ## Section 9: Helping the IOCCC
 </div>
@@ -4429,9 +4431,9 @@ that be prove helpful.
 
 Jump to: [top](#)
 
-</ul>
 
-<ul>
+
+
 <div id="misc">
 ## Section 10: Miscellaneous IOCCC
 </div>
@@ -6403,9 +6405,9 @@ and inexplicable.
 
 Share and enjoy! ☺️
 
-</ul>
 
-<ul>
+
+
 <div id="history">
 <div id="ioccc_history">
 ## Section 11: History of the IOCCC
@@ -6807,8 +6809,8 @@ immediately after the BSD BOF, where the winners of a new IOCCC were
 announced in the early years of the IOCCC.
 
 Jump to: [top](#)
-</ul>
-</ul>
+
+
 
 <hr style="width:10%;text-align:left;margin-left:0">
 


### PR DESCRIPTION
This was forgotten in the previous commit.

Also shorten some command lines (end line with '\').