### PR TITLE
Typo fixes 

### DIFF
--- a/2006/toledo2/README.md
+++ b/2006/toledo2/README.md
@@ -48,8 +48,9 @@ To end the program hit ctrl-z.
 
 ## Alternate code:
 
-This version, as noted, should work for DOS/Windows. It uses non-standard
-functions in place of `read(2)` and `write(2)`.
+This version, as noted above, should work for DOS/Windows. It uses non-standard
+functions in place of `read(2)` and `write(2)`, and is based on the author's
+remarks.
 
 
 ### Alternate build:

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -432,8 +432,9 @@ does not seem to happen in macOS or linux in 2023.</p>
     RUN</code></pre>
 <p>To end the program hit ctrl-z.</p>
 <h2 id="alternate-code">Alternate code:</h2>
-<p>This version, as noted, should work for DOS/Windows. It uses non-standard
-functions in place of <code>read(2)</code> and <code>write(2)</code>.</p>
+<p>This version, as noted above, should work for DOS/Windows. It uses non-standard
+functions in place of <code>read(2)</code> and <code>write(2)</code>, and is based on the author’s
+remarks.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>

--- a/2006/toledo3/README.md
+++ b/2006/toledo3/README.md
@@ -9,7 +9,7 @@ compile.  For more information see the
 FAQ on "[X11](../../faq.html#X11)".
 
 The author provided two alternate versions, one which adds a status bar and
-another that makes it text only. The author also provided a version that they
+another that makes it text only. The author also described a version that they
 tested with Windows.  See [Alternate code](#alternate-code) below.
 
 
@@ -29,16 +29,19 @@ tested with Windows.  See [Alternate code](#alternate-code) below.
 
 ## Alternate code:
 
-The author provided two additional versions, [toledo3-sbar.c](%%REPO_URL%%/2006/toledo3/toledo3-sbar.c)
-and [toledo3-txt.c](%%REPO_URL%%/2006/toledo3/toledo3-txt.c). Respectively these create a status bar and
-make the game text only.
+The author provided two additional versions,
+[toledo3-sbar.c](%%REPO_URL%%/2006/toledo3/toledo3-sbar.c) and
+[toledo3-txt.c](%%REPO_URL%%/2006/toledo3/toledo3-txt.c). Respectively these
+create a status bar and make the game text only. Based on the author's remarks,
+another version, [toledo3.alt.c](%%REPO_URL%%/2006/toledo3/toledo3.alt.c), was
+added that should work with Windows.
 
 
 ### Alternate build:
 
 With the exception of the Windows version, these are built by default. To build
-the Windows version, [toledo3.alt.c](%%REPO_URL%%/2006/toledo3/toledo3.alt.c), you will have to figure out
-how to compile Windows code.
+the Windows version, [toledo3.alt.c](%%REPO_URL%%/2006/toledo3/toledo3.alt.c),
+you will have to figure out how to compile Windows code.
 
 
 ### Alternate use:

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -414,20 +414,23 @@ Location: <a href="../../location.html#MX">MX</a> - <em>United Mexican States</e
 compile. For more information see the
 FAQ on “<a href="../../faq.html#X11">X11</a>”.</p>
 <p>The author provided two alternate versions, one which adds a status bar and
-another that makes it text only. The author also provided a version that they
+another that makes it text only. The author also described a version that they
 tested with Windows. See <a href="#alternate-code">Alternate code</a> below.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./toledo3 [1 | 2 | 3 [b]]</code></pre>
 <h2 id="try">Try:</h2>
 <pre><code>    ./toledo3 1</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
-<p>The author provided two additional versions, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3-sbar.c">toledo3-sbar.c</a>
-and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3-txt.c">toledo3-txt.c</a>. Respectively these create a status bar and
-make the game text only.</p>
+<p>The author provided two additional versions,
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3-sbar.c">toledo3-sbar.c</a> and
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3-txt.c">toledo3-txt.c</a>. Respectively these
+create a status bar and make the game text only. Based on the author’s remarks,
+another version, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>, was
+added that should work with Windows.</p>
 <h3 id="alternate-build">Alternate build:</h3>
 <p>With the exception of the Windows version, these are built by default. To build
-the Windows version, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>, you will have to figure out
-how to compile Windows code.</p>
+the Windows version, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>,
+you will have to figure out how to compile Windows code.</p>
 <h3 id="alternate-use">Alternate use:</h3>
 <p>Use <code>toledo3-sbar</code> and <code>toledo3-txt</code> as you would <code>toledo3</code> above.</p>
 <p>As for the Windows version, <code>toledo3.alt</code>, we presume you can open it like any

--- a/bin/README.md
+++ b/bin/README.md
@@ -460,6 +460,32 @@ We recommend that this tool be invoked via the top level `Makefile`:
     make find_missing_links
 ```
 
+<div id="find-invalid-json">
+### [find-invalid-json.sh](%%REPO_URL%%/bin/find-invalid-json.sh)
+</div>
+
+This script uses the `jparse(1)` tool, which can be obtained from the
+[mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)'s copy of the
+[jparse repo](https://github.com/xexyl/jparse/), and searches for any invalid
+JSON files in the tree.
+
+This is important because the IOCCC makes extensive use of JSON.
+
+Usage:
+
+``` <!---sh-->
+    bin/find-invalid-json.sh -v 1
+```
+
+If no invalid JSON files are found, this tool exits 0 with no output
+(debug messages not withstanding), otherwise this tool will exit non-zero.
+
+We recommend that this tool be invoked via the top level `Makefile`:
+
+``` <!---sh-->
+    make find_invalid_json
+```
+
 
 <div id="format-headers">
 ### [format-headers.sh](%%REPO_URL%%/bin/format-headers.sh)

--- a/bin/format-headers.sh
+++ b/bin/format-headers.sh
@@ -5,31 +5,20 @@
 # We formats headers in README.md files so that before a line that starts with
 # '##' (as in '^##') that have specific names there are two blank lines (\n\n).
 #
-# Script written by Landon with minor improvements by Cody Boone Ferguson where
-# now it only acts on files under git control rather than any README.md file in
-# the [0-9]{4} directories.
+# This script was written sometime in 2023 or 2024 by:
 #
-# Copyright (c) 2023-2024 by Landon Curt Noll.  All Rights Reserved.
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
 #
-# Permission to use, copy, modify, and distribute this software and
-# its documentation for any purpose and without fee is hereby granted,
-# provided that the above copyright, this permission notice and text
-# this comment, and the disclaimer below appear in all of the following:
+# which uses Perl code by Landon Curt Noll, with the improvement that instead of
+# acting on all README.md files, it only acts on README.md files under git
+# control.
 #
-#       supporting documentation
-#       source copies
-#       source works derived from this source
-#       binaries derived from this source or from derived source
+# The Perl code makes sure that for certain headers in the README.md files,
+# there are the correct number of blank lines before/after.
 #
-# LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
-# INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
-# EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
-# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
-# USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-# PERFORMANCE OF THIS SOFTWARE.
-#
-# chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#   "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
 

--- a/bin/index.html
+++ b/bin/index.html
@@ -669,6 +669,20 @@ that is <strong>NOT</strong> an IOCCC markdown best practice.</p>
 details.</p>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
 <pre><code>    make find_missing_links</code></pre>
+<div id="find-invalid-json">
+<h3 id="find-invalid-json.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/find-invalid-json.sh">find-invalid-json.sh</a></h3>
+</div>
+<p>This script uses the <code>jparse(1)</code> tool, which can be obtained from the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>’s copy of the
+<a href="https://github.com/xexyl/jparse/">jparse repo</a>, and searches for any invalid
+JSON files in the tree.</p>
+<p>This is important because the IOCCC makes extensive use of JSON.</p>
+<p>Usage:</p>
+<pre><code>    bin/find-invalid-json.sh -v 1</code></pre>
+<p>If no invalid JSON files are found, this tool exits 0 with no output
+(debug messages not withstanding), otherwise this tool will exit non-zero.</p>
+<p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
+<pre><code>    make find_invalid_json</code></pre>
 <div id="format-headers">
 <h3 id="format-headers.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/format-headers.sh">format-headers.sh</a></h3>
 </div>

--- a/bin/md2html.cfg
+++ b/bin/md2html.cfg
@@ -23,7 +23,7 @@
 #
 #	-H navbar=. -o bin/subst.default.sh
 #
-# you will need 4 intended "cfg_option" lines:
+# you will need 4 indented "cfg_option" lines:
 #
 #	some_file_glob
 #		-H
@@ -31,7 +31,7 @@
 #		-o
 #		bin/subst.default.sh
 #
-# The above intending is performed with 1 or more whitespace
+# The above indenting is performed with 1 or more whitespace
 # characters, although we use a leading tab "convention"
 # out of deference to Makefile formats. :-)
 #
@@ -381,11 +381,11 @@ nojs-menu.md
 	-s
         TITLE=The International Obfuscated C Code Contest
 	-s
-	DESCRIPTION=Menu for when JavaScipt is disabled
+	DESCRIPTION=Menu for when JavaScript is disabled
 	-s
-	KEYWORDS=IOCCC, JavaScipt, no-JavaScipt, menu
+	KEYWORDS=IOCCC, JavaScript, no-JavaScript, menu
 	-s
-	HEADER_2=JavaScipt is disabled
+	HEADER_2=JavaScript is disabled
 	-D
 	./
 

--- a/bin/subst.default.sh
+++ b/bin/subst.default.sh
@@ -142,7 +142,7 @@ export USAGE="usage: $0 [-h] [-v level] [-V] [-d topdir] [-D docroot/] [-n] [-N]
 	-e string	output string, followed by newline, to stderr (def: do not)
 	-E exitcode	force exit with exitcode (def: exit based on success or failure of the action)
 
-	[ignored]	all arguments are igoored
+	[ignored]	all arguments are ignored
 
 Exit codes:
      0         all OK

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -12,8 +12,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 <title>The International Obfuscated C Code Contest</title>
 <link rel="icon" type="image/x-icon" href="./favicon.ico">
-<meta name="description" content="Menu for when JavaScipt is disabled">
-<meta name="keywords" content="IOCCC, JavaScipt, no-JavaScipt, menu">
+<meta name="description" content="Menu for when JavaScript is disabled">
+<meta name="keywords" content="IOCCC, JavaScript, no-JavaScript, menu">
 </head>
 
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
@@ -369,7 +369,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>JavaScipt is disabled</h2>
+  <h2>JavaScript is disabled</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->
@@ -417,7 +417,9 @@
 <li><a href="contact.html">Contacting the IOCCC</a></li>
 <li><a href="SECURITY.html">IOCCC Security Policy</a></li>
 <li><a href="thanks-for-help.html">Thanks for the help</a></li>
-<li><a href="markdown.html">IOCCC markdown</a>
+<li><a href="markdown.html">IOCCC markdown</a></li>
+<li><a href="bin/index.html">Website scripts</a></li>
+<li><a href="inc/index.html">Script include files</a>
 <!-- AFTER: last line of markdown file: nojs-menu.md --></li>
 </ul>
 

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -29,3 +29,5 @@
 * [IOCCC Security Policy](SECURITY.html)
 * [Thanks for the help](thanks-for-help.html)
 * [IOCCC markdown](markdown.html)
+* [Website scripts](bin/index.html)
+* [Script include files](inc/index.html)

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -408,7 +408,8 @@ on an IOCCC entry by entry basis.</p>
 <li><a href="#general_thanks">General thanks</a></li>
 <li><a href="#makefiles_fixes_improvements">Makefiles fixes and improvements</a></li>
 <li><a href="#consistency_improvements">Consistency improvements</a></li>
-<li><a href="#manifest_improvements">Manifest improvements</a></li>
+<li><a href="#try">Try script system</a></li>
+<li><a href="#website_improvements">Website and manifest improvements</a></li>
 <li><a href="#faq_improvements">FAQ improvements</a></li>
 <li><a href="#thank_you_honor_roll">Thank you honor roll</a></li>
 <li><a href="#neglect">Did we neglect to credit you?</a></li>
@@ -416,6 +417,7 @@ on an IOCCC entry by entry basis.</p>
 <div id="1984">
 <h1 id="the-1st-ioccc"><a href="1984/index.html">1984 - The 1st IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_anonymous">
 <h2 id="winning-entry-1984anonymous">Winning entry: <a href="1984/anonymous/index.html">1984/anonymous</a></h2>
 <h3 id="winning-entry-source-code-anonymous.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/anonymous/anonymous.c">anonymous.c</a></h3>
@@ -438,6 +440,7 @@ source code and the tattoo together as an image):</p>
  width=600 height=401></p>
 <p>The tattoo was done in 2005 by <a href="https://web.archive.org/web/20070120220721/https://thomasscovell.com/tattoo.php">Thomas
 Scovell</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_decot">
 <h2 id="winning-entry-1984decot">Winning entry: <a href="1984/decot/index.html">1984/decot</a></h2>
 <h3 id="winning-entry-source-code-decot.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.c">decot.c</a></h3>
@@ -493,11 +496,13 @@ with <code>gcc</code> - but not <code>clang</code> - or at least some versions.<
 <code>make alt</code> rule only uses <code>-traditional-cpp</code>.</p>
 <p>To see the diff between the original and the alternate code, try:</p>
 <pre class="&lt;!--sh--&gt;"><code>        cd 1984/decot ; make diff_orig_alt</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_laman">
 <h2 id="winning-entry-1984laman">Winning entry: <a href="1984/laman/index.html">1984/laman</a></h2>
 <h3 id="winning-entry-source-code-laman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">laman.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_mullender">
 <h2 id="winning-entry-1984mullender">Winning entry: <a href="1984/mullender/index.html">1984/mullender</a></h2>
 <h3 id="winning-entry-source-code-mullender.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">mullender.c</a></h3>
@@ -519,9 +524,11 @@ header file <code>a.out.h</code> that is not available in all modern systems, Co
 copy of it as to what it should have been at the time, in the fabulous <a href="https://github.com/dspinellis/unix-history-repo/tree/Research-Release">Unix
 History
 Repo</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1985">
 <h1 id="the-2nd-ioccc"><a href="1985/index.html">1985 - The 2nd IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1985_applin">
 <h2 id="winning-entry-1984applin">Winning entry: <a href="1985/applin/index.html">1984/applin</a></h2>
 <h3 id="winning-entry-source-code-applin.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/applin/applin.c">applin.c</a></h3>
@@ -542,6 +549,7 @@ Ironically this fix was discovered through Linux!</p>
 shell, after the output (despite having <code>\n</code> in the string - can you figure out
 why?) but to make it more friendly to users Cody made it print a <code>\n</code> prior to
 returning to the shell. The original code does not have this change.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1985_august">
 <h2 id="winning-entry-1985august">Winning entry: <a href="1985/august/index.html">1985/august</a></h2>
 <h3 id="winning-entry-source-code-august.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/august/august.c">august.c</a></h3>
@@ -550,8 +558,7 @@ returning to the shell. The original code does not have this change.</p>
 versions of <code>clang</code> object to the number of args of <code>main()</code>, saying that it must
 be 0, 2 or 3. The version this has been observed in does not actually object to
 1 arg but it is entirely possible that this changes so a second arg (that’s not
-needed and is unused) has been added just in case.</p>
-<p>See the
+needed and is unused) has been added just in case. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Cody also added the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/august/primes.sh">primes.sh</a> which allows one
@@ -562,6 +569,7 @@ way.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/august/try.sh">try.sh</a> script (which runs <code>primes.sh</code>
 whether <code>primes(6)</code> is installed or not, but it only does it once with the
 default value).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1985_lycklama">
 <h2 id="winning-entry-1985lycklama">Winning entry: <a href="1985/lycklama/index.html">1985/lycklama</a></h2>
 <h3 id="winning-entry-source-code-lycklama.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/lycklama/lycklama.c">lycklama.c</a></h3>
@@ -573,6 +581,7 @@ changed the <code>#o</code> lines to <code>#define</code>. Also <code>unistd.h</
 <p><a href="#yusuke">Yusuke</a> provided some useful information that amounts to an alternate version
 that Cody added. See the <a href="1985/lycklama/index.html">index.html</a> for details.</p>
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/lycklama/try.alt.sh">try.alt.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1985_shapiro">
 <h2 id="winning-entry-1985shapiro">Winning entry: <a href="1985/shapiro/index.html">1985/shapiro</a></h2>
 <h3 id="winning-entry-source-code-shapiro.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/shapiro/shapiro.c">shapiro.c</a></h3>
@@ -584,6 +593,7 @@ sizes (five times) and then compiles and runs it. After the five runs it prompts
 you to enter a number, in an infinite loop, exiting if any non-digits are in
 input (this includes negative numbers which in the code actually sets it back to
 39, the default).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1985_sicherman">
 <h2 id="winning-entry-1985sicherman">Winning entry: <a href="1985/sicherman/index.html">1985/sicherman</a></h2>
 <h3 id="winning-entry-source-code-1985sicherman">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/sicherman.c">1985/sicherman</a></h3>
@@ -667,29 +677,33 @@ don’t even bother calling <code>subr()</code>?</p>
 should they object to <code>main()</code> having only one arg.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1985/sicherman/try.alt.sh">try.alt.sh</a> scripts.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986">
 <h1 id="the-3rd-ioccc"><a href="1986/index.html">1986 - The 3rd IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_applin">
 <h2 id="winning-entry-1986applin">Winning entry: <a href="1986/applin/index.html">1986/applin</a></h2>
 <h3 id="winning-entry-source-code-applin.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/applin/applin.c">applin.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made the C file executable so one does not have to do <code>sh ./applin.c</code> or <code>./applin</code>; they can do either <code>./applin.c</code> or <code>./applin</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_bright">
 <h2 id="winning-entry-1986bright">Winning entry: <a href="1986/bright/index.html">1986/bright</a></h2>
 <h3 id="winning-entry-source-code-bright.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/bright/bright.c">bright.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/bright/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_hague">
 <h2 id="winning-entry-1986hague">Winning entry: <a href="1986/hague/index.html">1986/hague</a></h2>
 <h3 id="winning-entry-source-code-hague.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/hague/hague.c">hague.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this use <code>fgets()</code>.
 Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/hague/try.sh">try.sh</a> script which also feeds to the
-program the <code>input.txt</code> text file that Cody added.</p>
-<p>See the
+program the <code>input.txt</code> text file that Cody added. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_holloway">
 <h2 id="winning-entry-1986holloway">Winning entry: <a href="1986/holloway/index.html">1986/holloway</a></h2>
 <h3 id="winning-entry-source-code-holloway.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/holloway/holloway.c">holloway.c</a></h3>
@@ -701,6 +715,7 @@ a <code>char **</code>) to a <code>char **</code> and updating the <code>*s</cod
 caused a segfault. By adding a new variable, <code>char *t</code>, initialising it to <code>s</code>
 and then using <code>t</code> instead of <code>s</code> it compiles and runs successfully under
 <code>clang</code> and <code>gcc</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_marshall">
 <h2 id="winning-entry-1986marshall">Winning entry: <a href="1986/marshall/index.html">1986/marshall</a></h2>
 <h3 id="winning-entry-source-code-marshall.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a></h3>
@@ -744,6 +759,7 @@ the directory) slightly so that it was possible to silence it. In particular:</p
     1 warning generated.</code></pre>
 <p>which can be disabled. It results in the same behaviour but this way no warnings
 are produced.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_pawka">
 <h2 id="winning-entry-1986pawka">Winning entry: <a href="1986/pawka/index.html">1986/pawka</a></h2>
 <h3 id="winning-entry-source-code-pawka.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/pawka/pawka.c">pawka.c</a></h3>
@@ -751,6 +767,7 @@ are produced.</p>
 <p><a href="#cody">Cody</a> noticed and fixed a funny mistake in the <code>Makefile</code> where a
 <code>-Wno-strict-prototypes</code> was in the wrong location, suggesting that there is a
 <code>-D</code> needed to compile the entry but this is not actually so.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_stein">
 <h2 id="winning-entry-1986stein">Winning entry: <a href="1986/stein/index.html">1986/stein</a></h2>
 <h3 id="winning-entry-source-code-stein.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/stein/stein.c">stein.c</a></h3>
@@ -762,6 +779,7 @@ avoid problems with news and mail but as it is the <strong>Best one liner</stron
 code is now one line.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/stein/stein.sh">stein.sh</a> script which runs the two
 commands that we suggest in order to get it to show clean output.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_wall">
 <h2 id="winning-entry-1986wall">Winning entry: <a href="1986/wall/index.html">1986/wall</a></h2>
 <h3 id="winning-entry-source-code-wall.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/wall/wall.c">wall.c</a></h3>
@@ -827,14 +845,17 @@ work with <code>gcc</code> - but it still required <code>-traditional-cpp</code>
 <li>And of course as noted two strings had to be <code>strdup()</code>d.</li>
 </ul>
 <p>There might have been other changes as well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987">
 <h1 id="the-4th-ioccc"><a href="1987/index.html">1987 - The 4th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987_biggar">
 <h2 id="winning-entry-1987biggar">Winning entry: <a href="1987/biggar/index.html">1987/biggar</a></h2>
 <h3 id="winning-entry-source-code-biggar.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/biggar/biggar.c">biggar.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/biggar/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987_heckbert">
 <h2 id="winning-entry-1987heckbert">Winning entry: <a href="1987/heckbert/index.html">1987/heckbert</a></h2>
 <h3 id="winning-entry-source-code-heckbert.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/heckbert/heckbert.c">heckbert.c</a></h3>
@@ -847,6 +868,7 @@ program works but also how the folded code can recreate the original.</p>
 of <code>strings.h</code> and because it’s identical in use to <code>strchr(3)</code> (and we noted
 that for System V we had to do this) Cody added to the Makefile
 <code>-Dindex=strchr</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987_hines">
 <h2 id="winning-entry-1987hines">Winning entry: <a href="1987/hines/index.html">1987/hines</a></h2>
 <h3 id="winning-entry-source-code-hines.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/hines/hines.c">hines.c</a></h3>
@@ -855,6 +877,7 @@ that for System V we had to do this) Cody added to the Makefile
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/hines/goto.c">goto.c</a> and the text file <a href="1987/hines/goto.txt">goto.txt</a>
 for demonstration purposes. Notice that the program is case sensitive which
 running the program on the text file demonstrates.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987_lievaart">
 <h2 id="winning-entry-1987lievaart">Winning entry: <a href="1987/lievaart/index.html">1987/lievaart</a></h2>
 <h3 id="winning-entry-source-code-lievaart.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/lievaart/lievaart.c">lievaart.c</a></h3>
@@ -893,15 +916,16 @@ immediately goes back to the prompting of the level.</p>
 <code>#define D define</code> even though it’s unused. This was done for both versions as
 well (the one with the board and the one without, the entry itself with the
 size constraints of the contest).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987_wall">
 <h2 id="winning-entry-1987wall">Winning entry: <a href="1987/wall/index.html">1987/wall</a></h2>
 <h3 id="winning-entry-source-code-wall.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/wall/wall.c">wall.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>.</p>
-<p>See the
+<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/wall/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1987_westley">
 <h2 id="winning-entry-1987westley">Winning entry: <a href="1987/westley/index.html">1987/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1987/westley/westley.c">westley.c</a></h3>
@@ -916,9 +940,11 @@ since the code was commented out it’s probably not a big deal to have it remov
 instead as it does look more symmetrical now.</p>
 <p>Cody also added to the <code>Makefile</code> <code>-include stdio.h</code> in the nowadays very
 unlikely(?) but nevertheless suggested case that <code>putchar(3)</code> is not available.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988">
 <h1 id="the-5th-ioccc"><a href="1988/index.html">1988 - The 5th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_dale">
 <h2 id="winning-entry-1988dale">Winning entry: <a href="1988/dale/index.html">1988/dale</a></h2>
 <h3 id="winning-entry-source-code-dale.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/dale.c">dale.c</a></h3>
@@ -973,6 +999,7 @@ modern compilers do not allow directives like:</p>
 <p>However, to keep the entry as close to as possible in look, Cody kept the <code>_</code>
 macro in place but it’s no longer used.</p>
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_isaak">
 <h2 id="winning-entry-1988isaak">Winning entry: <a href="1988/isaak/index.html">1988/isaak</a></h2>
 <h3 id="winning-entry-source-code-isaak.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/isaak/isaak.c">isaak.c</a></h3>
@@ -985,6 +1012,7 @@ index.html file for more details.</p>
 <p>Cody also uudecoded and removed the file <code>isaak.encode</code>, putting the output in
 <code>isaak.output.txt</code>. This was done strictly for historical remarks that can be
 found in the index.html file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_litmaath">
 <h2 id="winning-entry-1988litmaath">Winning entry: <a href="1988/litmaath/index.html">1988/litmaath</a></h2>
 <h3 id="winning-entry-source-code-litmaath.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/litmaath/litmaath.c">litmaath.c</a></h3>
@@ -992,6 +1020,7 @@ found in the index.html file.</p>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/litmaath/litmaath.alt.c">alternate code</a>
 which is code that we suggested at the time of publication, in the remarks, to
 help understand the entry, and for fun.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_phillipps">
 <h2 id="winning-entry-1988phillipps">Winning entry: <a href="1988/phillipps/index.html">1988/phillipps</a></h2>
 <h3 id="winning-entry-source-code-phillipps.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/phillipps/phillipps.c">phillipps.c</a></h3>
@@ -1009,14 +1038,15 @@ functions and tried to match the format as best as possible of what
 once did; instead, the format of <code>pain()</code> is exactly like how <code>main()</code> was as it’s the
 same code, just a <code>p</code> instead of an <code>m</code> in the name. Additionally, <code>main()</code> returns
 <code>!pain(...)</code> like <code>main()</code> used to do to itself (<code>pain()</code> does as well).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_reddy">
 <h2 id="winning-entry-1988reddy">Winning entry: <a href="1988/reddy/index.html">1988/reddy</a></h2>
 <h3 id="winning-entry-source-code-reddy.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/reddy/reddy.c">reddy.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>.</p>
-<p>See the
+<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_spinellis">
 <h2 id="winning-entry-1988spinellis">Winning entry: <a href="1988/spinellis/index.html">1988/spinellis</a></h2>
 <h3 id="winning-entry-source-code-spinellis.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/spinellis/spinellis.c">spinellis.c</a></h3>
@@ -1031,6 +1061,7 @@ original. See the index.html file for details on the alternate code.</p>
 <p>Meanwhile Cody was twisted enough to point out (though to be fair he felt sick
 doing this) that with a slight modification this entry can be C++ instead. We don’t
 thank him for this ghastly point! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_westley">
 <h2 id="winning-entry-1988westley">Winning entry: <a href="1988/westley/index.html">1988/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/westley/westley.c">westley.c</a></h3>
@@ -1043,9 +1074,11 @@ what happens with current compilers! See the index.html files for details.</p>
 entry as seeing the code with the result at once is far more beautiful.</p>
 <p>Cody also changed the <code>int</code>s to be <code>float</code> as that’s what they are printed as:
 not strictly necessary but nonetheless more correct, even if not warned against.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989">
 <h1 id="the-6th-ioccc"><a href="1989/index.html">1989 - The 6th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_fubar">
 <h2 id="winning-entry-1989fubar">Winning entry: <a href="1989/fubar/index.html">1989/fubar</a></h2>
 <h3 id="winning-entry-source-code-fubar.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/fubar/fubar.c">fubar.c</a></h3>
@@ -1077,6 +1110,7 @@ might end up failing to work even after changing it back. This was resolved by:<
 <p>Cody also ‘modernised’ the script to use <code>bash</code> and fixed for ShellCheck. The
 <code>if [ .. ]</code> was changed in the C code as well as the script.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/fubar/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_jar.1">
 <h2 id="winning-entry-1989jar.1">Winning entry: <a href="1989/jar.1/index.html">1989/jar.1</a></h2>
 <h3 id="winning-entry-source-code-jar.1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.1/jar.1.c">jar.1.c</a></h3>
@@ -1093,6 +1127,7 @@ most certainly do have a personality and they can be very sociable.</p>
 alternate code directly, to match that of the main entry. As we simulate the
 functionality anyway, and since one may still run the code or the script (for
 the original entry and the alternate code) anyway, it works out well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_jar.2">
 <h2 id="winning-entry-1989jar.2">Winning entry: <a href="1989/jar.2/index.html">1989/jar.2</a></h2>
 <h3 id="winning-entry-source-code-jar.2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/jar.2/jar.2.c">jar.2.c</a></h3>
@@ -1123,6 +1158,7 @@ result in:</p>
 
     shell returned 2</code></pre>
 <p>because the <code>alt</code> rule had what normally is in the <code>${PROG}.alt</code> rule.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_ovdluhe">
 <h2 id="winning-entry-1989ovdluhe">Winning entry: <a href="1989/ovdluhe/index.html">1989/ovdluhe</a></h2>
 <h3 id="winning-entry-source-code-ovdluhe.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/ovdluhe/ovdluhe.c">ovdluhe.c</a></h3>
@@ -1141,6 +1177,7 @@ the author’s remarks and the <a href="https://github.com/ioccc-src/temp-test-i
 uses the alternate code, allowing one to configure the alt build. See the index.html
 for details. The fix described above was fixed in this version too, after it was
 discovered and fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_paul">
 <h2 id="winning-entry-1989paul">Winning entry: <a href="1989/paul/index.html">1989/paul</a></h2>
 <h3 id="winning-entry-source-code-paul.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/paul/paul.c">paul.c</a></h3>
@@ -1151,6 +1188,7 @@ he was using lldb and saw that the type of a pointer was too <code>long</code> :
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/paul/paul.alt.c">alternate version</a>
 which has the trace function that the author included but commented out. See the
 index.html for details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_robison">
 <h2 id="winning-entry-1989robison">Winning entry: <a href="1989/robison/index.html">1989/robison</a></h2>
 <h3 id="winning-entry-source-code-robison.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/robison.c">robison.c</a></h3>
@@ -1160,6 +1198,7 @@ made, try:</p>
 <pre><code>    cd 1989/robison ; make diff_orig_prog</code></pre>
 <p>(It adds the C token pasting operator <code>##</code> instead of <code>/**/</code>.)</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_tromp">
 <h2 id="winning-entry-1989tromp">Winning entry: <a href="1989/tromp/index.html">1989/tromp</a></h2>
 <h3 id="winning-entry-source-code-tromp.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/tromp/tromp.c">tromp.c</a></h3>
@@ -1184,11 +1223,13 @@ various other things, so that now the alt version, which is better, can be used.
 <p>Although we appreciate the help here, he cynically noted that he had to have an
 IOCCC <a href="https://en.wikipedia.org/wiki/Tetris">Tetris</a> working (this of course was
 not his only reason :-) )</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_vanb">
 <h2 id="winning-entry-1989vanb">Winning entry: <a href="1989/vanb/index.html">1989/vanb</a></h2>
 <h3 id="winning-entry-source-code-vanb.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/vanb/vanb.c">vanb.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/vanb/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_westley">
 <h2 id="winning-entry-1989westley">Winning entry: <a href="1989/westley/index.html">1989/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/westley/westley.c">westley.c</a></h3>
@@ -1253,9 +1294,11 @@ compiles it will work for compilers like <code>gcc</code> and one can then use t
 output.</p>
 <p>The <code>compile.sh</code> script allows one to specify the compiler with the <code>CC</code>
 environmental variable; see the index.html for details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990">
 <h1 id="the-7th-ioccc"><a href="1990/index.html">1990 - The 7th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_baruch">
 <h2 id="winning-entry-1990baruch">Winning entry: <a href="1990/baruch/index.html">1990/baruch</a></h2>
 <h3 id="winning-entry-source-code-baruch.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/baruch.c">baruch.c</a></h3>
@@ -1269,16 +1312,16 @@ question (i.e. it was only tested in the original entry). YMMV.</p>
 <p>Cody also made the code look more like the original, removing the <code>int</code> from
 the variables, adding instead <code>-Wno-implicit-int</code>. The newline added by the
 judges was retained.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_cmills">
 <h2 id="winning-entry-1990cmills">Winning entry: <a href="1990/cmills/index.html">1990/cmills</a></h2>
 <h3 id="winning-entry-source-code-cmills.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/cmills/cmills.c">cmills.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> got this to work in modern systems (it previously resulted in a bus
-error).</p>
-<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>.</p>
-<p>See the
+error). <a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_dds">
 <h2 id="winning-entry-1990dds">Winning entry: <a href="1990/dds/index.html">1990/dds</a></h2>
 <h3 id="winning-entry-source-code-dds.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dds/dds.c">dds.c</a></h3>
@@ -1291,10 +1334,10 @@ more like the original in this way by redefining <code>free</code> to have the c
 operator itself.</p>
 <p>Cody fixed another compiler error by removing the erroneous prototype to
 <code>fopen(3)</code>. Cody also changed a <code>char *</code> used for file I/O to be a proper <code>FILE *</code> and fixed a typo in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dds/LANDER.BAS">LANDER.BAS</a>.</p>
-<p>Cody also made this use <code>fgets(3)</code>.</p>
-<p>See the
+<p>Cody also made this use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_dg">
 <h2 id="winning-entry-1990dg">Winning entry: <a href="1990/dg/index.html">1990/dg</a></h2>
 <h3 id="winning-entry-source-code-dg.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dg/dg.c">dg.c</a></h3>
@@ -1311,6 +1354,7 @@ but later Cody added it back to make it more like the original).</p>
 <p>The second problem was suggested by the judges at the time of judging, to do
 with if the C preprocessor botches single quotes in <code>cpp</code> expansion.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/dg/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_jaw">
 <h2 id="winning-entry-1990jaw">Winning entry: <a href="1990/jaw/index.html">1990/jaw</a></h2>
 <h3 id="winning-entry-source-code-jaw.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/jaw/jaw.c">jaw.c</a></h3>
@@ -1326,6 +1370,7 @@ the time of releasing the winning entries of 1990.</p>
 <p><strong>NOTE</strong>: as <code>btoa</code> is not common we used a ruby script from <a href="#yusuke">Yusuke</a> but with a minor
 fix applied by Cody that made the program just show <code>oops</code> twice (twice is not
 a typo here) from invalid input but which now works.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_pjr">
 <h2 id="winning-entry-1990pjr">Winning entry: <a href="1990/pjr/index.html">1990/pjr</a></h2>
 <h3 id="winning-entry-source-code-pjr.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/pjr/pjr.c">pjr.c</a></h3>
@@ -1333,6 +1378,7 @@ a typo here) from invalid input but which now works.</p>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/pjr/pjr.alt.c">alternate code</a> which was suggested by the judges
 in the case that your compiler cannot compile <code>X=g()...</code> but it actually does
 something else and is recommended by the author as well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_scjones">
 <h2 id="winning-entry-1990scjones">Winning entry: <a href="1990/scjones/index.html">1990/scjones</a></h2>
 <h3 id="winning-entry-source-code-scjones.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/scjones/scjones.c">scjones.c</a></h3>
@@ -1342,6 +1388,7 @@ suggested <code>-trigraphs</code>. Both work but we used Yusuke’s idea as this
 first.</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/scjones/try.sh">try.sh</a> script to show exactly what the
 entry does.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_tbr">
 <h2 id="winning-entry-1990tbr">Winning entry: <a href="1990/tbr/index.html">1990/tbr</a></h2>
 <h3 id="winning-entry-source-code-tbr.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/tbr/tbr.c">tbr.c</a></h3>
@@ -1354,11 +1401,10 @@ author.</p>
 <p>Cody also changed the code (in both versions) to use <code>fgets(3)</code> instead of
 <code>gets(3)</code> so one would not get a warning about the use of <code>gets(3)</code> at linking
 time or execution, the latter of which was causing confusing output due to the
-warning being interspersed with the program’s interactive output.</p>
-<p>See the
+warning being interspersed with the program’s interactive output. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
-for more details on why this change was
-done more generally.</p>
+for more details on why this change was done more generally.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_theorem">
 <h2 id="winning-entry-1990theorem">Winning entry: <a href="1990/theorem/index.html">1990/theorem</a></h2>
 <h3 id="winning-entry-source-code-theorem.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/theorem/theorem.c">theorem.c</a></h3>
@@ -1378,8 +1424,7 @@ but as he was testing the <code>fibonacci.c</code> bug he ended up changing it a
 <pre><code>    if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;</code></pre>
 <p>be changed to just test the value of <code>A</code> when <code>a</code> is argv and <code>A</code> is argc? You
 tell us!</p>
-<p>Cody also changed the code to use <code>fgets(3)</code>.</p>
-<p>See the
+<p>Cody also changed the code to use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
 <p>Since this program is so incredible the extra fixes were deemed worth having and
@@ -1393,6 +1438,7 @@ original program and some of the programs it generates.</p>
 <p><a href="#yusuke">Yusuke</a> pointed out that <code>atof(3)</code> nowadays needs <code>#include &lt;stdlib.h&gt;</code> which was
 used in order to get this to work initially (prior to this output was there but
 incomplete).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_stig">
 <h2 id="winning-entry-1990stig">Winning entry: <a href="1990/stig/index.html">1990/stig</a></h2>
 <h3 id="winning-entry-source-code-stig.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/stig/stig.c">stig.c</a></h3>
@@ -1401,6 +1447,7 @@ incomplete).</p>
 worked fine in macOS).</p>
 <p>He also changed the <code>Makefile</code> to use <code>bash</code> not <code>zsh</code> as not all systems have
 <code>zsh</code> and the <code>Makefile</code> actually sets <code>SHELL</code> to <code>bash</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_westley">
 <h2 id="winning-entry-1990westley">Winning entry: <a href="1990/westley/index.html">1990/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.c">westley.c</a></h3>
@@ -1409,16 +1456,21 @@ worked fine in macOS).</p>
 in places for a <code>short int</code> which was changed to just <code>1</code>. Since it’s
 instructional to see the differences he has provided an alternate version,
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.alt.c">westley.alt.c</a>, which is the original
-code.</p>
+code (see <a href="1990/westley/index.html#alternate-code">Alternate code in
+1990/westley/index.html</a>).</p>
 <p>He also changed the <code>argc</code> to be an <code>int</code>, not a <code>char</code>, even though it might
-often be the same (this in particular was done for <code>clang</code>).</p>
+often be the same (this in particular was done for <code>clang</code>). See the
+FAQ on “<a href="faq.html#arg_count">main function args</a>”
+for more details.</p>
 <p>He also fixed the code to not enter an infinite loop if arg is a number not &gt; 0.
 To be more like the original the number of args passed to the program has not
 been fixed so that if one passes no arg it will still likely crash.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991">
 <h1 id="the-8th-ioccc"><a href="1991/index.html">1991 - The 8th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_ant">
 <h2 id="winning-entry-1991ant">Winning entry: <a href="1991/ant/index.html">1991/ant</a></h2>
 <h3 id="winning-entry-source-code-ant.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/ant/ant.c">ant.c</a></h3>
@@ -1442,6 +1494,10 @@ will be a bit easier to use for those familiar with vim in the following ways
 <li>Use <code>q</code> to exit.</li>
 </ul>
 <p>The other keys were left unchanged.</p>
+<p>See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>
+for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_brnstnd">
 <h2 id="winning-entry-1991brnstnd">Winning entry: <a href="1991/brnstnd/index.html">1991/brnstnd</a></h2>
 <h3 id="winning-entry-source-code-brnstnd.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/brnstnd/brnstnd.c">brnstnd.c</a></h3>
@@ -1458,6 +1514,7 @@ slightly more like the original, even though it’s unused.</p>
 <a href="1991/brnstnd/try.txt">try.txt</a> which the script uses.</p>
 <p>Cody also fixed the make clobber rule which left a symbolic link in the
 directory even after the target file was deleted (from make clobber).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_buzzard">
 <h2 id="winning-entry-1991buzzard">Winning entry: <a href="1991/buzzard/index.html">1991/buzzard</a></h2>
 <h3 id="winning-entry-source-code-buzzard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">buzzard.c</a></h3>
@@ -1468,12 +1525,15 @@ calls <code>atoi(3)</code> took an arg without any type specified and as an impl
 it was not a <code>char *</code> which crashed the program in modern systems.</p>
 <p>Cody also made the file name in the code (which is the default maze file) not
 hard-coded but instead be <code>__FILE__</code>.</p>
-<p>Finally Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.alt.c">alternate
+<p>Finally Cody added the <a href="1991/buzzard/index.html#alternate-code">alternate
 version</a> which will possibly feel more
 at home with those familiar with vi(m): <code>k</code> for forward, <code>h</code> for left and <code>l</code>
 for right. This version also has a more useful way to exit, just entering <code>q</code>
 followed by enter, rather than completing (and it’s a maze) or killing the
-program. We still recommend you try the original version first, of course.</p>
+program. We still recommend you try the original version first, of course. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_davidguy">
 <h2 id="winning-entry-1991davidguy">Winning entry: <a href="1991/davidguy/index.html">1991/davidguy</a></h2>
 <h3 id="winning-entry-source-code-davidguy.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/davidguy/davidguy.c">davidguy.c</a></h3>
@@ -1482,6 +1542,7 @@ program. We still recommend you try the original version first, of course.</p>
 <a href="#cody">Cody</a> added to the <code>Makefile</code> some <code>-include</code> options. These appear to
 not be strictly necessary (currently) but it was done due to other syscalls
 being a problem not being declared first, to hopefully future-proof it.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_dds">
 <h2 id="winning-entry-1991dds">Winning entry: <a href="1991/dds/index.html">1991/dds</a></h2>
 <h3 id="winning-entry-source-code-dds.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/dds/dds.c">dds.c</a></h3>
@@ -1567,6 +1628,7 @@ opened for reading or a file could not be opened for writing it would not crash.
 The definition of whether that should be a bug to fix or a feature to not fix
 was pondered and changed numerous times and ultimately that problem with this
 entry was fixed. It has not been done in all.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_fine">
 <h2 id="winning-entry-1991fine">Winning entry: <a href="1991/fine/index.html">1991/fine</a></h2>
 <h3 id="winning-entry-source-code-fine.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/fine/fine.c">fine.c</a></h3>
@@ -1588,6 +1650,7 @@ the <code>Makefile</code> which now has a <code>-DB=(int)b</code> so that <code>
 some fun input for fun but mostly different output. He added a great string from
 Brian Westley and Cody also added several of his own (can you figure out exactly
 which ones? :-) )</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_rince">
 <h2 id="winning-entry-1991rince">Winning entry: <a href="1991/rince/index.html">1991/rince</a></h2>
 <h3 id="winning-entry-source-code-rince.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/rince/rince.c">rince.c</a></h3>
@@ -1605,6 +1668,7 @@ the above fix was applied to these versions too.</p>
 <p>The file <code>map-key.jpg</code> was added to help those with smaller screens as
 unfortunately the formatting of the key to the map was not easy to change in a
 way without ruining how it looks (beyond making it one column only).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_westley">
 <h2 id="winning-entry-1991westley">Winning entry: <a href="1991/westley/index.html">1991/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-4">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">westley.c</a></h3>
@@ -1620,13 +1684,15 @@ also improved it so that warnings/errors/about to compile messages are not shown
 unless the <code>-e</code> option is used. This is because the errors being shown kind of
 ruins the experience. Finally he made it pass
 <a href="https://www.shellcheck.net">ShellCheck</a>.</p>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.alt.c">alt version</a> which
+<p>Cody also added the <a href="1991/westley/index.html#alternate-code">alt version</a> which
 is based on the author’s remarks, a version that supposedly (:-) ) always wins.</p>
 <p>Cody also fixed the make clobber rule where a file was left lying about when it
 should have been removed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992">
 <h1 id="the-9th-ioccc"><a href="1992/index.html">1992 - The 9th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_adrian">
 <h2 id="winning-entry-1992adrian">Winning entry: <a href="1992/adrian/index.html">1992/adrian</a></h2>
 <h3 id="winning-entry-source-code-adrian.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">adrian.c</a></h3>
@@ -1681,6 +1747,7 @@ the additional tools.</p>
 and some of the tools this entry generates. Unlike other scripts, it does not
 clear the screen after compilation so that one can see how the other files are
 generated.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_albert">
 <h2 id="winning-entry-1992albert">Winning entry: <a href="1992/albert/index.html">1992/albert</a></h2>
 <h3 id="winning-entry-source-code-albert.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/albert.c">albert.c</a></h3>
@@ -1695,6 +1762,7 @@ return <code>void</code>.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/try.alt.sh">try.alt.sh</a> scripts that correspond to the entry and
 the alternate code.</p>
 <p>Even so, check <a href="bugs.html#1992_albert">1992/albert in bugs.html</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_ant">
 <h2 id="winning-entry-1992ant">Winning entry: <a href="1992/ant/index.html">1992/ant</a></h2>
 <h3 id="winning-entry-source-code-ant.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/ant/ant.c">ant.c</a></h3>
@@ -1720,6 +1788,7 @@ thanks to Anthony! For this version,
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/ant/try.alt.sh">try.alt.sh</a> was added and an alternate test
 Makefile (along the lines of the author’s provided test Makefile) was added,
 updated to use <code>ant.alt</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_buzzard.1">
 <h2 id="winning-entry-1992buzzard.1">Winning entry: <a href="1992/buzzard.1/index.html">1992/buzzard.1</a></h2>
 <h3 id="winning-entry-source-code-buzzard.1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.1/buzzard.1.c">buzzard.1.c</a></h3>
@@ -1730,6 +1799,7 @@ a bug so it was fixed at that point as it only took a few seconds and had to be
 verified that it was consistent with the <a href="bugs.html">bugs.html</a> file.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.1/try.sh">try.sh</a> script to try out some
 commands that we suggested and some additional ones that he provide for some fun.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_buzzard.2">
 <h2 id="winning-entry-1992buzzard.2">Winning entry: <a href="1992/buzzard.2/index.html">1992/buzzard.2</a></h2>
 <h3 id="winning-entry-source-code-buzzard.2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.2/buzzard.2.c">buzzard.2.c</a></h3>
@@ -1739,6 +1809,7 @@ commands that we suggested and some additional ones that he provide for some fun
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.2/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/buzzard.2/try.alt.sh">try.alt.sh</a> scripts that correspond to the entry
 and its alternate code.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_gson">
 <h2 id="winning-entry-1992gson">Winning entry: <a href="1992/gson/index.html">1992/gson</a></h2>
 <h3 id="winning-entry-source-code-gson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/gson/gson.c">gson.c</a></h3>
@@ -1751,6 +1822,7 @@ included in their remarks. See the index.html for its purpose. It was NOT fixed
 for <a href="https://www.shellcheck.net">ShellCheck</a>
 because the author deliberately obfuscated it so <strong>PLEASE <em>DO NOT</em> FIX THIS OR
 MODERNISE IT</strong>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_imc">
 <h2 id="winning-entry-1992imc">Winning entry: <a href="1992/imc/index.html">1992/imc</a></h2>
 <h3 id="winning-entry-source-code-imc.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/imc/imc.c">imc.c</a></h3>
@@ -1761,13 +1833,14 @@ returned a value but this will cause problems where <code>exit(3)</code> returns
 source code was modified to avoid this problem but like Cody did with other fixes
 he made this more like the original by redefining <code>exit</code> to use the comma
 operator so that it could be used in binary expressions.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_kivinen">
 <h2 id="winning-entry-1992kivinen">Winning entry: <a href="1992/kivinen/index.html">1992/kivinen</a></h2>
 <h3 id="winning-entry-source-code-kivinen.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/kivinen/kivinen.c">kivinen.c</a></h3>
 </div>
 <p>It was observed that on modern systems this goes much too quick. <a href="#yusuke">Yusuke</a> created
 a patch that calls <code>usleep(3)</code> but <a href="#cody">Cody</a> thought the value was too slow so he
-made it a macro in the <code>Makefile</code> <code>Z</code> (which can be redefined with <code>make SLEEP=...</code>), defaulting at 15000. This was made an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/kivinen/kivinen.alt.c">alternate
+made it a macro in the <code>Makefile</code> <code>Z</code> (which can be redefined with <code>make SLEEP=...</code>), defaulting at 15000. This was made an <a href="1992/kivinen/index.html#alternate-code">alternate
 version</a> and it is recommended one use
 the alternate version first. See the index.html file to see how to reconfigure it.</p>
 <p>Cody also made the fixed version (the code relied on <code>exit(3)</code> returning to use
@@ -1780,13 +1853,13 @@ start and end character.</p>
 defect with the number of args to <code>main()</code> though when it comes to 1 arg it is
 only in an error message if say 4 args are used. This is out of an abundance of
 caution as it’s quite possible that <code>clang</code> or the ANSI C committee end up further
-changing this.</p>
-<p>See the
+changing this. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back. See
 <a href="bugs.html#1992_kivinen">1992/kivinen in bugs.html</a> for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_lush">
 <h2 id="winning-entry-1992lush">Winning entry: <a href="1992/lush/index.html">1992/lush</a></h2>
 <h3 id="winning-entry-source-code-lush.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/lush/lush.c">lush.c</a></h3>
@@ -1796,18 +1869,19 @@ it works (see <a href="1992/lush/index.html#judges-remarks">Judges’ remarks in
 file</a>) this will not work with <code>clang</code>.</p>
 <p><a href="#cody">Cody</a> also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/lush/lush.sh">lush.sh</a> script to
 demonstrate it as using make was problematic.</p>
-<p>Cody made it use <code>fgets()</code> instead of <code>gets()</code>.</p>
-<p>See the
+<p>Cody made it use <code>fgets()</code> instead of <code>gets()</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
 <p><strong>NOTE</strong>: this entry cannot work with <code>clang</code> due to different compiler messages (it
 will compile fine but it won’t work). See <a href="bugs.html#1992_lush">1992/lush in
 bugs.html</a> for details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_marangon">
 <h2 id="winning-entry-1992marangon">Winning entry: <a href="1992/marangon/index.html">1992/marangon</a></h2>
 <h3 id="winning-entry-source-code-marangon.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/marangon/marangon.c">marangon.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this more portable by changing the <code>void main()</code> to be <code>int main()</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_nathan">
 <h2 id="winning-entry-1992nathan">Winning entry: <a href="1992/nathan/index.html">1992/nathan</a></h2>
 <h3 id="winning-entry-source-code-nathan.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/nathan.c">nathan.c</a></h3>
@@ -1821,6 +1895,7 @@ viewer would note that it has the same typos as the originally published code.</
 participates in the IOCCC, that it must be our fault! :-)</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/nathan/try.sh">try.sh</a> script that runs a
 few commands that we suggested as well as one he provided.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_vern">
 <h2 id="winning-entry-1992vern">Winning entry: <a href="1992/vern/index.html">1992/vern</a></h2>
 <h3 id="winning-entry-source-code-vern.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">vern.c</a></h3>
@@ -1836,6 +1911,7 @@ new char arrays (always cleared in the beginning of the loop) and then using
 both numbers (using <code>"%o %o"</code> does not solve the problem).</p>
 <p>This was deemed a problem to fix as the Judges’ remarks hinted that this was how
 it used to be.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_westley">
 <h2 id="winning-entry-1992westley">Winning entry: <a href="1992/westley/index.html">1992/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-5">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">westley.c</a></h3>
@@ -1874,9 +1950,11 @@ world</a> or just the
 <a href="https://en.wikipedia.org/wiki/United_States">USA</a>, respectively, without enough
 args (2). And not that we need the help or anything for this :-) but we
 encourage you to try the original without two args :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993">
 <h1 id="the-10th-ioccc"><a href="1993/index.html">1993 - The 10th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_ant">
 <h2 id="winning-entry-1993ant">Winning entry: <a href="1993/ant/index.html">1993/ant</a></h2>
 <h3 id="winning-entry-source-code-ant.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">ant.c</a></h3>
@@ -1889,15 +1967,17 @@ This was put in as <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/ma
 versions, one which was converted from <code>K&amp;R</code> and worked without modification and
 another which Cody had to slightly modify to get it to work in modern systems.
 But since only one was needed the one that worked already was used.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_cmills">
 <h2 id="winning-entry-1993cmills">Winning entry: <a href="1993/cmills/index.html">1993/cmills</a></h2>
 <h3 id="winning-entry-source-code-cmills.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/cmills/cmills.c">cmills.c</a></h3>
 </div>
 <p><a href="#yusuke">Yusuke</a> suggested that with modern systems this goes too fast so he added a call
 to <code>usleep(3)</code> in a patch he made. <a href="#cody">Cody</a> made it configurable at compilation by
-using a macro. This is in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/cmills/cmills.alt.c">alternate
+using a macro. This is in the <a href="1993/cmills/cmills.alt.c">alternate
 version</a> which is the recommended one to try
 first.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_dgibson">
 <h2 id="winning-entry-1993dgibson">Winning entry: <a href="1993/dgibson/index.html">1993/dgibson</a></h2>
 <h3 id="winning-entry-source-code-dgibson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/dgibson/dgibson.c">dgibson.c</a></h3>
@@ -1906,11 +1986,13 @@ first.</p>
 which assumed that <code>.</code> is in the path.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/dgibson/try.sh">try.sh</a> script which runs the above
 mentioned script on all the data files.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_ejb">
 <h2 id="winning-entry-1993ejb">Winning entry: <a href="1993/ejb/index.html">1993/ejb</a></h2>
 <h3 id="winning-entry-source-code-ejb.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ejb/ejb.c">ejb.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ejb/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_jonth">
 <h2 id="winning-entry-1993jonth">Winning entry: <a href="1993/jonth/index.html">1993/jonth</a></h2>
 <h3 id="winning-entry-source-code-jonth.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/jonth/jonth.c">jonth.c</a></h3>
@@ -1924,23 +2006,26 @@ so that it would compile. It used to be that you could get away with code like:<
 <p>and expect <code>G;</code> to equate to <code>int i, j;</code> (though it’s now a long) and <code>K</code> to mean
 <code>case</code> but that’s no longer the case so the offending lines had <code>#define</code>
 prepended to them.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_leo">
 <h2 id="winning-entry-1993leo">Winning entry: <a href="1993/leo/index.html">1993/leo</a></h2>
 <h3 id="winning-entry-source-code-leo.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/leo/leo.c">leo.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to work with modern compilers. This involved different header
 files for functions.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_lmfjyh">
 <h2 id="winning-entry-1993lmfjyh">Winning entry: <a href="1993/lmfjyh/index.html">1993/lmfjyh</a></h2>
 <h3 id="winning-entry-source-code-lmfjyh.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">lmfjyh.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.alt.c">alternate
+<p><a href="#cody">Cody</a> added an <a href="1993/lmfjyh/index.html#alternate-code">alternate
 version</a> which does what the program did
 with <code>gcc</code> &lt; 2.3.3. See the index.html file for details and for why this was made
 the alternate version, not the actual entry.</p>
 <p>Cody also made the <code>Makefile</code> delete the very unsafe filename that is compiled (or
 would be compiled if <code>gcc</code> &lt; 2.3.3) whether or not compilation succeeds (which is
 highly unlikely).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_plummer">
 <h2 id="winning-entry-1993plummer">Winning entry: <a href="1993/plummer/index.html">1993/plummer</a></h2>
 <h3 id="winning-entry-source-code-plummer.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/plummer.c">plummer.c</a></h3>
@@ -1955,6 +2040,7 @@ one we recommend one try first. See the index.html files for details.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/plummer/try.alt.sh">try.alt.sh</a> scripts that correspond to the original
 entry and the alt version, both allowing one to change the args (and in the case
 of the alt one allowing one to change the amount to sleep).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_rince">
 <h2 id="winning-entry-1993rince">Winning entry: <a href="1993/rince/index.html">1993/rince</a></h2>
 <h3 id="winning-entry-source-code-rince.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">rince.c</a></h3>
@@ -1968,14 +2054,15 @@ the second one, to make movement keys (of the default game) more familiar to vi
 users. The slowing down was based on our suggestion that it might be desired to
 slow down but Cody did it in such a way that makes it easy to configure at
 compile time. See the index.html for details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_schnitzi">
 <h2 id="winning-entry-1993schnitzi">Winning entry: <a href="1993/schnitzi/index.html">1993/schnitzi</a></h2>
 <h3 id="winning-entry-source-code-schnitzi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">schnitzi.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code> not <code>gets(3)</code>.</p>
-<p>See the
+<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code> not <code>gets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_vanb">
 <h2 id="winning-entry-1993vanb">Winning entry: <a href="1993/vanb/index.html">1993/vanb</a></h2>
 <h3 id="winning-entry-source-code-vanb.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">vanb.c</a></h3>
@@ -1991,16 +2078,19 @@ arg (as it was 0 at file scope already this is perfectly fine and it means
 there’s no need to cast it to an int in the function call though that would also
 work).</p>
 <p>Cody also added the alternate code, provided by the author, which is:</p>
-<pre><code>    ... a version of the program before it got formatted into the VIII,
-    augmented with comments showing where each state begins. N1 and N2 are
-    notes.</code></pre>
+<blockquote>
+<p>… a version of the program before it got formatted into the VIII, augmented
+with comments showing where each state begins. N1 and N2 are notes.</p>
+</blockquote>
 <p>but fixed to work with <code>clang</code> as well.</p>
 <p><strong>NOTE</strong>: the <code>N1</code> and <code>N2</code> are provided as notes in the index.html file describing
 this code. Other code is also described there.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994">
 <h1 id="the-11th-ioccc"><a href="1994/index.html">1994 - The 11th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_dodsond2">
 <h2 id="winning-entry-1994dodsond2">Winning entry: <a href="1994/dodsond2/index.html">1994/dodsond2</a></h2>
 <h3 id="winning-entry-source-code-1994dodsond2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2</a></h3>
@@ -2029,6 +2119,7 @@ reset so you could only get the arrows back once even if the robber stole more.
 Now the counters are reset. The way this bug was fixed is that there is now a
 counter for how many you have found and how many you shot in addition to the two
 that already existed, how many you had and how many were stolen.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_horton">
 <h2 id="winning-entry-1994horton">Winning entry: <a href="1994/horton/index.html">1994/horton</a></h2>
 <h3 id="winning-entry-source-code-1994horton">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/horton.c">1994/horton</a></h3>
@@ -2044,6 +2135,7 @@ shouldn’t be.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/horton/try.alt.sh">try.alt.sh</a>.</p>
 <p>Finally he added the article (written by the entry’s author) cited in
 <a href="1994/horton/login_sept92-pp28-31.pdf">login_sept92-pp28-31.pdf</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_imc">
 <h2 id="winning-entry-1994imc">Winning entry: <a href="1994/imc/index.html">1994/imc</a></h2>
 <h3 id="winning-entry-source-code-imc.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/imc/imc.c">imc.c</a></h3>
@@ -2053,6 +2145,7 @@ shouldn’t be.</p>
 this was not necessary (in multiple systems) it can sometimes be a problem and
 as it was noticed it was changed (the only case this was done except in the
 entries that actually did not work because of missing or incorrect prototypes).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_ldb">
 <h2 id="winning-entry-1994ldb">Winning entry: <a href="1994/ldb/index.html">1994/ldb</a></h2>
 <h3 id="winning-entry-source-code-ldb.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">ldb.c</a></h3>
@@ -2063,8 +2156,7 @@ comma operator was needed.</p>
 <p>Cody also fixed it for <code>clang</code> under Linux which objected to incompatible pointer
 type (because <code>time(2)</code> takes a <code>time_t *</code> which in some systems is a <code>long *</code>
 but what was being passed to it is an <code>int</code>).</p>
-<p>Cody also changed the entry to use <code>fgets(3)</code> instead of <code>gets(3)</code>.</p>
-<p>See the
+<p>Cody also changed the entry to use <code>fgets(3)</code> instead of <code>gets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
 <p>This one has
@@ -2078,6 +2170,7 @@ rather than an annoying warning. A subtlety about this fix: if a line is greater
 than 231 in length if the program chooses that line it might print the first 231
 characters or it might print (up to) the next 231 characters and so on.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_schnitzi">
 <h2 id="winning-entry-1994schnitzi">Winning entry: <a href="1994/schnitzi/index.html">1994/schnitzi</a></h2>
 <h3 id="winning-entry-source-code-schnitzi.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/schnitzi.c">schnitzi.c</a></h3>
@@ -2088,7 +2181,9 @@ generate code that compile and another <a href="https://github.com/ioccc-src/tem
 size</a> which, when fed its own source code, will
 generate compilable code but not with the same buffer size but rather the
 original buffer size. Cody explains this at <a href="bugs.html#1994-schnitzi">1994/schnitzi in
-bugs.html</a>.</p>
+bugs.html</a>. See also the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>The purpose for these versions it both demonstrate how the magic works behind it
 and to help others, should they wish, get the code to work with <code>fgets(3)</code>, with
 or without an increase in buffer size. Note that without this feeding longer
@@ -2098,6 +2193,7 @@ details. Later on, if nobody takes up the task, Cody might resume it, but for
 now there is more important work to do so that the next contest can run.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/try.alt.sh">try.alt.sh</a> scripts.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_shapiro">
 <h2 id="winning-entry-1994shapiro">Winning entry: <a href="1994/shapiro/index.html">1994/shapiro</a></h2>
 <h3 id="winning-entry-source-code-shapiro.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">shapiro.c</a></h3>
@@ -2109,11 +2205,13 @@ assumed that <code>getc()</code> will return <code>-1</code> on EOF or error, no
 where <code>EOF != -1</code> it could result in an infinite loop.</p>
 <p>For an interesting problem that occurred here and what was done to solve it,
 check <a href="bugs.html#1994_shapiro">1994/shapiro in bugs.html</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_smr">
 <h2 id="winning-entry-1994smr">Winning entry: <a href="1994/smr/index.html">1994/smr</a></h2>
 <h3 id="winning-entry-source-code-smr.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/smr/smr.c">smr.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/smr/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_tvr">
 <h2 id="winning-entry-1994tvr">Winning entry: <a href="1994/tvr/index.html">1994/tvr</a></h2>
 <h3 id="winning-entry-source-code-1994tvr">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.c">1994/tvr</a></h3>
@@ -2131,10 +2229,10 @@ each mode allowed with two sizes, 128 and 256, allowing one to quit or skip each
 to be terminated but it was a pretty straightforward fix. <code>gets()</code> was defined
 to use <code>fgets()</code> and the inclusion of <code>stdio.h</code> had to be added but to make it
 more like the original entry this was done in the Makefile. The alternate code was
-also changed to use <code>fgets(3)</code>.</p>
-<p>See the
+also changed to use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_weisberg">
 <h2 id="winning-entry-1994weisberg">Winning entry: <a href="1994/weisberg/index.html">1994/weisberg</a></h2>
 <h3 id="winning-entry-source-code-weisberg.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/weisberg/weisberg.c">weisberg.c</a></h3>
@@ -2148,6 +2246,7 @@ number but rather a newline.</p>
 lines of the <code>weisberg</code>, feeding it to <code>primes(1)</code>, showing those that are
 primes. It only does the reversed output because the program actually prints
 primes.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_westley">
 <h2 id="winning-entry-1994westley">Winning entry: <a href="1994/westley/index.html">1994/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-6">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/westley.c">westley.c</a></h3>
@@ -2159,17 +2258,20 @@ start to finish.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/westley.alt.c">alternate version</a>
 that will look fine on terminals not set to 80 columns and the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.alt.sh">try.alt.sh</a> script to automate the play
-along the lines of the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.sh">try.sh</a> script.</p>
+along the lines of the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/westley/try.sh">try.sh</a> script. We
+recommend you use this version first, whether you use the script or not.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995">
 <h1 id="the-12th-ioccc"><a href="1995/index.html">1995 - The 12th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_cdua">
 <h2 id="winning-entry-1995cdua">Winning entry: <a href="1995/cdua/index.html">1995/cdua</a></h2>
 <h3 id="winning-entry-source-code-cdua.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">cdua.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this so that it would work with macOS. Once it could compile it
 additionally segfaulted under macOS which he also fixed.</p>
-<p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.alt.c">alternate code</a> for fun :-) ) (in
+<p>Cody also provided the <a href="1995/cdua/cdua.alt.c">alternate code</a> for fun :-) ) (in
 particular to make it easier to see the program do what it does in systems that
 are too fast … if there is such a thing anyway :-) ). See the index.html for
 details on this.</p>
@@ -2178,21 +2280,23 @@ details on this.</p>
 type of args. In particular some versions supposedly only allow 0, 2 or 3 args.
 It actually appears to allow 1 but if you specify 4 it says 0, 2 or 3 and it is
 an error but it’s entirely possible that they will eventually make the defect
-function as the error message claims.</p>
-<p>See the
+function as the error message claims. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_dodsond1">
 <h2 id="winning-entry-1995dodsond1">Winning entry: <a href="1995/dodsond1/index.html">1995/dodsond1</a></h2>
 <h3 id="winning-entry-source-code-dodsond1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/dodsond1/dodsond1.c">dodsond1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/dodsond1/try.sh">try.sh</a> script that uses the text file he
 provided which is input we suggested one try with the entry.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_esde">
 <h2 id="winning-entry-1995esde">Winning entry: <a href="1995/esde/index.html">1995/esde</a></h2>
 <h3 id="winning-entry-source-code-esde.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/esde/esde.c">esde.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/esde/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_garry">
 <h2 id="winning-entry-1995garry">Winning entry: <a href="1995/garry/index.html">1995/garry</a></h2>
 <h3 id="winning-entry-source-code-garry.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/garry/garry.c">garry.c</a></h3>
@@ -2209,11 +2313,13 @@ alt version he also added the <a href="https://github.com/ioccc-src/temp-test-io
 script to use the alt code, though the alt version is not as important as
 alternate code in other entries. In order to get the paging to work right for
 the <code>garry.data</code> file leading blank lines had to be added.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_heathbar">
 <h2 id="winning-entry-1995heathbar">Winning entry: <a href="1995/heathbar/index.html">1995/heathbar</a></h2>
 <h3 id="winning-entry-source-code-1995heathbar">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/heathbar/heathbar.c">1995/heathbar</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/heathbar/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_leo">
 <h2 id="winning-entry-1995leo">Winning entry: <a href="1995/leo/index.html">1995/leo</a></h2>
 <h3 id="winning-entry-source-code-leo.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/leo/leo.c">leo.c</a></h3>
@@ -2222,6 +2328,7 @@ the <code>garry.data</code> file leading blank lines had to be added.</p>
 <p>At our change in how to deal with spoilers, Cody also uudecoded the spoiler
 information about the secret switch, provided by the author, putting it in
 <a href="1995/leo/secret.html">secret.html</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_makarios">
 <h2 id="winning-entry-1995makarios">Winning entry: <a href="1995/makarios/index.html">1995/makarios</a></h2>
 <h3 id="winning-entry-source-code-makarios.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/makarios/makarios.c">makarios.c</a></h3>
@@ -2230,16 +2337,19 @@ information about the secret switch, provided by the author, putting it in
 which only allows <code>main()</code> to have 0, 2 or 3 args. This is done by a new
 function (<code>pain()</code> as it’s annoying that <code>clang</code> is this way :-) ) that <code>main()</code>
 calls which has the four args.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_savastio">
 <h2 id="winning-entry-1995savastio">Winning entry: <a href="1995/savastio/index.html">1995/savastio</a></h2>
 <h3 id="winning-entry-source-code-savastio.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">savastio.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_schnitzi">
 <h2 id="winning-entry-1995schnitzi">Winning entry: <a href="1995/schnitzi/index.html">1995/schnitzi</a></h2>
 <h3 id="winning-entry-source-code-schnitzi.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/schnitzi/schnitzi.c">schnitzi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/schnitzi/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_vanschnitz">
 <h2 id="winning-entry-1995vanschnitz">Winning entry: <a href="1995/vanschnitz/index.html">1995/vanschnitz</a></h2>
 <h3 id="winning-entry-source-code-vanschnitz.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.c">vanschnitz.c</a></h3>
@@ -2247,12 +2357,14 @@ calls which has the four args.</p>
 <p><a href="#cody">Cody</a> added the authors’ <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.alt.c">deobfuscation source code</a>
 as in 2023 we have decided that in most
 cases all the code should be available for the wider audience, without having to
-extract it. The exception is when the files are created by the entry or the
-entry decrypts the text or something like that.</p>
+extract it (the exception, of course, is when the files are created by the entry or the
+entry decrypts the text or something like that).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996">
 <h1 id="the-13th-ioccc"><a href="1996/index.html">1996 - The 13th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_august">
 <h2 id="winning-entry-1996august">Winning entry: <a href="1996/august/index.html">1996/august</a></h2>
 <h3 id="winning-entry-source-code-august.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/august/august.c">august.c</a></h3>
@@ -2268,6 +2380,7 @@ problem existed in macOS.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/august/try.sh">try.sh</a> script that runs all the
 commands that were given by the judges in the try section, with the fix above
 applied.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_dalbec">
 <h2 id="winning-entry-1996dalbec">Winning entry: <a href="1996/dalbec/index.html">1996/dalbec</a></h2>
 <h3 id="winning-entry-source-code-dalbec.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/dalbec/dalbec.c">dalbec.c</a></h3>
@@ -2284,6 +2397,7 @@ the fix was wrong.</p>
 number is printed on a line by itself rather than having a long string of
 numbers on the same line.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/dalbec/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_eldby">
 <h2 id="winning-entry-1996eldby">Winning entry: <a href="1996/eldby/index.html">1996/eldby</a></h2>
 <h3 id="winning-entry-source-code-eldby.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/eldby/eldby.c">eldby.c</a></h3>
@@ -2293,6 +2407,7 @@ numbers on the same line.</p>
 like back in 1996 with modern systems and importantly also for those who are sensitive to text
 flashing by rapidly. We recommend that you try the alternate version first due to
 these reasons.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_gandalf">
 <h2 id="winning-entry-1996gandalf">Winning entry: <a href="1996/gandalf/index.html">1996/gandalf</a></h2>
 <h3 id="winning-entry-source-code-gandalf.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/gandalf/gandalf.c">gandalf.c</a></h3>
@@ -2305,11 +2420,13 @@ really demonstrate the different ways of running the program ends up showing
 either different output or the same output that we briefly pointed out.</p>
 <p>BTW: it is perilous to try the patience of
 <a href="https://www.glyphweb.com/arda/g/gandalf.html">Gandalf</a>. Go ahead, try it! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_huffman">
 <h2 id="winning-entry-1996huffman">Winning entry: <a href="1996/huffman/index.html">1996/huffman</a></h2>
 <h3 id="winning-entry-source-code-huffman.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/huffman/huffman.c">huffman.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/huffman/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_jonth">
 <h2 id="winning-entry-1996jonth">Winning entry: <a href="1996/jonth/index.html">1996/jonth</a></h2>
 <h3 id="winning-entry-source-code-jonth.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">jonth.c</a></h3>
@@ -2318,11 +2435,13 @@ either different output or the same output that we briefly pointed out.</p>
 pointer <code>w</code>, which points to <code>XCreateWindow()</code>, did not specify the parameters of
 the function in the pointer assignment.</p>
 <p><strong>NOTE</strong>: if there is no X server running this program will still crash.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_rcm">
 <h2 id="winning-entry-1996rcm">Winning entry: <a href="1996/rcm/index.html">1996/rcm</a></h2>
 <h3 id="winning-entry-source-code-rcm.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/rcm/rcm.c">rcm.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/rcm/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_schweikh1">
 <h2 id="winning-entry-1996schweikh1">Winning entry: <a href="1996/schweikh1/index.html">1996/schweikh1</a></h2>
 <h3 id="winning-entry-source-code-schweikh1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh1/schweikh1.c">schweikh1.c</a></h3>
@@ -2335,6 +2454,7 @@ working <code>/usr/include/rrno.h</code> is found first, which shouldn’t cause
 on other systems (the other file is
 <code>gcc-lib/sparc-sun-solaris2.5/2.7.2/include/errno.h</code>). Thus Cody also added this to
 the <code>Makefile</code> for the (likely?) few who still use Solaris.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_schweikh2">
 <h2 id="winning-entry-1996schweikh2">Winning entry: <a href="1996/schweikh2/index.html">1996/schweikh2</a></h2>
 <h3 id="winning-entry-source-code-schweikh2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh2/schweikh2.c">schweikh2.c</a></h3>
@@ -2344,6 +2464,7 @@ a few commands to try along with a shorter version of something the author
 suggested one try (at the end of the script it prompts if you wish to run the
 author’s idea, with a <code>sleep</code> and <code>echo</code> in between to help one distinguish the
 output better, with the warning that it is an infinite loop).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_schweikh3">
 <h2 id="winning-entry-1996schweikh3">Winning entry: <a href="1996/schweikh3/index.html">1996/schweikh3</a></h2>
 <h2 id="source-code-schweikh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/schweikh3/schweikh3.c">schweikh3.c</a></h2>
@@ -2351,6 +2472,7 @@ output better, with the warning that it is an infinite loop).</p>
 <p><a href="#cody">Cody</a> updated the <code>Makefile</code> so that if it fails to compile it will try the
 method suggested for SunOS rather than having to update the <code>Makefile</code> manually or
 running a more complicated command: now one can just run <code>make</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_westley">
 <h2 id="winning-entry-1996westley">Winning entry: <a href="1996/westley/index.html">1996/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-7">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/westley/westley.c">westley.c</a></h3>
@@ -2369,10 +2491,14 @@ index.html file.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/westley/try.alt.sh">try.alt.sh</a> scripts to automate showing the different
 clocks, both with the fixed version and the original (alt) version.</p>
 <p>Also, to fix any potential problem with displaying in GitHub the scripts
-provided by the author, Cody added ‘.sh’ to the <code>clock[1-3].sh</code> scripts.</p>
+provided by the author, Cody added ‘.sh’ to the <code>clock[1-3].sh</code> scripts (this
+was done before the displaying / downloading of files was devised but it helps
+to show that they are scripts anyway).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998">
 <h1 id="the-14th-ioccc"><a href="1998/index.html">1998 - The 14th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_banks">
 <h2 id="winning-entry-1998banks">Winning entry: <a href="1998/banks/index.html">1998/banks</a></h2>
 <h3 id="winning-entry-source-code-banks.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/banks/banks.c">banks.c</a></h3>
@@ -2387,6 +2513,7 @@ they do have page up and page down but this gives a default for those who don’
 have them like with Macs. The alt build hard codes the page up and page down
 alternatives because not doing so would overly complicate both builds and since
 you can configure them all in both builds it shouldn’t matter.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_bas1">
 <h2 id="winning-entry-1998bas1">Winning entry: <a href="1998/bas1/index.html">1998/bas1</a></h2>
 <h3 id="winning-entry-source-code-bas1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas1/bas1.c">bas1.c</a></h3>
@@ -2396,18 +2523,19 @@ versions of <code>clang</code> whine about the number of args on top of what typ
 In particular some versions claim that they only allow 0, 2 or 3 args. It
 appears that they do allow 1 but for instance 4 is not allowed. However as it’s
 quite possible they will ‘fix’ this defect it would be better to have this not
-be a problem at such a time.</p>
-<p>See the
+be a problem at such a time. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas1/bas1.sh">bas1.sh</a> script to simplify running the
 program.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_bas2">
 <h2 id="winning-entry-1998bas2">Winning entry: <a href="1998/bas2/index.html">1998/bas2</a></h2>
 <h3 id="winning-entry-source-code-bas2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas2/bas2.c">bas2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/bas2/try.sh">try.sh</a> script which runs some default actions
 as well as allowing one to pass in different file names or strings.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_chaos">
 <h2 id="winning-entry-1998chaos">Winning entry: <a href="1998/chaos/index.html">1998/chaos</a></h2>
 <h3 id="winning-entry-source-code-chaos.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/chaos/chaos.c">chaos.c</a></h3>
@@ -2417,6 +2545,7 @@ exiting the program (in both versions).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/chaos/try.sh">try.sh</a> script that runs the program on
 all the data files, giving instructions on how to rotate and zoom in and out,
 prior to each run.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_df">
 <h2 id="winning-entry-1998df">Winning entry: <a href="1998/df/index.html">1998/df</a></h2>
 <h3 id="winning-entry-source-code-df.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/df/df.c">df.c</a></h3>
@@ -2430,6 +2559,7 @@ for why this has to be done this way.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/df/try.sh">try.sh</a> script which runs the program in a
 loop until one hits <code>q</code> (or <code>Q</code>) or sends intr/ctrl-c. He also proposed there’s
 a way to cheat very easily. Can you figure out how?</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_dlowe">
 <h2 id="winning-entry-1998dlowe">Winning entry: <a href="1998/dlowe/index.html">1998/dlowe</a></h2>
 <h3 id="winning-entry-source-code-dlowe.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dlowe/dlowe.c">dlowe.c</a></h3>
@@ -2442,18 +2572,23 @@ to be <code>int</code> (in both versions).</p>
 program, a local pootifier of web pages and a CGI pootifier. See <a href="1998/dlowe/index.html#historical-remarks">historical
 remarks</a> for more details on the
 pootify scripts.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_dloweneil">
 <h2 id="winning-entry-1998dloweneil">Winning entry: <a href="1998/dloweneil/index.html">1998/dloweneil</a></h2>
 <h3 id="winning-entry-source-code-dloweneil.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.c">dloweneil.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.alt.c">alternate code</a> which has vi(m) movement
 (in addition to the other keys except for dropping it’s not <code>d</code> but <code>j</code> or
-space) keys as well as allowing one to quit the game.</p>
+space) keys as well as allowing one to quit the game. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_dorssel">
 <h2 id="winning-entry-1998dorssel">Winning entry: <a href="1998/dorssel/index.html">1998/dorssel</a></h2>
 <h3 id="winning-entry-source-code-dorssel.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/dorssel.c">dorssel.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dorssel/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_fanf">
 <h2 id="winning-entry-1998fanf">Winning entry: <a href="1998/fanf/index.html">1998/fanf</a></h2>
 <h3 id="winning-entry-source-code-fanf.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/fanf/fanf.c">fanf.c</a></h3>
@@ -2467,14 +2602,14 @@ versions of <code>clang</code> complain about the number of args to <code>main()
 claim that only 0, 2 or 3 are allowed but it does allow 1 anyway. It is quite
 possible though that this will change so it is fixed in case this happens. As it
 is mostly just through the C pre-processor Cody added a new macro to make the
-code look like the original with just an extra arg.</p>
-<p>See the
+code look like the original with just an extra arg. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>In some versions of <code>clang</code> <code>-Wno-int-conversion</code> had to be added to the
 <code>CSILENCE</code> variable of the Makefile.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/fanf/try.sh">try.sh</a> script to show the output of some
 of the expressions that we selected.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_schnitzi">
 <h2 id="winning-entry-1998schnitzi">Winning entry: <a href="1998/schnitzi/index.html">1998/schnitzi</a></h2>
 <h3 id="winning-entry-source-code-schnitzi.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">schnitzi.c</a></h3>
@@ -2494,6 +2629,7 @@ doing:</p>
 <pre><code>    ((V[1]&amp;&amp;((atoi(V[1])&gt;0&amp;&amp;atoi(V[1])&lt;27))||(exit(1),1)));</code></pre>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/try.sh">try.sh</a> script to help users try the
 commands that we recommended as well as some added by him.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_schweikh1">
 <h2 id="winning-entry-1998schweikh1">Winning entry: <a href="1998/schweikh1/index.html">1998/schweikh1</a></h2>
 <h3 id="winning-entry-source-code-1998schweikh1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/schweikh1.c">1998/schweikh1</a></h3>
@@ -2539,6 +2675,7 @@ the macros in the form of <code>gcc -dM</code> i.e., the lines are in the form <
 <p>Cody also added the perl script that the author provided that they used to
 compute the character count in the code according to the contest rules of 1998
 in the file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh1/charcount.pl">charcount.pl</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_schweikh2">
 <h2 id="winning-entry-1998schweikh2">Winning entry: <a href="1998/schweikh2/index.html">1998/schweikh2</a></h2>
 <h3 id="winning-entry-source-code-schweikh2.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh2/schweikh2.c">schweikh2.c</a></h3>
@@ -2556,19 +2693,21 @@ index.html.</p>
 have a problem with that in the future which is not entirely out of the
 question.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_schweikh3">
 <h2 id="winning-entry-1998schweikh3">Winning entry: <a href="1998/schweikh3/index.html">1998/schweikh3</a></h2>
 <h3 id="winning-entry-source-code-schweikh3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/schweikh3.c">schweikh3.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/schweikh3.alt.c">alternate
+<p><a href="#cody">Cody</a> added the <a href="1998/schweikh3/index.html#alternate-code">alternate
 code</a> which allows one
 to reconfigure the size constant in the rare case that the author wrote about
-occurs.</p>
+occurs. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>Cody made <code>main()</code> have two args out of an abundance of caution as some versions
 of <code>clang</code> say that <code>main()</code> can only have 0, 2 or 3 args. These versions accept 1
 arg but it is entirely possible that they fix this so this should prevent it
-from breaking if that happens.</p>
-<p>See the
+from breaking if that happens. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schweikh3/try.sh">try.sh</a> script to make it easier to try
@@ -2577,15 +2716,16 @@ command.</p>
 <p>Cody also made the <code>Makefile</code> rule <code>all</code> symlink the entry to <code>samefile</code> as that
 is the name of the program.</p>
 <p>The author stated that:</p>
-<pre><code>    In the remote event that the input has more than `8192` files with
-    the same size (on systems where `sizeof (char *) == 4`, or `4096` when
-    `sizeof (char *) == 8`), increase the manifest constant 32767 on line
-    31.</code></pre>
-<p>so Cody changed the constant to a macro in the <code>Makefile</code> called <code>SZ</code> so one can
+<blockquote>
+<p>In the remote event that the input has more than <code>8192</code> files with the same
+size (on systems where <code>sizeof (char *) == 4</code>, or <code>4096</code> when <code>sizeof (char *) == 8</code>), increase the manifest constant 32767 on line 31.</p>
+</blockquote>
+<p>… so Cody changed the constant to a macro in the <code>Makefile</code> called <code>SZ</code> so one can
 more easily do this (though it indeed seems highly unlikely). See the index.html
 for more details.</p>
 <p>There actually is a web page for the tool and this was added to the author
 information for the entry. It has not been added to any JSON file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_tomtorfs">
 <h2 id="winning-entry-1998tomtorfs">Winning entry: <a href="1998/tomtorfs/index.html">1998/tomtorfs</a></h2>
 <h3 id="winning-entry-source-code-tomtorfs.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/tomtorfs/tomtorfs.c">tomtorfs.c</a></h3>
@@ -2599,19 +2739,21 @@ the <code>EXIT_FAILURE</code> change was done by redefining <code>exit(3)</code>
 program had <code>return 1</code>).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/tomtorfs/try.sh">try.sh</a> script to try out a few
 commands that we recommended.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000">
 <h1 id="the-15th-ioccc"><a href="2000/index.html">2000 - The 15th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_anderson">
 <h2 id="winning-entry-2000anderson">Winning entry: <a href="2000/anderson/index.html">2000/anderson</a></h2>
 <h3 id="winning-entry-source-code-anderson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/anderson//anderson.c">anderson.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> changed this entry to use <code>fgets(3)</code> instead of <code>gets(3)</code>.
 This involved changing the <code>K</code> arg to <code>gets(3)</code> to <code>&amp;K</code> in <code>fgets(3)</code>.
-Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/anderson/try.sh">try.sh</a> script.</p>
-<p>See the
+Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/anderson/try.sh">try.sh</a> script. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_bmeyer">
 <h2 id="winning-entry-2000bmeyer">Winning entry: <a href="2000/bmeyer/index.html">2000/bmeyer</a></h2>
 <h3 id="winning-entry-source-code-bmeyer.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/bmeyer//bmeyer.c">bmeyer.c</a></h3>
@@ -2619,6 +2761,7 @@ for why this was done.</p>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/bmeyer/try.sh">try.sh</a> script with some improvements to the
 commands we recommended like not assuming the number of columns one has in their
 terminal.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_briddlebane">
 <h2 id="winning-entry-2000briddlebane">Winning entry: <a href="2000/briddlebane/index.html">2000/briddlebane</a></h2>
 <h3 id="winning-entry-source-code-briddlebane.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/briddlebane//briddlebane.c">briddlebane.c</a></h3>
@@ -2627,12 +2770,14 @@ terminal.</p>
 <code>libm</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/briddlebane/try.sh">try.sh</a> script for those who are
 feeling a bit too confident, cocky or even happy :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_dhyang">
 <h2 id="winning-entry-2000dhyang">Winning entry: <a href="2000/dhyang/index.html">2000/dhyang</a></h2>
 <h3 id="winning-entry-source-code-dhyang.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dhyang//dhyang.c">dhyang.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this more portable by changing the <code>void main</code> to <code>int main</code>.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dhyang/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_dlowe">
 <h2 id="winning-entry-2000dlowe">Winning entry: <a href="2000/dlowe/index.html">2000/dlowe</a></h2>
 <h3 id="winning-entry-source-code-dlowe.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe//dlowe.c">dlowe.c</a></h3>
@@ -2640,12 +2785,14 @@ feeling a bit too confident, cocky or even happy :-)</p>
 <p><a href="#cody">Cody</a> fixed this to compile with more recent perl versions; the symbol that’s now
 <code>PL_na</code> was once <code>na</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_jarijyrki">
 <h2 id="winning-entry-2000jarijyrki">Winning entry: <a href="2000/jarijyrki/index.html">2000/jarijyrki</a></h2>
 <h3 id="winning-entry-source-code-jarijyrki.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/jarijyrki//jarijyrki.c">jarijyrki.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made it easier to compile this in some cases by adding <code>X11/</code> to the
 includes of <code>Xlib.h</code> and <code>keysym.h</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_natori">
 <h2 id="winning-entry-2000natori">Winning entry: <a href="2000/natori/index.html">2000/natori</a></h2>
 <h3 id="winning-entry-source-code-natori.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/natori//natori.c">natori.c</a></h3>
@@ -2653,7 +2800,7 @@ includes of <code>Xlib.h</code> and <code>keysym.h</code>.</p>
 <p><a href="#cody">Cody</a> fixed this for modern compilers. Depending on the compiler it would either
 segfault when run or not compile at all (<code>gcc</code> and <code>clang</code> respectively). The
 compiler fix is due to <code>clang</code> being more strict about arg types to <code>main()</code>.</p>
-<p>Cody also provided <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/natori/natori.alt.c">alternate code</a> that
+<p>Cody also provided <a href="2000/natori/index.html#alternate-code">alternate code</a> that
 supports the southern hemisphere, based on the author’s remarks.</p>
 <p>Cody also provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/natori/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/natori/try.alt.sh">try.alt.sh</a> scripts that show the Moon phase in
@@ -2669,33 +2816,40 @@ like the original entry but with the two fixes.</p>
 <p>Finally Cody fixed the <code>Makefile</code> that had the <code>-Wno-foo</code> options in the <code>CDEFINE</code>
 variable which although works it is incongruent with the other Makefiles and is
 more confusing (though not really).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_primenum">
 <h2 id="winning-entry-2000primenum">Winning entry: <a href="2000/primenum/index.html">2000/primenum</a></h2>
 <h3 id="winning-entry-source-code-primenum.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum//primenum.c">primenum.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> made this more portable by changing the <code>void main</code> to <code>int main</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_rince">
 <h2 id="winning-entry-2000rince">Winning entry: <a href="2000/rince/index.html">2000/rince</a></h2>
 <h3 id="winning-entry-source-code-rince.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince//rince.c">rince.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_robison">
 <h2 id="winning-entry-2000robison">Winning entry: <a href="2000/robison/index.html">2000/robison</a></h2>
 <h3 id="winning-entry-source-code-robison.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/robison//robison.c">robison.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed an infinite loop that occurred if invalid input was entered, flooding
 the screen with:</p>
-<pre><code>    Black position and direction: illegal</code></pre>
+<blockquote>
+<p>Black position and direction: illegal</p>
+</blockquote>
 <p>This was fixed by having the <code>scanf(3)</code> read in a string and then use <code>atoi(3)</code>
 on it to assign to the <code>int</code>s, much like with <a href="#1987_lievaart">1987/lievaart</a>.
 The strings are <code>char[5]</code> and the <code>%</code> specifier is <code>%4s</code> which is enough for the
 game.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_schneiderwent">
 <h2 id="winning-entry-2000schneiderwent">Winning entry: <a href="2000/schneiderwent/index.html">2000/schneiderwent</a></h2>
 <h3 id="winning-entry-source-code-schneiderwent.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/schneiderwent//schneiderwent.c">schneiderwent.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/schneiderwent/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_thadgavin">
 <h2 id="winning-entry-2000thadgavin">Winning entry: <a href="2000/thadgavin/index.html">2000/thadgavin</a></h2>
 <h3 id="winning-entry-source-code-thadgavin.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/thadgavin//thadgavin.c">thadgavin.c</a></h3>
@@ -2712,14 +2866,15 @@ will impact the curses and the SDL versions as Cody does not have a DOS system
 to test the other version in.</p>
 <p>Due to a terrible design choice of the SDL1 developers something had to be
 changed. As was noted in the log at the time:</p>
-<pre><code>    The SDL version did not work for a number of reasons. First of all the
-    code requires that SDL is defined. Second the path[sic] wrong header file was
-    included. Third the SDL1 developers thought it would be a great idea
-    (but obviously it&#39;s a terrible idea) to redefine main() (!!) so that any
-    program that uses SDL1 has to have the same args as their definition.
-    This program had &#39;main()&#39; so the error message was:
-
-        thadgavin.c:60:1: error: conflicting types for &#39;SDL_main&#39;
+<blockquote>
+<p>The SDL version did not work for a number of reasons. First of all the
+code requires that SDL is defined. Second the path[sic] wrong header file was
+included. Third the SDL1 developers thought it would be a great idea
+(but obviously it’s a terrible idea) to redefine main() (!!) so that any
+program that uses SDL1 has to have the same args as their definition.
+This program had ‘main()’ so the error message was:</p>
+</blockquote>
+<pre><code>        thadgavin.c:60:1: error: conflicting types for &#39;SDL_main&#39;
         main()
         ^
         /opt/local/include/SDL/SDL_main.h:34:14: note: expanded from macro &#39;main&#39;
@@ -2729,22 +2884,26 @@ changed. As was noted in the log at the time:</p>
         extern int SDL_main(int argc, char *argv[]);
                    ^
         1 warning and 1 error generated.
-        make: *** [thadgavin_sdl] Error 1
-
-    Thus main() was changed to &#39;int main(int argc, char **argv)&#39;.</code></pre>
+        make: *** [thadgavin_sdl] Error 1</code></pre>
+<blockquote>
+<p>Thus <code>main()</code> was changed to <code>int main(int argc, char **argv)</code>.</p>
+</blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_tomx">
 <h2 id="winning-entry-2000tomx">Winning entry: <a href="2000/tomx/index.html">2000/tomx</a></h2>
 <h3 id="winning-entry-source-code-tomx.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/tomx//tomx.c">tomx.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/tomx/tomx.alt.c">alternate code</a> based on the
-author’s remarks with a fix for modern systems and he also added the two
+<p><a href="#cody">Cody</a> added the <a href="2000/tomx/index.html#alternate-code">alternate code</a> based on the
+author’s remarks with a fix for modern systems, and he also added the two
 scripts, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/tomx/try.sh">try.sh</a> and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/tomx/try.alt.sh">try.alt.sh</a> for
 the main code and the alternate code respectively.</p>
 <p>And although the scripts do <code>chmod +x</code> on the source code (see the index.html for
 details) the source code is now executable by default.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001">
 <h1 id="the-16th-ioccc"><a href="2001/index.html">2001 - The 16th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_anonymous">
 <h2 id="winning-entry-2001anonymous">Winning entry: <a href="2001/anonymous/index.html">2001/anonymous</a></h2>
 <h3 id="winning-entry-source-code-anonymous.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous//anonymous.c">anonymous.c</a></h3>
@@ -2807,6 +2966,7 @@ what the entry supports).</p>
 <p>As well he added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/try.sh">try.sh</a> script so that one can
 attempt to use the program as it was designed but if compiling as 32-bit fails
 it will at least run the supplementary program as a 64-bit program directly.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_bellard">
 <h2 id="winning-entry-2001bellard">Winning entry: <a href="2001/bellard/index.html">2001/bellard</a></h2>
 <h3 id="winning-entry-source-code-bellard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard//bellard.c">bellard.c</a></h3>
@@ -2835,6 +2995,7 @@ checked prior to running the function just like the author did for the factorial
 (overflowing at <code>&gt;12</code>). Either way unfortunately this entry seems to not work in
 64-bit Linux or macOS. See below portability notes as well as another fix in
 this entry by Yusuke.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="portability-notes">Portability notes:</h2>
 <p>With a tip from Yusuke we rediscovered the author’s <a href="https://bellard.org/otcc/">web page for this
 program</a> where it is stated that this will only work
@@ -2844,6 +3005,7 @@ used <code>gcc 2.95.2</code> but we do not know if that’s relevant or not.</p>
 versions of <code>clang</code> it is. With <code>gcc</code> we can get away with <code>-rdynamic -fno-pie -Wl,-z,execstack</code> which solves the problem of execution in memory but any
 compiler that does not support this would not work. Thus we use the modification
 by Yusuke.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_cheong">
 <h2 id="winning-entry-2001cheong">Winning entry: <a href="2001/cheong/index.html">2001/cheong</a></h2>
 <h3 id="winning-entry-source-code-cheong.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong//cheong.c">cheong.c</a></h3>
@@ -2854,6 +3016,7 @@ letter word that would match the format and because it’s pain that <code>clang
 this. :-) This fix makes a point of the author’s notes on portability no longer
 valid, BTW.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_coupard">
 <h2 id="winning-entry-2001coupard">Winning entry: <a href="2001/coupard/index.html">2001/coupard</a></h2>
 <h3 id="winning-entry-source-code-coupard.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/coupard//coupard.c">coupard.c</a></h3>
@@ -2873,7 +3036,9 @@ support implicit int:</p>
 or <code>/dev/sound/dsp</code> (which is most everyone nowadays, it seems, and especially
 those with macOS) (to do with sound; see his
 <a href="2013/endoh3/index.html">2013/endoh3/index.html</a> entry where he also refers to
-sound devices in macOS).</p>
+sound devices in macOS as well as our
+FAQ on “<a href="faq.html#sound">sound</a>”).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_ctk">
 <h2 id="winning-entry-2001ctk">Winning entry: <a href="2001/ctk/index.html">2001/ctk</a></h2>
 <h3 id="winning-entry-source-code-ctk.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ctk//ctk.c">ctk.c</a></h3>
@@ -2884,20 +3049,25 @@ the ANSI escape codes. This works with both Linux and macOS.</p>
 etc.) after exiting even if you don’t press ‘q’, if you crash or if you kill the
 program prematurely. This was done by adding an explicit call to <code>e()</code> at the
 end of <code>main()</code>.</p>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ctk/ctk.alt.c">alternate code</a> that adds
-vi(m) movement keys.</p>
+<p>Cody also added the <a href="2001/ctk/index.html#alternate-code">alternate
+code</a> that adds
+vi(m) movement keys. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_dgbeards">
 <h2 id="winning-entry-2001dgbeards">Winning entry: <a href="2001/dgbeards/index.html">2001/dgbeards</a></h2>
 <h3 id="winning-entry-source-code-dgbeards.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards//dgbeards.c">dgbeards.c</a></h3>
 </div>
 <p>The author provided two changes: one to speed it up and one to make it not crash
-on losing. <a href="#cody">Cody</a> provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.alt.c">alternate
+on losing. <a href="#cody">Cody</a> provided an <a href="2001/dgbeards/index.html#alternate-code">alternate
 version</a> which does the former but
 not the latter as he he felt that the idea of crashing on losing (see the
 index.html for details on why that might be) too good to get rid. The author
 explains how to make this change, however.</p>
 <p>Cody also points out that there is a way to get the computer to automatically lose
 very quickly. Do you know what it is?</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_herrmann1">
 <h2 id="winning-entry-2001herrmann1">Winning entry: <a href="2001/herrmann1/index.html">2001/herrmann1</a></h2>
 <h3 id="winning-entry-source-code-herrmann1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1//herrmann1.c">herrmann1.c</a></h3>
@@ -2910,10 +3080,13 @@ it’s also how you invoke the program.</p>
 author’s remarks.</p>
 <p>He also fixed the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.sh">script herrmann1.sh</a> for
 shellcheck. In particular there were quite a few:</p>
-<pre><code>    SC2086 (info): Double quote to prevent globbing and word splitting.
-    SC2248 (style): Prefer double quoting even when variables don&#39;t contain special characters.</code></pre>
-<p>errors/warnings.</p>
+<blockquote>
+<p>SC2086 (info): Double quote to prevent globbing and word splitting.<br>
+SC2248 (style): Prefer double quoting even when variables don’t contain special characters.</p>
+</blockquote>
+<p>… errors/warnings.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_herrmann2">
 <h2 id="winning-entry-2001herrmann2">Winning entry: <a href="2001/herrmann2/index.html">2001/herrmann2</a></h2>
 <h3 id="winning-entry-source-code-herrmann2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann2//herrmann2.c">herrmann2.c</a></h3>
@@ -2927,6 +3100,7 @@ respectively, and changing specific references to the <code>argv</code> arg, cas
 useful than any other place as the command to try is quite long with C code.</p>
 <p>For some reason the original code was missing (presumingly because it had been
 added to <code>.gitignore</code> by accident) but Cody restored it from the archive.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_kev">
 <h2 id="winning-entry-2001kev">Winning entry: <a href="2001/kev/index.html">2001/kev</a></h2>
 <h3 id="winning-entry-source-code-kev.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev//kev.c">kev.c</a></h3>
@@ -2936,27 +3110,32 @@ speed and <code>socket(2)</code> call that the author had set up.</p>
 <p>Cody also slowed down the ball just a tad (it was already a <code>-D</code> macro that was used
 in the code) as it went too fast for the speed at which the paddles move even
 when holding down the movement keys (but see below).</p>
-<p>Cody also provided an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.alt.c">alternate version</a> which lets you use
-the arrow keys on your keyboard instead of the more awkward ‘<code>,</code>’ and ‘<code>.</code>’.</p>
+<p>Cody also provided an <a href="2001/kev/index.html#alternate-code">alternate version</a> which lets you use
+the arrow keys on your keyboard instead of the more awkward ‘<code>,</code>’ and ‘<code>.</code>’. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>Cody updated both versions to have <code>#ifndef..#endif</code> pairs for the macros so one
 can more easily configure different settings without having to specify all of
 them (though this change became unnecessary with an improvement on how it was
 done). The speed, <code>SPEED</code>, will be set to <code>50</code> if it’s not defined at the compiler
 line as <code>50</code> is what it used to be set to. This way it’s more to the original but
 without having to sacrifice playability by running <code>make</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_ollinger">
 <h2 id="winning-entry-2001ollinger">Winning entry: <a href="2001/ollinger/index.html">2001/ollinger</a></h2>
 <h3 id="winning-entry-source-code-ollinger.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger//ollinger.c">ollinger.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_schweikh">
 <h2 id="winning-entry-2001schweikh">Winning entry: <a href="2001/schweikh/index.html">2001/schweikh</a></h2>
 <h3 id="winning-entry-source-code-schweikh.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh//schweikh.c">schweikh.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> fixed this to not crash if not enough args as this was not documented by
-the author. The other problems are documented so were not fixed. See
+the author. The other problems are documented so were not fixed. See the
 index.html for details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_westley">
 <h2 id="winning-entry-2001westley">Winning entry: <a href="2001/westley/index.html">2001/westley</a></h2>
 <h3 id="winning-entry-source-code-westley.c-8">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley//westley.c">westley.c</a></h3>
@@ -2966,23 +3145,29 @@ automate a heap of commands that we, the IOCCC judges, suggested, as well as
 some additional ones that he thought would be fun. He also provided the sort
 and punch card versions, described in the index.html, based on the author’s
 remarks, through <code>Makefile</code> rules that generate the files by default with <code>make all</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004">
 <h1 id="the-17th-ioccc"><a href="2004/index.html">2004 - The 17th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_anonymous">
 <h2 id="winning-entry-2004anonymous">Winning entry: <a href="2004/anonymous/index.html">2004/anonymous</a></h2>
 <h3 id="winning-entry-source-code-anonymous.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/anonymous//anonymous.c">anonymous.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/anonymous/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_arachnid">
 <h2 id="winning-entry-2004arachnid">Winning entry: <a href="2004/arachnid/index.html">2004/arachnid</a></h2>
 <h3 id="winning-entry-source-code-arachnid.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/arachnid//arachnid.c">arachnid.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/arachnid/arachnid.alt.c">alternate
+<p><a href="#cody">Cody</a> added an <a href="2004/arachnid/index.html#alternate-code">alternate
 version</a> which
 allows those like himself used to <code>h</code>, <code>j</code>, <code>k</code> and <code>l</code> movement keys to not get
 lost. Non rogue players, vi users and Dvorak typists are invited to get lost (or
-use the original version)! :-)</p>
+use the original version)! :-) See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_burley">
 <h2 id="winning-entry-2004burley">Winning entry: <a href="2004/burley/index.html">2004/burley</a></h2>
 <h3 id="winning-entry-source-code-burley.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/burley//burley.c">burley.c</a></h3>
@@ -3005,9 +3190,10 @@ unknown by Cody if this is because it used to be allowed to have binary
 expression with <code>void</code> or if it is for some other reason).</p>
 <p><code>longjmp(3)</code> was being called with one arg which was an element
 of an <code>int[4][1000]</code> which had to be changed to a <code>jmp_buf p[4]</code> (this due to
-the prototype being included).</p>
+the addition of <code>#include &lt;setjmp.h&gt;</code>).</p>
 <p>Finally the optimiser cannot be enabled so the compiler flags were changed for
 this, forcing <code>-O0</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_gavare">
 <h2 id="winning-entry-2004gavare">Winning entry: <a href="2004/gavare/index.html">2004/gavare</a></h2>
 <h3 id="winning-entry-source-code-gavare.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavare//gavare.c">gavare.c</a></h3>
@@ -3024,11 +3210,14 @@ and anti-alias setting at compile time. This is based on the author’s remarks.
 that was used during development, found on their <a href="https://gavare.se/ioccc/ioccc_gavare.c.html">website about the
 entry</a>.</li>
 </ul>
+<p>See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <div id="2004_gavin">
 <h2 id="winning-entry-2004gavin">Winning entry: <a href="2004/gavin/index.html">2004/gavin</a></h2>
 <h3 id="winning-entry-source-code-gavin.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin//gavin.c">gavin.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/gavin.alt.c">alternate code</a> for
+<p><a href="#cody">Cody</a> provided the <a href="2004/gavin/index.html#alternate-code">alternate code</a> for
 those who want to use QEMU. The most important part of this is the macro <code>K</code> has
 to be defined as <code>1</code>, not <code>0</code>.</p>
 <p><a href="#yusuke">Yusuke</a> provided the <code>kernel</code> and <code>fs.tar</code> files which can be used if
@@ -3037,6 +3226,7 @@ files provided, found under the <a href="https://github.com/ioccc-src/temp-test-
 the <code>img/fs.tar</code> extracts into <code>fs/</code> so you will have to fix the tarball; this
 is done this way to prevent extraction from the entry directory overwriting the
 files and causing <code>make clobber</code> to wipe some of them out.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_hibachi">
 <h2 id="winning-entry-2004hibachi">Winning entry: <a href="2004/hibachi/index.html">2004/hibachi</a></h2>
 <h3 id="winning-entry-source-code-hibachi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi//hibachi.c">hibachi.c</a></h3>
@@ -3053,11 +3243,13 @@ unobfuscated version that Cody added in, with thanks to Anthony! This also
 required a minor fix in the inclusion of <code>ctype.h</code> and various other fixes as
 well, namely to get the program to work as <code>alt</code> rather than <code>-spoiler</code> (it is
 not even known if it would work otherwise).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_hoyle">
 <h2 id="winning-entry-2004hoyle">Winning entry: <a href="2004/hoyle/index.html">2004/hoyle</a></h2>
 <h3 id="winning-entry-source-code-hoyle.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hoyle//hoyle.c">hoyle.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hoyle/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_jdalbec">
 <h2 id="winning-entry-2004jdalbec">Winning entry: <a href="2004/jdalbec/index.html">2004/jdalbec</a></h2>
 <h3 id="winning-entry-source-code-jdalbec.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec//jdalbec.c">jdalbec.c</a></h3>
@@ -3082,12 +3274,15 @@ this ended up with a number of errors like:</p>
 <p>and various other problems. However there does seem to be a problem at least
 with some <code>gcc</code> versions in macOS but this appears to be due to errors in
 <code>/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/cdefs.h</code>.</p>
-<p>Cody also added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.alt.c">alternate code</a> which allows
+<p>Cody also added <a href="2004/jdalbec/index.html#alternate-code">alternate code</a> which allows
 one to control how many numbers after the <code>:</code> to print before printing a
 newline, so that one can see the output a bit better (though for lines that have
-a lot of numbers this will be harder to see).</p>
+a lot of numbers this will be harder to see). See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>Finally Cody added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/try.alt.sh">try.alt.sh</a> to demonstrate both versions.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_kopczynski">
 <h2 id="winning-entry-2004kopczynski">Winning entry: <a href="2004/kopczynski/index.html">2004/kopczynski</a></h2>
 <h3 id="winning-entry-source-code-kopczynski.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski//kopczynski.c">kopczynski.c</a></h3>
@@ -3096,15 +3291,14 @@ a lot of numbers this will be harder to see).</p>
 discovered it will not work otherwise.</p>
 <p>Cody, out of an abundance of caution for <code>clang</code>, added a second arg to <code>main()</code>
 as some versions complain about the number of args and although they accept 1 it
-is entirely possible it will eventually be that they don’t.</p>
-<p>See the
-FAQ on “<a href="faq.html#arg_count">main function args</a>”
-for more details.</p>
+is entirely possible it will eventually be that they don’t. See the FAQ on
+“<a href="faq.html#arg_count">main function args</a>” for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski/try.sh">try.sh</a> script and various data
 files: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/kopczynski/kopczynski-a">kopczynski-a</a> to demonstrate what happens when art more
 like a letter is fed to the program, and the <code>kopczynski*-rev</code> files which are
 the data files reversed with <code>rev(1)</code>. One had to be modified additionally to
 get it to work, that being <code>kopczynski-10-rev</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_newbern">
 <h2 id="winning-entry-2004newbern">Winning entry: <a href="2004/newbern/index.html">2004/newbern</a></h2>
 <h3 id="winning-entry-source-code-newbern.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/newbern//newbern.c">newbern.c</a></h3>
@@ -3113,23 +3307,25 @@ get it to work, that being <code>kopczynski-10-rev</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/newbern/try.sh">try.sh</a> script (with a hidden feature
 that the author referred to and was documented by <a href="#yusuke">Yusuke</a> though Cody
 chose the word <code>IOCCC</code> instead of <code>AAA</code>).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_omoikane">
 <h2 id="winning-entry-2004omoikane">Winning entry: <a href="2004/omoikane/index.html">2004/omoikane</a></h2>
 <h3 id="winning-entry-source-code-omoikane.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/omoikane//omoikane.c">omoikane.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/omoikane/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_schnitzi">
 <h2 id="winning-entry-2004schnitzi">Winning entry: <a href="2004/schnitzi/index.html">2004/schnitzi</a></h2>
 <h3 id="winning-entry-source-code-schnitzi.c-4">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi//schnitzi.c">schnitzi.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>.</p>
-<p>See the
+<p><a href="#cody">Cody</a> made this use <code>fgets(3)</code>. See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for why this was done.</p>
 <p>He also changed the time factor in the data files as the animations went too
 fast in modern systems, especially the scrolling text of
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi/schnitzi.inp1">schnitzi.inp1</a>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/schnitzi/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_sds">
 <h2 id="winning-entry-2004sds">Winning entry: <a href="2004/sds/index.html">2004/sds</a></h2>
 <h3 id="winning-entry-source-code-sds.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds//sds.c">sds.c</a></h3>
@@ -3138,6 +3334,7 @@ fast in modern systems, especially the scrolling text of
 <p>Also, after the <code>README.md</code> file had copyright changes, it broke the script so
 Cody made a copy of the older <code>README.md</code> file into <code>README_sds.txt</code> and added that
 to the repo for the script instead.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_vik2">
 <h2 id="winning-entry-2004vik2">Winning entry: <a href="2004/vik2/index.html">2004/vik2</a></h2>
 <h3 id="winning-entry-source-code-vik2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/vik2//vik2.c">vik2.c</a></h3>
@@ -3191,9 +3388,11 @@ which used to be generated by the <code>Makefile</code> via <code>cc -E</code>.<
 <p>Cody also made it so that the <code>FNAME</code> is (for the entry file itself and
 <code>vik2_1.c</code> - there are other places it should not be done) <code>__FILE__</code>
 just to make it a bit easier to compile.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005">
 <h1 id="the-18th-ioccc"><a href="2005/index.html">2005 - The 18th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_aidan">
 <h2 id="winning-entry-2005aidan">Winning entry: <a href="2005/aidan/index.html">2005/aidan</a></h2>
 <h3 id="winning-entry-source-code-aidan.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/aidan//aidan.c">aidan.c</a></h3>
@@ -3201,14 +3400,19 @@ just to make it a bit easier to compile.</p>
 <p><a href="#cody">Cody</a> fixed the test script, described by the author in their remarks, to refer
 to the proper compiled program (it’s hardcoded). This had never been done and so
 the script did not even work (at least modernly?).</p>
-<p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/aidan/aidan.alt.c">alternate code</a> based on the
+<p>He also added the <a href="2005/aidan/index.html#alternate-code">alternate code</a> based on the
 author’s remarks which is a different approach than the one used and which
-(according to the author) ‘<code>is slower (particularly in worst-case or nearly so scenarios), inelegant, and not a good starting place for sudoku generation.</code>’</p>
+(according to the author):</p>
+<blockquote>
+<p>… is slower (particularly in worst-case or nearly so
+scenarios), inelegant, and not a good starting place for sudoku generation.</p>
+</blockquote>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/aidan/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/aidan/try.alt.sh">try.alt.sh</a> scripts that correspond to the entry and
 alternate code respectively.</p>
 <p>Cody added the <code>make test</code> and <code>make test-n0</code> rules for easier use of the test
 suite.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_anon">
 <h2 id="winning-entry-2005anon">Winning entry: <a href="2005/anon/index.html">2005/anon</a></h2>
 <h3 id="winning-entry-source-code-anon.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon//anon.c">anon.c</a></h3>
@@ -3218,8 +3422,11 @@ not work and end up causing a bus error. Instead of <code>stty sane</code> it us
 <p>The author noted that one can define <code>NO_STTY</code> to not use <code>stty(1)</code> at all
 (either to prevent having to hit enter or to turn echo off/on) and this is
 explained in the index.html.</p>
-<p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.alt.c">alternate code</a> with vi(m) like
-movements.</p>
+<p>Cody added the <a href="2005/anon/index.html#alternate-code">alternate code</a> with vi(m) like
+movements. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_boutines">
 <h2 id="winning-entry-2005boutines">Winning entry: <a href="2005/boutines/index.html">2005/boutines</a></h2>
 <h3 id="winning-entry-source-code-boutines.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/boutines//boutines.c">boutines.c</a></h3>
@@ -3227,6 +3434,7 @@ movements.</p>
 <p><a href="#cody">Cody</a> added the <a href="2005/boutines/input.txt">input.txt</a> data file based on suggested
 input from the author, adapting it to a command to try out.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/boutines/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_giljade">
 <h2 id="winning-entry-2005giljade">Winning entry: <a href="2005/giljade/index.html">2005/giljade</a></h2>
 <h3 id="winning-entry-source-code-giljade.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade//giljade.c">giljade.c</a></h3>
@@ -3274,17 +3482,20 @@ temporary file the compilation including the ‘Line’ lines. After that is don
 uses <code>grep -c</code> on the file to show that there are indeed as many versions the
 program generates as the author states, 180. If it does not find 180 it is an
 error; otherwise it is success. See <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/test.sh">test.sh</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_jetro">
 <h2 id="winning-entry-2005jetro">Winning entry: <a href="2005/jetro/index.html">2005/jetro</a></h2>
 <h3 id="winning-entry-source-code-jetro.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/jetro//jetro.c">jetro.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) for systems like Linux that seem to
 not do it implicitly (like macOS does).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_klausler">
 <h2 id="winning-entry-2005klausler">Winning entry: <a href="2005/klausler/index.html">2005/klausler</a></h2>
 <h3 id="winning-entry-source-code-klausler.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/klausler//klausler.c">klausler.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/klausler/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_mikeash">
 <h2 id="winning-entry-2005mikeash">Winning entry: <a href="2005/mikeash/index.html">2005/mikeash</a></h2>
 <h3 id="winning-entry-source-code-mikeash.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash//mikeash.c">mikeash.c</a></h3>
@@ -3310,6 +3521,7 @@ what is supposed to happen. It is not known, however, if having to change the
 <code>\N</code> to <code>\n</code> ended up breaking any LISP. The other examples given by the author
 also show correct output though.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_mynx">
 <h2 id="winning-entry-2005mynx">Winning entry: <a href="2005/mynx/index.html">2005/mynx</a></h2>
 <h3 id="winning-entry-source-code-mynx.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx//mynx.c">mynx.c</a></h3>
@@ -3325,15 +3537,17 @@ does scan for <code>https</code>. Futile, maybe, based on how <code>https</code>
 case just enjoy it for what it was, without it working with websites that do not
 support <code>http</code>. But there might be some command line that will let it work that
 way or perhaps someone wants to add the necessary code, updating the file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_persano">
 <h2 id="winning-entry-2005persano">Winning entry: <a href="2005/persano/index.html">2005/persano</a></h2>
 <h3 id="winning-entry-source-code-persano.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/persano//persano.c">persano.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added the (untested) <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/persano/persano.alt.c">alternate
+<p><a href="#cody">Cody</a> added the (untested) <a href="2005/persano/index.html#alternate-code">alternate
 code</a> which should work for Windows as
 it sets binary mode on <code>stdout</code>. This was based on the author’s remarks but it
 is untested as Cody has no Windows system to test it on.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/persano/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_sykes">
 <h2 id="winning-entry-2005sykes">Winning entry: <a href="2005/sykes/index.html">2005/sykes</a></h2>
 <h3 id="winning-entry-source-code-sykes.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes//sykes.c">sykes.c</a></h3>
@@ -3362,6 +3576,7 @@ run the test suite. The program will enter an infinite loop after it runs so you
 have to hit ctrl-c to end it which the script tells you.</p>
 <p>The scripts note every time that one will have to send ctrl-c or whatever their
 interrupt is set to in order to exit the program.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_timwi">
 <h2 id="winning-entry-2005timwi">Winning entry: <a href="2005/timwi/index.html">2005/timwi</a></h2>
 <h3 id="winning-entry-source-code-timwi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/timwi//timwi.c">timwi.c</a></h3>
@@ -3369,6 +3584,7 @@ interrupt is set to in order to exit the program.</p>
 <p><a href="#cody">Cody</a> added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/timwi/try.sh">try.sh</a>. It only has one command as he doesn’t
 want to knacker his brain any more than it might or might not already be :-) and
 he doesn’t want to damage anyone else’s brain either. :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_toledo">
 <h2 id="winning-entry-2005toledo">Winning entry: <a href="2005/toledo/index.html">2005/toledo</a></h2>
 <h3 id="winning-entry-source-code-toledo.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/toledo//toledo.c">toledo.c</a></h3>
@@ -3378,6 +3594,7 @@ defect where <code>main()</code> can only have 0, 2 or 3 args (it was 4). It now
 another function that takes 4 args and which is what used to be <code>main()</code>.</p>
 <p>The <a href="2005/toledo/index.html#alternate-code">alternate versions</a> that the author
 provided were also fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_vince">
 <h2 id="winning-entry-2005vince">Winning entry: <a href="2005/vince/index.html">2005/vince</a></h2>
 <h3 id="winning-entry-source-code-vince.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/vince//vince.c">vince.c</a></h3>
@@ -3389,9 +3606,11 @@ to concatenate to it <code>.c</code>. But this assumes that the executable is th
 as the source file which isn’t always true. The author even stated: ‘<code>as long as the source is in the same directory as the executable it should be able to find it</code>’ but the source code file name is not always the same as the executable
 with the appropriate extension so this might be called a bug fix as well though
 if one runs it from another directory, specifying the directory, it’ll not catch it.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006">
 <h1 id="the-19th-ioccc"><a href="2006/index.html">2006 - The 19th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_birken">
 <h2 id="winning-entry-2006birken">Winning entry: <a href="2006/birken/index.html">2006/birken</a></h2>
 <h3 id="winning-entry-source-code-birken.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/birken//birken.c">birken.c</a></h3>
@@ -3400,6 +3619,7 @@ if one runs it from another directory, specifying the directory, it’ll not cat
 The problem was a missing <code>+1</code> for <code>strlen(3)</code> with <code>malloc(3)</code>. This prevented
 it from working.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/birken/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_borsanyi">
 <h2 id="winning-entry-2006borsanyi">Winning entry: <a href="2006/borsanyi/index.html">2006/borsanyi</a></h2>
 <h3 id="winning-entry-source-code-borsanyi.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi//borsanyi.c">borsanyi.c</a></h3>
@@ -3407,39 +3627,44 @@ it from working.</p>
 <p><a href="#cody">Cody</a> fixed the <code>Makefile</code> to work in systems where the <code>lpthread</code> is not
 implicitly linked in.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_grothe">
 <h2 id="winning-entry-2006grothe">Winning entry: <a href="2006/grothe/index.html">2006/grothe</a></h2>
 <h3 id="winning-entry-source-code-grothe.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/grothe//grothe.c">grothe.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/grothe/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_hamre">
 <h2 id="winning-entry-2006hamre">Winning entry: <a href="2006/hamre/index.html">2006/hamre</a></h2>
 <h3 id="winning-entry-source-code-hamre.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre//hamre.c">hamre.c</a></h3>
 </div>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/try.sh">try.sh</a> script.</p>
+<p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_monge">
 <h2 id="winning-entry-2006monge">Winning entry: <a href="2006/monge/index.html">2006/monge</a></h2>
 <h3 id="winning-entry-source-code-monge.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge//monge.c">monge.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge/monge.alt.c">alternate code</a> that lets
-one resize the image and redefine the number of iterations.</p>
+<p><a href="#cody">Cody</a> added the <a href="2006/monge/index.html#alternate-code">alternate code</a> that lets
+one resize the image and redefine the number of iterations. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge/try.alt.sh">try.alt.sh</a> scripts.</p>
-<p>Cody also fixed the <code>Makefile</code> to use <code>sdl-config</code> (which is what the author
-stated too though that was noticed later), not <code>sdl2-config</code> as two functions
-that are used were removed from <a href="https://www.libsdl.org">SDL2</a>,
-thus making it not link. Since SDL2 is still available and since changing the
-code to use SDL2 is much more complicated and also makes the entry less like
-the original it was simply made to link in SDL1.</p>
-<p>Nevertheless this entry does require x86/x86_64 CPUS. This is a documented
-feature but one which we will accept fixes to. See <a href="bugs.html#2006_monge">2006/monge in
-bugs.html</a>.</p>
+<p>Cody also fixed the <code>Makefile</code> to use <code>sdl-config</code>, not <code>sdl2-config</code>, as two
+functions that are used were removed from <a href="https://www.libsdl.org">SDL2</a>, thus
+making it not link.</p>
+<p>Nevertheless this entry does require x86/x86_64 CPUS (this is a documented
+feature).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_night">
 <h2 id="winning-entry-2006night">Winning entry: <a href="2006/night/index.html">2006/night</a></h2>
 <h3 id="winning-entry-source-code-night.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/night//night.c">night.c</a></h3>
 </div>
 <p>As <a href="#cody">Cody</a> is a lost :-) <code>vim</code> user he took the author’s remarks to add support
-back for arrow keys in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/night/night.alt.c">alternate version</a>.</p>
+back for arrow keys in the <a href="2006/night/index.html#alternate-code">alternate
+version</a>. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>” for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_sloane">
 <h2 id="winning-entry-2006sloane">Winning entry: <a href="2006/sloane/index.html">2006/sloane</a></h2>
 <h3 id="winning-entry-source-code-sloane.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sloane//sloane.c">sloane.c</a></h3>
@@ -3455,12 +3680,6 @@ some versions do allow only one arg. This was done at first because it’s not
 used but Cody discovered that later versions of <code>clang</code> have an additional defect
 where it does not allow only one arg so the second arg to <code>main()</code> was added
 back.</p>
-<p>This was an unfortunate problem for the alternate code as he has been using <code>Z</code>
-for alternate code <code>usleep()</code> (for sleep) but in this case unfortunately the
-original entry used <code>Z</code> in <code>main()</code> (though unused) so to make it more like the
-original Cody renamed the macro <code>Z</code> for <code>usleep()</code> to <code>S</code> instead which can
-stand for sleep and also it is kind of like a backwards <code>Z</code>. That way <code>Z</code> could
-be in <code>main()</code>.</p>
 <p>Cody also made sure that the <code>Makefile</code> links in <code>libm</code> as not all systems do this
 by default.</p>
 <p>Since the author suggested that the lack of certain <code>#include</code>s might break the
@@ -3470,33 +3689,36 @@ program in some systems he also added <code>-include ...</code> to the <code>Mak
 <h3 id="winning-entry-source-code-stewart.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart//stewart.c">stewart.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_sykes1">
 <h2 id="winning-entry-2006sykes1">Winning entry: <a href="2006/sykes1/index.html">2006/sykes1</a></h2>
 <h3 id="winning-entry-source-code-sykes1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1//sykes1.c">sykes1.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.alt.c">alternate
+<p><a href="#cody">Cody</a> provided the <a href="2006/sykes1/index.html#alternate-code">alternate
 code</a> based on the
 author’s remarks.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/try.sh">try.sh</a> script.</p>
 <p>Cody also provided the <a href="2006/sykes1/bedlam-cubes.pdf">bedlam-cubes.pdf</a> file,
 obtained from the Internet Wayback Machine, as the file was no longer available.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_sykes2">
 <h2 id="winning-entry-2006sykes2">Winning entry: <a href="2006/sykes2/index.html">2006/sykes2</a></h2>
 <h3 id="winning-entry-source-code-sykes2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2//sykes2.c">sykes2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution for <code>clang</code>’s defects, made <code>main()</code> have
 2 args instead of 1 as some versions report that <code>main()</code> must have 0, 2 or 3
-args, even though at least one of those versions allows 1 arg only.</p>
-<p>See the
+args, even though at least one of those versions allows 1 arg only. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2/try.sh">try.sh</a> script for easier use of the
-entry to show the clock update in real time.</p>
+<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes2/try.sh">try.sh</a> script for easier
+use of the entry to show the clock update in real time.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_toledo1">
 <h2 id="winning-entry-2006toledo1">Winning entry: <a href="2006/toledo1/index.html">2006/toledo1</a></h2>
 <h3 id="winning-entry-source-code-toledo1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo1//toledo1.c">toledo1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo1/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_toledo2">
 <h2 id="winning-entry-2006toledo2">Winning entry: <a href="2006/toledo2/index.html">2006/toledo2</a></h2>
 <h3 id="winning-entry-source-code-toledo2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2//toledo2.c">toledo2.c</a></h3>
@@ -3505,7 +3727,7 @@ entry to show the clock update in real time.</p>
 macOS - it did not seem to be a problem under Linux, at least not fedora. The
 problem was wrong variable types - implicit <code>int</code>s instead of <code>FILE *</code>s. It now
 works with both macOS and Linux.</p>
-<p>Cody also added the (untested) <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.alt.c">alternate
+<p>Cody also added the (untested) <a href="2006/toledo2/index.html#alternate-code">alternate
 code</a> that is based on the author’s remarks to
 port this to systems that have the non-standard <code>kbhit()</code> and <code>getch()</code> (not the
 one from curses) which is typically (always?) in <code>conio.h</code>.</p>
@@ -3514,6 +3736,7 @@ the program and modified the <code>fread(3)</code>/<code>fwrite(3)</code> sectio
 <code>FILE *e</code> (that Cody changed) instead of <code>int y</code>, making it to work on x86_64
 (perhaps Cody’s fix was for arm64 only?). Also, he added a note to clarify from
 where appears the <code>IMPORT.COM</code> and <code>HALT.COM</code> files.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_toledo3">
 <h2 id="winning-entry-2006toledo3">Winning entry: <a href="2006/toledo3/index.html">2006/toledo3</a></h2>
 <h3 id="winning-entry-source-code-toledo3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3//toledo3.c">toledo3.c</a></h3>
@@ -3523,33 +3746,38 @@ modern (64-bit) systems. The crash appears to only occur in macOS but the fix
 lets it work in both Linux and macOS. The problem was that it relied on 32-bits
 so some <code>int</code>s were changed to <code>long</code>s. The display problem might or might not
 have been a problem in Linux with the old <code>int</code>s but this is no longer known.</p>
-<p>Cody also added the code that <em>should</em> work for Windows,
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>, based on the author’s remarks.
-We’re not able to test this.</p>
+<p>Cody also added the code that should work for Windows (it was tested by the
+author), <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo3/toledo3.alt.c">toledo3.alt.c</a>, based on the
+author’s remarks; see <a href="2006/toledo3/index.html#alternate-code">Alternate code in
+2006/toledo3/index.html</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011">
 <h1 id="the-20th-ioccc"><a href="2011/index.html">2011 - The 20th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_akari">
 <h2 id="winning-entry-2011akari">Winning entry: <a href="2011/akari/index.html">2011/akari</a></h2>
 <h3 id="winning-entry-source-code-akari.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/akari//akari.c">akari.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/akari/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_blakely">
 <h2 id="winning-entry-2011blakely">Winning entry: <a href="2011/blakely/index.html">2011/blakely</a></h2>
 <h3 id="winning-entry-source-code-blakely.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/blakely//blakely.c">blakely.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/blakely/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_borsanyi">
 <h2 id="winning-entry-2011borsanyi">Winning entry: <a href="2011/borsanyi/index.html">2011/borsanyi</a></h2>
 <h3 id="winning-entry-source-code-borsanyi.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi//borsanyi.c">borsanyi.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a>, out of an abundance of caution, added a second arg to <code>main()</code> as some
 versions of <code>clang</code> complain about not only the type of each arg to <code>main()</code> but
-the number of args as well.</p>
-<p>See the
+the number of args as well. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_dlowe">
 <h2 id="winning-entry-2011dlowe">Winning entry: <a href="2011/dlowe/index.html">2011/dlowe</a></h2>
 <h3 id="winning-entry-source-code-dlowe.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/dlowe//dlowe.c">dlowe.c</a></h3>
@@ -3567,11 +3795,13 @@ The file could have been named to that but it is not POSIX safe so the <code>[]<
 were removed. At the same time, for the same reason (though the link worked),
 the file <code>2011/dlowe/dlowe-aux-data/png-1/image_thumb[40].png</code> was renamed to
 <code>image_thumb.png</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_fredriksson">
 <h2 id="winning-entry-2011fredriksson">Winning entry: <a href="2011/fredriksson/index.html">2011/fredriksson</a></h2>
 <h3 id="winning-entry-source-code-fredriksson.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson//fredriksson.c">fredriksson.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_goren">
 <h2 id="winning-entry-2011goren">Winning entry: <a href="2011/goren/index.html">2011/goren</a></h2>
 <h3 id="winning-entry-source-code-goren.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/goren//goren.c">goren.c</a></h3>
@@ -3582,7 +3812,12 @@ for 64-bit so it was then tested as a 32-bit binary (Linux) and 64-bit binary
 (Linux, macOS) and both work. It was fixed by changing some <code>int</code>s to <code>long</code>s
 and now it does work with 64-bit systems as well as 32-bit systems.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/goren/try.sh">try.sh</a> script.</p>
-<p>Cody added the following words of wisdom: <code>'"this" is not a pipe but "|" is'</code>.</p>
+<p>Cody added the following words of wisdom:</p>
+<blockquote>
+<p>“this” is not a pipe but “|” is</p>
+</blockquote>
+<p>:-).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_hamaji">
 <h2 id="winning-entry-2011hamaji">Winning entry: <a href="2011/hamaji/index.html">2011/hamaji</a></h2>
 <h3 id="winning-entry-source-code-hamaji.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hamaji//hamaji.c">hamaji.c</a></h3>
@@ -3595,16 +3830,19 @@ and now it does work with 64-bit systems as well as 32-bit systems.</p>
 The latter two <code>.nono</code> files were taken from
 <a href="https://web.archive.org/web/20130218055139/http://codegolf.com/paint-by-numbers" class="uri">https://web.archive.org/web/20130218055139/http://codegolf.com/paint-by-numbers</a>
 and the others were from the authors’ remarks.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_hou">
 <h2 id="winning-entry-2011hou">Winning entry: <a href="2011/hou/index.html">2011/hou</a></h2>
 <h3 id="winning-entry-source-code-hou.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hou//hou.c">hou.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/hou/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_konno">
 <h2 id="winning-entry-2011konno">Winning entry: <a href="2011/konno/index.html">2011/konno</a></h2>
 <h3 id="winning-entry-source-code-konno.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno//konno.c">konno.c</a></h3>
 </div>
 <p>Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_richards">
 <h2 id="winning-entry-2011richards">Winning entry: <a href="2011/richards/index.html">2011/richards</a></h2>
 <h3 id="winning-entry-source-code-richards.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards//richards.c">richards.c</a></h3>
@@ -3623,6 +3861,7 @@ not be worth, as it is a possible starting point that Cody added.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards/try.alt.sh">try.alt.sh</a> scripts. The <code>try.alt.sh</code> script will be
 helpful to test any fixes for Apple silicon chips (see <a href="bugs.html#2011_richards">2011/richards in
 bugs.html</a> for more details).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_toledo">
 <h2 id="winning-entry-2011toledo">Winning entry: <a href="2011/toledo/index.html">2011/toledo</a></h2>
 <h3 id="winning-entry-source-code-toledo.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/toledo//toledo.c">toledo.c</a></h3>
@@ -3633,28 +3872,33 @@ version that should work in Windows, based on the author’s remarks and support
 file, <code>layer.c</code>.</p>
 <p>The <code>Makefile</code> was also modified by Cody to make it simpler to redefine the
 controls, width and height.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_vik">
 <h2 id="winning-entry-2011vik">Winning entry: <a href="2011/vik/index.html">2011/vik</a></h2>
 <h3 id="winning-entry-source-code-vik.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik//vik.c">vik.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/try.sh">try.sh</a> script.</p>
-<p>Cody also added an <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.alt.c">alternate version</a> for Windows
+<p>Cody also added an <a href="2011/vik/index.html#alternate-code">alternate version</a> for Windows
 based on the author’s comments (along with looking up the function for the right
 header files). To build try the <code>alt</code> rule of the <code>Makefile</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_zucker">
 <h2 id="winning-entry-2011zucker">Winning entry: <a href="2011/zucker/index.html">2011/zucker</a></h2>
 <h3 id="winning-entry-source-code-zucker.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/zucker//zucker.c">zucker.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/zucker/try.sh">try.sh</a> script.</p>
-<p>Cody also added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/zucker/zucker.alt.c">alternate code</a> that should work on
+<p>Cody also added <a href="2011/zucker/index.html#alternate-code">alternate
+code</a> that should work on
 Windows, based on the author’s remarks that if the system distinguishes binary
 and text then <code>stdout</code> needs to be set to binary mode.</p>
 <p>Cody also added the PDF file
 <a href="2011/zucker/sphere-tracing.pdf">sphere-tracing.pdf</a> in case the link
 eventually dies.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012">
 <h1 id="the-21st-ioccc"><a href="2012/index.html">2012 - The 21st IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_blakely">
 <h2 id="winning-entry-2012blakely">Winning entry: <a href="2012/blakely/index.html">2012/blakely</a></h2>
 <h3 id="winning-entry-source-code-blakely.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely//blakely.c">blakely.c</a></h3>
@@ -3662,11 +3906,13 @@ eventually dies.</p>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) as not all systems do this
 implicitly (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_deckmyn">
 <h2 id="winning-entry-2012deckmyn">Winning entry: <a href="2012/deckmyn/index.html">2012/deckmyn</a></h2>
 <h3 id="winning-entry-source-code-deckmyn.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn//deckmyn.c">deckmyn.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_endoh1">
 <h2 id="winning-entry-2012endoh1">Winning entry: <a href="2012/endoh1/index.html">2012/endoh1</a></h2>
 <h3 id="winning-entry-source-code-endoh1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1//endoh1.c">endoh1.c</a></h3>
@@ -3678,7 +3924,9 @@ let one control how fast the fluid moves (how long to sleep in between writes)
 and also the gravity factor, the pressure factor and the viscosity factor as
 well as an alarm that lets one run it in a loop without having to hit
 ctrl-c/intr in between (the alarm can be disabled, however). The <code>Makefile</code> allows
-one to easily do this with variable names rather than redefining <code>CDEFINE</code>.</p>
+one to easily do this with variable names rather than redefining <code>CDEFINE</code>. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>The two different alt versions is because there are two versions: the original
 and the colour version added by the author, <a href="#yusuke">Yusuke</a>, at the request of
 the judges.</p>
@@ -3686,7 +3934,9 @@ the judges.</p>
 the alternate code in two ways, one with setting the gravity factor to <code>I</code> and another
 with the default, and which is run on the source file and each of the text files
 supplied by the author. This code has an alarm set at 10 seconds so that one
-need not hit ctrl-c/intr in between .. say to make it more fluid :-)</p>
+need not hit ctrl-c/intr in between .. say to make it more fluid :-) See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1/try.alt.bw.sh">try.alt.bw.sh</a> which is the
 same as the <code>try.alt.sh</code> except it does not use the coloured version.</p>
 <p>Finally Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1/try.sh">try.sh</a> and
@@ -3695,6 +3945,7 @@ same as the <code>try.alt.sh</code> except it does not use the coloured version.
 version without colour, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1/endoh1.c">endoh1.c</a>.</p>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh1/endoh1.alt2.c">endoh1.alt2.c</a> was provided by the author,
 <a href="#yusuke">Yusuke</a>, at the time of the contest as a de-obfuscated version.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_endoh2">
 <h2 id="winning-entry-2012endoh2">Winning entry: <a href="2012/endoh2/index.html">2012/endoh2</a></h2>
 <h3 id="winning-entry-source-code-endoh2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh2//endoh2.c">endoh2.c</a></h3>
@@ -3703,6 +3954,7 @@ version without colour, <a href="https://github.com/ioccc-src/temp-test-ioccc/bl
 everything, filtered through less.</p>
 <p>Cody also fixed a typo in the ruby script
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/endoh2/find-font-table.rb">find-font-table.rb</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_grothe">
 <h2 id="winning-entry-2012grothe">Winning entry: <a href="2012/grothe/index.html">2012/grothe</a></h2>
 <h3 id="winning-entry-source-code-grothe.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/grothe//grothe.c">grothe.c</a></h3>
@@ -3711,8 +3963,7 @@ everything, filtered through less.</p>
 <p>Cody also changed <code>argv</code> to be not <code>const char **</code> but <code>char **</code>, mostly out of an
 abundance of caution in case <code>clang</code>, which already imposes restrictions on the
 types of args to <code>main()</code> including to do with <code>char **</code>, decides to further
-restrict them.</p>
-<p>See the
+restrict them. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Cody also restored the original code from the archive.</p>
@@ -3722,6 +3973,7 @@ to, in case the other domain ends up expiring or stops redirecting to the more
 recent domain. For historical purposes the old link was
 <code>http://recipes.stevex.net/</code> but it redirects to <code>https://www.mealsteps.com</code>
 which the recipe file now links to.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_hamano">
 <h2 id="winning-entry-2012hamano">Winning entry: <a href="2012/hamano/index.html">2012/hamano</a></h2>
 <h3 id="winning-entry-source-code-hamano.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hamano//hamano.c">hamano.c</a></h3>
@@ -3729,6 +3981,7 @@ which the recipe file now links to.</p>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hamano/try.sh">try.sh</a> script and the helper
 Makefile rules <code>hint.pdf</code>, <code>hint</code>, <code>hello.pdf</code> and <code>hello</code> to simplify the
 procedure for both <code>hint.pdf</code> and <code>hello.pdf</code> as well as compiling them as C.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_hou">
 <h2 id="winning-entry-2012hou">Winning entry: <a href="2012/hou/index.html">2012/hou</a></h2>
 <h3 id="winning-entry-source-code-hou.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/hou//hou.c">hou.c</a></h3>
@@ -3738,6 +3991,7 @@ markdown file</a> as the changes made when converting to a GitHub
 index.html made the generated html not look correct; it did not have a title, a
 stylesheet etc. due to the fact that there is no <code>#</code> header (which specified
 title and stylesheet) and other formatting changes.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_kang">
 <h2 id="winning-entry-2012kang">Winning entry: <a href="2012/kang/index.html">2012/kang</a></h2>
 <h3 id="winning-entry-source-code-kang.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/kang//kang.c">kang.c</a></h3>
@@ -3748,11 +4002,13 @@ title and stylesheet) and other formatting changes.</p>
 <p>In the German script it uses the umlaut for five (<code>fünf</code>) and also does it
 without the umlaut (add an ‘e’ i.e. <code>fuenf</code>). Notice how the program picks up on
 this!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_konno">
 <h2 id="winning-entry-2012konno">Winning entry: <a href="2012/konno/index.html">2012/konno</a></h2>
 <h3 id="winning-entry-source-code-konno.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/konno//konno.c">konno.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/konno/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_omoikane">
 <h2 id="winning-entry-2012omoikane">Winning entry: <a href="2012/omoikane/index.html">2012/omoikane</a></h2>
 <h3 id="winning-entry-source-code-omoikane.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane//omoikane.c">omoikane.c</a></h3>
@@ -3767,19 +4023,22 @@ on <code>stdin</code> and <code>stdout</code> which should theoretically make it
 comes from the author’s remarks.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/omoikane/try.alt.sh">try.alt.sh</a> scripts.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_tromp">
 <h2 id="winning-entry-2012tromp">Winning entry: <a href="2012/tromp/index.html">2012/tromp</a></h2>
 <h3 id="winning-entry-source-code-tromp.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp//tromp.c">tromp.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_vik">
 <h2 id="winning-entry-2012vik">Winning entry: <a href="2012/vik/index.html">2012/vik</a></h2>
 <h3 id="winning-entry-source-code-vik.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik//vik.c">vik.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/try.sh">try.sh</a> script.</p>
 <p>Based on the author’s description it should be possible to get this entry to work
-for Windows. With his instructions Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.alt.c">alternate
+for Windows. With his instructions Cody also added the <a href="2012/vik/index.html#alternate-code">alternate
 version</a> that does this.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_zeitak">
 <h2 id="winning-entry-2012zeitak">Winning entry: <a href="2012/zeitak/index.html">2012/zeitak</a></h2>
 <h3 id="winning-entry-source-code-zeitak.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak//zeitak.c">zeitak.c</a></h3>
@@ -3789,7 +4048,7 @@ version</a> that does this.</p>
 correctly be flagged as incorrect (including a text file and a Java file, with a
 joke, to show that it’s not that it parses C but rather just matching pairs
 though that’s probably obvious) and some correctly nested files were also added
-including <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/anonymous/index.html">1984/anonymous</a> (as the
+including <a href="1984/anonymous/index.html">1984/anonymous</a> (as the
 author explicitly mentioned it), both the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak/anonymous.alt.c">original
 version</a> (.alt.c) and the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/zeitak/anonymous.c">modified version</a> that works with macOS
@@ -3802,6 +4061,7 @@ variable that prevented compilation.</p>
 look at the program source with tab space of 4 characters so Cody added the
 command to do this in vim for those who use it, in the judges’ remarks, to make
 it easier for those who do not know how, and to make it more obvious to try it.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013">
 <h1 id="the-22nd-ioccc"><a href="2013/index.html">2013 - The 22nd IOCCC</a></h1>
 </div>
@@ -3821,16 +4081,19 @@ recommendations, except that Cody made it configurable at compile time. The
 compile time.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/birken/try.sh">try.sh</a> script for the entry and the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/birken/try.alt.sh">try.alt.sh</a> script for the alternate code.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_cable1">
 <h2 id="winning-entry-2013cable1">Winning entry: <a href="2013/cable1/index.html">2013/cable1</a></h2>
 <h3 id="winning-entry-source-code-cable1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable1//cable1.c">cable1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable1/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_cable2">
 <h2 id="winning-entry-2013cable2">Winning entry: <a href="2013/cable2/index.html">2013/cable2</a></h2>
 <h3 id="winning-entry-source-code-cable2.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2//cable2.c">cable2.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_cable3">
 <h2 id="winning-entry-2013cable3">Winning entry: <a href="2013/cable3/index.html">2013/cable3</a></h2>
 <h3 id="winning-entry-source-code-cable3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable3//cable3.c">cable3.c</a></h3>
@@ -3852,7 +4115,7 @@ entirely to solve the problem.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable3/cable3.sh">cable3.sh</a> for consistency with other entries that have
 wrapper scripts) to not assume that the program has been compiled by running
 <code>make clobber all || exit 1</code> and he also made it pass <code>shellcheck</code> (using <code>[[ .. ]]</code> over <code>[ .. ]</code>).</p>
-<p>As well, based on the author’s remarks, Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable3/cable3.alt.c">alternate
+<p>As well, based on the author’s remarks, Cody added the <a href="2013/cable3/index.html#alternate-code">alternate
 code</a> which should be compilable for Windows/MS Visual
 Studio. This is done by in the compile line undefining <code>KB</code> (<code>-UKB</code>) and then in
 the source code defining <code>KB</code> to what the author suggested,
@@ -3862,6 +4125,7 @@ this will not link in Unix systems (including macOS).</p>
 referred to, found at the <a href="https://github.com/adriancable/8086tiny/tree/master">GitHub repo for the
 entry</a>, and the <code>ready-made 40MB hard disk image containing a whole bunch of software</code> in <code>hd.img</code> that the
 author linked to at <code>https://bitly.com/1bU8URK</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_dlowe">
 <h2 id="winning-entry-2013dlowe">Winning entry: <a href="2013/dlowe/index.html">2013/dlowe</a></h2>
 <h3 id="winning-entry-source-code-dlowe.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe//dlowe.c">dlowe.c</a></h3>
@@ -3882,11 +4146,13 @@ the symlink as it uses it, even though it runs <code>make clobber all</code>.</p
 program.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/diff.sh">diff.sh</a> script which is based on some
 commands to try that he suggested to see how different lengths look.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh1">
 <h2 id="winning-entry-2013endoh1">Winning entry: <a href="2013/endoh1/index.html">2013/endoh1</a></h2>
 <h3 id="winning-entry-source-code-endoh1.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1//endoh1.c">endoh1.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh2">
 <h2 id="winning-entry-2013endoh2">Winning entry: <a href="2013/endoh2/index.html">2013/endoh2</a></h2>
 <h3 id="winning-entry-source-code-endoh2.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh2//endoh2.c">endoh2.c</a></h3>
@@ -3903,16 +4169,17 @@ checking these requirements it will exit if either is not found.</p>
 where it comes from it will appear to be an error in the Ruby script (it might
 also appear to be an issue with the script even if you know of <code>convert</code>).</p>
 <p>The entry can still be enjoyed if you do not have these tools, however.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh3">
 <h2 id="winning-entry-2013endoh3">Winning entry: <a href="2013/endoh3/index.html">2013/endoh3</a></h2>
 <h3 id="winning-entry-source-code-endoh3.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3//endoh3.c">endoh3.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/try.sh">try.sh</a> script.</p>
 <p>Cody also (out of an abundance of caution for <code>clang(1)</code> which is strict with
-arg type and count to <code>main()</code>) added a second (unused) arg to <code>main()</code>.</p>
-<p>See the
+arg type and count to <code>main()</code>) added a second (unused) arg to <code>main()</code>. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh4">
 <h2 id="winning-entry-2013endoh4">Winning entry: <a href="2013/endoh4/index.html">2013/endoh4</a></h2>
 <h3 id="winning-entry-source-code-endoh4.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4//endoh4.c">endoh4.c</a></h3>
@@ -3926,6 +4193,7 @@ pass more than one file to the script.</p>
 <p>Cody also made it easier to redefine the size at compilation time (see the
 author’s remarks for more details on what this means). The <code>endoh4.sh</code> script
 allows one to redefine it as well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_hou">
 <h2 id="winning-entry-2013hou">Winning entry: <a href="2013/hou/index.html">2013/hou</a></h2>
 <h3 id="winning-entry-source-code-hou.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou//hou.c">hou.c</a></h3>
@@ -3949,9 +4217,10 @@ does not).</p>
 rule in the <code>Makefile</code> was originally removed as part of the above but it was
 restored so that one can see what the author is talking about.</p>
 <p>Further, after the file <code>2013/hou/doc/example.markdown</code> was moved to
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/doc/example.md">2013/hou/doc/example.md</a> to match the rest of the repo
-this broke <code>make</code> which Cody also fixed.</p>
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/doc/example.md">2013/hou/doc/example.md</a> by us, to match
+the rest of the repo, <code>make</code> was broken, which Cody fixed.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_mills">
 <h2 id="winning-entry-2013mills">Winning entry: <a href="2013/mills/index.html">2013/mills</a></h2>
 <h2 id="source-code-mills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">mills.c</a></h2>
@@ -3962,11 +4231,13 @@ after the first call to <code>close(2)</code>. The problem was that because the 
 The backlog was changed to <code>10</code> and this solves the problem. It is not known if
 this was specific to macOS but it was not specific to a browser as Safari and
 Firefox both had the problem.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_misaka">
 <h2 id="winning-entry-2013misaka">Winning entry: <a href="2013/misaka/index.html">2013/misaka</a></h2>
 <h3 id="winning-entry-source-code-misaka.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/misaka//misaka.c">misaka.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/misaka/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_morgan1">
 <h2 id="winning-entry-2013morgan1">Winning entry: <a href="2013/morgan1/index.html">2013/morgan1</a></h2>
 <h3 id="winning-entry-source-code-morgan1.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/morgan1//morgan1.c">morgan1.c</a></h3>
@@ -3974,26 +4245,30 @@ Firefox both had the problem.</p>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) as not all systems do this
 implicitly (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/morgan1/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_robison">
 <h2 id="winning-entry-2013robison">Winning entry: <a href="2013/robison/index.html">2013/robison</a></h2>
 <h3 id="winning-entry-source-code-robison.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/robison//robison.c">robison.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/robison/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014">
 <h1 id="the-23rd-ioccc"><a href="2014/index.html">2014 - The 23rd IOCCC</a></h1>
 </div>
 <p><a href="#yusuke">Yusuke</a> added the missing <code>rules.txt</code>, <code>iocccsize.c</code> and <code>iocccsize.mk</code> files.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_birken">
 <h2 id="winning-entry-2014birken">Winning entry: <a href="2014/birken/index.html">2014/birken</a></h2>
 <h3 id="winning-entry-source-code-prog.c">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/birken//prog.c">prog.c</a></h3>
 </div>
-<p><a href="#cody">Cody</a> provided the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/birken/prog.alt.c">alternate
+<p><a href="#cody">Cody</a> provided the <a href="2014/birken/index.html#alternate-code">alternate
 code</a> that lets one redefine the port to
 bind to in case there is a firewall issue or there is some other reason to not
 have the default port. Remember that ports &lt; 1024 are privileged. It also lets
 you redefine the timing constant <code>STARDATE</code> (see the author’s remarks for more
 details on this macro). The <code>Makefile</code> was made to use variables so it’s easier to
 redefine the port and timing constant.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_deak">
 <h2 id="winning-entry-2014deak">Winning entry: <a href="2014/deak/index.html">2014/deak</a></h2>
 <h3 id="winning-entry-source-code-prog.c-1">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/deak//prog.c">prog.c</a></h3>
@@ -4006,12 +4281,15 @@ be what the program would look like if, as the author put it:</p>
 <p>The usage of recognizable elements from the C programming language in the
 application source code is intentionally kept to a bare minimum.</p>
 </blockquote>
-<p>.. was not true.</p>
+<p>.. was not true. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>This alternate version did not originally compile because a value was left off the
 <code>return</code> statement (this might have been fixed in the index.html file too) so
 that was fixed and it also has <code>#include &lt;stdio.h&gt;</code> for <code>putchar(3)</code>. The
 <code>#ifndef..#define..#endif</code> was not part of the original alternate code, of course.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/deak/try.alt.sh">try.alt.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_endoh1">
 <h2 id="winning-entry-2014endoh1">Winning entry: <a href="2014/endoh1/index.html">2014/endoh1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-2">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh1//prog.c">prog.c</a></h3>
@@ -4025,17 +4303,17 @@ install <code>gem</code>. Then it tells you how to install <code>rake</code>. If
 then it tells you to install a specific gem and then to try again. Finally if
 <code>rake</code> succeeds it will verify that <code>prog</code> is executable and if it is it will
 run it.</p>
-<p>After more work on the manifest was done Cody had to update the <code>clobber</code> rule
-to remove some text files so as to not cause problems with an invalid manifest.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh1/try.sh">try.sh</a> script.</p>
 <p>To silence the annoying misleading indentation warning and to prevent debug
 symbols from being built with <code>rake</code> Cody also updated the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh1/Rakefile">Rakefile</a> slightly.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_endoh2">
 <h2 id="winning-entry-2014endoh2">Winning entry: <a href="2014/endoh2/index.html">2014/endoh2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-3">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/endoh2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_maffiodo1">
 <h2 id="winning-entry-2014maffiodo1">Winning entry: <a href="2014/maffiodo1/index.html">2014/maffiodo1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-4">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1//prog.c">prog.c</a></h3>
@@ -4047,18 +4325,21 @@ symbols from being built with <code>rake</code> Cody also updated the
 Mario Bros</a> and one of <a href="http://en.wikipedia.org/wiki/The_Great_Giana_Sisters">The
 Great Giana Sisters</a>, but
 which let one configure the width and height of the game.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_maffiodo2">
 <h2 id="winning-entry-2014maffiodo2">Winning entry: <a href="2014/maffiodo2/index.html">2014/maffiodo2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-5">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/try.sh">try.sh</a> script.</p>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.alt.c">alternate code</a>
+<p>Cody also added the <a href="2014/maffiodo2/index.html#alternate-code">alternate code</a>
 provided by the author.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_morgan">
 <h2 id="winning-entry-2014morgan">Winning entry: <a href="2014/morgan/index.html">2014/morgan</a></h2>
 <h3 id="winning-entry-source-code-prog.c-6">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/morgan//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/morgan/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_sinon">
 <h2 id="winning-entry-2014sinon">Winning entry: <a href="2014/sinon/index.html">2014/sinon</a></h2>
 <h3 id="winning-entry-source-code-prog.c-7">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/sinon//prog.c">prog.c</a></h3>
@@ -4074,6 +4355,7 @@ which overwrites it with output that is not code.</p>
 is installed) run the demo mode and then after that it will run the above noted
 scripts in a loop until the user says they do not want to try again (or they
 kill it). This is done this way in case it jams (see index.html for details).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_skeggs">
 <h2 id="winning-entry-2014skeggs">Winning entry: <a href="2014/skeggs/index.html">2014/skeggs</a></h2>
 <h3 id="winning-entry-source-code-prog.c-8">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/skeggs//prog.c">prog.c</a></h3>
@@ -4089,6 +4371,7 @@ originally done because it seemed to work but since it uses <code>dlsym()</code>
 added later to make it more portable.</p>
 <p>The program creates files in the working directory as part of how it works (see
 the index.html file for details) so Cody made sure that <code>make clobber</code> (via <code>make clean</code>) removes those files and so that they are ignored by <code>.gitignore</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_vik">
 <h2 id="winning-entry-2014vik">Winning entry: <a href="2014/vik/index.html">2014/vik</a></h2>
 <h3 id="winning-entry-source-code-prog.c-9">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik//prog.c">prog.c</a></h3>
@@ -4100,6 +4383,7 @@ translation of the raw audio to text is buggy in some cases.</p>
 theoretically work for Microsoft Windows compilers (if anything works in Windows
 :-) ). We have no way of testing this and if anything has changed since 2014
 that would break it we do not know.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_wiedijk">
 <h2 id="winning-entry-2014wiedijk">Winning entry: <a href="2014/wiedijk/index.html">2014/wiedijk</a></h2>
 <h3 id="winning-entry-source-code-prog.c-10">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/wiedijk//prog.c">prog.c</a></h3>
@@ -4110,9 +4394,11 @@ specify what <code>indent</code> tool they want to use and also change which <co
 should they want to. It also checks that both of these two tools exist and are
 executable and it pipes it through <code>less(1)</code> as it’s longer than a page worth of
 output.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015">
 <h1 id="the-24th-ioccc"><a href="2015/index.html">2015 - The 24th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_burton">
 <h2 id="winning-entry-2015burton">Winning entry: <a href="2015/burton/index.html">2015/burton</a></h2>
 <h3 id="winning-entry-source-code-prog.c-11">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/burton//prog.c">prog.c</a></h3>
@@ -4142,25 +4428,29 @@ to not have to maintain two copies of the same text.</p>
 <code>calc.alt</code>. <code>ecalc</code> and <code>ecalc.alt</code> also work. This is because the program is
 called <code>calc</code> and is in documentation including the man page. Thus one only need
 add a <code>./</code> to the commands in the man page/index.html.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_dogon">
 <h2 id="winning-entry-2015dogon">Winning entry: <a href="2015/dogon/index.html">2015/dogon</a></h2>
 <h3 id="winning-entry-source-code-prog.c-12">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/dogon//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> improved the <code>Makefile</code> so that one can easily change the dimensions
 at compilation time via <code>make(1)</code>.</p>
-<p>Cody also added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/dogon/prog.alt.c">alternate code</a> that is
+<p>Cody also added <a href="2015/dogon/index.html#alternate-code">alternate code</a> that is
 based on the author’s remarks, suggesting that one change the value of <code>q</code> to a
 different number, in order to see a bug that they avoided.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_duble">
 <h2 id="winning-entry-2015duble">Winning entry: <a href="2015/duble/index.html">2015/duble</a></h2>
 <h3 id="winning-entry-source-code-prog.c-13">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/duble//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/duble/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_endoh2">
 <h2 id="winning-entry-2015endoh2">Winning entry: <a href="2015/endoh2/index.html">2015/endoh2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-14">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_endoh3">
 <h2 id="winning-entry-2015endoh3">Winning entry: <a href="2015/endoh3/index.html">2015/endoh3</a></h2>
 <h3 id="winning-entry-source-code-prog.c-15">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh3//prog.c">prog.c</a></h3>
@@ -4173,11 +4463,13 @@ use of the make rule he added (to enjoy the theme of the entry, <a href="https:/
 Future</a> using this entry by
 simply typing <code>make back_to</code>, <code>make future</code> or <code>make mullender</code>) and then runs
 the famous <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">1984/mullender.c</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_endoh4">
 <h2 id="winning-entry-2015endoh4">Winning entry: <a href="2015/endoh4/index.html">2015/endoh4</a></h2>
 <h3 id="winning-entry-source-code-prog.c-16">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh4//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/endoh4/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_hou">
 <h2 id="winning-entry-2015hou">Winning entry: <a href="2015/hou/index.html">2015/hou</a></h2>
 <h3 id="winning-entry-source-code-prog.c-17">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou//prog.c">prog.c</a></h3>
@@ -4189,6 +4481,7 @@ which the <code>try.sh</code> script uses.</p>
 <p>Cody also added the RFC 1321 text file, <a href="2015/hou/rfc1321.txt">rfc1321.txt</a> to
 the directory, to make it so one need not download it, and which the index.html
 file now links to.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_howe">
 <h2 id="winning-entry-2015howe">Winning entry: <a href="2015/howe/index.html">2015/howe</a></h2>
 <h3 id="winning-entry-source-code-prog.c-18">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe//prog.c">prog.c</a></h3>
@@ -4206,22 +4499,26 @@ addition prompted the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob
 <p>The fact there are alternate versions necessitated the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe/prog.alt-test.sh">prog.alt-test.sh</a> which Cody added as
 well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_mills1">
 <h2 id="winning-entry-2015mills1">Winning entry: <a href="2015/mills1/index.html">2015/mills1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-19">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills1/try.sh">try.sh</a> script which changes the
 parameters to what we had in the judges’ remarks to make it easier.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_mills2">
 <h2 id="winning-entry-2015mills2">Winning entry: <a href="2015/mills2/index.html">2015/mills2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-20">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_muth">
 <h2 id="winning-entry-2015muth">Winning entry: <a href="2015/muth/index.html">2015/muth</a></h2>
 <h3 id="winning-entry-source-code-prog.c-21">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/muth//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/muth/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_schweikhardt">
 <h2 id="winning-entry-2015schweikhardt">Winning entry: <a href="2015/schweikhardt/index.html">2015/schweikhardt</a></h2>
 <h3 id="winning-entry-source-code-prog.c-22">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt//prog.c">prog.c</a></h3>
@@ -4231,6 +4528,7 @@ this. It was decided by Cody to do <code>-UEOF -DEOF=-1</code> so as to not have
 the code any with C preprocessor directives (the preferred way) or changing
 <code>EOF</code> to <code>-1</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_yang">
 <h2 id="winning-entry-2015yang">Winning entry: <a href="2015/yang/index.html">2015/yang</a></h2>
 <h3 id="winning-entry-source-code-prog.c-23">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/yang//prog.c">prog.c</a></h3>
@@ -4240,22 +4538,26 @@ files from compiling properly, trying instead to compile already compiled code.<
 <p>He also added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux seems to not but macOS does).</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/yang/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018">
 <h1 id="the-25th-ioccc"><a href="2018/index.html">2018 - The 25th IOCCC</a></h1>
 </div>
 <p><a href="#cody">Cody</a> added the missing <code>README.md</code> file from the winner archive back to
 the repo.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_anderson">
 <h2 id="winning-entry-2018anderson">Winning entry: <a href="2018/anderson/index.html">2018/anderson</a></h2>
 <h3 id="winning-entry-source-code-prog.c-24">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/anderson/try.alt.sh">try.alt.sh</a> scripts.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_algmyr">
 <h2 id="winning-entry-2018algmyr">Winning entry: <a href="2018/algmyr/index.html">2018/algmyr</a></h2>
 <h3 id="winning-entry-source-code-prog.c-25">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_bellard">
 <h2 id="winning-entry-2018bellard">Winning entry: <a href="2018/bellard/index.html">2018/bellard</a></h2>
 <h3 id="winning-entry-source-code-prog.c-26">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/bellard//prog.c">prog.c</a></h3>
@@ -4265,16 +4567,16 @@ the repo.</p>
 some versions of <code>clang</code> object to the number of args of <code>main()</code>, saying that it
 must be 0, 2 or 3. The version this has been observed in does not actually
 object to 1 arg but it is entirely possible that this changes so a second arg
-(that’s not needed and is unused) has been added just in case.</p>
-<p>See the
+(that’s not needed and is unused) has been added just in case. See the
 FAQ on “<a href="faq.html#arg_count">main function args</a>”
 for more details.</p>
 <p>Cody also added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux doesn’t seem to but macOS does).</p>
-<p>Cody also added <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/bellard/prog.alt.c">alternate code</a> that should
+<p>Cody also added <a href="2018/bellard/index.html#alternate-code">alternate code</a> that should
 work for Windows, based on the author’s remarks. The same thing with the number
 of args to <code>main()</code> that was done in the original entry was done with this
 version as well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_burton1">
 <h2 id="winning-entry-2018burton1">Winning entry: <a href="2018/burton1/index.html">2018/burton1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-27">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1//prog.c">prog.c</a></h3>
@@ -4283,6 +4585,7 @@ version as well.</p>
 script (it referred to <code>prog</code> not <code>./prog</code>).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1/try.sh">try.sh</a> script which also uses
 <code>scripthd.sh</code> to show how it differs from <code>prog</code> itself.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_burton2">
 <h2 id="winning-entry-2018burton2">Winning entry: <a href="2018/burton2/index.html">2018/burton2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-28">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2//prog.c">prog.c</a></h3>
@@ -4295,6 +4598,7 @@ file <code>tac.1</code>.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2/tokcount.sh">tokcount.sh</a> script which was
 included in the remarks of the author but not an included file.</p>
 <p>Finally Cody added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_ciura">
 <h2 id="winning-entry-2018ciura">Winning entry: <a href="2018/ciura/index.html">2018/ciura</a></h2>
 <h3 id="winning-entry-source-code-prog.c-29">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ciura//prog.c">prog.c</a></h3>
@@ -4303,6 +4607,7 @@ included in the remarks of the author but not an included file.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ciura/try.alt.sh">try.alt.sh</a> scripts and the PDF file,
 <a href="2018/ciura/lexicon.pdf">lexicon.pdf</a>, that was a dead link, restored from the
 Internet Wayback Machine.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_endoh1">
 <h2 id="winning-entry-2018endoh1">Winning entry: <a href="2018/endoh1/index.html">2018/endoh1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-30">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh1//prog.c">prog.c</a></h3>
@@ -4314,6 +4619,7 @@ the user they should open it in a GIF viewer that can show animation in animated
 GIF files. It offers an example command for macOS like the judges did in their
 remarks. The input files offered includes the <code>prog.c</code> as the author,
 <a href="#yusuke">Yusuke</a>, suggested that it too has a secret.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_endoh2">
 <h2 id="winning-entry-2018endoh2">Winning entry: <a href="2018/endoh2/index.html">2018/endoh2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-31">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/endoh2//prog.c">prog.c</a></h3>
@@ -4326,6 +4632,7 @@ three of the other scripts but each allows one to send an interrupt in the loops
 and still continue to the next script (if one does it when not in a loop it will
 exit the script). The <code>make python</code> and <code>make python3</code> rules in the <code>Makefile</code> now
 run the respective scripts.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_hou">
 <h2 id="winning-entry-2018hou">Winning entry: <a href="2018/hou/index.html">2018/hou</a></h2>
 <h3 id="winning-entry-source-code-prog.c-32">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou//prog.c">prog.c</a></h3>
@@ -4333,6 +4640,7 @@ run the respective scripts.</p>
 <p><a href="#cody">Cody</a> added explicit linking of libm (<code>-lm</code>) for systems that do not do this
 (Linux doesn’t seem to but macOS does).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_mills">
 <h2 id="winning-entry-2018mills">Winning entry: <a href="2018/mills/index.html">2018/mills</a></h2>
 <h3 id="winning-entry-source-code-prog.c-33">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/mills//prog.c">prog.c</a></h3>
@@ -4345,6 +4653,7 @@ run) enter and then exit and then start the program again. Also if you do add a
 file you should run <code>sync</code> prior to exiting or else the file might not exist or
 it might be corrupt. See <a href="bugs.html#2018_mills">2018/mills in bugs.html</a> for more
 details on the bug.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_poikola">
 <h2 id="winning-entry-2018poikola">Winning entry: <a href="2018/poikola/index.html">2018/poikola</a></h2>
 <h3 id="winning-entry-source-code-prog.c-34">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/poikola//prog.c">prog.c</a></h3>
@@ -4356,11 +4665,13 @@ file. The rule requires the tool <code>pdflatex</code>.</p>
 problem where the macOS <code>Terminal.app</code> does not work properly for this program.
 We added some additional notes on what might happen (it varies depending on
 configuration).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_vokes">
 <h2 id="winning-entry-2018vokes">Winning entry: <a href="2018/vokes/index.html">2018/vokes</a></h2>
 <h3 id="winning-entry-source-code-prog.c-35">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_yang">
 <h2 id="winning-entry-2018yang">Winning entry: <a href="2018/yang/index.html">2018/yang</a></h2>
 <h3 id="winning-entry-source-code-prog.c-36">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/yang//prog.c">prog.c</a></h3>
@@ -4368,9 +4679,11 @@ configuration).</p>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/yang/try.sh">try.sh</a> script. This script will ask
 if the user wants to see some of the deobfuscation information and only show them if they type
 <code>y</code> or <code>Y</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019">
 <h1 id="the-26th-ioccc"><a href="2019/index.html">2019 - The 26th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_adamovsky">
 <h2 id="winning-entry-2019adamovsky">Winning entry: <a href="2019/adamovsky/index.html">2019/adamovsky</a></h2>
 <h3 id="winning-entry-source-code-prog.c-37">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky//prog.c">prog.c</a></h3>
@@ -4378,6 +4691,7 @@ if the user wants to see some of the deobfuscation information and only show the
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/try.sh">try.sh</a> script and the Unlambda
 file <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/crash.unl">crash.unl</a> which is in the judges’ remarks as
 to what can crash it - but it’s not a bug, it’s a feature.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_burton">
 <h2 id="winning-entry-2019burton">Winning entry: <a href="2019/burton/index.html">2019/burton</a></h2>
 <h3 id="winning-entry-source-code-prog.c-38">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton//prog.c">prog.c</a></h3>
@@ -4389,10 +4703,13 @@ side-by-side comparison on several files of the entry and <code>wc(1)</code> as 
 running <code>make test</code>.</p>
 <p>Cody also fixed the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/check.sh">check.sh</a> in case
 <code>x</code> is specified and is not executable and also made it satisfy ShellCheck.
-ShellCheck was fixed to not be a
-<a href="https://en.wikipedia.org/wiki/Cattle">cow</a> and/or (to use <a href="https://simpsons.fandom.com/wiki/Bart_Simpson">Bart
-Simpson</a>‘s advice :-) )’<a href="https://en.wikipedia.org/wiki/Don%27t_have_a_cow">not have a cow</a>’ about certain things (including one thing it was wrong about)
-in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/cow.sh">cow.sh</a> <del>moo</del>too.</p>
+ShellCheck was fixed to not be a <a href="https://en.wikipedia.org/wiki/Cattle">cow</a>
+and/or (to use <a href="https://simpsons.fandom.com/wiki/Bart_Simpson">Bart Simpson</a>‘s
+advice :-) )’<a href="https://en.wikipedia.org/wiki/Don%27t_have_a_cow">not have a
+cow</a>’ about certain things
+(including one thing it was wrong about) in
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/cow.sh">cow.sh</a> <del>moo</del>too.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_ciura">
 <h2 id="winning-entry-2019ciura">Winning entry: <a href="2019/ciura/index.html">2019/ciura</a></h2>
 <h3 id="winning-entry-source-code-prog.c-39">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura//prog.c">prog.c</a></h3>
@@ -4411,6 +4728,7 @@ website.</p>
 <p>Finally he added the scripts for the different languages that use the alternate
 version but with the caveat that only English appears to work. Again, see <a href="bugs.html#2019_ciura">2019/ciura in
 bugs.html</a> for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_diels-grabsch1">
 <h2 id="winning-entry-2019diels-grabsch1">Winning entry: <a href="2019/diels-grabsch1/index.html">2019/diels-grabsch1</a></h2>
 <h3 id="winning-entry-source-code-prog.c-40">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch1//prog.c">prog.c</a></h3>
@@ -4418,9 +4736,9 @@ bugs.html</a> for more details.</p>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch1/try.sh">try.sh</a> script.</p>
 <p>Cody also added the file <a href="2019/diels-grabsch1/Shakespeare.txt">Shakespeare.txt</a>
 from <a href="2019/mills/index.html">2019/mills</a> (after running <code>make</code>) so that one can
-not worry about having the entire IOCCC winning entry tree (or at least the 2019 tree each
-entry in a subdirectory). This was important as we now have tarballs for each
-entry by themselves.</p>
+not worry about having the entire IOCCC winning entry tree (or at least the 2019
+tree). This was important as we now have tarballs for each entry by themselves.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_diels-grabsch2">
 <h2 id="winning-entry-2019diels-grabsch2">Winning entry: <a href="2019/diels-grabsch2/index.html">2019/diels-grabsch2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-41">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/diels-grabsch2//prog.c">prog.c</a></h3>
@@ -4430,6 +4748,7 @@ script. This script will try and show the difference (i.e. the same output)
 between the program and the result of <code>sha512sum</code> or <code>shasum -a 512</code>, if these
 tools can be found, or otherwise just run the program itself, showing its own
 <a href="https://en.wikipedia.org/wiki/SHA-2">sha512</a> value.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_dogon">
 <h2 id="winning-entry-2019dogon">Winning entry: <a href="2019/dogon/index.html">2019/dogon</a></h2>
 <h3 id="winning-entry-source-code-prog.c-42">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/dogon//prog.c">prog.c</a></h3>
@@ -4444,6 +4763,7 @@ time by improving the <code>Makefile</code>.</p>
 that this was done (some typos were fixed as well but only some - the purpose
 was to only correct spelling and only some, not to change wording or anything
 else).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_duble">
 <h2 id="winning-entry-2019duble">Winning entry: <a href="2019/duble/index.html">2019/duble</a></h2>
 <h3 id="winning-entry-source-code-prog.c-43">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble//prog.c">prog.c</a></h3>
@@ -4457,6 +4777,7 @@ an easy way to tell the user how to compile it, assuming that the environmental
 variables <code>LINES</code> and <code>COLUMNS</code> are set. But even if they’re not set it explains
 how to easily compile the program to a specific size. Note that <code>LINES</code> and
 <code>COLUMNS</code> is not available to scripts so it can’t make use of them that way.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_endoh">
 <h2 id="winning-entry-2019endoh">Winning entry: <a href="2019/endoh/index.html">2019/endoh</a></h2>
 <h3 id="winning-entry-source-code-prog.c-44">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh//prog.c">prog.c</a></h3>
@@ -4470,11 +4791,13 @@ arg) prints out the character of the ASCII value (uses <code>isascii(3)</code> f
 combined with the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/try.sh">try.sh</a> script that he added allows one
 to easily reconstruct the source code through GDB by the fact it’s a backtrace
 quine.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_giles">
 <h2 id="winning-entry-2019giles">Winning entry: <a href="2019/giles/index.html">2019/giles</a></h2>
 <h3 id="winning-entry-source-code-prog.c-45">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/giles//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/giles/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_karns">
 <h2 id="winning-entry-2019karns">Winning entry: <a href="2019/karns/index.html">2019/karns</a></h2>
 <h3 id="winning-entry-source-code-prog.c-46">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns//prog.c">prog.c</a></h3>
@@ -4485,6 +4808,7 @@ that the author reported where it sometimes segfaults but Cody did not try
 debugging it since it works with <code>-O0</code>.)</p>
 <p>He also added the script <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/try.sh">try.sh</a> to showcase the entry a
 bit more easily.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_lynn">
 <h2 id="winning-entry-2019lynn">Winning entry: <a href="2019/lynn/index.html">2019/lynn</a></h2>
 <h3 id="winning-entry-source-code-prog.c-47">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn//prog.c">prog.c</a></h3>
@@ -4494,11 +4818,13 @@ bit more easily.</p>
 <a href="2019/lynn/example-2.txt">example-2.txt</a> text files from
 <a href="2018/vokes/index.html">2018/vokes</a> so that the entry does not rely on any other
 entry existing.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_mills">
 <h2 id="winning-entry-2019mills">Winning entry: <a href="2019/mills/index.html">2019/mills</a></h2>
 <h3 id="winning-entry-source-code-prog.c-48">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_poikola">
 <h2 id="winning-entry-2019poikola">Winning entry: <a href="2019/poikola/index.html">2019/poikola</a></h2>
 <h3 id="winning-entry-source-code-prog.c-49">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola//prog.c">prog.c</a></h3>
@@ -4506,8 +4832,10 @@ entry existing.</p>
 <p><a href="#cody">Cody</a> added the missing <code>docs</code> rule to the <code>Makefile</code> that forms a PDF
 file. The rule requires the tool
 <a href="https://tug.org/applications/pdftex/index.html">pdflatex</a>.</p>
-<p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.alt.c">alternate code</a> which
-adds a newline after each number for parsing in additional ways.</p>
+<p>Cody also added the <a href="2019/poikola/index.html#alternate-code">alternate code</a> which
+adds a newline after each number for parsing in additional ways. See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/try.alt.sh">try.alt.sh</a> scripts.</p>
 <p>Cody also disabled the optimiser because the author stated that for <code>clang</code> the
@@ -4516,6 +4844,7 @@ suggesting that with some versions of <code>GCC</code> it might not be correct w
 0 and since 0 works with <code>clang</code> that’s okay. Similarly, the same for C standards
 tested: <code>gnu17</code> was not tested but <code>gnu11</code> was so the standard was set to
 <code>gnu11</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_yang">
 <h2 id="winning-entry-2019yang">Winning entry: <a href="2019/yang/index.html">2019/yang</a></h2>
 <h3 id="winning-entry-source-code-prog.c-50">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang//prog.c">prog.c</a></h3>
@@ -4524,9 +4853,11 @@ tested: <code>gnu17</code> was not tested but <code>gnu11</code> was so the stan
 slightly updating the <a href="2019/yang/sample_input.txt">sample_input.txt</a> file
 (removed trailing newlines as it resulted in <code>diff</code> showing differences when it
 shouldn’t) and adding the <a href="2019/yang/ioccc.txt">ioccc.txt</a> file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020">
 <h1 id="the-27th-ioccc"><a href="2020/index.html">2020 - The 27th IOCCC</a></h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_burton">
 <h2 id="winning-entry-2020burton">Winning entry: <a href="2020/burton/index.html">2020/burton</a></h2>
 <h3 id="winning-entry-source-code-prog.c-51">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton//prog.c">prog.c</a></h3>
@@ -4538,6 +4869,7 @@ assumed that <code>prog_be</code> was in <code>PATH</code> which is unlikely so 
 Endian counterpart) so that it shows that the files are identical rather than
 showing nothing at all.</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_carlini">
 <h2 id="winning-entry-2020carlini">Winning entry: <a href="2020/carlini/index.html">2020/carlini</a></h2>
 <h3 id="winning-entry-source-code-prog.c-52">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini//prog.c">prog.c</a></h3>
@@ -4546,6 +4878,7 @@ showing nothing at all.</p>
 first glance might not appear to have a point, it actually does, namely showing
 how you can automate play and then reminding you to actually play for real, with
 a friend, whether that’s real or imagined.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_endoh2">
 <h2 id="winning-entry-2020endoh2">Winning entry: <a href="2020/endoh2/index.html">2020/endoh2</a></h2>
 <h3 id="winning-entry-source-code-prog.c-53">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2//prog.c">prog.c</a></h3>
@@ -4556,6 +4889,7 @@ longer known (but fortunately was already extracted). These files, originally
 put in <code>spoiler/</code> were moved to
 <a href="2020/endoh2/obfuscation/index.html">obfuscation/</a>.</p>
 <p>He also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh2/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_endoh3">
 <h2 id="winning-entry-2020endoh3">Winning entry: <a href="2020/endoh3/index.html">2020/endoh3</a></h2>
 <h3 id="winning-entry-source-code-prog.c-54">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3//prog.c">prog.c</a></h3>
@@ -4581,16 +4915,10 @@ problem in any system).</p>
 <p>Cody also added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3/run_clock.alt.sh">run_clock.alt.sh</a> script
 which is analogous to the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/endoh3/run_clock.sh">run_clock.sh</a> but for the
 alternate code provided by the author, Yusuke.</p>
-<div id="2020_ferguson1">
-<h2 id="winning-entry-2020ferguson1">Winning entry: <a href="2020/ferguson1/index.html">2020/ferguson1</a></h2>
-<h3 id="winning-entry-source-code-prog.c-55">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1//prog.c">prog.c</a></h3>
-</div>
-<p>Just for awareness: <a href="#cody">Cody</a> made some corrections to the vital <a href="2020/ferguson1/chocolate-cake.html">Double
-layered chocolate fudge cake recipe</a> :-)
-Other fixes were made but as it’s his entry it’s not worth noting.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_giles">
 <h2 id="winning-entry-2020giles">Winning entry: <a href="2020/giles/index.html">2020/giles</a></h2>
-<h3 id="winning-entry-source-code-prog.c-56">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-55">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/try.sh">try.sh</a> script. This script does
 the conversion of <code>pi.wav</code> (showing the digits) and also converts the number for
@@ -4601,14 +4929,16 @@ perfect.</p>
 neither are installed it warns the user about this, linking to the FAQ about it,
 and tells them they will have to play the WAV files manually. Otherwise it’ll
 use the program to play the WAV files (and in one case <code>stdout</code>).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_kurdyukov1">
 <h2 id="winning-entry-2020kurdyukov1">Winning entry: <a href="2020/kurdyukov1/index.html">2020/kurdyukov1</a></h2>
-<h3 id="winning-entry-source-code-prog.c-57">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov1//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-56">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov1//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov1/try.sh">try.sh</a> script.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_kurdyukov2">
 <h2 id="winning-entry-2020kurdyukov2">Winning entry: <a href="2020/kurdyukov2/index.html">2020/kurdyukov2</a></h2>
-<h3 id="winning-entry-source-code-prog.c-58">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov2//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-57">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov2//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov2/try.sh">try.sh</a> script.</p>
 <p>Cody also added <code>-L</code>/<code>-I</code> paths to the <code>Makefile</code> to let this compile more easily if
@@ -4620,17 +4950,18 @@ of ways: <code>shellcheck(1)</code>, make sure the program is compiled first (al
 specify which compiler to use with <code>CC=foo ./makegif.sh ...</code>), checking that
 <code>convert(1)</code> is found and that it worked properly (linking to the proper FAQ
 entry if not installed or it fails).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_kurdyukov3">
 <h2 id="winning-entry-2020kurdyukov3">Winning entry: <a href="2020/kurdyukov3/index.html">2020/kurdyukov3</a></h2>
-<h3 id="winning-entry-source-code-prog.c-59">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov3//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-58">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov3//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov3/try.sh">try.sh</a> script.</p>
 <p>He also added a link that has much more details about this phenomenon to the
-index.html. Naturally he’s one of the ones who can read text even if it’s even
-more jumbled but we know of others too.</p>
+index.html.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_kurdyukov4">
 <h2 id="winning-entry-2020kurdyukov4">Winning entry: <a href="2020/kurdyukov4/index.html">2020/kurdyukov4</a></h2>
-<h3 id="winning-entry-source-code-prog.c-60">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-59">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/kurdyukov4/try.sh">try.sh</a> script.</p>
 <p>Cody also added from <a href="2019/mills/index.html">2019/mills</a> the text file
@@ -4645,9 +4976,10 @@ to us Tolkienists as <code>HoMe</code>), which he naturally :-) has, by the late
 <a href="https://en.wikipedia.org/wiki/Christopher_Tolkien">Christopher Tolkien</a>, son
 and literary executor and heir to <a href="https://www.tolkienestate.com/life/biography/">J.R.R.
 Tolkien</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_otterness">
 <h2 id="winning-entry-2020otterness">Winning entry: <a href="2020/otterness/index.html">2020/otterness</a></h2>
-<h3 id="winning-entry-source-code-prog.c-61">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-60">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the MIDI files <a href="2020/otterness/cvikl.mid">cvikl.mid</a> and
 <a href="2020/otterness/entertainer.mid">entertainer.mid</a> from the URLs we suggested so
@@ -4657,24 +4989,30 @@ even if the domain or link goes dead.</p>
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/try.alt.sh">try.alt.sh</a> script for the author’s
 unobfuscated version that Cody added as
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.alt.c">prog.alt.c</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_tsoj">
 <h2 id="winning-entry-2020tsoj">Winning entry: <a href="2020/tsoj/index.html">2020/tsoj</a></h2>
-<h3 id="winning-entry-source-code-prog.c-62">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/tsoj//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-61">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/tsoj//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added <a href="2020/tsoj/index.html#alternate-code">alternate code</a> that will feel
 more at home for vi users. One might still end up cursing (see the index.html
-file) but probably a lot less :-)</p>
+file) but probably a lot less :-) See the
+FAQ on “<a href="faq.html#alt_code">alternate code</a>”
+for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_yang">
 <h2 id="winning-entry-2020yang">Winning entry: <a href="2020/yang/index.html">2020/yang</a></h2>
-<h3 id="winning-entry-source-code-prog.c-63">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/yang//prog.c">prog.c</a></h3>
+<h3 id="winning-entry-source-code-prog.c-62">Winning entry source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/yang//prog.c">prog.c</a></h3>
 </div>
 <p><a href="#cody">Cody</a> added the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/yang/try.sh">try.sh</a> script.</p>
 <p>Cody also added a make rule (<code>make cppp</code>) for the author’s provided C++ code
-that can preprocess the generated output to make them more acceptable to typical
+that can pre-process the generated output to make them more acceptable to typical
 compilers. See the index.html for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="general_thanks">
 <h1 id="general-thanks">General thanks</h1>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="makefiles_fixes_improvements">
 <h2 id="makefiles-fixes-and-improvements">Makefiles fixes and improvements</h2>
 </div>
@@ -4722,11 +5060,12 @@ variables.</p>
 this, along with many other fixes and changes to the Makefiles were made by
 Cody’s <a href="https://github.com/xexyl/sgit">sgit tool</a> but many other changes he did
 manually.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="consistency_improvements">
 <h2 id="consistency-improvements">Consistency improvements</h2>
 </div>
 <p><a href="#cody">Cody</a>, being the IOCCC’s resident corrections officer :-) (and a fine one at
-that, we think :-) ), made many, many typ0 (… :-) ) fixes throughout the
+that, we think :-) ), made many, many typo fixes throughout the
 README.md files, scripts, other data files, Makefiles (see above) etc.</p>
 <p>He also updated the formatting of the README.md files, used to generate the
 index.html files, after renaming the old files to README.md, as well as changing
@@ -4738,23 +5077,46 @@ be made consistent but adding markdown where necessary in the remarks is).</p>
 <p>Some of these fixes were done with his <a href="https://github.com/xexyl/sgit">sgit
 tool</a> as well but the vast majority were done
 manually.</p>
-<div id="manifest_improvements">
-<h2 id="manifest-improvements">Manifest improvements</h2>
+<p>Jump to: <a href="#">top</a></p>
+<div id="try">
+<h2 id="try-script-system">Try script system</h2>
 </div>
-<p><a href="#cody">Cody</a> greatly improved the manifest of the winning entries so that the
-links to the files in the index.html files make sense and are consistent,
-although some might not make as much sense unless one looks into the entry.</p>
+<p><a href="#cody">Cody</a> devised the <code>try</code> script system and added the many <code>try.sh</code>,
+<code>try.alt.sh</code> and various other forms, as well as a number of wrapper scripts to
+more easily run programs. It is not always useful but these scripts do a variety
+of things to really show off the entries, so this really helps with the
+presentation of the winning entries.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="website_improvements">
+<h2 id="website-and-manifest-improvements">Website and manifest improvements</h2>
+</div>
+<p><a href="#cody">Cody</a> helped in many ways to make the website much more presentable by:</p>
+<ul>
+<li>converting old hints files to README.md files (fixing problems in the process)</li>
+<li>converting other files to markdown</li>
+<li>extending the stylesheet for a few improvements</li>
+<li>fixing many different kinds of problems in many files</li>
+<li>writing a few <a href="bin/index.html">website scripts</a>, improving a few others as
+well as identifying and/or fixing bugs in others</li>
+<li>greatly improving the manifest of the winning entries so that the links to the
+files in the index.html files make more sense and are consistent (although it
+might be said that some of them will not make sense if you don’t understand the
+entry or at least do not read the index.html file)</li>
+</ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="faq_improvements">
 <h2 id="faq-improvements">FAQ improvements</h2>
 </div>
 <p><a href="#cody">Cody</a> greatly extended the FAQ to include much more information and he
-helped reorganise it as well, from the new <code>faq.md</code> file.</p>
+helped reorganise it as well, from the new <code>faq.md</code> file that he started.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="thank_you_honor_roll">
 <h2 id="thank-you-honor-roll">Thank you honor roll</h2>
 </div>
 <p>There are a number of people who have contributed to <strong>many many
 changes</strong>, fixes and <strong>many important improvements</strong> that we
 wish to <strong>especially thank</strong>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="authors">Authors</h3>
 <p>A good number of the <a href="authors.html">winning entries of the
 IOCCC</a> tested, identified and helped correct
@@ -4762,6 +5124,7 @@ and/or improve the write-ups of fellow IOCCC entries for the year that they won.
 The list of those entries is too long to mention: nevertheless the <a href="judges.html">IOCCC
 judges</a> <strong>VERY MUCH APPRECIATE</strong> those who
 helped improve the presentation of their fellow IOCCC entries.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="cody">
 <h3 id="cody-boone-ferguson">Cody Boone Ferguson</h3>
 </div>
@@ -4806,6 +5169,7 @@ bug fixed others.</p>
 <p><strong>THANK YOU VERY MUCH</strong> for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC entries and fixing almost all past entries for modern
 systems!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="yusuke">
 <h3 id="yusuke-endoh">Yusuke Endoh</h3>
 </div>
@@ -4818,6 +5182,7 @@ fixes were <strong>EXTREMELY TECHNICALLY CHALLENGING</strong>, such as
 <a href="thanks-for-help.html#1992_lush">1992/lush</a> and
 <a href="thanks-for-help.html#2001_ctk">2001/ctk</a>. <strong>THANK YOU VERY MUCH</strong> for
 your help!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="neglect">
 <h2 id="did-we-neglect-to-credit-you">Did we neglect to credit you?</h2>
 </div>
@@ -4827,6 +5192,7 @@ to add you to this <a href="thanks-for-help.html">thanks for the help</a> file.<
 <p>If you believe we incorporated one of your fixes to an IOCCC winning entry (that you
 are not the author of) for which we neglected to mention in this file, please
 <a href="contact.html">contact the IOCCC</a> so that we may correct the record.</p>
+<p>Jump to: <a href="#">top</a></p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -24,7 +24,8 @@ on an IOCCC entry by entry basis.
 - [General thanks](#general_thanks)
 - [Makefiles fixes and improvements](#makefiles_fixes_improvements)
 - [Consistency improvements](#consistency_improvements)
-- [Manifest improvements](#manifest_improvements)
+- [Try script system](#try)
+- [Website and manifest improvements](#website_improvements)
 - [FAQ improvements](#faq_improvements)
 - [Thank you honor roll](#thank_you_honor_roll)
 - [Did we neglect to credit you?](#neglect)
@@ -34,6 +35,7 @@ on an IOCCC entry by entry basis.
 # [1984 - The 1st IOCCC](1984/index.html)
 </div>
 
+Jump to: [top](#)
 
 <div id="1984_anonymous">
 ## Winning entry: [1984/anonymous](1984/anonymous/index.html)
@@ -64,6 +66,8 @@ source code and the tattoo together as an image):
 The tattoo was done in 2005 by [Thomas
 Scovell](https://web.archive.org/web/20070120220721/https://thomasscovell.com/tattoo.php).
 
+
+Jump to: [top](#)
 
 <div id="1984_decot">
 ## Winning entry: [1984/decot](1984/decot/index.html)
@@ -142,6 +146,7 @@ To see the diff between the original and the alternate code, try:
         cd 1984/decot ; make diff_orig_alt
 ```
 
+Jump to: [top](#)
 
 <div id="1984_laman">
 ## Winning entry: [1984/laman](1984/laman/index.html)
@@ -150,6 +155,7 @@ To see the diff between the original and the alternate code, try:
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1984/laman/try.sh) script.
 
+Jump to: [top](#)
 
 <div id="1984_mullender">
 ## Winning entry: [1984/mullender](1984/mullender/index.html)
@@ -176,11 +182,13 @@ copy of it as to what it should have been at the time, in the fabulous [Unix
 History
 Repo](https://github.com/dspinellis/unix-history-repo/tree/Research-Release).
 
+Jump to: [top](#)
 
 <div id="1985">
 # [1985 - The 2nd IOCCC](1985/index.html)
 </div>
 
+Jump to: [top](#)
 
 <div id="1985_applin">
 ## Winning entry: [1984/applin](1985/applin/index.html)
@@ -208,6 +216,7 @@ shell, after the output (despite having `\n` in the string - can you figure out
 why?) but to make it more friendly to users Cody made it print a `\n` prior to
 returning to the shell. The original code does not have this change.
 
+Jump to: [top](#)
 
 <div id="1985_august">
 ## Winning entry: [1985/august](1985/august/index.html)
@@ -218,9 +227,7 @@ returning to the shell. The original code does not have this change.
 versions of `clang` object to the number of args of `main()`, saying that it must
 be 0, 2 or 3. The version this has been observed in does not actually object to
 1 arg but it is entirely possible that this changes so a second arg (that's not
-needed and is unused) has been added just in case.
-
-See the
+needed and is unused) has been added just in case. See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
@@ -234,6 +241,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/august/try.sh) script (which runs
 whether `primes(6)` is installed or not, but it only does it once with the
 default value).
 
+Jump to: [top](#)
 
 <div id="1985_lycklama">
 ## Winning entry: [1985/lycklama](1985/lycklama/index.html)
@@ -250,6 +258,7 @@ that Cody added. See the [index.html](1985/lycklama/index.html) for details.
 
 Cody also provided the [try.alt.sh](%%REPO_URL%%/1985/lycklama/try.alt.sh) script.
 
+Jump to: [top](#)
 
 <div id="1985_shapiro">
 ## Winning entry: [1985/shapiro](1985/shapiro/index.html)
@@ -264,6 +273,7 @@ you to enter a number, in an infinite loop, exiting if any non-digits are in
 input (this includes negative numbers which in the code actually sets it back to
 39, the default).
 
+Jump to: [top](#)
 
 <div id="1985_sicherman">
 ## Winning entry: [1985/sicherman](1985/sicherman/index.html)
@@ -378,11 +388,13 @@ should they object to `main()` having only one arg.
 Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 [try.alt.sh](%%REPO_URL%%/1985/sicherman/try.alt.sh) scripts.
 
+Jump to: [top](#)
 
 <div id="1986">
 # [1986 - The 3rd IOCCC](1986/index.html)
 </div>
 
+Jump to: [top](#)
 
 <div id="1986_applin">
 ## Winning entry: [1986/applin](1986/applin/index.html)
@@ -392,6 +404,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 [Cody](#cody) made the C file executable so one does not have to do `sh
 ./applin.c` or `./applin`; they can do either `./applin.c` or `./applin`.
 
+Jump to: [top](#)
 
 <div id="1986_bright">
 ## Winning entry: [1986/bright](1986/bright/index.html)
@@ -400,6 +413,7 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1986/bright/try.sh) script.
 
+Jump to: [top](#)
 
 <div id="1986_hague">
 ## Winning entry: [1986/hague](1986/hague/index.html)
@@ -408,12 +422,11 @@ Cody also added the [try.sh](%%REPO_URL%%/1985/sicherman/try.sh) and
 
 [Cody](#cody) made this use `fgets()`.
 Cody also added the [try.sh](%%REPO_URL%%/1986/hague/try.sh) script which also feeds to the
-program the `input.txt` text file that Cody added.
-
-See the
+program the `input.txt` text file that Cody added.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
+Jump to: [top](#)
 
 <div id="1986_holloway">
 ## Winning entry: [1986/holloway](1986/holloway/index.html)
@@ -428,6 +441,7 @@ caused a segfault. By adding a new variable, `char *t`, initialising it to `s`
 and then using `t` instead of `s` it compiles and runs successfully under
 `clang` and `gcc`.
 
+Jump to: [top](#)
 
 <div id="1986_marshall">
 ## Winning entry: [1986/marshall](1986/marshall/index.html)
@@ -495,6 +509,7 @@ which gave:
 which can be disabled. It results in the same behaviour but this way no warnings
 are produced.
 
+Jump to: [top](#)
 
 <div id="1986_pawka">
 ## Winning entry: [1986/pawka](1986/pawka/index.html)
@@ -505,6 +520,7 @@ are produced.
 `-Wno-strict-prototypes` was in the wrong location, suggesting that there is a
 `-D` needed to compile the entry but this is not actually so.
 
+Jump to: [top](#)
 
 <div id="1986_stein">
 ## Winning entry: [1986/stein](1986/stein/index.html)
@@ -520,6 +536,7 @@ code is now one line.
 Cody also added the [stein.sh](%%REPO_URL%%/1986/stein/stein.sh) script which runs the two
 commands that we suggest in order to get it to show clean output.
 
+Jump to: [top](#)
 
 <div id="1986_wall">
 ## Winning entry: [1986/wall](1986/wall/index.html)
@@ -632,11 +649,13 @@ Some of the changes required:
 
 There might have been other changes as well.
 
+Jump to: [top](#)
 
 <div id="1987">
 # [1987 - The 4th IOCCC](1987/index.html)
 </div>
 
+Jump to: [top](#)
 
 <div id="1987_biggar">
 ## Winning entry: [1987/biggar](1987/biggar/index.html)
@@ -645,6 +664,7 @@ There might have been other changes as well.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1987/biggar/try.sh) script.
 
+Jump to: [top](#)
 
 <div id="1987_heckbert">
 ## Winning entry: [1987/heckbert](1987/heckbert/index.html)
@@ -663,6 +683,7 @@ of `strings.h` and because it's identical in use to `strchr(3)` (and we noted
 that for System V we had to do this) Cody added to the Makefile
 `-Dindex=strchr`.
 
+Jump to: [top](#)
 
 <div id="1987_hines">
 ## Winning entry: [1987/hines](1987/hines/index.html)
@@ -674,6 +695,7 @@ that for System V we had to do this) Cody added to the Makefile
 for demonstration purposes. Notice that the program is case sensitive which
 running the program on the text file demonstrates.
 
+Jump to: [top](#)
 
 <div id="1987_lievaart">
 ## Winning entry: [1987/lievaart](1987/lievaart/index.html)
@@ -722,21 +744,20 @@ Cody also made this ever so slightly like the original code by adding back the
 well (the one with the board and the one without, the entry itself with the
 size constraints of the contest).
 
+Jump to: [top](#)
 
 <div id="1987_wall">
 ## Winning entry: [1987/wall](1987/wall/index.html)
 ### Winning entry source code: [wall.c](%%REPO_URL%%/1987/wall/wall.c)
 </div>
 
-[Cody](#cody) made this use `fgets(3)`.
-
-See the
+[Cody](#cody) made this use `fgets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
-
 Cody also added the [try.sh](%%REPO_URL%%/1987/wall/try.sh) script.
 
+Jump to: [top](#)
 
 <div id="1987_westley">
 ## Winning entry: [1987/westley](1987/westley/index.html)
@@ -758,9 +779,15 @@ Cody also added to the `Makefile` `-include stdio.h` in the nowadays very
 unlikely(?) but nevertheless suggested case that `putchar(3)` is not available.
 
 
+Jump to: [top](#)
+
+
 <div id="1988">
 # [1988 - The 5th IOCCC](1988/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1988_dale">
@@ -843,6 +870,9 @@ macro in place but it's no longer used.
 Cody also provided the [try.sh](%%REPO_URL%%/1988/dale/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1988_isaak">
 ## Winning entry: [1988/isaak](1988/isaak/index.html)
 ### Winning entry source code: [isaak.c](%%REPO_URL%%/1988/isaak/isaak.c)
@@ -859,6 +889,9 @@ Cody also uudecoded and removed the file `isaak.encode`, putting the output in
 found in the index.html file.
 
 
+Jump to: [top](#)
+
+
 <div id="1988_litmaath">
 ## Winning entry: [1988/litmaath](1988/litmaath/index.html)
 ### Winning entry source code: [litmaath.c](%%REPO_URL%%/1988/litmaath/litmaath.c)
@@ -867,6 +900,9 @@ found in the index.html file.
 [Cody](#cody) added the [alternate code](%%REPO_URL%%/1988/litmaath/litmaath.alt.c)
 which is code that we suggested at the time of publication, in the remarks, to
 help understand the entry, and for fun.
+
+
+Jump to: [top](#)
 
 
 <div id="1988_phillipps">
@@ -891,16 +927,20 @@ same code, just a `p` instead of an `m` in the name. Additionally, `main()` retu
 `!pain(...)` like `main()` used to do to itself (`pain()` does as well).
 
 
+Jump to: [top](#)
+
+
 <div id="1988_reddy">
 ## Winning entry: [1988/reddy](1988/reddy/index.html)
 ### Winning entry source code: [reddy.c](%%REPO_URL%%/1988/reddy/reddy.c)
 </div>
 
-[Cody](#cody) made this use `fgets(3)`.
-
-See the
+[Cody](#cody) made this use `fgets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
+
+
+Jump to: [top](#)
 
 
 <div id="1988_spinellis">
@@ -922,6 +962,9 @@ doing this) that with a slight modification this entry can be C++ instead. We do
 thank him for this ghastly point! :-)
 
 
+Jump to: [top](#)
+
+
 <div id="1988_westley">
 ## Winning entry: [1988/westley](1988/westley/index.html)
 ### Winning entry source code: [westley.c](%%REPO_URL%%/1988/westley/westley.c)
@@ -938,12 +981,15 @@ entry as seeing the code with the result at once is far more beautiful.
 Cody also changed the `int`s to be `float` as that's what they are printed as:
 not strictly necessary but nonetheless more correct, even if not warned against.
 
-
+Jump to: [top](#)
 
 
 <div id="1989">
 # [1989 - The 6th IOCCC](1989/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1989_fubar">
@@ -986,6 +1032,9 @@ Cody also 'modernised' the script to use `bash` and fixed for ShellCheck. The
 Cody also added the [try.sh](%%REPO_URL%%/1989/fubar/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1989_jar.1">
 ## Winning entry: [1989/jar.1](1989/jar.1/index.html)
 ### Winning entry source code: [jar.1.c](%%REPO_URL%%/1989/jar.1/jar.1.c)
@@ -1004,6 +1053,9 @@ Whilst he was at it, Cody made it so that one need not run the alt script or
 alternate code directly, to match that of the main entry. As we simulate the
 functionality anyway, and since one may still run the code or the script (for
 the original entry and the alternate code) anyway, it works out well.
+
+
+Jump to: [top](#)
 
 
 <div id="1989_jar.2">
@@ -1050,6 +1102,9 @@ result in:
 because the `alt` rule had what normally is in the `${PROG}.alt` rule.
 
 
+Jump to: [top](#)
+
+
 
 <div id="1989_ovdluhe">
 ## Winning entry: [1989/ovdluhe](1989/ovdluhe/index.html)
@@ -1074,6 +1129,9 @@ for details. The fix described above was fixed in this version too, after it was
 discovered and fixed.
 
 
+Jump to: [top](#)
+
+
 <div id="1989_paul">
 ## Winning entry: [1989/paul](1989/paul/index.html)
 ### Winning entry source code: [paul.c](%%REPO_URL%%/1989/paul/paul.c)
@@ -1086,6 +1144,9 @@ he was using lldb and saw that the type of a pointer was too `long` :-)
 Cody also provided the [alternate version](%%REPO_URL%%/1989/paul/paul.alt.c)
 which has the trace function that the author included but commented out. See the
 index.html for details.
+
+
+Jump to: [top](#)
 
 
 <div id="1989_robison">
@@ -1104,6 +1165,9 @@ made, try:
 (It adds the C token pasting operator `##` instead of `/**/`.)
 
 Cody added the [try.sh](%%REPO_URL%%/1989/robison/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1989_tromp">
@@ -1138,12 +1202,18 @@ IOCCC [Tetris](https://en.wikipedia.org/wiki/Tetris) working (this of course was
 not his only reason :-) )
 
 
+Jump to: [top](#)
+
+
 <div id="1989_vanb">
 ## Winning entry: [1989/vanb](1989/vanb/index.html)
 ### Winning entry source code: [vanb.c](%%REPO_URL%%/1989/vanb/vanb.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1989/vanb/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1989_westley">
@@ -1223,9 +1293,15 @@ The `compile.sh` script allows one to specify the compiler with the `CC`
 environmental variable; see the index.html for details.
 
 
+Jump to: [top](#)
+
+
 <div id="1990">
 # [1990 - The 7th IOCCC](1990/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1990_baruch">
@@ -1246,20 +1322,20 @@ the variables, adding instead `-Wno-implicit-int`. The newline added by the
 judges was retained.
 
 
+Jump to: [top](#)
+
+
 <div id="1990_cmills">
 ## Winning entry: [1990/cmills](1990/cmills/index.html)
 ### Winning entry source code: [cmills.c](%%REPO_URL%%/1990/cmills/cmills.c)
 </div>
 
 [Yusuke](#yusuke) got this to work in modern systems (it previously resulted in a bus
-error).
-
-[Cody](#cody) made this use `fgets(3)`.
-
-See the
+error).  [Cody](#cody) made this use `fgets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
+Jump to: [top](#)
 
 
 <div id="1990_dds">
@@ -1279,12 +1355,11 @@ Cody fixed another compiler error by removing the erroneous prototype to
 `fopen(3)`.  Cody also changed a `char *` used for file I/O to be a proper `FILE
 *` and fixed a typo in [LANDER.BAS](%%REPO_URL%%/1990/dds/LANDER.BAS).
 
-Cody also made this use `fgets(3)`.
-
-See the
+Cody also made this use `fgets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
+Jump to: [top](#)
 
 
 <div id="1990_dg">
@@ -1313,6 +1388,9 @@ with if the C preprocessor botches single quotes in `cpp` expansion.
 Cody also added the [try.sh](%%REPO_URL%%/1990/dg/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1990_jaw">
 ## Winning entry: [1990/jaw](1990/jaw/index.html)
 ### Winning entry source code: [jaw.c](%%REPO_URL%%/1990/jaw/jaw.c)
@@ -1334,6 +1412,9 @@ fix applied by Cody that made the program just show `oops` twice (twice is not
 a typo here) from invalid input but which now works.
 
 
+Jump to: [top](#)
+
+
 <div id="1990_pjr">
 ## Winning entry: [1990/pjr](1990/pjr/index.html)
 ### Winning entry source code: [pjr.c](%%REPO_URL%%/1990/pjr/pjr.c)
@@ -1342,6 +1423,9 @@ a typo here) from invalid input but which now works.
 [Cody](#cody) added the [alternate code](%%REPO_URL%%/1990/pjr/pjr.alt.c) which was suggested by the judges
 in the case that your compiler cannot compile `X=g()...` but it actually does
 something else and is recommended by the author as well.
+
+
+Jump to: [top](#)
 
 
 <div id="1990_scjones">
@@ -1355,6 +1439,9 @@ first.
 
 Cody added the [try.sh](%%REPO_URL%%/1990/scjones/try.sh) script to show exactly what the
 entry does.
+
+
+Jump to: [top](#)
 
 
 <div id="1990_tbr">
@@ -1372,12 +1459,11 @@ author.
 Cody also changed the code (in both versions) to use `fgets(3)` instead of
 `gets(3)` so one would not get a warning about the use of `gets(3)` at linking
 time or execution, the latter of which was causing confusing output due to the
-warning being interspersed with the program's interactive output.
-
-See the
+warning being interspersed with the program's interactive output.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
-for more details on why this change was
-done more generally.
+for more details on why this change was done more generally.
+
+Jump to: [top](#)
 
 
 <div id="1990_theorem">
@@ -1407,9 +1493,7 @@ BTW: why can't the fix:
 be changed to just test the value of `A` when `a` is argv and `A` is argc? You
 tell us!
 
-Cody also changed the code to use `fgets(3)`.
-
-See the
+Cody also changed the code to use `fgets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
@@ -1430,6 +1514,9 @@ used in order to get this to work initially (prior to this output was there but
 incomplete).
 
 
+Jump to: [top](#)
+
+
 <div id="1990_stig">
 ## Winning entry: [1990/stig](1990/stig/index.html)
 ### Winning entry source code: [stig.c](%%REPO_URL%%/1990/stig/stig.c)
@@ -1442,6 +1529,9 @@ He also changed the `Makefile` to use `bash` not `zsh` as not all systems have
 `zsh` and the `Makefile` actually sets `SHELL` to `bash`.
 
 
+Jump to: [top](#)
+
+
 <div id="1990_westley">
 ## Winning entry: [1990/westley](1990/westley/index.html)
 ### Winning entry source code: [westley.c](%%REPO_URL%%/1990/westley/westley.c)
@@ -1451,10 +1541,14 @@ He also changed the `Makefile` to use `bash` not `zsh` as not all systems have
 in places for a `short int` which was changed to just `1`.  Since it's
 instructional to see the differences he has provided an alternate version,
 [westley.alt.c](%%REPO_URL%%/1990/westley/westley.alt.c), which is the original
-code.
+code (see [Alternate code in
+1990/westley/index.html](1990/westley/index.html#alternate-code)).
 
 He also changed the `argc` to be an `int`, not a `char`, even though it might
-often be the same (this in particular was done for `clang`).
+often be the same (this in particular was done for `clang`). See the
+FAQ on "[main function args](faq.html#arg_count)"
+for more details.
+
 
 He also fixed the code to not enter an infinite loop if arg is a number not > 0.
 To be more like the original the number of args passed to the program has not
@@ -1464,9 +1558,15 @@ Cody also added the [try.sh](%%REPO_URL%%/1990/westley/try.sh) script.
 
 
 
+Jump to: [top](#)
+
+
 <div id="1991">
 # [1991 - The 8th IOCCC](1991/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1991_ant">
@@ -1496,6 +1596,12 @@ will be a bit easier to use for those familiar with vim in the following ways
 
 The other keys were left unchanged.
 
+See the
+FAQ on "[alternate code](faq.html#alt_code)
+for why this was done.
+
+Jump to: [top](#)
+
 
 <div id="1991_brnstnd">
 ## Winning entry: [1991/brnstnd](1991/brnstnd/index.html)
@@ -1518,6 +1624,9 @@ Cody also added the [try.sh](%%REPO_URL%%/1991/brnstnd/try.sh) script and
 Cody also fixed the make clobber rule which left a symbolic link in the
 directory even after the target file was deleted (from make clobber).
 
+
+Jump to: [top](#)
+
 <div id="1991_buzzard">
 ## Winning entry: [1991/buzzard](1991/buzzard/index.html)
 ### Winning entry source code: [buzzard.c](%%REPO_URL%%/1991/buzzard/buzzard.c)
@@ -1532,11 +1641,16 @@ Cody also made the file name in the code (which is the default maze file) not
 hard-coded but instead be `__FILE__`.
 
 Finally Cody added the [alternate
-version](%%REPO_URL%%/1991/buzzard/buzzard.alt.c) which will possibly feel more
+version](1991/buzzard/index.html#alternate-code) which will possibly feel more
 at home with those familiar with vi(m): `k` for forward, `h` for left and `l`
 for right. This version also has a more useful way to exit, just entering `q`
 followed by enter, rather than completing (and it's a maze) or killing the
-program. We still recommend you try the original version first, of course.
+program. We still recommend you try the original version first, of course. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="1991_davidguy">
@@ -1548,6 +1662,9 @@ As some systems like macOS can be particular about not declaring functions
 [Cody](#cody) added to the `Makefile` some `-include` options. These appear to
 not be strictly necessary (currently) but it was done due to other syscalls
 being a problem not being declared first, to hopefully future-proof it.
+
+
+Jump to: [top](#)
 
 
 <div id="1991_dds">
@@ -1694,6 +1811,9 @@ was pondered and changed numerous times and ultimately that problem with this
 entry was fixed. It has not been done in all.
 
 
+Jump to: [top](#)
+
+
 <div id="1991_fine">
 ## Winning entry: [1991/fine](1991/fine/index.html)
 ### Winning entry source code: [fine.c](%%REPO_URL%%/1991/fine/fine.c)
@@ -1722,6 +1842,9 @@ Brian Westley and Cody also added several of his own (can you figure out exactly
 which ones? :-) )
 
 
+Jump to: [top](#)
+
+
 <div id="1991_rince">
 ## Winning entry: [1991/rince](1991/rince/index.html)
 ### Winning entry source code: [rince.c](%%REPO_URL%%/1991/rince/rince.c)
@@ -1744,6 +1867,9 @@ unfortunately the formatting of the key to the map was not easy to change in a
 way without ruining how it looks (beyond making it one column only).
 
 
+Jump to: [top](#)
+
+
 <div id="1991_westley">
 ## Winning entry: [1991/westley](1991/westley/index.html)
 ### Winning entry source code: [westley.c](%%REPO_URL%%/1991/westley/westley.c)
@@ -1762,16 +1888,22 @@ unless the `-e` option is used.  This is because the errors being shown kind of
 ruins the experience. Finally he made it pass
 [ShellCheck](https://www.shellcheck.net).
 
-Cody also added the [alt version](%%REPO_URL%%/1991/westley/westley.alt.c) which
+Cody also added the [alt version](1991/westley/index.html#alternate-code) which
 is based on the author's remarks, a version that supposedly (:-) ) always wins.
 
 Cody also fixed the make clobber rule where a file was left lying about when it
 should have been removed.
 
 
+Jump to: [top](#)
+
+
 <div id="1992">
 # [1992 - The 9th IOCCC](1992/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1992_adrian">
@@ -1857,6 +1989,9 @@ clear the screen after compilation so that one can see how the other files are
 generated.
 
 
+Jump to: [top](#)
+
+
 <div id="1992_albert">
 ## Winning entry: [1992/albert](1992/albert/index.html)
 ### Winning entry source code: [albert.c](%%REPO_URL%%/1992/albert/albert.c)
@@ -1874,6 +2009,9 @@ Cody also added the [try.sh](%%REPO_URL%%/1992/albert/try.sh) and
 the alternate code.
 
 Even so, check [1992/albert in bugs.html](bugs.html#1992_albert).
+
+
+Jump to: [top](#)
 
 
 <div id="1992_ant">
@@ -1908,6 +2046,9 @@ Makefile (along the lines of the author's provided test Makefile) was added,
 updated to use `ant.alt`.
 
 
+
+Jump to: [top](#)
+
 <div id="1992_buzzard.1">
 ## Winning entry: [1992/buzzard.1](1992/buzzard.1/index.html)
 ### Winning entry source code: [buzzard.1.c](%%REPO_URL%%/1992/buzzard.1/buzzard.1.c)
@@ -1920,6 +2061,9 @@ verified that it was consistent with the [bugs.html](bugs.html) file.
 
 He also added the [try.sh](%%REPO_URL%%/1992/buzzard.1/try.sh) script to try out some
 commands that we suggested and some additional ones that he provide for some fun.
+
+
+Jump to: [top](#)
 
 
 <div id="1992_buzzard.2">
@@ -1935,6 +2079,9 @@ Cody also added the [try.sh](%%REPO_URL%%/1992/buzzard.2/try.sh) and
 and its alternate code.
 
 
+Jump to: [top](#)
+
+
 <div id="1992_gson">
 ## Winning entry: [1992/gson](1992/gson/index.html)
 ### Winning entry source code: [gson.c](%%REPO_URL%%/1992/gson/gson.c)
@@ -1948,8 +2095,11 @@ Cody also added the [try.sh](%%REPO_URL%%/1992/gson/try.sh) script.
 Cody also added the [mkdict.sh](%%REPO_URL%%/1992/gson/mkdict.sh) script that the author
 included in their remarks. See the index.html for its purpose. It was NOT fixed
 for [ShellCheck](https://www.shellcheck.net)
-because the author deliberately obfuscated it so **PLEASE *DO NOT* FIX THIS OR
+because the author deliberately obfuscated it so **PLEASE _DO NOT_ FIX THIS OR
 MODERNISE IT**.
+
+Jump to: [top](#)
+
 
 
 <div id="1992_imc">
@@ -1966,6 +2116,9 @@ he made this more like the original by redefining `exit` to use the comma
 operator so that it could be used in binary expressions.
 
 
+Jump to: [top](#)
+
+
 <div id="1992_kivinen">
 ## Winning entry: [1992/kivinen](1992/kivinen/index.html)
 ### Winning entry source code: [kivinen.c](%%REPO_URL%%/1992/kivinen/kivinen.c)
@@ -1975,7 +2128,7 @@ It was observed that on modern systems this goes much too quick. [Yusuke](#yusuk
 a patch that calls `usleep(3)` but [Cody](#cody) thought the value was too slow so he
 made it a macro in the `Makefile` `Z` (which can be redefined with `make
 SLEEP=...`), defaulting at 15000. This was made an [alternate
-version](%%REPO_URL%%/1992/kivinen/kivinen.alt.c) and it is recommended one use
+version](1992/kivinen/index.html#alternate-code) and it is recommended one use
 the alternate version first. See the index.html file to see how to reconfigure it.
 
 Cody also made the fixed version (the code relied on `exit(3)` returning to use
@@ -1989,16 +2142,16 @@ Cody made `main()` have two args, not one, as some versions of `clang` have a
 defect with the number of args to `main()` though when it comes to 1 arg it is
 only in an error message if say 4 args are used. This is out of an abundance of
 caution as it's quite possible that `clang` or the ANSI C committee end up further
-changing this.
-
-See the
+changing this. See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
-
 
 Yusuke also noted that there is a bug in the program where right after starting
 it moves towards the right but if you click the mouse it goes back. See
 [1992/kivinen in bugs.html](bugs.html#1992_kivinen) for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="1992_lush">
@@ -2013,9 +2166,7 @@ file](1992/lush/index.html#judges-remarks)) this will not work with `clang`.
 [Cody](#cody) also provided the [lush.sh](%%REPO_URL%%/1992/lush/lush.sh) script to
 demonstrate it as using make was problematic.
 
-Cody made it use `fgets()` instead of `gets()`.
-
-See the
+Cody made it use `fgets()` instead of `gets()`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
@@ -2024,12 +2175,18 @@ will compile fine but it won't work). See [1992/lush in
 bugs.html](bugs.html#1992_lush) for details.
 
 
+Jump to: [top](#)
+
+
 <div id="1992_marangon">
 ## Winning entry: [1992/marangon](1992/marangon/index.html)
 ### Winning entry source code: [marangon.c](%%REPO_URL%%/1992/marangon/marangon.c)
 </div>
 
 [Cody](#cody) made this more portable by changing the `void main()` to be `int main()`.
+
+
+Jump to: [top](#)
 
 
 <div id="1992_nathan">
@@ -2050,6 +2207,9 @@ Cody also added the [try.sh](%%REPO_URL%%/1992/nathan/try.sh) script that runs a
 few commands that we suggested as well as one he provided.
 
 
+Jump to: [top](#)
+
+
 <div id="1992_vern">
 ## Winning entry: [1992/vern](1992/vern/index.html)
 ### Winning entry source code: [vern.c](%%REPO_URL%%/1992/vern/vern.c)
@@ -2068,6 +2228,9 @@ both numbers (using `"%o %o"` does not solve the problem).
 
 This was deemed a problem to fix as the Judges' remarks hinted that this was how
 it used to be.
+
+
+Jump to: [top](#)
 
 
 <div id="1992_westley">
@@ -2117,9 +2280,15 @@ args (2). And not that we need the help or anything for this :-) but we
 encourage you to try the original without two args :-)
 
 
+Jump to: [top](#)
+
+
 <div id="1993">
 # [1993 - The 10th IOCCC](1993/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1993_ant">
@@ -2138,6 +2307,9 @@ another which Cody had to slightly modify to get it to work in modern systems.
 But since only one was needed the one that worked already was used.
 
 
+Jump to: [top](#)
+
+
 <div id="1993_cmills">
 ## Winning entry: [1993/cmills](1993/cmills/index.html)
 ### Winning entry source code: [cmills.c](%%REPO_URL%%/1993/cmills/cmills.c)
@@ -2146,8 +2318,11 @@ But since only one was needed the one that worked already was used.
 [Yusuke](#yusuke) suggested that with modern systems this goes too fast so he added a call
 to `usleep(3)` in a patch he made. [Cody](#cody) made it configurable at compilation by
 using a macro. This is in the [alternate
-version](%%REPO_URL%%/1993/cmills/cmills.alt.c) which is the recommended one to try
+version](1993/cmills/cmills.alt.c) which is the recommended one to try
 first.
+
+
+Jump to: [top](#)
 
 
 <div id="1993_dgibson">
@@ -2162,12 +2337,18 @@ Cody also added the [try.sh](%%REPO_URL%%/1993/dgibson/try.sh) script which runs
 mentioned script on all the data files.
 
 
+Jump to: [top](#)
+
+
 <div id="1993_ejb">
 ## Winning entry: [1993/ejb](1993/ejb/index.html)
 ### Winning entry source code: [ejb.c](%%REPO_URL%%/1993/ejb/ejb.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1993/ejb/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1993_jonth">
@@ -2190,6 +2371,9 @@ and expect `G;` to equate to `int i, j;` (though it's now a long) and `K` to mea
 prepended to them.
 
 
+Jump to: [top](#)
+
+
 <div id="1993_leo">
 ## Winning entry: [1993/leo](1993/leo/index.html)
 ### Winning entry source code: [leo.c](%%REPO_URL%%/1993/leo/leo.c)
@@ -2199,19 +2383,25 @@ prepended to them.
 files for functions.
 
 
+Jump to: [top](#)
+
+
 <div id="1993_lmfjyh">
 ## Winning entry: [1993/lmfjyh](1993/lmfjyh/index.html)
 ### Winning entry source code: [lmfjyh.c](%%REPO_URL%%/1993/lmfjyh/lmfjyh.c)
 </div>
 
 [Cody](#cody) added an [alternate
-version](%%REPO_URL%%/1993/lmfjyh/lmfjyh.alt.c) which does what the program did
+version](1993/lmfjyh/index.html#alternate-code) which does what the program did
 with `gcc` < 2.3.3. See the index.html file for details and for why this was made
 the alternate version, not the actual entry.
 
 Cody also made the `Makefile` delete the very unsafe filename that is compiled (or
 would be compiled if `gcc` < 2.3.3) whether or not compilation succeeds (which is
 highly unlikely).
+
+
+Jump to: [top](#)
 
 
 <div id="1993_plummer">
@@ -2233,6 +2423,9 @@ entry and the alt version, both allowing one to change the args (and in the case
 of the alt one allowing one to change the amount to sleep).
 
 
+Jump to: [top](#)
+
+
 <div id="1993_rince">
 ## Winning entry: [1993/rince](1993/rince/index.html)
 ### Winning entry source code: [rince.c](%%REPO_URL%%/1993/rince/rince.c)
@@ -2251,16 +2444,20 @@ slow down but Cody did it in such a way that makes it easy to configure at
 compile time. See the index.html for details.
 
 
+Jump to: [top](#)
+
+
 <div id="1993_schnitzi">
 ## Winning entry: [1993/schnitzi](1993/schnitzi/index.html)
 ### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1993/schnitzi/schnitzi.c)
 </div>
 
-[Cody](#cody) made this use `fgets(3)` not `gets(3)`.
-
-See the
+[Cody](#cody) made this use `fgets(3)` not `gets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
+
+
+Jump to: [top](#)
 
 
 
@@ -2284,11 +2481,8 @@ work).
 
 Cody also added the alternate code, provided by the author, which is:
 
-```
-    ... a version of the program before it got formatted into the VIII,
-    augmented with comments showing where each state begins. N1 and N2 are
-    notes.
-```
+> ... a version of the program before it got formatted into the VIII, augmented
+with comments showing where each state begins. N1 and N2 are notes.
 
 but fixed to work with `clang` as well.
 
@@ -2298,9 +2492,15 @@ this code. Other code is also described there.
 Cody also added the [try.sh](%%REPO_URL%%/1993/vanb/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1994">
 # [1994 - The 11th IOCCC](1994/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1994_dodsond2">
@@ -2337,6 +2537,9 @@ counter for how many you have found and how many you shot in addition to the two
 that already existed, how many you had and how many were stolen.
 
 
+Jump to: [top](#)
+
+
 <div id="1994_horton">
 ## Winning entry: [1994/horton](1994/horton/index.html)
 ### Winning entry source code: [1994/horton](%%REPO_URL%%/1994/horton/horton.c)
@@ -2358,6 +2561,9 @@ Finally he added the article (written by the entry's author) cited in
 [login_sept92-pp28-31.pdf](1994/horton/login_sept92-pp28-31.pdf).
 
 
+Jump to: [top](#)
+
+
 <div id="1994_imc">
 ## Winning entry: [1994/imc](1994/imc/index.html)
 ### Winning entry source code: [imc.c](%%REPO_URL%%/1994/imc/imc.c)
@@ -2369,6 +2575,9 @@ Cody also added inclusion of `unistd.h` for `getpid(2)`. While strictly speaking
 this was not necessary (in multiple systems) it can sometimes be a problem and
 as it was noticed it was changed (the only case this was done except in the
 entries that actually did not work because of missing or incorrect prototypes).
+
+
+Jump to: [top](#)
 
 
 <div id="1994_ldb">
@@ -2384,9 +2593,7 @@ Cody also fixed it for `clang` under Linux which objected to incompatible pointe
 type (because `time(2)` takes a `time_t *` which in some systems is a `long *`
 but what was being passed to it is an `int`).
 
-Cody also changed the entry to use `fgets(3)` instead of `gets(3)`.
-
-See the
+Cody also changed the entry to use `fgets(3)` instead of `gets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
@@ -2404,6 +2611,9 @@ characters or it might print (up to) the next 231 characters and so on.
 Cody also added the [try.sh](%%REPO_URL%%/1994/ldb/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1994_schnitzi">
 ## Winning entry: [1994/schnitzi](1994/schnitzi/index.html)
 ### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1994/schnitzi/schnitzi.c)
@@ -2415,7 +2625,9 @@ generate code that compile and another [one with a bigger buffer
 size](%%REPO_URL%%/1994/schnitzi/schnitzi.alt2.c) which, when fed its own source code, will
 generate compilable code but not with the same buffer size but rather the
 original buffer size. Cody explains this at [1994/schnitzi in
-bugs.html](bugs.html#1994-schnitzi).
+bugs.html](bugs.html#1994-schnitzi). See also the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 The purpose for these versions it both demonstrate how the magic works behind it
 and to help others, should they wish, get the code to work with `fgets(3)`, with
@@ -2427,6 +2639,9 @@ now there is more important work to do so that the next contest can run.
 
 Cody also added the [try.sh](%%REPO_URL%%/1994/schnitzi/try.sh) and
 [try.alt.sh](%%REPO_URL%%/1994/schnitzi/try.alt.sh) scripts.
+
+
+Jump to: [top](#)
 
 
 <div id="1994_shapiro">
@@ -2444,12 +2659,18 @@ For an interesting problem that occurred here and what was done to solve it,
 check [1994/shapiro in bugs.html](bugs.html#1994_shapiro).
 
 
+Jump to: [top](#)
+
+
 <div id="1994_smr">
 ## Winning entry: [1994/smr](1994/smr/index.html)
 ### Winning entry source code: [smr.c](%%REPO_URL%%/1994/smr/smr.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1994/smr/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1994_tvr">
@@ -2472,11 +2693,12 @@ In this case the newline had
 to be terminated but it was a pretty straightforward fix. `gets()` was defined
 to use `fgets()` and the inclusion of `stdio.h` had to be added but to make it
 more like the original entry this was done in the Makefile. The alternate code was
-also changed to use `fgets(3)`.
-
-See the
+also changed to use `fgets(3)`.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
+
+
+Jump to: [top](#)
 
 
 <div id="1994_weisberg">
@@ -2496,6 +2718,9 @@ primes. It only does the reversed output because the program actually prints
 primes.
 
 
+Jump to: [top](#)
+
+
 <div id="1994_westley">
 ## Winning entry: [1994/westley](1994/westley/index.html)
 ### Winning entry source code: [westley.c](%%REPO_URL%%/1994/westley/westley.c)
@@ -2509,12 +2734,19 @@ start to finish.
 Cody also added the [alternate version](%%REPO_URL%%/1994/westley/westley.alt.c)
 that will look fine on terminals not set to 80 columns and the
 [try.alt.sh](%%REPO_URL%%/1994/westley/try.alt.sh) script to automate the play
-along the lines of the [try.sh](%%REPO_URL%%/1994/westley/try.sh) script.
+along the lines of the [try.sh](%%REPO_URL%%/1994/westley/try.sh) script. We
+recommend you use this version first, whether you use the script or not.
+
+
+Jump to: [top](#)
 
 
 <div id="1995">
 # [1995 - The 12th IOCCC](1995/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1995_cdua">
@@ -2525,7 +2757,7 @@ along the lines of the [try.sh](%%REPO_URL%%/1994/westley/try.sh) script.
 [Cody](#cody) fixed this so that it would work with macOS. Once it could compile it
 additionally segfaulted under macOS which he also fixed.
 
-Cody also provided the [alternate code](%%REPO_URL%%/1995/cdua/cdua.alt.c) for fun :-) ) (in
+Cody also provided the [alternate code](1995/cdua/cdua.alt.c) for fun :-) ) (in
 particular to make it easier to see the program do what it does in systems that
 are too fast ... if there is such a thing anyway :-) ). See the index.html for
 details on this.
@@ -2535,11 +2767,12 @@ Out of an abundance of caution with `clang`, Cody also added a second arg to
 type of args. In particular some versions supposedly only allow 0, 2 or 3 args.
 It actually appears to allow 1 but if you specify 4 it says 0, 2 or 3 and it is
 an error but it's entirely possible that they will eventually make the defect
-function as the error message claims.
-
-See the
+function as the error message claims.  See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="1995_dodsond1">
@@ -2551,12 +2784,18 @@ for more details.
 provided which is input we suggested one try with the entry.
 
 
+Jump to: [top](#)
+
+
 <div id="1995_esde">
 ## Winning entry: [1995/esde](1995/esde/index.html)
 ### Winning entry source code: [esde.c](%%REPO_URL%%/1995/esde/esde.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/esde/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1995_garry">
@@ -2579,12 +2818,18 @@ alternate code in other entries.  In order to get the paging to work right for
 the `garry.data` file leading blank lines had to be added.
 
 
+Jump to: [top](#)
+
+
 <div id="1995_heathbar">
 ## Winning entry: [1995/heathbar](1995/heathbar/index.html)
 ### Winning entry source code: [1995/heathbar](%%REPO_URL%%/1995/heathbar/heathbar.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/heathbar/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1995_leo">
@@ -2599,6 +2844,9 @@ information about the secret switch, provided by the author, putting it in
 [secret.html](1995/leo/secret.html).
 
 
+Jump to: [top](#)
+
+
 <div id="1995_makarios">
 ## Winning entry: [1995/makarios](1995/makarios/index.html)
 ### Winning entry source code: [makarios.c](%%REPO_URL%%/1995/makarios/makarios.c)
@@ -2610,6 +2858,9 @@ function (`pain()` as it's annoying that `clang` is this way :-) ) that `main()`
 calls which has the four args.
 
 
+Jump to: [top](#)
+
+
 <div id="1995_savastio">
 ## Winning entry: [1995/savastio](1995/savastio/index.html)
 ### Winning entry source code: [savastio.c](%%REPO_URL%%/1995/savastio/savastio.c)
@@ -2618,12 +2869,18 @@ calls which has the four args.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/savastio/try.sh) script.
 
 
+
+Jump to: [top](#)
+
 <div id="1995_schnitzi">
 ## Winning entry: [1995/schnitzi](1995/schnitzi/index.html)
 ### Winning entry source code: [schnitzi.c](%%REPO_URL%%/1995/schnitzi/schnitzi.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1995/schnitzi/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1995_vanschnitz">
@@ -2634,15 +2891,21 @@ calls which has the four args.
 [Cody](#cody) added the authors' [deobfuscation source code](%%REPO_URL%%/1995/vanschnitz/vanschnitz.alt.c)
 as in 2023 we have decided that in most
 cases all the code should be available for the wider audience, without having to
-extract it. The exception is when the files are created by the entry or the
-entry decrypts the text or something like that.
+extract it (the exception, of course, is when the files are created by the entry or the
+entry decrypts the text or something like that).
 
 Cody also added the [try.sh](%%REPO_URL%%/1995/vanschnitz/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1996">
 # [1996 - The 13th IOCCC](1996/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1996_august">
@@ -2663,6 +2926,9 @@ problem existed in macOS.
 Cody also added the [try.sh](%%REPO_URL%%/1996/august/try.sh) script that runs all the
 commands that were given by the judges in the try section, with the fix above
 applied.
+
+
+Jump to: [top](#)
 
 
 <div id="1996_dalbec">
@@ -2686,6 +2952,9 @@ numbers on the same line.
 Cody also added the [try.sh](%%REPO_URL%%/1996/dalbec/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1996_eldby">
 ## Winning entry: [1996/eldby](1996/eldby/index.html)
 ### Winning entry source code: [eldby.c](%%REPO_URL%%/1996/eldby/eldby.c)
@@ -2696,6 +2965,9 @@ Cody also added the [try.sh](%%REPO_URL%%/1996/dalbec/try.sh) script.
 like back in 1996 with modern systems and importantly also for those who are sensitive to text
 flashing by rapidly. We recommend that you try the alternate version first due to
 these reasons.
+
+
+Jump to: [top](#)
 
 
 <div id="1996_gandalf">
@@ -2715,12 +2987,18 @@ BTW: it is perilous to try the patience of
 [Gandalf](https://www.glyphweb.com/arda/g/gandalf.html). Go ahead, try it! :-)
 
 
+Jump to: [top](#)
+
+
 <div id="1996_huffman">
 ## Winning entry: [1996/huffman](1996/huffman/index.html)
 ### Winning entry source code: [huffman.c](%%REPO_URL%%/1996/huffman/huffman.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1996/huffman/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1996_jonth">
@@ -2734,6 +3012,9 @@ the function in the pointer assignment.
 
 **NOTE**: if there is no X server running this program will still crash.
 
+Jump to: [top](#)
+
+
 
 <div id="1996_rcm">
 ## Winning entry: [1996/rcm](1996/rcm/index.html)
@@ -2741,6 +3022,9 @@ the function in the pointer assignment.
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1996/rcm/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1996_schweikh1">
@@ -2759,6 +3043,9 @@ on other systems (the other file is
 the `Makefile` for the (likely?) few who still use Solaris.
 
 
+Jump to: [top](#)
+
+
 <div id="1996_schweikh2">
 ## Winning entry: [1996/schweikh2](1996/schweikh2/index.html)
 ### Winning entry source code: [schweikh2.c](%%REPO_URL%%/1996/schweikh2/schweikh2.c)
@@ -2771,6 +3058,9 @@ author's idea, with a `sleep` and `echo` in between to help one distinguish the
 output better, with the warning that it is an infinite loop).
 
 
+Jump to: [top](#)
+
+
 <div id="1996_schweikh3">
 ## Winning entry: [1996/schweikh3](1996/schweikh3/index.html)
 ## Source code: [schweikh3.c](%%REPO_URL%%/1996/schweikh3/schweikh3.c)
@@ -2779,6 +3069,9 @@ output better, with the warning that it is an infinite loop).
 [Cody](#cody) updated the `Makefile` so that if it fails to compile it will try the
 method suggested for SunOS rather than having to update the `Makefile` manually or
 running a more complicated command: now one can just run `make`.
+
+
+Jump to: [top](#)
 
 
 <div id="1996_westley">
@@ -2802,12 +3095,20 @@ Cody also added the [try.sh](%%REPO_URL%%/1996/westley/try.sh) and
 clocks, both with the fixed version and the original (alt) version.
 
 Also, to fix any potential problem with displaying in GitHub the scripts
-provided by the author, Cody added '.sh' to the `clock[1-3].sh` scripts.
+provided by the author, Cody added '.sh' to the `clock[1-3].sh` scripts (this
+was done before the displaying / downloading of files was devised but it helps
+to show that they are scripts anyway).
+
+
+Jump to: [top](#)
 
 
 <div id="1998">
 # [1998 - The 14th IOCCC](1998/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="1998_banks">
@@ -2828,6 +3129,9 @@ alternatives because not doing so would overly complicate both builds and since
 you can configure them all in both builds it shouldn't matter.
 
 
+Jump to: [top](#)
+
+
 <div id="1998_bas1">
 ## Winning entry: [1998/bas1](1998/bas1/index.html)
 ### Winning entry source code: [bas1.c](%%REPO_URL%%/1998/bas1/bas1.c)
@@ -2838,15 +3142,16 @@ versions of `clang` whine about the number of args on top of what type they are
 In particular some versions claim that they only allow 0, 2 or 3 args. It
 appears that they do allow 1 but for instance 4 is not allowed. However as it's
 quite possible they will 'fix' this defect it would be better to have this not
-be a problem at such a time.
-
-See the
+be a problem at such a time.  See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
 
 Cody also added the [bas1.sh](%%REPO_URL%%/1998/bas1/bas1.sh) script to simplify running the
 program.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_bas2">
@@ -2856,6 +3161,9 @@ program.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1998/bas2/try.sh) script which runs some default actions
 as well as allowing one to pass in different file names or strings.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_chaos">
@@ -2869,6 +3177,9 @@ exiting the program (in both versions).
 Cody also added the [try.sh](%%REPO_URL%%/1998/chaos/try.sh) script that runs the program on
 all the data files, giving instructions on how to rotate and zoom in and out,
 prior to each run.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_df">
@@ -2889,6 +3200,9 @@ loop until one hits `q` (or `Q`) or sends intr/ctrl-c. He also proposed there's
 a way to cheat very easily. Can you figure out how?
 
 
+Jump to: [top](#)
+
+
 <div id="1998_dlowe">
 ## Winning entry: [1998/dlowe](1998/dlowe/index.html)
 ### Winning entry source code: [dlowe.c](%%REPO_URL%%/1998/dlowe/dlowe.c)
@@ -2905,6 +3219,9 @@ remarks](1998/dlowe/index.html#historical-remarks) for more details on the
 pootify scripts.
 
 
+Jump to: [top](#)
+
+
 <div id="1998_dloweneil">
 ## Winning entry: [1998/dloweneil](1998/dloweneil/index.html)
 ### Winning entry source code: [dloweneil.c](%%REPO_URL%%/1998/dloweneil/dloweneil.c)
@@ -2912,7 +3229,12 @@ pootify scripts.
 
 [Cody](#cody) added [alternate code](%%REPO_URL%%/1998/dloweneil/dloweneil.alt.c) which has vi(m) movement
 (in addition to the other keys except for dropping it's not `d` but `j` or
-space) keys as well as allowing one to quit the game.
+space) keys as well as allowing one to quit the game. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_dorssel">
@@ -2921,6 +3243,9 @@ space) keys as well as allowing one to quit the game.
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/1998/dorssel/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_fanf">
@@ -2938,9 +3263,7 @@ versions of `clang` complain about the number of args to `main()`. These version
 claim that only 0, 2 or 3 are allowed but it does allow 1 anyway. It is quite
 possible though that this will change so it is fixed in case this happens. As it
 is mostly just through the C pre-processor Cody added a new macro to make the
-code look like the original with just an extra arg.
-
-See the
+code look like the original with just an extra arg.  See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
@@ -2950,6 +3273,9 @@ In some versions of `clang` `-Wno-int-conversion` had to be added to the
 
 Cody also added the [try.sh](%%REPO_URL%%/1998/fanf/try.sh) script to show the output of some
 of the expressions that we selected.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_schnitzi">
@@ -2978,6 +3304,9 @@ doing:
 
 Cody also added the [try.sh](%%REPO_URL%%/1998/schnitzi/try.sh) script to help users try the
 commands that we recommended as well as some added by him.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_schweikh1">
@@ -3041,6 +3370,9 @@ compute the character count in the code according to the contest rules of 1998
 in the file [charcount.pl](%%REPO_URL%%/1998/schweikh1/charcount.pl).
 
 
+Jump to: [top](#)
+
+
 <div id="1998_schweikh2">
 ## Winning entry: [1998/schweikh2](1998/schweikh2/index.html)
 ### Winning entry source code: [schweikh2.c](%%REPO_URL%%/1998/schweikh2/schweikh2.c)
@@ -3067,22 +3399,25 @@ question.
 Cody also added the [try.sh](%%REPO_URL%%/1998/schweikh2/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="1998_schweikh3">
 ## Winning entry: [1998/schweikh3](1998/schweikh3/index.html)
 ### Winning entry source code: [schweikh3.c](%%REPO_URL%%/1998/schweikh3/schweikh3.c)
 </div>
 
 [Cody](#cody) added the [alternate
-code](%%REPO_URL%%/1998/schweikh3/schweikh3.alt.c) which allows one
+code](1998/schweikh3/index.html#alternate-code) which allows one
 to reconfigure the size constant in the rare case that the author wrote about
-occurs.
+occurs. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 Cody made `main()` have two args out of an abundance of caution as some versions
 of `clang` say that `main()` can only have 0, 2 or 3 args. These versions accept 1
 arg but it is entirely possible that they fix this so this should prevent it
-from breaking if that happens.
-
-See the
+from breaking if that happens.  See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
@@ -3096,19 +3431,19 @@ is the name of the program.
 
 The author stated that:
 
-```
-    In the remote event that the input has more than `8192` files with
-    the same size (on systems where `sizeof (char *) == 4`, or `4096` when
-    `sizeof (char *) == 8`), increase the manifest constant 32767 on line
-    31.
-```
+> In the remote event that the input has more than `8192` files with the same
+size (on systems where `sizeof (char *) == 4`, or `4096` when `sizeof (char *)
+== 8`), increase the manifest constant 32767 on line 31.
 
-so Cody changed the constant to a macro in the `Makefile` called `SZ` so one can
+... so Cody changed the constant to a macro in the `Makefile` called `SZ` so one can
 more easily do this (though it indeed seems highly unlikely). See the index.html
 for more details.
 
 There actually is a web page for the tool and this was added to the author
 information for the entry. It has not been added to any JSON file.
+
+
+Jump to: [top](#)
 
 
 <div id="1998_tomtorfs">
@@ -3129,9 +3464,15 @@ Cody also added the [try.sh](%%REPO_URL%%/1998/tomtorfs/try.sh) script to try ou
 commands that we recommended.
 
 
+Jump to: [top](#)
+
+
 <div id="2000">
 # [2000 - The 15th IOCCC](2000/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2000_anderson">
@@ -3141,11 +3482,12 @@ commands that we recommended.
 
 [Cody](#cody) changed this entry to use `fgets(3)` instead of `gets(3)`.
 This involved changing the `K` arg to `gets(3)` to `&K` in `fgets(3)`.
-Cody also added the [try.sh](%%REPO_URL%%/2000/anderson/try.sh) script.
-
-See the
+Cody also added the [try.sh](%%REPO_URL%%/2000/anderson/try.sh) script.  See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_bmeyer">
@@ -3156,6 +3498,9 @@ for why this was done.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2000/bmeyer/try.sh) script with some improvements to the
 commands we recommended like not assuming the number of columns one has in their
 terminal.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_briddlebane">
@@ -3170,6 +3515,9 @@ Cody also added the [try.sh](%%REPO_URL%%/2000/briddlebane/try.sh) script for th
 feeling a bit too confident, cocky or even happy :-)
 
 
+Jump to: [top](#)
+
+
 <div id="2000_dhyang">
 ## Winning entry: [2000/dhyang](2000/dhyang/index.html)
 ### Winning entry source code: [dhyang.c](%%REPO_URL%%/2000/dhyang//dhyang.c)
@@ -3178,6 +3526,9 @@ feeling a bit too confident, cocky or even happy :-)
 [Cody](#cody) made this more portable by changing the `void main` to `int main`.
 
 He also added the [try.sh](%%REPO_URL%%/2000/dhyang/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_dlowe">
@@ -3191,6 +3542,9 @@ He also added the [try.sh](%%REPO_URL%%/2000/dhyang/try.sh) script.
 Cody also added the [try.sh](%%REPO_URL%%/2000/dlowe/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2000_jarijyrki">
 ## Winning entry: [2000/jarijyrki](2000/jarijyrki/index.html)
 ### Winning entry source code: [jarijyrki.c](%%REPO_URL%%/2000/jarijyrki//jarijyrki.c)
@@ -3198,6 +3552,9 @@ Cody also added the [try.sh](%%REPO_URL%%/2000/dlowe/try.sh) script.
 
 [Cody](#cody) made it easier to compile this in some cases by adding `X11/` to the
 includes of `Xlib.h` and `keysym.h`.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_natori">
@@ -3209,7 +3566,7 @@ includes of `Xlib.h` and `keysym.h`.
 segfault when run or not compile at all (`gcc` and `clang` respectively). The
 compiler fix is due to `clang` being more strict about arg types to `main()`.
 
-Cody also provided [alternate code](%%REPO_URL%%/2000/natori/natori.alt.c) that
+Cody also provided [alternate code](2000/natori/index.html#alternate-code) that
 supports the southern hemisphere, based on the author's remarks.
 
 Cody also provided the [try.sh](%%REPO_URL%%/2000/natori/try.sh) and
@@ -3230,6 +3587,9 @@ variable which although works it is incongruent with the other Makefiles and is
 more confusing (though not really).
 
 
+Jump to: [top](#)
+
+
 <div id="2000_primenum">
 ## Winning entry: [2000/primenum](2000/primenum/index.html)
 ### Winning entry source code: [primenum.c](%%REPO_URL%%/2000/primenum//primenum.c)
@@ -3240,12 +3600,18 @@ more confusing (though not really).
 Cody also added the [try.sh](%%REPO_URL%%/2000/primenum/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2000_rince">
 ## Winning entry: [2000/rince](2000/rince/index.html)
 ### Winning entry source code: [rince.c](%%REPO_URL%%/2000/rince//rince.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2000/rince/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_robison">
@@ -3256,14 +3622,15 @@ Cody also added the [try.sh](%%REPO_URL%%/2000/primenum/try.sh) script.
 [Cody](#cody) fixed an infinite loop that occurred if invalid input was entered, flooding
 the screen with:
 
-```
-    Black position and direction: illegal
-```
+> Black position and direction: illegal
 
 This was fixed by having the `scanf(3)` read in a string and then use `atoi(3)`
 on it to assign to the `int`s, much like with [1987/lievaart](#1987_lievaart).
 The strings are `char[5]` and the `%` specifier is `%4s` which is enough for the
 game.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_schneiderwent">
@@ -3272,6 +3639,9 @@ game.
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2000/schneiderwent/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_thadgavin">
@@ -3294,14 +3664,13 @@ to test the other version in.
 Due to a terrible design choice of the SDL1 developers something had to be
 changed. As was noted in the log at the time:
 
-```
-    The SDL version did not work for a number of reasons. First of all the
-    code requires that SDL is defined. Second the path[sic] wrong header file was
-    included. Third the SDL1 developers thought it would be a great idea
-    (but obviously it's a terrible idea) to redefine main() (!!) so that any
-    program that uses SDL1 has to have the same args as their definition.
-    This program had 'main()' so the error message was:
-
+>    The SDL version did not work for a number of reasons. First of all the
+>    code requires that SDL is defined. Second the path[sic] wrong header file was
+>    included. Third the SDL1 developers thought it would be a great idea
+>    (but obviously it's a terrible idea) to redefine main() (!!) so that any
+>    program that uses SDL1 has to have the same args as their definition.
+>    This program had 'main()' so the error message was:
+``` <!---c-->
         thadgavin.c:60:1: error: conflicting types for 'SDL_main'
         main()
         ^
@@ -3313,9 +3682,12 @@ changed. As was noted in the log at the time:
                    ^
         1 warning and 1 error generated.
         make: *** [thadgavin_sdl] Error 1
-
-    Thus main() was changed to 'int main(int argc, char **argv)'.
 ```
+>
+>    Thus `main()` was changed to `int main(int argc, char **argv)`.
+
+
+Jump to: [top](#)
 
 
 <div id="2000_tomx">
@@ -3323,8 +3695,8 @@ changed. As was noted in the log at the time:
 ### Winning entry source code: [tomx.c](%%REPO_URL%%/2000/tomx//tomx.c)
 </div>
 
-[Cody](#cody) added the [alternate code](%%REPO_URL%%/2000/tomx/tomx.alt.c) based on the
-author's remarks with a fix for modern systems and he also added the two
+[Cody](#cody) added the [alternate code](2000/tomx/index.html#alternate-code) based on the
+author's remarks with a fix for modern systems, and he also added the two
 scripts, [try.sh](%%REPO_URL%%/2000/tomx/try.sh) and [try.alt.sh](%%REPO_URL%%/2000/tomx/try.alt.sh) for
 the main code and the alternate code respectively.
 
@@ -3332,9 +3704,15 @@ And although the scripts do `chmod +x` on the source code (see the index.html fo
 details) the source code is now executable by default.
 
 
+Jump to: [top](#)
+
+
 <div id="2001">
 # [2001 - The 16th IOCCC](2001/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2001_anonymous">
@@ -3428,6 +3806,9 @@ attempt to use the program as it was designed but if compiling as 32-bit fails
 it will at least run the supplementary program as a 64-bit program directly.
 
 
+Jump to: [top](#)
+
+
 <div id="2001_bellard">
 ## Winning entry: [2001/bellard](2001/bellard/index.html)
 ### Winning entry source code: [bellard.c](%%REPO_URL%%/2001/bellard//bellard.c)
@@ -3463,6 +3844,9 @@ checked prior to running the function just like the author did for the factorial
 this entry by Yusuke.
 
 
+Jump to: [top](#)
+
+
 ## Portability notes:
 
 With a tip from Yusuke we rediscovered the author's [web page for this
@@ -3477,6 +3861,9 @@ compiler that does not support this would not work. Thus we use the modification
 by Yusuke.
 
 
+Jump to: [top](#)
+
+
 <div id="2001_cheong">
 ## Winning entry: [2001/cheong](2001/cheong/index.html)
 ### Winning entry source code: [cheong.c](%%REPO_URL%%/2001/cheong//cheong.c)
@@ -3489,6 +3876,9 @@ this. :-) This fix makes a point of the author's notes on portability no longer
 valid, BTW.
 
 Cody also added the [try.sh](%%REPO_URL%%/2001/cheong/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2001_coupard">
@@ -3518,7 +3908,11 @@ Cody also added the [try.sh](%%REPO_URL%%/2001/coupard/try.sh) script.
 or `/dev/sound/dsp` (which is most everyone nowadays, it seems, and especially
 those with macOS) (to do with sound; see his
 [2013/endoh3/index.html](2013/endoh3/index.html) entry where he also refers to
-sound devices in macOS).
+sound devices in macOS as well as our
+FAQ on "[sound](faq.html#sound)").
+
+
+Jump to: [top](#)
 
 
 
@@ -3535,8 +3929,14 @@ etc.) after exiting even if you don't press 'q', if you crash or if you kill the
 program prematurely. This was done by adding an explicit call to `e()` at the
 end of `main()`.
 
-Cody also added the [alternate code](%%REPO_URL%%/2001/ctk/ctk.alt.c) that adds
-vi(m) movement keys.
+Cody also added the [alternate
+code](2001/ctk/index.html#alternate-code) that adds
+vi(m) movement keys. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="2001_dgbeards">
@@ -3546,13 +3946,16 @@ vi(m) movement keys.
 
 The author provided two changes: one to speed it up and one to make it not crash
 on losing. [Cody](#cody) provided an [alternate
-version](%%REPO_URL%%/2001/dgbeards/dgbeards.alt.c) which does the former but
+version](2001/dgbeards/index.html#alternate-code) which does the former but
 not the latter as he he felt that the idea of crashing on losing (see the
 index.html for details on why that might be) too good to get rid. The author
 explains how to make this change, however.
 
 Cody also points out that there is a way to get the computer to automatically lose
 very quickly. Do you know what it is?
+
+
+Jump to: [top](#)
 
 
 <div id="2001_herrmann1">
@@ -3572,14 +3975,15 @@ He also fixed the [script herrmann1.sh](%%REPO_URL%%/2001/herrmann1/herrmann1.sh
 shellcheck. In particular there were quite a few:
 
 
-```
-    SC2086 (info): Double quote to prevent globbing and word splitting.
-    SC2248 (style): Prefer double quoting even when variables don't contain special characters.
-```
+> SC2086 (info): Double quote to prevent globbing and word splitting.<br>
+> SC2248 (style): Prefer double quoting even when variables don't contain special characters.
 
-errors/warnings.
+... errors/warnings.
 
 Cody also added the [try.sh](%%REPO_URL%%/2001/herrmann1/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2001_herrmann2">
@@ -3600,6 +4004,9 @@ For some reason the original code was missing (presumingly because it had been
 added to `.gitignore` by accident) but Cody restored it from the archive.
 
 
+Jump to: [top](#)
+
+
 <div id="2001_kev">
 ## Winning entry: [2001/kev](2001/kev/index.html)
 ### Winning entry source code: [kev.c](%%REPO_URL%%/2001/kev//kev.c)
@@ -3612,8 +4019,10 @@ Cody also slowed down the ball just a tad (it was already a `-D` macro that was 
 in the code) as it went too fast for the speed at which the paddles move even
 when holding down the movement keys (but see below).
 
-Cody also provided an [alternate version](%%REPO_URL%%/2001/kev/kev.alt.c) which lets you use
-the arrow keys on your keyboard instead of the more awkward '`,`' and '`.`'.
+Cody also provided an [alternate version](2001/kev/index.html#alternate-code) which lets you use
+the arrow keys on your keyboard instead of the more awkward '`,`' and '`.`'. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 Cody updated both versions to have `#ifndef..#endif` pairs for the macros so one
 can more easily configure different settings without having to specify all of
@@ -3621,6 +4030,9 @@ them (though this change became unnecessary with an improvement on how it was
 done). The speed, `SPEED`, will be set to `50` if it's not defined at the compiler
 line as `50` is what it used to be set to. This way it's more to the original but
 without having to sacrifice playability by running `make`.
+
+
+Jump to: [top](#)
 
 
 <div id="2001_ollinger">
@@ -3632,16 +4044,22 @@ without having to sacrifice playability by running `make`.
 
 
 
+Jump to: [top](#)
+
+
 <div id="2001_schweikh">
 ## Winning entry: [2001/schweikh](2001/schweikh/index.html)
 ### Winning entry source code: [schweikh.c](%%REPO_URL%%/2001/schweikh//schweikh.c)
 </div>
 
 [Cody](#cody) fixed this to not crash if not enough args as this was not documented by
-the author. The other problems are documented so were not fixed. See
+the author. The other problems are documented so were not fixed. See the
 index.html for details.
 
 Cody also added the [try.sh](%%REPO_URL%%/2001/schweikh/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2001_westley">
@@ -3657,9 +4075,15 @@ remarks, through `Makefile` rules that generate the files by default with `make
 all`.
 
 
+Jump to: [top](#)
+
+
 <div id="2004">
 # [2004 - The 17th IOCCC](2004/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2004_anonymous">
@@ -3670,16 +4094,25 @@ all`.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/anonymous/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2004_arachnid">
 ## Winning entry: [2004/arachnid](2004/arachnid/index.html)
 ### Winning entry source code: [arachnid.c](%%REPO_URL%%/2004/arachnid//arachnid.c)
 </div>
 
 [Cody](#cody) added an [alternate
-version](%%REPO_URL%%/2004/arachnid/arachnid.alt.c) which
+version](2004/arachnid/index.html#alternate-code) which
 allows those like himself used to `h`, `j`, `k` and `l` movement keys to not get
 lost. Non rogue players, vi users and Dvorak typists are invited to get lost (or
-use the original version)! :-)
+use the original version)! :-) See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
+
+Jump to: [top](#)
 
 
 <div id="2004_burley">
@@ -3709,10 +4142,13 @@ expression with `void` or if it is for some other reason).
 
 `longjmp(3)` was being called with one arg which was an element
 of an `int[4][1000]` which had to be changed to a `jmp_buf p[4]` (this due to
-the prototype being included).
+the addition of `#include <setjmp.h>`).
 
 Finally the optimiser cannot be enabled so the compiler flags were changed for
 this, forcing `-O0`.
+
+
+Jump to: [top](#)
 
 
 <div id="2004_gavare">
@@ -3732,13 +4168,18 @@ and anti-alias setting at compile time. This is based on the author's remarks.
 that was used during development, found on their [website about the
 entry](https://gavare.se/ioccc/ioccc_gavare.c.html).
 
+See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
 
 <div id="2004_gavin">
 ## Winning entry: [2004/gavin](2004/gavin/index.html)
 ### Winning entry source code: [gavin.c](%%REPO_URL%%/2004/gavin//gavin.c)
 </div>
 
-[Cody](#cody) provided the [alternate code](%%REPO_URL%%/2004/gavin/gavin.alt.c) for
+[Cody](#cody) provided the [alternate code](2004/gavin/index.html#alternate-code) for
 those who want to use QEMU. The most important part of this is the macro `K` has
 to be defined as `1`, not `0`.
 
@@ -3748,6 +4189,9 @@ files provided, found under the [img/](%%REPO_URL%%/2004/gavin/img/) directory. 
 the `img/fs.tar` extracts into `fs/` so you will have to fix the tarball; this
 is done this way to prevent extraction from the entry directory overwriting the
 files and causing `make clobber` to wipe some of them out.
+
+
+Jump to: [top](#)
 
 
 <div id="2004_hibachi">
@@ -3771,12 +4215,18 @@ well, namely to get the program to work as `alt` rather than `-spoiler` (it is
 not even known if it would work otherwise).
 
 
+Jump to: [top](#)
+
+
 <div id="2004_hoyle">
 ## Winning entry: [2004/hoyle](2004/hoyle/index.html)
 ### Winning entry source code: [hoyle.c](%%REPO_URL%%/2004/hoyle//hoyle.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/hoyle/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2004_jdalbec">
@@ -3810,13 +4260,18 @@ and various other problems. However there does seem to be a problem at least
 with some `gcc` versions in macOS but this appears to be due to errors in
 `/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/cdefs.h`.
 
-Cody also added [alternate code](%%REPO_URL%%/2004/jdalbec/jdalbec.alt.c) which allows
+Cody also added [alternate code](2004/jdalbec/index.html#alternate-code) which allows
 one to control how many numbers after the `:` to print before printing a
 newline, so that one can see the output a bit better (though for lines that have
-a lot of numbers this will be harder to see).
+a lot of numbers this will be harder to see). See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 Finally Cody added [try.sh](%%REPO_URL%%/2004/jdalbec/try.sh) and
 [try.alt.sh](%%REPO_URL%%/2004/jdalbec/try.alt.sh) to demonstrate both versions.
+
+
+Jump to: [top](#)
 
 
 <div id="2004_kopczynski">
@@ -3829,17 +4284,17 @@ discovered it will not work otherwise.
 
 Cody, out of an abundance of caution for `clang`, added a second arg to `main()`
 as some versions complain about the number of args and although they accept 1 it
-is entirely possible it will eventually be that they don't.
-
-See the
-FAQ on "[main function args](faq.html#arg_count)"
-for more details.
+is entirely possible it will eventually be that they don't. See the FAQ on
+"[main function args](faq.html#arg_count)" for more details.
 
 Cody also added the [try.sh](%%REPO_URL%%/2004/kopczynski/try.sh) script and various data
 files: [kopczynski-a](%%REPO_URL%%/2004/kopczynski/kopczynski-a) to demonstrate what happens when art more
 like a letter is fed to the program, and the `kopczynski*-rev` files which are
 the data files reversed with `rev(1)`. One had to be modified additionally to
 get it to work, that being `kopczynski-10-rev`.
+
+
+Jump to: [top](#)
 
 
 <div id="2004_newbern">
@@ -3854,6 +4309,9 @@ that the author referred to and was documented by [Yusuke](#yusuke) though Cody
 chose the word `IOCCC` instead of `AAA`).
 
 
+Jump to: [top](#)
+
+
 <div id="2004_omoikane">
 ## Winning entry: [2004/omoikane](2004/omoikane/index.html)
 ### Winning entry source code: [omoikane.c](%%REPO_URL%%/2004/omoikane//omoikane.c)
@@ -3862,14 +4320,15 @@ chose the word `IOCCC` instead of `AAA`).
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2004/omoikane/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2004_schnitzi">
 ## Winning entry: [2004/schnitzi](2004/schnitzi/index.html)
 ### Winning entry source code: [schnitzi.c](%%REPO_URL%%/2004/schnitzi//schnitzi.c)
 </div>
 
-[Cody](#cody) made this use `fgets(3)`.
-
-See the
+[Cody](#cody) made this use `fgets(3)`. See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for why this was done.
 
@@ -3879,6 +4338,8 @@ fast in modern systems, especially the scrolling text of
 [schnitzi.inp1](%%REPO_URL%%/2004/schnitzi/schnitzi.inp1).
 
 Cody also added the [try.sh](%%REPO_URL%%/2004/schnitzi/try.sh) script.
+
+Jump to: [top](#)
 
 
 <div id="2004_sds">
@@ -3891,6 +4352,9 @@ Cody also added the [try.sh](%%REPO_URL%%/2004/schnitzi/try.sh) script.
 Also, after the `README.md` file had copyright changes, it broke the script so
 Cody made a copy of the older `README.md` file into `README_sds.txt` and added that
 to the repo for the script instead.
+
+Jump to: [top](#)
+
 
 
 <div id="2004_vik2">
@@ -3955,9 +4419,15 @@ Cody also made it so that the `FNAME` is (for the entry file itself and
 just to make it a bit easier to compile.
 
 
+Jump to: [top](#)
+
+
 <div id="2005">
 # [2005 - The 18th IOCCC](2005/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2005_aidan">
@@ -3969,10 +4439,12 @@ just to make it a bit easier to compile.
 to the proper compiled program (it's hardcoded). This had never been done and so
 the script did not even work (at least modernly?).
 
-He also added the [alternate code](%%REPO_URL%%/2005/aidan/aidan.alt.c) based on the
+He also added the [alternate code](2005/aidan/index.html#alternate-code) based on the
 author's remarks which is a different approach than the one used and which
-(according to the author) '`is slower (particularly in worst-case or nearly so
-scenarios), inelegant, and not a good starting place for sudoku generation.`'
+(according to the author):
+
+> ... is slower (particularly in worst-case or nearly so
+scenarios), inelegant, and not a good starting place for sudoku generation.
 
 Cody added the [try.sh](%%REPO_URL%%/2005/aidan/try.sh) and
 [try.alt.sh](%%REPO_URL%%/2005/aidan/try.alt.sh) scripts that correspond to the entry and
@@ -3980,6 +4452,9 @@ alternate code respectively.
 
 Cody added the `make test` and `make test-n0` rules for easier use of the test
 suite.
+
+
+Jump to: [top](#)
 
 
 <div id="2005_anon">
@@ -3995,8 +4470,13 @@ The author noted that one can define `NO_STTY` to not use `stty(1)` at all
 (either to prevent having to hit enter or to turn echo off/on) and this is
 explained in the index.html.
 
-Cody added the [alternate code](%%REPO_URL%%/2005/anon/anon.alt.c) with vi(m) like
-movements.
+Cody added the [alternate code](2005/anon/index.html#alternate-code) with vi(m) like
+movements. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="2005_boutines">
@@ -4008,6 +4488,9 @@ movements.
 input from the author, adapting it to a command to try out.
 
 Cody also added the [try.sh](%%REPO_URL%%/2005/boutines/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2005_giljade">
@@ -4081,6 +4564,9 @@ program generates as the author states, 180.  If it does not find 180 it is an
 error; otherwise it is success. See [test.sh](%%REPO_URL%%/2005/giljade/test.sh).
 
 
+Jump to: [top](#)
+
+
 <div id="2005_jetro">
 ## Winning entry: [2005/jetro](2005/jetro/index.html)
 ### Winning entry source code: [jetro.c](%%REPO_URL%%/2005/jetro//jetro.c)
@@ -4091,12 +4577,18 @@ not do it implicitly (like macOS does).
 
 
 
+Jump to: [top](#)
+
+
 <div id="2005_klausler">
 ## Winning entry: [2005/klausler](2005/klausler/index.html)
 ### Winning entry source code: [klausler.c](%%REPO_URL%%/2005/klausler//klausler.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2005/klausler/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2005_mikeash">
@@ -4134,6 +4626,9 @@ also show correct output though.
 Cody also added the [try.sh](%%REPO_URL%%/2005/mikeash/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2005_mynx">
 ## Winning entry: [2005/mynx](2005/mynx/index.html)
 ### Winning entry source code: [mynx.c](%%REPO_URL%%/2005/mynx//mynx.c)
@@ -4154,17 +4649,23 @@ support `http`. But there might be some command line that will let it work that
 way or perhaps someone wants to add the necessary code, updating the file.
 
 
+Jump to: [top](#)
+
+
 <div id="2005_persano">
 ## Winning entry: [2005/persano](2005/persano/index.html)
 ### Winning entry source code: [persano.c](%%REPO_URL%%/2005/persano//persano.c)
 </div>
 
 [Cody](#cody) added the (untested) [alternate
-code](%%REPO_URL%%/2005/persano/persano.alt.c) which should work for Windows as
+code](2005/persano/index.html#alternate-code) which should work for Windows as
 it sets binary mode on `stdout`. This was based on the author's remarks but it
 is untested as Cody has no Windows system to test it on.
 
 Cody also added the [try.sh](%%REPO_URL%%/2005/persano/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2005_sykes">
@@ -4209,6 +4710,9 @@ The scripts note every time that one will have to send ctrl-c or whatever their
 interrupt is set to in order to exit the program.
 
 
+Jump to: [top](#)
+
+
 <div id="2005_timwi">
 ## Winning entry: [2005/timwi](2005/timwi/index.html)
 ### Winning entry source code: [timwi.c](%%REPO_URL%%/2005/timwi//timwi.c)
@@ -4217,6 +4721,9 @@ interrupt is set to in order to exit the program.
 [Cody](#cody) added [try.sh](%%REPO_URL%%/2005/timwi/try.sh). It only has one command as he doesn't
 want to knacker his brain any more than it might or might not already be :-) and
 he doesn't want to damage anyone else's brain either. :-)
+
+
+Jump to: [top](#)
 
 
 <div id="2005_toledo">
@@ -4230,6 +4737,9 @@ another function that takes 4 args and which is what used to be `main()`.
 
 The [alternate versions](2005/toledo/index.html#alternate-code) that the author
 provided were also fixed.
+
+
+Jump to: [top](#)
 
 
 <div id="2005_vince">
@@ -4248,9 +4758,15 @@ with the appropriate extension so this might be called a bug fix as well though
 if one runs it from another directory, specifying the directory, it'll not catch it.
 
 
+Jump to: [top](#)
+
+
 <div id="2006">
 # [2006 - The 19th IOCCC](2006/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2006_birken">
@@ -4265,6 +4781,9 @@ it from working.
 Cody also added the [try.sh](%%REPO_URL%%/2006/birken/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2006_borsanyi">
 ## Winning entry: [2006/borsanyi](2006/borsanyi/index.html)
 ### Winning entry source code: [borsanyi.c](%%REPO_URL%%/2006/borsanyi//borsanyi.c)
@@ -4276,6 +4795,9 @@ implicitly linked in.
 Cody also added the [try.sh](%%REPO_URL%%/2006/borsanyi/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2006_grothe">
 ## Winning entry: [2006/grothe](2006/grothe/index.html)
 ### Winning entry source code: [grothe.c](%%REPO_URL%%/2006/grothe//grothe.c)
@@ -4284,12 +4806,18 @@ Cody also added the [try.sh](%%REPO_URL%%/2006/borsanyi/try.sh) script.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2006/grothe/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2006_hamre">
 ## Winning entry: [2006/hamre](2006/hamre/index.html)
 ### Winning entry source code: [hamre.c](%%REPO_URL%%/2006/hamre//hamre.c)
 </div>
 
-Cody also added the [try.sh](%%REPO_URL%%/2006/hamre/try.sh) script.
+Cody added the [try.sh](%%REPO_URL%%/2006/hamre/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2006_monge">
@@ -4297,22 +4825,22 @@ Cody also added the [try.sh](%%REPO_URL%%/2006/hamre/try.sh) script.
 ### Winning entry source code: [monge.c](%%REPO_URL%%/2006/monge//monge.c)
 </div>
 
-[Cody](#cody) added the [alternate code](%%REPO_URL%%/2006/monge/monge.alt.c) that lets
-one resize the image and redefine the number of iterations.
+[Cody](#cody) added the [alternate code](2006/monge/index.html#alternate-code) that lets
+one resize the image and redefine the number of iterations. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 Cody also added the [try.sh](%%REPO_URL%%/2006/monge/try.sh) and
 [try.alt.sh](%%REPO_URL%%/2006/monge/try.alt.sh) scripts.
 
-Cody also fixed the `Makefile` to use `sdl-config` (which is what the author
-stated too though that was noticed later), not `sdl2-config` as two functions
-that are used were removed from [SDL2](https://www.libsdl.org),
-thus making it not link. Since SDL2 is still available and since changing the
-code to use SDL2 is much more complicated and also makes the entry less like
-the original it was simply made to link in SDL1.
+Cody also fixed the `Makefile` to use `sdl-config`, not `sdl2-config`, as two
+functions that are used were removed from [SDL2](https://www.libsdl.org), thus
+making it not link.
 
-Nevertheless this entry does require x86/x86_64 CPUS. This is a documented
-feature but one which we will accept fixes to. See [2006/monge in
-bugs.html](bugs.html#2006_monge).
+Nevertheless this entry does require x86/x86_64 CPUS (this is a documented
+feature).
+
+Jump to: [top](#)
 
 
 <div id="2006_night">
@@ -4321,8 +4849,11 @@ bugs.html](bugs.html#2006_monge).
 </div>
 
 As [Cody](#cody) is a lost :-) `vim` user he took the author's remarks to add support
-back for arrow keys in the [alternate version](%%REPO_URL%%/2006/night/night.alt.c).
+back for arrow keys in the [alternate
+version](2006/night/index.html#alternate-code). See the
+FAQ on "[alternate code](faq.html#alt_code)" for more details.
 
+Jump to: [top](#)
 
 <div id="2006_sloane">
 ## Winning entry: [2006/sloane](2006/sloane/index.html)
@@ -4343,13 +4874,6 @@ used but Cody discovered that later versions of `clang` have an additional defec
 where it does not allow only one arg so the second arg to `main()` was added
 back.
 
-This was an unfortunate problem for the alternate code as he has been using `Z`
-for alternate code `usleep()` (for sleep) but in this case unfortunately the
-original entry used `Z` in `main()` (though unused) so to make it more like the
-original Cody renamed the macro `Z` for `usleep()` to `S` instead which can
-stand for sleep and also it is kind of like a backwards `Z`. That way `Z` could
-be in `main()`.
-
 Cody also made sure that the `Makefile` links in `libm` as not all systems do this
 by default.
 
@@ -4365,19 +4889,25 @@ program in some systems he also added `-include ...` to the `Makefile` as well.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2006/stewart/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2006_sykes1">
 ## Winning entry: [2006/sykes1](2006/sykes1/index.html)
 ### Winning entry source code: [sykes1.c](%%REPO_URL%%/2006/sykes1//sykes1.c)
 </div>
 
 [Cody](#cody) provided the [alternate
-code](%%REPO_URL%%/2006/sykes1/sykes1.alt.c) based on the
+code](2006/sykes1/index.html#alternate-code) based on the
 author's remarks.
 
 Cody also added the [try.sh](%%REPO_URL%%/2006/sykes1/try.sh) script.
 
 Cody also provided the [bedlam-cubes.pdf](2006/sykes1/bedlam-cubes.pdf) file,
 obtained from the Internet Wayback Machine, as the file was no longer available.
+
+Jump to: [top](#)
+
 
 
 <div id="2006_sykes2">
@@ -4387,15 +4917,14 @@ obtained from the Internet Wayback Machine, as the file was no longer available.
 
 [Cody](#cody), out of an abundance of caution for `clang`'s defects, made `main()` have
 2 args instead of 1 as some versions report that `main()` must have 0, 2 or 3
-args, even though at least one of those versions allows 1 arg only.
-
-See the
+args, even though at least one of those versions allows 1 arg only. See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
+Cody also added the [try.sh](%%REPO_URL%%/2006/sykes2/try.sh) script for easier
+use of the entry to show the clock update in real time.
 
-Cody also added the [try.sh](%%REPO_URL%%/2006/sykes2/try.sh) script for easier use of the
-entry to show the clock update in real time.
+Jump to: [top](#)
 
 
 <div id="2006_toledo1">
@@ -4404,6 +4933,9 @@ entry to show the clock update in real time.
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2006/toledo1/try.sh) script.
+
+Jump to: [top](#)
+
 
 
 <div id="2006_toledo2">
@@ -4417,7 +4949,7 @@ problem was wrong variable types - implicit `int`s instead of `FILE *`s. It now
 works with both macOS and Linux.
 
 Cody also added the (untested) [alternate
-code](%%REPO_URL%%/2006/toledo2/toledo2.alt.c) that is based on the author's remarks to
+code](2006/toledo2/index.html#alternate-code) that is based on the author's remarks to
 port this to systems that have the non-standard `kbhit()` and `getch()` (not the
 one from curses) which is typically (always?) in `conio.h`.
 
@@ -4426,6 +4958,9 @@ the program and modified the `fread(3)`/`fwrite(3)` section to use the variable
 `FILE *e` (that Cody changed) instead of `int y`, making it to work on x86_64
 (perhaps Cody's fix was for arm64 only?). Also, he added a note to clarify from
 where appears the `IMPORT.COM` and `HALT.COM` files.
+
+Jump to: [top](#)
+
 
 
 
@@ -4440,14 +4975,21 @@ lets it work in both Linux and macOS. The problem was that it relied on 32-bits
 so some `int`s were changed to `long`s. The display problem might or might not
 have been a problem in Linux with the old `int`s but this is no longer known.
 
-Cody also added the code that _should_ work for Windows,
-[toledo3.alt.c](%%REPO_URL%%/2006/toledo3/toledo3.alt.c), based on the author's remarks.
-We're not able to test this.
+Cody also added the code that should work for Windows (it was tested by the
+author), [toledo3.alt.c](%%REPO_URL%%/2006/toledo3/toledo3.alt.c), based on the
+author's remarks; see [Alternate code in
+2006/toledo3/index.html](2006/toledo3/index.html#alternate-code).
+
+
+Jump to: [top](#)
 
 
 <div id="2011">
 # [2011 - The 20th IOCCC](2011/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2011_akari">
@@ -4458,12 +5000,18 @@ We're not able to test this.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/akari/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2011_blakely">
 ## Winning entry: [2011/blakely](2011/blakely/index.html)
 ### Winning entry source code: [blakely.c](%%REPO_URL%%/2011/blakely//blakely.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/blakely/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2011_borsanyi">
@@ -4473,14 +5021,15 @@ We're not able to test this.
 
 [Cody](#cody), out of an abundance of caution, added a second arg to `main()` as some
 versions of `clang` complain about not only the type of each arg to `main()` but
-the number of args as well.
-
-See the
+the number of args as well. See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
 
 Cody also added the [try.sh](%%REPO_URL%%/2011/borsanyi/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2011_dlowe">
@@ -4504,12 +5053,18 @@ the file `2011/dlowe/dlowe-aux-data/png-1/image_thumb[40].png` was renamed to
 `image_thumb.png`.
 
 
+Jump to: [top](#)
+
+
 <div id="2011_fredriksson">
 ## Winning entry: [2011/fredriksson](2011/fredriksson/index.html)
 ### Winning entry source code: [fredriksson.c](%%REPO_URL%%/2011/fredriksson//fredriksson.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/fredriksson/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2011_goren">
@@ -4525,7 +5080,13 @@ and now it does work with 64-bit systems as well as 32-bit systems.
 
 Cody also added the [try.sh](%%REPO_URL%%/2011/goren/try.sh) script.
 
-Cody added the following words of wisdom: `'"this" is not a pipe but "|" is'`.
+Cody added the following words of wisdom:
+
+> "this" is not a pipe but "|" is
+
+:-).
+
+Jump to: [top](#)
 
 
 <div id="2011_hamaji">
@@ -4543,6 +5104,9 @@ The latter two `.nono` files were taken from
 and the others were from the authors' remarks.
 
 
+Jump to: [top](#)
+
+
 <div id="2011_hou">
 ## Winning entry: [2011/hou](2011/hou/index.html)
 ### Winning entry source code: [hou.c](%%REPO_URL%%/2011/hou//hou.c)
@@ -4551,12 +5115,18 @@ and the others were from the authors' remarks.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/hou/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2011_konno">
 ## Winning entry: [2011/konno](2011/konno/index.html)
 ### Winning entry source code: [konno.c](%%REPO_URL%%/2011/konno//konno.c)
 </div>
 
 Cody added the [try.sh](%%REPO_URL%%/2011/konno/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2011_richards">
@@ -4581,6 +5151,9 @@ helpful to test any fixes for Apple silicon chips (see [2011/richards in
 bugs.html](bugs.html#2011_richards) for more details).
 
 
+
+Jump to: [top](#)
+
 <div id="2011_toledo">
 ## Winning entry: [2011/toledo](2011/toledo/index.html)
 ### Winning entry source code: [toledo.c](%%REPO_URL%%/2011/toledo//toledo.c)
@@ -4595,6 +5168,9 @@ The `Makefile` was also modified by Cody to make it simpler to redefine the
 controls, width and height.
 
 
+Jump to: [top](#)
+
+
 <div id="2011_vik">
 ## Winning entry: [2011/vik](2011/vik/index.html)
 ### Winning entry source code: [vik.c](%%REPO_URL%%/2011/vik//vik.c)
@@ -4602,9 +5178,12 @@ controls, width and height.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/vik/try.sh) script.
 
-Cody also added an [alternate version](%%REPO_URL%%/2011/vik/vik.alt.c) for Windows
+Cody also added an [alternate version](2011/vik/index.html#alternate-code) for Windows
 based on the author's comments (along with looking up the function for the right
 header files). To build try the `alt` rule of the `Makefile`.
+
+
+Jump to: [top](#)
 
 
 <div id="2011_zucker">
@@ -4614,7 +5193,8 @@ header files). To build try the `alt` rule of the `Makefile`.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2011/zucker/try.sh) script.
 
-Cody also added [alternate code](%%REPO_URL%%/2011/zucker/zucker.alt.c) that should work on
+Cody also added [alternate
+code](2011/zucker/index.html#alternate-code) that should work on
 Windows, based on the author's remarks that if the system distinguishes binary
 and text then `stdout` needs to be set to binary mode.
 
@@ -4623,9 +5203,15 @@ Cody also added the PDF file
 eventually dies.
 
 
+Jump to: [top](#)
+
+
 <div id="2012">
 # [2012 - The 21st IOCCC](2012/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2012_blakely">
@@ -4639,12 +5225,18 @@ implicitly (Linux doesn't seem to but macOS does).
 Cody also added the [try.sh](%%REPO_URL%%/2012/blakely/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2012_deckmyn">
 ## Winning entry: [2012/deckmyn](2012/deckmyn/index.html)
 ### Winning entry source code: [deckmyn.c](%%REPO_URL%%/2012/deckmyn//deckmyn.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/deckmyn/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2012_endoh1">
@@ -4660,7 +5252,9 @@ let one control how fast the fluid moves (how long to sleep in between writes)
 and also the gravity factor, the pressure factor and the viscosity factor as
 well as an alarm that lets one run it in a loop without having to hit
 ctrl-c/intr in between (the alarm can be disabled, however). The `Makefile` allows
-one to easily do this with variable names rather than redefining `CDEFINE`.
+one to easily do this with variable names rather than redefining `CDEFINE`. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 The two different alt versions is because there are two versions: the original
 and the colour version added by the author, [Yusuke](#yusuke), at the request of
@@ -4670,7 +5264,9 @@ Cody also added the [try.alt.sh](%%REPO_URL%%/2012/endoh1/try.alt.sh) script tha
 the alternate code in two ways, one with setting the gravity factor to `I` and another
 with the default, and which is run on the source file and each of the text files
 supplied by the author. This code has an alarm set at 10 seconds so that one
-need not hit ctrl-c/intr in between .. say to make it more fluid :-)
+need not hit ctrl-c/intr in between .. say to make it more fluid :-) See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 Cody also added the [try.alt.bw.sh](%%REPO_URL%%/2012/endoh1/try.alt.bw.sh) which is the
 same as the `try.alt.sh` except it does not use the coloured version.
@@ -4684,6 +5280,8 @@ The [endoh1.alt2.c](%%REPO_URL%%/2012/endoh1/endoh1.alt2.c) was provided by the 
 [Yusuke](#yusuke), at the time of the contest as a de-obfuscated version.
 
 
+Jump to: [top](#)
+
 <div id="2012_endoh2">
 ## Winning entry: [2012/endoh2](2012/endoh2/index.html)
 ### Winning entry source code: [endoh2.c](%%REPO_URL%%/2012/endoh2//endoh2.c)
@@ -4696,6 +5294,9 @@ Cody also fixed a typo in the ruby script
 [find-font-table.rb](%%REPO_URL%%/2012/endoh2/find-font-table.rb).
 
 
+Jump to: [top](#)
+
+
 <div id="2012_grothe">
 ## Winning entry: [2012/grothe](2012/grothe/index.html)
 ### Winning entry source code: [grothe.c](%%REPO_URL%%/2012/grothe//grothe.c)
@@ -4706,9 +5307,7 @@ Cody also fixed a typo in the ruby script
 Cody also changed `argv` to be not `const char **` but `char **`, mostly out of an
 abundance of caution in case `clang`, which already imposes restrictions on the
 types of args to `main()` including to do with `char **`, decides to further
-restrict them.
-
-See the
+restrict them. See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
@@ -4723,6 +5322,9 @@ recent domain. For historical purposes the old link was
 which the recipe file now links to.
 
 
+Jump to: [top](#)
+
+
 <div id="2012_hamano">
 ## Winning entry: [2012/hamano](2012/hamano/index.html)
 ### Winning entry source code: [hamano.c](%%REPO_URL%%/2012/hamano//hamano.c)
@@ -4731,6 +5333,9 @@ which the recipe file now links to.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/hamano/try.sh) script and the helper
 Makefile rules `hint.pdf`, `hint`, `hello.pdf` and `hello` to simplify the
 procedure for both `hint.pdf` and `hello.pdf` as well as compiling them as C.
+
+
+Jump to: [top](#)
 
 
 <div id="2012_hou">
@@ -4743,6 +5348,9 @@ markdown file](%%REPO_URL%%/2012/hou/hint.md) as the changes made when convertin
 index.html made the generated html not look correct; it did not have a title, a
 stylesheet etc. due to the fact that there is no `#` header (which specified
 title and stylesheet) and other formatting changes.
+
+
+Jump to: [top](#)
 
 
 <div id="2012_kang">
@@ -4759,12 +5367,18 @@ without the umlaut (add an 'e' i.e. `fuenf`). Notice how the program picks up on
 this!
 
 
+Jump to: [top](#)
+
+
 <div id="2012_konno">
 ## Winning entry: [2012/konno](2012/konno/index.html)
 ### Winning entry source code: [konno.c](%%REPO_URL%%/2012/konno//konno.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/konno/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2012_omoikane">
@@ -4785,12 +5399,18 @@ Cody also added the [try.sh](%%REPO_URL%%/2012/omoikane/try.sh) and
 [try.alt.sh](%%REPO_URL%%/2012/omoikane/try.alt.sh) scripts.
 
 
+Jump to: [top](#)
+
+
 <div id="2012_tromp">
 ## Winning entry: [2012/tromp](2012/tromp/index.html)
 ### Winning entry source code: [tromp.c](%%REPO_URL%%/2012/tromp//tromp.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2012/tromp/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2012_vik">
@@ -4802,7 +5422,10 @@ Cody also added the [try.sh](%%REPO_URL%%/2012/omoikane/try.sh) and
 
 Based on the author's description it should be possible to get this entry to work
 for Windows. With his instructions Cody also added the [alternate
-version](%%REPO_URL%%/2012/vik/vik.alt.c) that does this.
+version](2012/vik/index.html#alternate-code) that does this.
+
+
+Jump to: [top](#)
 
 
 <div id="2012_zeitak">
@@ -4815,7 +5438,7 @@ version](%%REPO_URL%%/2012/vik/vik.alt.c) that does this.
 correctly be flagged as incorrect (including a text file and a Java file, with a
 joke, to show that it's not that it parses C but rather just matching pairs
 though that's probably obvious) and some correctly nested files were also added
-including [1984/anonymous](%%REPO_URL%%/1984/anonymous/index.html) (as the
+including [1984/anonymous](1984/anonymous/index.html) (as the
 author explicitly mentioned it), both the [original
 version](%%REPO_URL%%/2012/zeitak/anonymous.alt.c) (.alt.c) and the
 [modified version](%%REPO_URL%%/2012/zeitak/anonymous.c) that works with macOS
@@ -4830,6 +5453,9 @@ A minor point is that the author noted that one should
 look at the program source with tab space of 4 characters so Cody added the
 command to do this in vim for those who use it, in the judges' remarks, to make
 it easier for those who do not know how, and to make it more obvious to try it.
+
+
+Jump to: [top](#)
 
 
 <div id="2013">
@@ -4858,6 +5484,9 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/birken/try.sh) script for the ent
 [try.alt.sh](%%REPO_URL%%/2013/birken/try.alt.sh) script for the alternate code.
 
 
+Jump to: [top](#)
+
+
 <div id="2013_cable1">
 ## Winning entry: [2013/cable1](2013/cable1/index.html)
 ### Winning entry source code: [cable1.c](%%REPO_URL%%/2013/cable1//cable1.c)
@@ -4866,12 +5495,18 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/birken/try.sh) script for the ent
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/cable1/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2013_cable2">
 ## Winning entry: [2013/cable2](2013/cable2/index.html)
 ### Winning entry source code: [cable2.c](%%REPO_URL%%/2013/cable2//cable2.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/cable2/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2013_cable3">
@@ -4902,7 +5537,7 @@ wrapper scripts) to not assume that the program has been compiled by running
 ]]` over `[ .. ]`).
 
 As well, based on the author's remarks, Cody added the [alternate
-code](%%REPO_URL%%/2013/cable3/cable3.alt.c) which should be compilable for Windows/MS Visual
+code](2013/cable3/index.html#alternate-code) which should be compilable for Windows/MS Visual
 Studio. This is done by in the compile line undefining `KB` (`-UKB`) and then in
 the source code defining `KB` to what the author suggested,
 `(kb=H(8),kbhit())&&(r[1190]=getch(),H(7))`. It need hardly be mentioned that
@@ -4914,6 +5549,9 @@ referred to, found at the [GitHub repo for the
 entry](https://github.com/adriancable/8086tiny/tree/master), and the `ready-made
 40MB hard disk image containing a whole bunch of software` in `hd.img` that the
 author linked to at `https://bitly.com/1bU8URK`.
+
+
+Jump to: [top](#)
 
 
 <div id="2013_dlowe">
@@ -4944,12 +5582,18 @@ He also added the [diff.sh](%%REPO_URL%%/2013/dlowe/diff.sh) script which is bas
 commands to try that he suggested to see how different lengths look.
 
 
+Jump to: [top](#)
+
+
 <div id="2013_endoh1">
 ## Winning entry: [2013/endoh1](2013/endoh1/index.html)
 ### Winning entry source code: [endoh1.c](%%REPO_URL%%/2013/endoh1//endoh1.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/endoh1/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2013_endoh2">
@@ -4973,6 +5617,9 @@ also appear to be an issue with the script even if you know of `convert`).
 The entry can still be enjoyed if you do not have these tools, however.
 
 
+Jump to: [top](#)
+
+
 <div id="2013_endoh3">
 ## Winning entry: [2013/endoh3](2013/endoh3/index.html)
 ### Winning entry source code: [endoh3.c](%%REPO_URL%%/2013/endoh3//endoh3.c)
@@ -4981,11 +5628,12 @@ The entry can still be enjoyed if you do not have these tools, however.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/endoh3/try.sh) script.
 
 Cody also (out of an abundance of caution for `clang(1)` which is strict with
-arg type and count to `main()`) added a second (unused) arg to `main()`.
-
-See the
+arg type and count to `main()`) added a second (unused) arg to `main()`. See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="2013_endoh4">
@@ -5003,6 +5651,9 @@ pass more than one file to the script.
 Cody also made it easier to redefine the size at compilation time (see the
 author's remarks for more details on what this means). The `endoh4.sh` script
 allows one to redefine it as well.
+
+
+Jump to: [top](#)
 
 
 <div id="2013_hou">
@@ -5041,10 +5692,12 @@ rule in the `Makefile` was originally removed as part of the above but it was
 restored so that one can see what the author is talking about.
 
 Further, after the file `2013/hou/doc/example.markdown` was moved to
-[2013/hou/doc/example.md](%%REPO_URL%%/2013/hou/doc/example.md) to match the rest of the repo
-this broke `make` which Cody also fixed.
+[2013/hou/doc/example.md](%%REPO_URL%%/2013/hou/doc/example.md) by us, to match
+the rest of the repo, `make` was broken, which Cody fixed.
 
 Cody also added the [try.sh](%%REPO_URL%%/2013/hou/try.sh) script.
+
+Jump to: [top](#)
 
 
 <div id="2013_mills">
@@ -5060,12 +5713,18 @@ this was specific to macOS but it was not specific to a browser as Safari and
 Firefox both had the problem.
 
 
+Jump to: [top](#)
+
+
 <div id="2013_misaka">
 ## Winning entry: [2013/misaka](2013/misaka/index.html)
 ### Winning entry source code: [misaka.c](%%REPO_URL%%/2013/misaka//misaka.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/misaka/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2013_morgan1">
@@ -5079,12 +5738,18 @@ implicitly (Linux doesn't seem to but macOS does).
 Cody also added the [try.sh](%%REPO_URL%%/2013/morgan1/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2013_robison">
 ## Winning entry: [2013/robison](2013/robison/index.html)
 ### Winning entry source code: [robison.c](%%REPO_URL%%/2013/robison//robison.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2013/robison/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2014">
@@ -5095,18 +5760,23 @@ Cody also added the [try.sh](%%REPO_URL%%/2013/morgan1/try.sh) script.
 iocccsize.mk` files.
 
 
+Jump to: [top](#)
+
+
 <div id="2014_birken">
 ## Winning entry: [2014/birken](2014/birken/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2014/birken//prog.c)
 </div>
 
 [Cody](#cody) provided the [alternate
-code](%%REPO_URL%%/2014/birken/prog.alt.c) that lets one redefine the port to
+code](2014/birken/index.html#alternate-code) that lets one redefine the port to
 bind to in case there is a firewall issue or there is some other reason to not
 have the default port. Remember that ports < 1024 are privileged. It also lets
 you redefine the timing constant `STARDATE` (see the author's remarks for more
 details on this macro). The `Makefile` was made to use variables so it's easier to
 redefine the port and timing constant.
+
+Jump to: [top](#)
 
 
 <div id="2014_deak">
@@ -5122,7 +5792,9 @@ be what the program would look like if, as the author put it:
 > The usage of recognizable elements from the C programming language in the
 application source code is intentionally kept to a bare minimum.
 
-.. was not true.
+.. was not true. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 This alternate version did not originally compile because a value was left off the
 `return` statement (this might have been fixed in the index.html file too) so
@@ -5130,6 +5802,9 @@ that was fixed and it also has `#include <stdio.h>` for `putchar(3)`. The
 `#ifndef..#define..#endif` was not part of the original alternate code, of course.
 
 Cody also added the [try.alt.sh](%%REPO_URL%%/2014/deak/try.alt.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2014_endoh1">
@@ -5147,14 +5822,14 @@ then it tells you to install a specific gem and then to try again. Finally if
 `rake` succeeds it will verify that `prog` is executable and if it is it will
 run it.
 
-After more work on the manifest was done Cody had to update the `clobber` rule
-to remove some text files so as to not cause problems with an invalid manifest.
-
 Cody also added the [try.sh](%%REPO_URL%%/2014/endoh1/try.sh) script.
 
 To silence the annoying misleading indentation warning and to prevent debug
 symbols from being built with `rake` Cody also updated the
 [Rakefile](%%REPO_URL%%/2014/endoh1/Rakefile) slightly.
+
+
+Jump to: [top](#)
 
 
 <div id="2014_endoh2">
@@ -5164,6 +5839,9 @@ symbols from being built with `rake` Cody also updated the
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/endoh2/try.sh) script.
 
+
+
+Jump to: [top](#)
 
 <div id="2014_maffiodo1">
 ## Winning entry: [2014/maffiodo1](2014/maffiodo1/index.html)
@@ -5180,6 +5858,9 @@ Great Giana Sisters](http://en.wikipedia.org/wiki/The_Great_Giana_Sisters), but
 which let one configure the width and height of the game.
 
 
+Jump to: [top](#)
+
+
 <div id="2014_maffiodo2">
 ## Winning entry: [2014/maffiodo2](2014/maffiodo2/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2014/maffiodo2//prog.c)
@@ -5187,8 +5868,11 @@ which let one configure the width and height of the game.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/maffiodo2/try.sh) script.
 
-Cody also added the [alternate code](%%REPO_URL%%/2014/maffiodo2/prog.alt.c)
+Cody also added the [alternate code](2014/maffiodo2/index.html#alternate-code)
 provided by the author.
+
+
+Jump to: [top](#)
 
 
 <div id="2014_morgan">
@@ -5197,6 +5881,9 @@ provided by the author.
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2014/morgan/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2014_sinon">
@@ -5217,6 +5904,9 @@ Cody also added the [try.sh](%%REPO_URL%%/2014/sinon/try.sh) script that will fi
 is installed) run the demo mode and then after that it will run the above noted
 scripts in a loop until the user says they do not want to try again (or they
 kill it). This is done this way in case it jams (see index.html for details).
+
+
+Jump to: [top](#)
 
 
 <div id="2014_skeggs">
@@ -5240,6 +5930,9 @@ the index.html file for details) so Cody made sure that `make clobber` (via `mak
 clean`) removes those files and so that they are ignored by `.gitignore`.
 
 
+Jump to: [top](#)
+
+
 <div id="2014_vik">
 ## Winning entry: [2014/vik](2014/vik/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2014/vik//prog.c)
@@ -5255,6 +5948,9 @@ theoretically work for Microsoft Windows compilers (if anything works in Windows
 that would break it we do not know.
 
 
+Jump to: [top](#)
+
+
 <div id="2014_wiedijk">
 ## Winning entry: [2014/wiedijk](2014/wiedijk/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2014/wiedijk//prog.c)
@@ -5268,9 +5964,15 @@ executable and it pipes it through `less(1)` as it's longer than a page worth of
 output.
 
 
+Jump to: [top](#)
+
+
 <div id="2015">
 # [2015 - The 24th IOCCC](2015/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2015_burton">
@@ -5317,6 +6019,9 @@ called `calc` and is in documentation including the man page. Thus one only need
 add a `./` to the commands in the man page/index.html.
 
 
+Jump to: [top](#)
+
+
 <div id="2015_dogon">
 ## Winning entry: [2015/dogon](2015/dogon/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2015/dogon//prog.c)
@@ -5325,9 +6030,12 @@ add a `./` to the commands in the man page/index.html.
 [Cody](#cody) improved the `Makefile` so that one can easily change the dimensions
 at compilation time via `make(1)`.
 
-Cody also added [alternate code](%%REPO_URL%%/2015/dogon/prog.alt.c) that is
+Cody also added [alternate code](2015/dogon/index.html#alternate-code) that is
 based on the author's remarks, suggesting that one change the value of `q` to a
 different number, in order to see a bug that they avoided.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_duble">
@@ -5338,12 +6046,18 @@ different number, in order to see a bug that they avoided.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/duble/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2015_endoh2">
 ## Winning entry: [2015/endoh2](2015/endoh2/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2015/endoh2//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/endoh2/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_endoh3">
@@ -5362,12 +6076,18 @@ simply typing `make back_to`, `make future` or `make mullender`) and then runs
 the famous [1984/mullender.c](%%REPO_URL%%/1984/mullender/mullender.c).
 
 
+Jump to: [top](#)
+
+
 <div id="2015_endoh4">
 ## Winning entry: [2015/endoh4](2015/endoh4/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2015/endoh4//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/endoh4/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_hou">
@@ -5384,6 +6104,9 @@ which the `try.sh` script uses.
 Cody also added the RFC 1321 text file, [rfc1321.txt](2015/hou/rfc1321.txt) to
 the directory, to make it so one need not download it, and which the index.html
 file now links to.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_howe">
@@ -5408,6 +6131,9 @@ The fact there are alternate versions necessitated the
 well.
 
 
+Jump to: [top](#)
+
+
 <div id="2015_mills1">
 ## Winning entry: [2015/mills1](2015/mills1/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2015/mills1//prog.c)
@@ -5415,6 +6141,9 @@ well.
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/mills1/try.sh) script which changes the
 parameters to what we had in the judges' remarks to make it easier.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_mills2">
@@ -5425,12 +6154,18 @@ parameters to what we had in the judges' remarks to make it easier.
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/mills2/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2015_muth">
 ## Winning entry: [2015/muth](2015/muth/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2015/muth//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2015/muth/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_schweikhardt">
@@ -5444,6 +6179,9 @@ the code any with C preprocessor directives (the preferred way) or changing
 `EOF` to `-1`.
 
 Cody also added the [try.sh](%%REPO_URL%%/2015/schweikhardt/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2015_yang">
@@ -5460,12 +6198,18 @@ He also added explicit linking of libm (`-lm`) for systems that do not do this
 He also added the [try.sh](%%REPO_URL%%/2015/yang/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2018">
 # [2018 - The 25th IOCCC](2018/index.html)
 </div>
 
 [Cody](#cody) added the missing `README.md` file from the winner archive back to
 the repo.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_anderson">
@@ -5477,6 +6221,9 @@ the repo.
 [try.alt.sh](%%REPO_URL%%/2018/anderson/try.alt.sh) scripts.
 
 
+Jump to: [top](#)
+
+
 <div id="2018_algmyr">
 ## Winning entry: [2018/algmyr](2018/algmyr/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2018/algmyr//prog.c)
@@ -5484,6 +6231,9 @@ the repo.
 
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/algmyr/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_bellard">
@@ -5497,9 +6247,7 @@ Cody also, out of abundance of caution, added a second arg to `main()` because
 some versions of `clang` object to the number of args of `main()`, saying that it
 must be 0, 2 or 3. The version this has been observed in does not actually
 object to 1 arg but it is entirely possible that this changes so a second arg
-(that's not needed and is unused) has been added just in case.
-
-See the
+(that's not needed and is unused) has been added just in case.  See the
 FAQ on "[main function args](faq.html#arg_count)"
 for more details.
 
@@ -5507,10 +6255,13 @@ for more details.
 Cody also added explicit linking of libm (`-lm`) for systems that do not do this
 (Linux doesn't seem to but macOS does).
 
-Cody also added [alternate code](%%REPO_URL%%/2018/bellard/prog.alt.c) that should
+Cody also added [alternate code](2018/bellard/index.html#alternate-code) that should
 work for Windows, based on the author's remarks. The same thing with the number
 of args to `main()` that was done in the original entry was done with this
 version as well.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_burton1">
@@ -5523,6 +6274,9 @@ script (it referred to `prog` not `./prog`).
 
 Cody also added the [try.sh](%%REPO_URL%%/2018/burton1/try.sh) script which also uses
 `scripthd.sh` to show how it differs from `prog` itself.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_burton2">
@@ -5543,6 +6297,9 @@ included in the remarks of the author but not an included file.
 Finally Cody added the [try.sh](%%REPO_URL%%/2018/burton2/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2018_ciura">
 ## Winning entry: [2018/ciura](2018/ciura/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2018/ciura//prog.c)
@@ -5552,6 +6309,9 @@ Finally Cody added the [try.sh](%%REPO_URL%%/2018/burton2/try.sh) script.
 [try.alt.sh](%%REPO_URL%%/2018/ciura/try.alt.sh) scripts and the PDF file,
 [lexicon.pdf](2018/ciura/lexicon.pdf), that was a dead link, restored from the
 Internet Wayback Machine.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_endoh1">
@@ -5566,6 +6326,9 @@ the user they should open it in a GIF viewer that can show animation in animated
 GIF files. It offers an example command for macOS like the judges did in their
 remarks. The input files offered includes the `prog.c` as the author,
 [Yusuke](#yusuke), suggested that it too has a secret.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_endoh2">
@@ -5583,6 +6346,9 @@ exit the script). The `make python` and `make python3` rules in the `Makefile` n
 run the respective scripts.
 
 
+Jump to: [top](#)
+
+
 <div id="2018_hou">
 ## Winning entry: [2018/hou](2018/hou/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2018/hou//prog.c)
@@ -5592,6 +6358,9 @@ run the respective scripts.
 (Linux doesn't seem to but macOS does).
 
 Cody also added the [try.sh](%%REPO_URL%%/2018/hou/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_mills">
@@ -5607,6 +6376,9 @@ run) enter and then exit and then start the program again. Also if you do add a
 file you should run `sync` prior to exiting or else the file might not exist or
 it might be corrupt. See [2018/mills in bugs.html](bugs.html#2018_mills) for more
 details on the bug.
+
+
+Jump to: [top](#)
 
 
 <div id="2018_poikola">
@@ -5625,6 +6397,9 @@ We added some additional notes on what might happen (it varies depending on
 configuration).
 
 
+Jump to: [top](#)
+
+
 <div id="2018_vokes">
 ## Winning entry: [2018/vokes](2018/vokes/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2018/vokes//prog.c)
@@ -5632,6 +6407,8 @@ configuration).
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2018/vokes/try.sh) script.
 
+
+Jump to: [top](#)
 
 <div id="2018_yang">
 ## Winning entry: [2018/yang](2018/yang/index.html)
@@ -5644,9 +6421,15 @@ if the user wants to see some of the deobfuscation information and only show the
 
 
 
+Jump to: [top](#)
+
+
 <div id="2019">
 # [2019 - The 26th IOCCC](2019/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2019_adamovsky">
@@ -5657,6 +6440,9 @@ if the user wants to see some of the deobfuscation information and only show the
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/adamovsky/try.sh) script and the Unlambda
 file [crash.unl](%%REPO_URL%%/2019/adamovsky/crash.unl) which is in the judges' remarks as
 to what can crash it - but it's not a bug, it's a feature.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_burton">
@@ -5673,11 +6459,14 @@ running `make test`.
 
 Cody also fixed the script [check.sh](%%REPO_URL%%/2019/burton/check.sh) in case
 `x` is specified and is not executable and also made it satisfy ShellCheck.
-ShellCheck was fixed to not be a
-[cow](https://en.wikipedia.org/wiki/Cattle) and/or (to use [Bart
-Simpson](https://simpsons.fandom.com/wiki/Bart_Simpson)'s advice :-) )
-'[not have a cow](https://en.wikipedia.org/wiki/Don%27t_have_a_cow)' about certain things (including one thing it was wrong about)
-in [cow.sh](%%REPO_URL%%/2019/burton/cow.sh) <del>moo</del>too.
+ShellCheck was fixed to not be a [cow](https://en.wikipedia.org/wiki/Cattle)
+and/or (to use [Bart Simpson](https://simpsons.fandom.com/wiki/Bart_Simpson)'s
+advice :-) ) '[not have a
+cow](https://en.wikipedia.org/wiki/Don%27t_have_a_cow)' about certain things
+(including one thing it was wrong about) in
+[cow.sh](%%REPO_URL%%/2019/burton/cow.sh) <del>moo</del>too.
+
+Jump to: [top](#)
 
 
 <div id="2019_ciura">
@@ -5706,6 +6495,9 @@ bugs.html](bugs.html#2019_ciura) for more details.
 
 
 
+Jump to: [top](#)
+
+
 <div id="2019_diels-grabsch1">
 ## Winning entry: [2019/diels-grabsch1](2019/diels-grabsch1/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2019/diels-grabsch1//prog.c)
@@ -5715,9 +6507,11 @@ bugs.html](bugs.html#2019_ciura) for more details.
 
 Cody also added the file [Shakespeare.txt](2019/diels-grabsch1/Shakespeare.txt)
 from [2019/mills](2019/mills/index.html) (after running `make`) so that one can
-not worry about having the entire IOCCC winning entry tree (or at least the 2019 tree each
-entry in a subdirectory). This was important as we now have tarballs for each
-entry by themselves.
+not worry about having the entire IOCCC winning entry tree (or at least the 2019
+tree). This was important as we now have tarballs for each entry by themselves.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_diels-grabsch2">
@@ -5730,6 +6524,9 @@ script. This script will try and show the difference (i.e. the same output)
 between the program and the result of `sha512sum` or `shasum -a 512`, if these
 tools can be found, or otherwise just run the program itself, showing its own
 [sha512](https://en.wikipedia.org/wiki/SHA-2) value.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_dogon">
@@ -5753,6 +6550,9 @@ was to only correct spelling and only some, not to change wording or anything
 else).
 
 
+Jump to: [top](#)
+
+
 <div id="2019_duble">
 ## Winning entry: [2019/duble](2019/duble/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2019/duble//prog.c)
@@ -5767,6 +6567,9 @@ an easy way to tell the user how to compile it, assuming that the environmental
 variables `LINES` and `COLUMNS` are set. But even if they're not set it explains
 how to easily compile the program to a specific size. Note that `LINES` and
 `COLUMNS` is not available to scripts so it can't make use of them that way.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_endoh">
@@ -5786,12 +6589,18 @@ to easily reconstruct the source code through GDB by the fact it's a backtrace
 quine.
 
 
+Jump to: [top](#)
+
+
 <div id="2019_giles">
 ## Winning entry: [2019/giles](2019/giles/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2019/giles//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/giles/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_karns">
@@ -5808,6 +6617,9 @@ He also added the script [try.sh](%%REPO_URL%%/2019/karns/try.sh) to showcase th
 bit more easily.
 
 
+Jump to: [top](#)
+
+
 <div id="2019_lynn">
 ## Winning entry: [2019/lynn](2019/lynn/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2019/lynn//prog.c)
@@ -5821,12 +6633,18 @@ Cody also added the [example-1.txt](2019/lynn/example-1.txt) and
 entry existing.
 
 
+Jump to: [top](#)
+
+
 <div id="2019_mills">
 ## Winning entry: [2019/mills](2019/mills/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2019/mills//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2019/mills/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_poikola">
@@ -5838,8 +6656,10 @@ entry existing.
 file. The rule requires the tool
 [pdflatex](https://tug.org/applications/pdftex/index.html).
 
-Cody also added the [alternate code](%%REPO_URL%%/2019/poikola/prog.alt.c) which
-adds a newline after each number for parsing in additional ways.
+Cody also added the [alternate code](2019/poikola/index.html#alternate-code) which
+adds a newline after each number for parsing in additional ways. See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
 
 Cody also added the [try.sh](%%REPO_URL%%/2019/poikola/try.sh) and
 [try.alt.sh](%%REPO_URL%%/2019/poikola/try.alt.sh) scripts.
@@ -5850,6 +6670,9 @@ suggesting that with some versions of `GCC` it might not be correct with levels 
 0 and since 0 works with `clang` that's okay. Similarly, the same for C standards
 tested: `gnu17` was not tested but `gnu11` was so the standard was set to
 `gnu11`.
+
+
+Jump to: [top](#)
 
 
 <div id="2019_yang">
@@ -5863,9 +6686,15 @@ slightly updating the [sample_input.txt](2019/yang/sample_input.txt) file
 shouldn't) and adding the [ioccc.txt](2019/yang/ioccc.txt) file.
 
 
+Jump to: [top](#)
+
+
 <div id="2020">
 # [2020 - The 27th IOCCC](2020/index.html)
 </div>
+
+
+Jump to: [top](#)
 
 
 <div id="2020_burton">
@@ -5884,6 +6713,9 @@ showing nothing at all.
 Cody also added the [try.sh](%%REPO_URL%%/2020/burton/try.sh) script.
 
 
+Jump to: [top](#)
+
+
 <div id="2020_carlini">
 ## Winning entry: [2020/carlini](2020/carlini/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2020/carlini//prog.c)
@@ -5893,6 +6725,9 @@ Cody also added the [try.sh](%%REPO_URL%%/2020/burton/try.sh) script.
 first glance might not appear to have a point, it actually does, namely showing
 how you can automate play and then reminding you to actually play for real, with
 a friend, whether that's real or imagined.
+
+
+Jump to: [top](#)
 
 
 <div id="2020_endoh2">
@@ -5907,6 +6742,9 @@ put in `spoiler/` were moved to
 [obfuscation/](2020/endoh2/obfuscation/index.html).
 
 He also added the [try.sh](%%REPO_URL%%/2020/endoh2/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2020_endoh3">
@@ -5924,7 +6762,7 @@ funny error when running it:
 
 If run from within vim a different error message occurred:
 
-```
+``` <!---sh-->
     /bin/bash: ./run_clock.sh: /usr/bin/end: bad interpreter: No such file or directory
 ```
 
@@ -5949,14 +6787,8 @@ which is analogous to the [run_clock.sh](%%REPO_URL%%/2020/endoh3/run_clock.sh) 
 alternate code provided by the author, Yusuke.
 
 
-<div id="2020_ferguson1">
-## Winning entry: [2020/ferguson1](2020/ferguson1/index.html)
-### Winning entry source code: [prog.c](%%REPO_URL%%/2020/ferguson1//prog.c)
-</div>
+Jump to: [top](#)
 
-Just for awareness: [Cody](#cody) made some corrections to the vital [Double
-layered chocolate fudge cake recipe](2020/ferguson1/chocolate-cake.html) :-)
-Other fixes were made but as it's his entry it's not worth noting.
 
 
 <div id="2020_giles">
@@ -5976,12 +6808,18 @@ and tells them they will have to play the WAV files manually. Otherwise it'll
 use the program to play the WAV files (and in one case `stdout`).
 
 
+Jump to: [top](#)
+
+
 <div id="2020_kurdyukov1">
 ## Winning entry: [2020/kurdyukov1](2020/kurdyukov1/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2020/kurdyukov1//prog.c)
 </div>
 
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov1/try.sh) script.
+
+
+Jump to: [top](#)
 
 
 <div id="2020_kurdyukov2">
@@ -6003,6 +6841,9 @@ specify which compiler to use with `CC=foo ./makegif.sh ...`), checking that
 entry if not installed or it fails).
 
 
+Jump to: [top](#)
+
+
 <div id="2020_kurdyukov3">
 ## Winning entry: [2020/kurdyukov3](2020/kurdyukov3/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2020/kurdyukov3//prog.c)
@@ -6011,8 +6852,9 @@ entry if not installed or it fails).
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/kurdyukov3/try.sh) script.
 
 He also added a link that has much more details about this phenomenon to the
-index.html. Naturally he's one of the ones who can read text even if it's even
-more jumbled but we know of others too.
+index.html.
+
+Jump to: [top](#)
 
 
 <div id="2020_kurdyukov4">
@@ -6037,6 +6879,9 @@ and literary executor and heir to [J.R.R.
 Tolkien](https://www.tolkienestate.com/life/biography/).
 
 
+Jump to: [top](#)
+
+
 <div id="2020_otterness">
 ## Winning entry: [2020/otterness](2020/otterness/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2020/otterness//prog.c)
@@ -6054,6 +6899,9 @@ unobfuscated version that Cody added as
 [prog.alt.c](%%REPO_URL%%/2020/otterness/prog.alt.c).
 
 
+
+Jump to: [top](#)
+
 <div id="2020_tsoj">
 ## Winning entry: [2020/tsoj](2020/tsoj/index.html)
 ### Winning entry source code: [prog.c](%%REPO_URL%%/2020/tsoj//prog.c)
@@ -6061,7 +6909,12 @@ unobfuscated version that Cody added as
 
 [Cody](#cody) added [alternate code](2020/tsoj/index.html#alternate-code) that will feel
 more at home for vi users. One might still end up cursing (see the index.html
-file) but probably a lot less :-)
+file) but probably a lot less :-) See the
+FAQ on "[alternate code](faq.html#alt_code)"
+for more details.
+
+
+Jump to: [top](#)
 
 
 <div id="2020_yang">
@@ -6072,8 +6925,11 @@ file) but probably a lot less :-)
 [Cody](#cody) added the [try.sh](%%REPO_URL%%/2020/yang/try.sh) script.
 
 Cody also added a make rule (`make cppp`) for the author's provided C++ code
-that can preprocess the generated output to make them more acceptable to typical
+that can pre-process the generated output to make them more acceptable to typical
 compilers. See the index.html for more details.
+
+
+Jump to: [top](#)
 
 
 
@@ -6081,6 +6937,7 @@ compilers. See the index.html for more details.
 # General thanks
 </div>
 
+Jump to: [top](#)
 
 <div id="makefiles_fixes_improvements">
 ## Makefiles fixes and improvements
@@ -6141,13 +6998,14 @@ this, along with many other fixes and changes to the Makefiles were made by
 Cody's [sgit tool](https://github.com/xexyl/sgit) but many other changes he did
 manually.
 
+Jump to: [top](#)
 
 <div id="consistency_improvements">
 ## Consistency improvements
 </div>
 
 [Cody](#cody), being the IOCCC's resident corrections officer :-) (and a fine one at
-that, we think :-) ), made many, many typ0 (... :-) ) fixes throughout the
+that, we think :-) ), made many, many typo fixes throughout the
 README.md files, scripts, other data files, Makefiles (see above) etc.
 
 He also updated the formatting of the README.md files, used to generate the
@@ -6163,21 +7021,53 @@ Some of these fixes were done with his [sgit
 tool](https://github.com/xexyl/sgit) as well but the vast majority were done
 manually.
 
+Jump to: [top](#)
 
-<div id="manifest_improvements">
-## Manifest improvements
+
+<div id="try">
+## Try script system
 </div>
 
-[Cody](#cody) greatly improved the manifest of the winning entries so that the
-links to the files in the index.html files make sense and are consistent,
-although some might not make as much sense unless one looks into the entry.
+[Cody](#cody) devised the `try` script system and added the many `try.sh`,
+`try.alt.sh` and various other forms, as well as a number of wrapper scripts to
+more easily run programs. It is not always useful but these scripts do a variety
+of things to really show off the entries, so this really helps with the
+presentation of the winning entries.
+
+
+Jump to: [top](#)
+
+
+<div id="website_improvements">
+## Website and manifest improvements
+</div>
+
+[Cody](#cody) helped in many ways to make the website much more presentable by:
+
+- converting old hints files to README.md files (fixing problems in the process)
+- converting other files to markdown
+- extending the stylesheet for a few improvements
+- fixing many different kinds of problems in many files
+- writing a few [website scripts](bin/index.html), improving a few others as
+well as identifying and/or fixing bugs in others
+- greatly improving the manifest of the winning entries so that the links to the
+files in the index.html files make more sense and are consistent (although it
+might be said that some of them will not make sense if you don't understand the
+entry or at least do not read the index.html file)
+
+
+Jump to: [top](#)
+
 
 <div id="faq_improvements">
 ## FAQ improvements
 </div>
 
 [Cody](#cody) greatly extended the FAQ to include much more information and he
-helped reorganise it as well, from the new `faq.md` file.
+helped reorganise it as well, from the new `faq.md` file that he started.
+
+
+Jump to: [top](#)
 
 
 <div id="thank_you_honor_roll">
@@ -6187,6 +7077,9 @@ helped reorganise it as well, from the new `faq.md` file.
 There are a number of people who have contributed to **many many
 changes**, fixes and **many important improvements** that we
 wish to **especially thank**.
+
+
+Jump to: [top](#)
 
 
 <div id="authors">
@@ -6199,6 +7092,9 @@ and/or improve the write-ups of fellow IOCCC entries for the year that they won.
 The list of those entries is too long to mention: nevertheless the [IOCCC
 judges](judges.html) **VERY MUCH APPRECIATE** those who
 helped improve the presentation of their fellow IOCCC entries.
+
+
+Jump to: [top](#)
 
 
 <div id="cody">
@@ -6253,6 +7149,9 @@ presentation of past IOCCC entries and fixing almost all past entries for modern
 systems!
 
 
+Jump to: [top](#)
+
+
 <div id="yusuke">
 ### Yusuke Endoh
 </div>
@@ -6268,6 +7167,9 @@ fixes were **EXTREMELY TECHNICALLY CHALLENGING**, such as
 your help!
 
 
+Jump to: [top](#)
+
+
 <div id="neglect">
 ## Did we neglect to credit you?
 </div>
@@ -6279,6 +7181,9 @@ to add you to this [thanks for the help](thanks-for-help.html) file.
 If you believe we incorporated one of your fixes to an IOCCC winning entry (that you
 are not the author of) for which we neglected to mention in this file, please
 [contact the IOCCC](contact.html) so that we may correct the record.
+
+
+Jump to: [top](#)
 
 
 <!--


### PR DESCRIPTION
           
Typos were fixed in bin/md2html.cfg, bin/subst.default.sh,
nojs-menu.html and nojs-menu.md.

The nojs-menu.html now links to bin/index.html and inc/index.html but 
the rest of the html files for now do not. It seems like it might be 
good if they do, at least bin/index.html, but if that is decided against
this can be rolled back instead.