### PR TITLE
Bug fixes in bin/find-invalid-json.sh

### DIFF
--- a/bin/find-invalid-json.sh
+++ b/bin/find-invalid-json.sh
@@ -207,7 +207,7 @@ find . -name '*.json' -print |
     # get name of each JSON file
     while read -r JSON_FILE; do
 	# try parsing JSON file
-	if ! "$JPARSE" "$JSON_FILE"; then
+	if ! "$JPARSE" "$JSON_FILE" 2>/dev/null; then
 	    echo "$JSON_FILE is invalid JSON"
 	fi
 # this writes the invalid JSON files to the temporary error file
@@ -217,7 +217,6 @@ done > "$TMP_INVALID_JSON"
 #
 INVALID_JSON_COUNT=$(wc -l < "$TMP_INVALID_JSON" | tr -d ' ')
 export INVALID_JSON_COUNT
-((INVALID_JSON_COUNT=INVALID_JSON_COUNT/4))
 
 
 # report on any invalid JSON files

--- a/faq.html
+++ b/faq.html
@@ -3570,7 +3570,9 @@ depended on operation system and library features that where common back then
 but are different/missing today.</p>
 <p>Please see the other FAQs in this section as they might offer helpful
 hints, especially in cases were something else needs to be installed.</p>
-<p>Please see the <a href="bugs.html">bugs.html</a> file for details about known problems with IOCCC entries. In some cases you may be dealing with a problematic entry. In a few fun cases, the IOCCC does not compile by design!</p>
+<p>Please see the <a href="bugs.html">bugs.html</a> file for details about known problems with
+IOCCC entries. In some cases you may be dealing with a problematic entry. In a
+few fun cases, the IOCCC does not compile by design!</p>
 <p>If you have a fix that makes a minimal impact to the entry, then
 please consider submitting that change in the form of a pull request.
 Please see
@@ -3681,26 +3683,8 @@ below note) this would be advisable.</p>
 <p><strong>NOTE</strong>: different versions of <code>clang</code> have other differences as well. For instance
 a defect of <code>clang</code> that required numerous entries to be fixed for clang is that it
 requires that <code>main()</code>’s arguments to be of a specific type. However some
-versions of <code>clang</code> are more strict in the number of args allowed. These reasons
-are part of why numerous entries had to be modified so that <code>main()</code> calls
-another function instead of doing it all in <code>main()</code> (another reason was that
-some entries that recursively called <code>main()</code> caused a crash or otherwise broke
-the entry in modern systems). Some entries do not work in <code>clang</code> (or at least do
-not work completely) due to these defects, for instance
-<a href="1989/westley/index.html">1989/westley</a>; <a href="authors.html#Cody_Boone_Ferguson">Cody Boone
-Ferguson</a> was able to
-get much of it to work and looking at that entry might be of value to your
-submissions, at least if you can figure the code out :-). To see the
-differences, try from <code>1989/westley</code>:</p>
-<pre><code>    make diff_orig_prog</code></pre>
-<p>If you have <code>colordiff</code> try:</p>
-<pre><code>    make DIFF=colordiff diff_orig_prog</code></pre>
-<p>Alternatively you can try:</p>
-<pre><code>    git diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..eb9e69fde657acc8c85a618a8a99af4c2f93b21d westley.c</code></pre>
-<p>As you can see, using <code>clang</code> has some additional problems to work out but if
-you can get your entry to work well in <code>clang</code> it might very well be considered
-better than other entries.</p>
-<p>Jump to: <a href="#">top</a></p>
+versions of <code>clang</code> are more strict in the number of args allowed.
+Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
 <div id="running_entries">

--- a/faq.html
+++ b/faq.html
@@ -390,11 +390,6 @@
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <p>IOCCC FAQ Table of Contents</p>
 <p>This is FAQ version <strong>28.1 2024-10-20</strong>.</p>
-<!--
-    NOTE: when updating the table of contents, make sure to use unordered
-    NOTE: lists to make it easier to add entries in the middle of a section,
-    NOTE: without having to update all the entries after that entry.
--->
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#submit">How can I enter the IOCCC?</a></li>

--- a/faq.html
+++ b/faq.html
@@ -3628,9 +3628,8 @@ for more information about pull requests.</p>
 </div>
 <p>If the entry requires gcc and you did not explicitly install gcc in macOS you
 will not be able to run or use these entries. This is because macOS gcc is
-actually clang, even <code>/usr/bin/gcc</code>.</p>
-<p>That being said many (if not most) of these entries have been fixed and some
-others will be looked at, when found.</p>
+actually clang, even <code>/usr/bin/gcc</code>. That being said many (if not most) of these
+entries have been fixed.</p>
 <p>In some cases the <a href="bugs.html">bugs.html</a> file may note a known macOS problem
 with an entry. Should you manage to port the entry, and assuming your changes
 also attempt to preserve the original intent of the IOCCC entry, we would

--- a/faq.md
+++ b/faq.md
@@ -4390,7 +4390,9 @@ but are different/missing today.
 Please see the other FAQs in this section as they might offer helpful
 hints, especially in cases were something else needs to be installed.
 
-Please see the [bugs.html](bugs.html) file for details about known problems with IOCCC entries.  In some cases you may be dealing with a problematic entry.  In a few fun cases, the IOCCC does not compile by design!
+Please see the [bugs.html](bugs.html) file for details about known problems with
+IOCCC entries.  In some cases you may be dealing with a problematic entry.  In a
+few fun cases, the IOCCC does not compile by design!
 
 If you have a fix that makes a minimal impact to the entry, then
 please consider submitting that change in the form of a pull request.
@@ -4534,38 +4536,7 @@ below note) this would be advisable.
 **NOTE**: different versions of `clang` have other differences as well. For instance
 a defect of `clang` that required numerous entries to be fixed for clang is that it
 requires that `main()`'s arguments to be of a specific type. However some
-versions of `clang` are more strict in the number of args allowed. These reasons
-are part of why numerous entries had to be modified so that `main()` calls
-another function instead of doing it all in `main()` (another reason was that
-some entries that recursively called `main()` caused a crash or otherwise broke
-the entry in modern systems). Some entries do not work in `clang` (or at least do
-not work completely) due to these defects, for instance
-[1989/westley](1989/westley/index.html); [Cody Boone
-Ferguson](authors.html#Cody_Boone_Ferguson) was able to
-get much of it to work and looking at that entry might be of value to your
-submissions, at least if you can figure the code out :-). To see the
-differences, try from `1989/westley`:
-
-``` <!---sh-->
-    make diff_orig_prog
-```
-
-If you have `colordiff` try:
-
-``` <!---sh-->
-    make DIFF=colordiff diff_orig_prog
-```
-
-Alternatively you can try:
-
-``` <!---sh-->
-    git diff d2a42f42e8f477f29e9d5ed09ce2bb349eaf7397..eb9e69fde657acc8c85a618a8a99af4c2f93b21d westley.c
-```
-
-As you can see, using `clang` has some additional problems to work out but if
-you can get your entry to work well in `clang` it might very well be considered
-better than other entries.
-
+versions of `clang` are more strict in the number of args allowed.
 Jump to: [top](#)
 
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.md
+++ b/faq.md
@@ -4464,10 +4464,8 @@ Jump to: [top](#)
 
 If the entry requires gcc and you did not explicitly install gcc in macOS you
 will not be able to run or use these entries. This is because macOS gcc is
-actually clang, even `/usr/bin/gcc`.
-
-That being said many (if not most) of these entries have been fixed and some
-others will be looked at, when found.
+actually clang, even `/usr/bin/gcc`. That being said many (if not most) of these
+entries have been fixed.
 
 In some cases the [bugs.html](bugs.html) file may note a known macOS problem
 with an entry.  Should you manage to port the entry, and assuming your changes

--- a/faq.md
+++ b/faq.md
@@ -2,12 +2,6 @@
 
 This is FAQ version **28.1 2024-10-20**.
 
-<!--
-    NOTE: when updating the table of contents, make sure to use unordered
-    NOTE: lists to make it easier to add entries in the middle of a section,
-    NOTE: without having to update all the entries after that entry.
--->
-
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
 - **Q 0.0**: <a class="normal" href="#submit">How can I enter the IOCCC?</a>

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -426,7 +426,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.16 2024-10-17</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.17 2024-10-20</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <div id="change_marks">
@@ -1409,7 +1409,7 @@ Even so, we do not recommend you try and submit a JSON parser due to
 the fact it will likely exceed <a href="rules.html#rule2">the source code size limit</a>
 and because you likely can’t beat <a href="https://github.com/westes/flex">flex</a> or
 <a href="https://www.gnu.org/software/bison/">bison</a> in obfuscation. This isn’t to
-say that <a href="https://www.json.org/json-en.html">the so-called JSON spec</a> is not
+say that <a href="https://github.com/xexyl/jparse/blob/master/json_README.md#so-called-json-spec">the so-called JSON spec</a> is not
 obfuscated, but unless you have some really clever way to compact and
 obfuscate a JSON parser more than <a href="https://github.com/westes/flex">flex</a> and
 <a href="https://www.gnu.org/software/bison/">bison</a> you will likely not win, either

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1519,7 +1519,7 @@ is a <strong>hint</strong>. :-)
 </p>
 <p class="leftbar">
 We <strong>RECOMMEND</strong> you put a reasonable amount effort into the content of the
-<code>remarks.md</code> file: it is a required for for a reason. :-)
+<code>remarks.md</code> file: it is a required for a reason. :-)
 </p>
 <div id="rules_abuse">
 <div id="abusing_rules">

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -50,7 +50,7 @@ writing by [contacting the judges](../contact.html).
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.16 2024-10-17**.
+These [IOCCC guidelines](guidelines.html) are version **28.17 2024-10-20**.
 </p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
@@ -1273,7 +1273,7 @@ Even so, we do not recommend you try and submit a JSON parser due to
 the fact it will likely exceed [the source code size limit](rules.html#rule2)
 and because you likely can't beat [flex](https://github.com/westes/flex) or
 [bison](https://www.gnu.org/software/bison/) in obfuscation. This isn't to
-say that [the so-called JSON spec](https://www.json.org/json-en.html) is not
+say that [the so-called JSON spec](https://github.com/xexyl/jparse/blob/master/json_README.md#so-called-json-spec) is not
 obfuscated, but unless you have some really clever way to compact and
 obfuscate a JSON parser more than [flex](https://github.com/westes/flex) and
 [bison](https://www.gnu.org/software/bison/) you will likely not win, either

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -1398,7 +1398,7 @@ is a **hint**.  :-)
 
 <p class="leftbar">
 We **RECOMMEND** you put a reasonable amount effort into the content of the
-`remarks.md` file: it is a required for for a reason.  :-)
+`remarks.md` file: it is a required for a reason.  :-)
 </p>
 
 


### PR DESCRIPTION
It incorrectly calculated the number of invalid JSON files.
    
Redirect jparse stderr to /dev/null as the script will be able to tell without the extra clutter.
