### PR TITLE
Fix mobile menus and add to menus

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1984/index.html
+++ b/1984/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1985/index.html
+++ b/1985/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/index.html
+++ b/1986/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/index.html
+++ b/1987/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/index.html
+++ b/1988/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/index.html
+++ b/1989/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/index.html
+++ b/1990/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/index.html
+++ b/1991/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/index.html
+++ b/1992/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/index.html
+++ b/1993/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/index.html
+++ b/1994/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/index.html
+++ b/1995/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/leo/secret.html
+++ b/1995/leo/secret.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/index.html
+++ b/1996/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/index.html
+++ b/1998/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/index.html
+++ b/2000/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/index.html
+++ b/2001/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/index.html
+++ b/2004/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/index.html
+++ b/2005/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/index.html
+++ b/2006/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/index.html
+++ b/2011/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/index.html
+++ b/2012/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/index.html
+++ b/2013/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/endoh1/quine-qr.html
+++ b/2014/endoh1/quine-qr.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/index.html
+++ b/2014/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/burton/obfuscation.html
+++ b/2015/burton/obfuscation.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/index.html
+++ b/2015/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/ferguson/FILES.html
+++ b/2018/ferguson/FILES.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/index.html
+++ b/2018/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/index.html
+++ b/2019/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/endoh2/obfuscation/index.html
+++ b/2020/endoh2/obfuscation/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/obfuscation.html
+++ b/2020/ferguson1/obfuscation.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/ferguson2/testing-procedure.html
+++ b/2020/ferguson2/testing-procedure.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/index.html
+++ b/2020/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/Makefile
+++ b/Makefile
@@ -739,6 +739,7 @@ www:
 	${MAKE} entry_index
 	${MAKE} gen_other_html
 	${MAKE} find_missing_links
+	${MAKE} find_invalid_json
 	@echo '=-=-=-=-=-= IOCCC complete make $@ =-=-=-=-=-='
 
 

--- a/README.html
+++ b/README.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/SECURITY.html
+++ b/SECURITY.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/author/index.html
+++ b/author/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/authors.html
+++ b/authors.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -106,7 +106,7 @@ Usage:
     bin/all-years.sh -v 1 bin/gen-year-index.sh -v 1
 ```
 
-Alternate usage:
+If you wish to run instead, for example, [chk-entry.sh](#chk-entry), then do:
 
 ``` <!---sh-->
     bin/all-years.sh -v 1 bin/chk-entry.sh
@@ -125,7 +125,9 @@ Usage:
     bin/all-run.sh -v 3 bin/quick-readme2index.sh -v 1
 ```
 
-Alternate usage:
+If you wish to run instead, for example, [readme2index.sh](#readme2index), then
+do:
+
 
 ``` <!---sh-->
     bin/all-run.sh -v 3 bin/readme2index.sh -v 1
@@ -144,7 +146,8 @@ Usage:
     bin/all-years.sh -v 1 bin/gen-year-index.sh -v 1
 ```
 
-Alternate usage:
+If you wish to run instead, for example, [chk-entry.sh](#chk-entry), then
+do:
 
 ``` <!---sh-->
     bin/all-years.sh -v 1 bin/chk-entry.sh
@@ -180,7 +183,7 @@ for more details on `.entry.json` files.
 ### [combine_author_handle.sh](%%REPO_URL%%/bin/combine_author_handle.sh)
 </div>
 
-Combine all author/author_handle.JSON files as single JSON file.
+Combine all author/author_handle.json files as single JSON file.
 
 The purpose of this tool is to make looking for information across all
 authors faster by temporarily forming them into a single JSON file.
@@ -220,6 +223,10 @@ Usage:
 **NOTE**: This tool assume that all JSON files have been formatted with the
 `bin/jprint-wrapper.sh` tool.  In particular the first line is just "{:,
 and the last line is just "}" and each JSON element is on its own line.
+
+**NOTE**: see the
+FAQ on "[author_handle.json](../faq.html#author_handle_json)"
+for more details on `author_handle.json` files.
 
 
 <div id="csv2entry">
@@ -277,7 +284,7 @@ We also sort the CSV files in the same way that [entry2csv](#entry2csv) sorts
 its CSV output files.  We do this in case the CSV files were imported into a
 spreadsheet where their order was changed before exporting.  This means one is
 free to order the CSV file content as you wish as this tool will reset these CSV
-file.
+files.
 
 Next this tool processes the non-CSV comment lines in
 [manifest.csv](#manifest_csv).  The 1st and 2nd fields of
@@ -291,7 +298,11 @@ only modify those `.entry.json` files when their content changes.
 semantic checks**.  For example, this tool does **NOT** verify that the manifest in
 the `.entry.json` file matches the files in the `YYYY/dir directory`, or even
 that the `.entry.json` contains a manifest (or any of the other required JSON
-content).
+content). Another tool will be modified to do this, at a later date.
+
+**NOTE**: you can obtain `jparse(1)` from the which can be obtained from the
+[mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)'s copy of the
+[jparse repo](https://github.com/xexyl/jparse/).
 
 
 <div id="cvt-submission">
@@ -330,13 +341,13 @@ that could be modified or removed by this tool (unless `-N` is used in which
 case this tool does nothing).  The compressed tarball, formed by default
 under the `/var/tmp` directory, may contain such as:
 
-- YYYY/dir/.info.json
-- YYYY/dir/.auth.json
-- YYYY/dir/remarks.md
-- YYYY/dir/README.md
-- YYYY/dir/index.md
-- YYYY/dir/YYYY_dir.tar.bz2
-- author/author_handle.json (could be more than one file)
+- `YYYY/dir/.info.json`
+- `YYYY/dir/.auth.json`
+- `YYYY/dir/remarks.md`
+- `YYYY/dir/README.md`
+- `YYYY/dir/index.md`
+- `YYYY/dir/YYYY_dir.tar.bz2`
+- `author/author_handle.json` (could be more than one file)
 
 Only those files that exist will be put into the compressed tarball.
 The compressed tarball formed (by default under the `/var/tmp` directory)
@@ -344,10 +355,10 @@ is of the following form:
 
 > YYYY_dir.mods.YYYYMMDD.hhmmss.tar.bz2
 
-Here "_YYYYMMDD.hhmmss_" is a date and timestamp from when the tool was executed.
+Here "`YYYYMMDD.hhmmss`" is a date and timestamp from when the tool was executed.
 
 The purpose of this compressed tarball is to allow the files in the
-submission directory (that could be modified or removed by this tool)
+entry directory (that could be modified or removed by this tool)
 to be restored as follows:
 
 ``` <!---sh-->
@@ -359,13 +370,14 @@ One may also restore modified `author/author_handle.json` files using:
 ``` <!---sh-->
     tar -jxvf /var/tmp/YYYY_dir.mods.YYYYMMDD.hhmmss.tar.bz2 author
 ```
+
 This tool will form `YYYY/dir/README.md` if needed, from `YYYY/dir/remarks.md`,
 `template/entry/README.md.head`, and `template/entry/README.md.tail`.
 
 **NOTE**: This interactive tool (unless `-i input_data` is used) does
-**NOT** perform all of the steps needed to make a directory a new winning
+**NOT** perform all of the steps needed to make a directory for a new winning
 IOCCC entry.  For example, files such as `YYYY/dir/README.md` and/or `YYYY/dir/index.html`
-might contain "_triple X_" patterns indicating where the [Judges](../judges.html)
+might contain "_triple X_" comments (`<!--XXXX-->`), indicating where the [Judges](../judges.html)
 need to add content.  Moreover, the `Makefile` and `.gitignore` files
 need to be examined for suitability, etc.
 
@@ -379,7 +391,7 @@ need to be examined for suitability, etc.
 This tool takes as input, all entry `.entry.json` files
 and updates 3 CSV files:
 
-- [author_wins.csv](#author_wins_csv) - each `author_handle` followed their `entry_id`s
+- [author_wins.csv](#author_wins_csv) - each `author_handle` followed by their `entry_id`s
 - [manifest.csv](#manifest_csv) - information about all files in all entries
 - [year_prize.csv](#year_prize_csv) - each `entry_id` followed by the entry's award title
 
@@ -427,14 +439,14 @@ In this case the command will list all the files of the
 
 Find all markdown links to local files that do not exist.
 
-This tool does **NOT** check that a remote URL exists.
-This tool only checks on links to local files.
+This tool does **NOT** check that a remote URL exists, it checks on
+links to local files.
 
-This tool does **NOT** check links in a given place in a file.
-This tool only checks that local files linked by markdown exist.
+This tool does **NOT** check links in a given place in a file, it
+checks that local files linked by markdown actually exist.
 
-This tool does **NOT** check HTML file links.
-This tool only checks markdown based links.
+This tool does **NOT** check HTML file links, it checks markdown
+based links.
 
 Usage:
 
@@ -443,7 +455,7 @@ Usage:
 ```
 
 If no missing links are found, this tool exits 0 with no output
-(debug messages not withstanding), otherwise this tool will exit non-zero.
+(debug messages notwithstanding), otherwise this tool will exit non-zero.
 
 **NOTE**: If the markdown link is malformed, this tool
 might generate an error about a file that does exist.
@@ -478,7 +490,7 @@ Usage:
 ```
 
 If no invalid JSON files are found, this tool exits 0 with no output
-(debug messages not withstanding), otherwise this tool will exit non-zero.
+(debug messages notwithstanding), otherwise this tool will exit non-zero.
 
 We recommend that this tool be invoked via the top level `Makefile`:
 
@@ -577,9 +589,6 @@ We recommend that this tool be invoked via the top level `Makefile`:
 ``` <!---sh-->
     make gen_sitemap
 ```
-
-**IMPORTANT NOTE**: if a file is open with vim or some editor that creates a swap
-file, this will cause a problem with the output.
 
 
 <div id="gen-status">
@@ -707,8 +716,7 @@ We recommend that this tool be invoked via the top level `Makefile`:
 </div>
 
 The [jfmt-wrapper.sh](%%REPO_URL%%/bin/jfmt-wrapper.sh) tool is a wrapper
-tool for `jfmt(1)`, a tool that will format a JSON
-# file into a canonical style.
+tool for `jfmt(1)`, a tool that will format a JSON file into a canonical style.
 
 **NOTE**: As of 2024 Oct 08 the `jfmt(1)` tool has not been written,
 so [jfmt-wrapper.sh](%%REPO_URL%%/bin/jfmt-wrapper.sh) uses the
@@ -805,7 +813,7 @@ and not have to use `-T` with `bin/jval-wrapper.sh`.
 ### [manifest.csv.entry.awk](%%REPO_URL%%/bin/manifest.csv.entry.awk)
 </div>
 
-Output manifest csv from a entry's manifest as found in its `.entry.json` file.
+Output `manifest.csv` from a entry's manifest as found in its `.entry.json` file.
 
 ``` <!---sh-->
     awk -f bin/manifest.csv.entry.awk YYYY/dir/.entry.json
@@ -816,7 +824,7 @@ Output manifest csv from a entry's manifest as found in its `.entry.json` file.
 ### [bin/manifest.entry.json.awk](%%REPO_URL%%/bin/manifest.entry.json.awk)
 </div>
 
-Output manifest table from a entry's `.entry.json` file.
+Output manifest table from an entry's `.entry.json` file.
 
 ``` <!---sh-->
     awk -v github=REPO_URL -f bin/manifest.entry.json.awk YYYY/dir/.entry.json
@@ -882,13 +890,13 @@ framework for doing so, creating a situation where the
 
 This tool can modify the top level `.allyear` file, and `YYYY/Makefile` files.
 
-**NOTE**: This tool assumes that [new-year.sh](#new_year) was executed to create
+**NOTE**: This tool assumes that [new-year.sh](#new-year) was executed to create
 the prerequisite `YYYY` directory and related files.
 
 **HINT**: Executing this tool on your submission will **NOT** make you an IOCCC winner.  :-)
 
 
-<div id="new_year">
+<div id="new-year">
 ### [new-year.sh](%%REPO_URL%%/bin/new-year.sh)
 </div>
 
@@ -899,10 +907,10 @@ This tool may modify the top level `.top` and `Makefile` files.
 It will form `YYYY/Makefile` and/or `YYYY/.year` if needed.
 It will form `YYYY/README.md` if needed, from `template/README.md.year`.
 
-**NOTE**: This tool **NOT** perform all of the steps needed to make a new IOCCC year directory.
+**NOTE**: This tool does **NOT** perform all of the steps needed to make a new IOCCC year directory.
 For example, files such as `YYYY/README.md` and/or `YYYY/index.html`
-might contain "_triple X_" patterns indicating where the [Judges](../judges.html)
-need to add content.
+might contain "_triple X_" comments (`<!-- XXX -->`) indicating where the
+[Judges](../judges.html) need to add content.
 
 Usage:
 
@@ -931,14 +939,15 @@ For example:
     bin/othermd2html.sh -v 1 2020/ferguson1/chocolate-cake.md
 ```
 
-The [othermd2html.sh](#othermd2html) tool is used by [gen-other-html.sh](#gen-other-html).
+The [othermd2html.sh](#othermd2html) tool is used by
+[gen-other-html.sh](#gen-other-html).
 
 
 <div id="output-index-author">
 ### [output-index-author.sh](%%REPO_URL%%/bin/output-index-author.sh)
 </div>
 
-Output author's or authors' related HTML details for an entry's index.html
+Output an author's or authors' related HTML details for an entry's index.html
 page.
 
 For an example, see the [author details in
@@ -966,7 +975,7 @@ the [md2html tool](index.html#md2html).
 
 Output the inventory for a given year's winning entries in HTML form. In other
 words in [1984](../1984/index.html) it would list, as links, the four winning
-entries, which you can see directly at [1984
+entries, which you can see directly at the [1984
 inventory](../1984/index.html#inventory).
 
 This tool is used in the [bin/md2html.cfg](%%REPO_URL%%/bin/md2html.cfg) file as part of
@@ -1017,7 +1026,7 @@ and `index.html` are correct.  If in doubt, use
 We recommend that this tool be invoked via the top level `Makefile`:
 
 ``` <!---sh-->
-    make quick_entry_index
+    make quick_readme2index
 ```
 
 

--- a/bin/combine_author_handle.sh
+++ b/bin/combine_author_handle.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# combine_author_handle.sh - output all author/author_handle.JSON files as single JSON file
+# combine_author_handle.sh - output all author/author_handle.json files as single JSON file
 #
-# We form a single JSON file out of all author/author_handle.JSON files.
-# We cannot simply cat the author/author_handle.JSON files because
-# each author/author_handle.JSON file opens and closes the JSON.
+# We form a single JSON file out of all author/author_handle.json files.
+# We cannot simply cat the author/author_handle.json files because
+# each author/author_handle.json file opens and closes the JSON.
 # So this tool removes the intermediate JSON document opening "{"
 # and closing "}".
 #

--- a/bin/find-missing-links.sh
+++ b/bin/find-missing-links.sh
@@ -447,7 +447,7 @@ fi
 #	# Markdown line: ..the markdown line containing the line..
 #	/missing/filename
 #
-"$GIT_TOOL" ls-files --exclude markdown.md --exclude ./tmp |
+find . -name '*.md' ! -name markdown.md ! -path './tmp/*' ! -path './NOTES/*' -print |
     LANG=C sort -d |
     xargs grep '\]([^)][^)]*)' /dev/null |
     sed -E \

--- a/bin/find-missing-links.sh
+++ b/bin/find-missing-links.sh
@@ -447,7 +447,7 @@ fi
 #	# Markdown line: ..the markdown line containing the line..
 #	/missing/filename
 #
-find . -name '*.md' ! -name markdown.md ! -path './tmp/*' -print |
+"$GIT_TOOL" ls-files --exclude markdown.md --exclude ./tmp |
     LANG=C sort -d |
     xargs grep '\]([^)][^)]*)' /dev/null |
     sed -E \

--- a/bin/index.html
+++ b/bin/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 
@@ -447,7 +470,7 @@ some odd need to do so.</p>
 <p>Run a command on all IOCCC years.</p>
 <p>Usage:</p>
 <pre><code>    bin/all-years.sh -v 1 bin/gen-year-index.sh -v 1</code></pre>
-<p>Alternate usage:</p>
+<p>If you wish to run instead, for example, <a href="#chk-entry">chk-entry.sh</a>, then do:</p>
 <pre><code>    bin/all-years.sh -v 1 bin/chk-entry.sh</code></pre>
 <div id="all-run">
 <h3 id="all-run.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/all-run.sh">all-run.sh</a></h3>
@@ -455,7 +478,8 @@ some odd need to do so.</p>
 <p>Run a command on all winning entries.</p>
 <p>Usage:</p>
 <pre><code>    bin/all-run.sh -v 3 bin/quick-readme2index.sh -v 1</code></pre>
-<p>Alternate usage:</p>
+<p>If you wish to run instead, for example, <a href="#readme2index">readme2index.sh</a>, then
+do:</p>
 <pre><code>    bin/all-run.sh -v 3 bin/readme2index.sh -v 1</code></pre>
 <div id="all-years">
 <h3 id="all-years.sh-1"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/all-years.sh">all-years.sh</a></h3>
@@ -463,7 +487,8 @@ some odd need to do so.</p>
 <p>Run a command on all IOCCC years.</p>
 <p>Usage:</p>
 <pre><code>    bin/all-years.sh -v 1 bin/gen-year-index.sh -v 1</code></pre>
-<p>Alternate usage:</p>
+<p>If you wish to run instead, for example, <a href="#chk-entry">chk-entry.sh</a>, then
+do:</p>
 <pre><code>    bin/all-years.sh -v 1 bin/chk-entry.sh</code></pre>
 <div id="chk-entry">
 <h3 id="chk-entry.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/chk-entry.sh">chk-entry.sh</a></h3>
@@ -481,7 +506,7 @@ for more details on <code>.entry.json</code> files.</p>
 <div id="combine-author-handle">
 <h3 id="combine_author_handle.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/combine_author_handle.sh">combine_author_handle.sh</a></h3>
 </div>
-<p>Combine all author/author_handle.JSON files as single JSON file.</p>
+<p>Combine all author/author_handle.json files as single JSON file.</p>
 <p>The purpose of this tool is to make looking for information across all
 authors faster by temporarily forming them into a single JSON file.</p>
 <p>Because <code>jsp(1)</code> open remembers the last copy of a given JSON member name.
@@ -504,6 +529,9 @@ due to the bogosity of the so-called JSON spec.</p>
 <p><strong>NOTE</strong>: This tool assume that all JSON files have been formatted with the
 <code>bin/jprint-wrapper.sh</code> tool. In particular the first line is just “{:,
 and the last line is just”}” and each JSON element is on its own line.</p>
+<p><strong>NOTE</strong>: see the
+FAQ on “<a href="../faq.html#author_handle_json">author_handle.json</a>”
+for more details on <code>author_handle.json</code> files.</p>
 <div id="csv2entry">
 <h3 id="csv2entry.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/csv2entry.sh">csv2entry.sh</a></h3>
 </div>
@@ -545,7 +573,7 @@ applications, when exporting to a CSV file, do not do this.</p>
 its CSV output files. We do this in case the CSV files were imported into a
 spreadsheet where their order was changed before exporting. This means one is
 free to order the CSV file content as you wish as this tool will reset these CSV
-file.</p>
+files.</p>
 <p>Next this tool processes the non-CSV comment lines in
 <a href="#manifest_csv">manifest.csv</a>. The 1st and 2nd fields of
 <a href="#manifest_csv">manifest.csv</a> refer to entry YYYY and entry subdirectory (i.e.,
@@ -557,7 +585,10 @@ only modify those <code>.entry.json</code> files when their content changes.</p>
 semantic checks</strong>. For example, this tool does <strong>NOT</strong> verify that the manifest in
 the <code>.entry.json</code> file matches the files in the <code>YYYY/dir directory</code>, or even
 that the <code>.entry.json</code> contains a manifest (or any of the other required JSON
-content).</p>
+content). Another tool will be modified to do this, at a later date.</p>
+<p><strong>NOTE</strong>: you can obtain <code>jparse(1)</code> from the which can be obtained from the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>’s copy of the
+<a href="https://github.com/xexyl/jparse/">jparse repo</a>.</p>
 <div id="cvt-submission">
 <h3 id="cvt-submission.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/cvt-submission.sh">cvt-submission.sh</a></h3>
 </div>
@@ -584,13 +615,13 @@ that could be modified or removed by this tool (unless <code>-N</code> is used i
 case this tool does nothing). The compressed tarball, formed by default
 under the <code>/var/tmp</code> directory, may contain such as:</p>
 <ul>
-<li>YYYY/dir/.info.json</li>
-<li>YYYY/dir/.auth.json</li>
-<li>YYYY/dir/remarks.md</li>
-<li>YYYY/dir/README.md</li>
-<li>YYYY/dir/index.md</li>
-<li>YYYY/dir/YYYY_dir.tar.bz2</li>
-<li>author/author_handle.json (could be more than one file)</li>
+<li><code>YYYY/dir/.info.json</code></li>
+<li><code>YYYY/dir/.auth.json</code></li>
+<li><code>YYYY/dir/remarks.md</code></li>
+<li><code>YYYY/dir/README.md</code></li>
+<li><code>YYYY/dir/index.md</code></li>
+<li><code>YYYY/dir/YYYY_dir.tar.bz2</code></li>
+<li><code>author/author_handle.json</code> (could be more than one file)</li>
 </ul>
 <p>Only those files that exist will be put into the compressed tarball.
 The compressed tarball formed (by default under the <code>/var/tmp</code> directory)
@@ -598,9 +629,9 @@ is of the following form:</p>
 <blockquote>
 <p>YYYY_dir.mods.YYYYMMDD.hhmmss.tar.bz2</p>
 </blockquote>
-<p>Here “<em>YYYYMMDD.hhmmss</em>” is a date and timestamp from when the tool was executed.</p>
+<p>Here “<code>YYYYMMDD.hhmmss</code>” is a date and timestamp from when the tool was executed.</p>
 <p>The purpose of this compressed tarball is to allow the files in the
-submission directory (that could be modified or removed by this tool)
+entry directory (that could be modified or removed by this tool)
 to be restored as follows:</p>
 <pre><code>    tar -jxvf /var/tmp/YYYY_dir.mods.YYYYMMDD.hhmmss.tar.bz2 YYYY/dir</code></pre>
 <p>One may also restore modified <code>author/author_handle.json</code> files using:</p>
@@ -608,9 +639,9 @@ to be restored as follows:</p>
 <p>This tool will form <code>YYYY/dir/README.md</code> if needed, from <code>YYYY/dir/remarks.md</code>,
 <code>template/entry/README.md.head</code>, and <code>template/entry/README.md.tail</code>.</p>
 <p><strong>NOTE</strong>: This interactive tool (unless <code>-i input_data</code> is used) does
-<strong>NOT</strong> perform all of the steps needed to make a directory a new winning
+<strong>NOT</strong> perform all of the steps needed to make a directory for a new winning
 IOCCC entry. For example, files such as <code>YYYY/dir/README.md</code> and/or <code>YYYY/dir/index.html</code>
-might contain “<em>triple X</em>” patterns indicating where the <a href="../judges.html">Judges</a>
+might contain “<em>triple X</em>” comments (<code>&lt;!--XXXX--&gt;</code>), indicating where the <a href="../judges.html">Judges</a>
 need to add content. Moreover, the <code>Makefile</code> and <code>.gitignore</code> files
 need to be examined for suitability, etc.</p>
 <p><strong>HINT</strong>: Executing this tool on your submission will <strong>NOT</strong> make you an IOCCC winner. :-)</p>
@@ -620,7 +651,7 @@ need to be examined for suitability, etc.</p>
 <p>This tool takes as input, all entry <code>.entry.json</code> files
 and updates 3 CSV files:</p>
 <ul>
-<li><a href="#author_wins_csv">author_wins.csv</a> - each <code>author_handle</code> followed their <code>entry_id</code>s</li>
+<li><a href="#author_wins_csv">author_wins.csv</a> - each <code>author_handle</code> followed by their <code>entry_id</code>s</li>
 <li><a href="#manifest_csv">manifest.csv</a> - information about all files in all entries</li>
 <li><a href="#year_prize_csv">year_prize.csv</a> - each <code>entry_id</code> followed by the entry’s award title</li>
 </ul>
@@ -650,16 +681,16 @@ from the <code>TOPDIR</code>.</p>
 <h3 id="find-missing-links.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/find-missing-links.sh">find-missing-links.sh</a></h3>
 </div>
 <p>Find all markdown links to local files that do not exist.</p>
-<p>This tool does <strong>NOT</strong> check that a remote URL exists.
-This tool only checks on links to local files.</p>
-<p>This tool does <strong>NOT</strong> check links in a given place in a file.
-This tool only checks that local files linked by markdown exist.</p>
-<p>This tool does <strong>NOT</strong> check HTML file links.
-This tool only checks markdown based links.</p>
+<p>This tool does <strong>NOT</strong> check that a remote URL exists, it checks on
+links to local files.</p>
+<p>This tool does <strong>NOT</strong> check links in a given place in a file, it
+checks that local files linked by markdown actually exist.</p>
+<p>This tool does <strong>NOT</strong> check HTML file links, it checks markdown
+based links.</p>
 <p>Usage:</p>
 <pre><code>    bin/find-missing-links.sh -v 1</code></pre>
 <p>If no missing links are found, this tool exits 0 with no output
-(debug messages not withstanding), otherwise this tool will exit non-zero.</p>
+(debug messages notwithstanding), otherwise this tool will exit non-zero.</p>
 <p><strong>NOTE</strong>: If the markdown link is malformed, this tool
 might generate an error about a file that does exist.
 If this tool claims that a file is missing that does exist,
@@ -680,7 +711,7 @@ JSON files in the tree.</p>
 <p>Usage:</p>
 <pre><code>    bin/find-invalid-json.sh -v 1</code></pre>
 <p>If no invalid JSON files are found, this tool exits 0 with no output
-(debug messages not withstanding), otherwise this tool will exit non-zero.</p>
+(debug messages notwithstanding), otherwise this tool will exit non-zero.</p>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
 <pre><code>    make find_invalid_json</code></pre>
 <div id="format-headers">
@@ -723,8 +754,6 @@ markdown files, of all entries.</p>
 <p>This would generate the <a href="../sitemap.xml">sitemap.xml</a> file.</p>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
 <pre><code>    make gen_sitemap</code></pre>
-<p><strong>IMPORTANT NOTE</strong>: if a file is open with vim or some editor that creates a swap
-file, this will cause a problem with the output.</p>
 <div id="gen-status">
 <h3 id="gen-status.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/gen-status.sh">gen-status.sh</a></h3>
 </div>
@@ -789,8 +818,7 @@ do that, that is not a problem.</p>
 <h3 id="jfmt-wrapper.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/jfmt-wrapper.sh">jfmt-wrapper.sh</a></h3>
 </div>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/jfmt-wrapper.sh">jfmt-wrapper.sh</a> tool is a wrapper
-tool for <code>jfmt(1)</code>, a tool that will format a JSON
-# file into a canonical style.</p>
+tool for <code>jfmt(1)</code>, a tool that will format a JSON file into a canonical style.</p>
 <p><strong>NOTE</strong>: As of 2024 Oct 08 the <code>jfmt(1)</code> tool has not been written,
 so <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/jfmt-wrapper.sh">jfmt-wrapper.sh</a> uses the
 <code>JSONPath.sh(1)</code> tool from the recently forked and modified
@@ -854,12 +882,12 @@ and not have to use <code>-T</code> with <code>bin/jval-wrapper.sh</code>.</p>
 <div id="manifest-csv-entry">
 <h3 id="manifest.csv.entry.awk"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/manifest.csv.entry.awk">manifest.csv.entry.awk</a></h3>
 </div>
-<p>Output manifest csv from a entry’s manifest as found in its <code>.entry.json</code> file.</p>
+<p>Output <code>manifest.csv</code> from a entry’s manifest as found in its <code>.entry.json</code> file.</p>
 <pre><code>    awk -f bin/manifest.csv.entry.awk YYYY/dir/.entry.json</code></pre>
 <div id="manifest-csv-json">
 <h3 id="binmanifest.entry.json.awk"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/manifest.entry.json.awk">bin/manifest.entry.json.awk</a></h3>
 </div>
-<p>Output manifest table from a entry’s <code>.entry.json</code> file.</p>
+<p>Output manifest table from an entry’s <code>.entry.json</code> file.</p>
 <pre><code>    awk -v github=REPO_URL -f bin/manifest.entry.json.awk YYYY/dir/.entry.json</code></pre>
 <div id="md2html-cfg">
 <h3 id="md2html.cfg"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/md2html.cfg">md2html.cfg</a></h3>
@@ -904,10 +932,10 @@ to make a directory a new winning IOCCC entry. It only starts the
 framework for doing so, creating a situation where the
 <a href="#cvt-submission">cvt-submission</a> tool be be run.</p>
 <p>This tool can modify the top level <code>.allyear</code> file, and <code>YYYY/Makefile</code> files.</p>
-<p><strong>NOTE</strong>: This tool assumes that <a href="#new_year">new-year.sh</a> was executed to create
+<p><strong>NOTE</strong>: This tool assumes that <a href="#new-year">new-year.sh</a> was executed to create
 the prerequisite <code>YYYY</code> directory and related files.</p>
 <p><strong>HINT</strong>: Executing this tool on your submission will <strong>NOT</strong> make you an IOCCC winner. :-)</p>
-<div id="new_year">
+<div id="new-year">
 <h3 id="new-year.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/new-year.sh">new-year.sh</a></h3>
 </div>
 <p>This tool is used by the <a href="../judges.html">Judges</a> as part of the final
@@ -915,10 +943,10 @@ steps to announce a new set of winning IOCCC entries.</p>
 <p>This tool may modify the top level <code>.top</code> and <code>Makefile</code> files.
 It will form <code>YYYY/Makefile</code> and/or <code>YYYY/.year</code> if needed.
 It will form <code>YYYY/README.md</code> if needed, from <code>template/README.md.year</code>.</p>
-<p><strong>NOTE</strong>: This tool <strong>NOT</strong> perform all of the steps needed to make a new IOCCC year directory.
+<p><strong>NOTE</strong>: This tool does <strong>NOT</strong> perform all of the steps needed to make a new IOCCC year directory.
 For example, files such as <code>YYYY/README.md</code> and/or <code>YYYY/index.html</code>
-might contain “<em>triple X</em>” patterns indicating where the <a href="../judges.html">Judges</a>
-need to add content.</p>
+might contain “<em>triple X</em>” comments (<code>&lt;!-- XXX --&gt;</code>) indicating where the
+<a href="../judges.html">Judges</a> need to add content.</p>
 <p>Usage:</p>
 <pre><code>    bin/new-year.sh -v 1 YYYY</code></pre>
 <p>Here, <code>YYYY</code> must be a new 4-digit (happy :-)) new IOCCC year.</p>
@@ -930,11 +958,12 @@ need to add content.</p>
 <pre><code>    bin/othermd2html.sh YYYY/dir/pathto.md</code></pre>
 <p>For example:</p>
 <pre><code>    bin/othermd2html.sh -v 1 2020/ferguson1/chocolate-cake.md</code></pre>
-<p>The <a href="#othermd2html">othermd2html.sh</a> tool is used by <a href="#gen-other-html">gen-other-html.sh</a>.</p>
+<p>The <a href="#othermd2html">othermd2html.sh</a> tool is used by
+<a href="#gen-other-html">gen-other-html.sh</a>.</p>
 <div id="output-index-author">
 <h3 id="output-index-author.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/output-index-author.sh">output-index-author.sh</a></h3>
 </div>
-<p>Output author’s or authors’ related HTML details for an entry’s index.html
+<p>Output an author’s or authors’ related HTML details for an entry’s index.html
 page.</p>
 <p>For an example, see the <a href="../1984/anonymous/index.html#author">author details in
 1984/anonymous</a>.</p>
@@ -953,7 +982,7 @@ the <a href="index.html#md2html">md2html tool</a>.</p>
 </div>
 <p>Output the inventory for a given year’s winning entries in HTML form. In other
 words in <a href="../1984/index.html">1984</a> it would list, as links, the four winning
-entries, which you can see directly at <a href="../1984/index.html#inventory">1984
+entries, which you can see directly at the <a href="../1984/index.html#inventory">1984
 inventory</a>.</p>
 <p>This tool is used in the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/md2html.cfg">bin/md2html.cfg</a> file as part of
 the <a href="index.html#md2html">md2html tool</a>.</p>
@@ -987,7 +1016,7 @@ modification times for <code>README.md</code>, <code>.entry.json</code>,
 and <code>index.html</code> are correct. If in doubt, use
 <a href="index.html#readme2index">readme2index.sh</a>.</p>
 <p>We recommend that this tool be invoked via the top level <code>Makefile</code>:</p>
-<pre><code>    make quick_entry_index</code></pre>
+<pre><code>    make quick_readme2index</code></pre>
 <div id="readme2index">
 <h3 id="readme2index.sh"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/readme2index.sh">readme2index.sh</a></h3>
 </div>

--- a/bugs.html
+++ b/bugs.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/contact.html
+++ b/contact.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/faq.html
+++ b/faq.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 
@@ -809,7 +832,7 @@ program(s), clean up any files made by the program etc.</li>
 </div>
 </div>
 </div>
-<p>First, <strong>PLEASE</strong> read the <a href="markdown.html">IOCCC markdown guidelines</a>.</p>
+<p>First, <strong>PLEASE</strong> read the <a href="markdown.html">IOCCC Markdown Guidelines</a>.</p>
 <p>Next, while you may put in as much or as little as you wish into your entry’s
 <code>remarks.md</code> file, we do have few important suggestions:</p>
 <p>We recommend that you explain how to use your entry. Explain the

--- a/inc/index.html
+++ b/inc/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -65,6 +65,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -143,8 +149,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="%%DOCROOT_SLASH%%bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -223,6 +235,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -277,6 +293,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/judges.html
+++ b/judges.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/license.html
+++ b/license.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/location.html
+++ b/location.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/markdown.html
+++ b/markdown.html
@@ -12,7 +12,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 <title>The International Obfuscated C Code Contest</title>
 <link rel="icon" type="image/x-icon" href="./favicon.ico">
-<meta name="description" content="IOCCC markdown guidelines">
+<meta name="description" content="IOCCC Markdown Guidelines">
 <meta name="keywords" content="IOCCC, markdown">
 </head>
 
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 
@@ -369,7 +392,7 @@
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>IOCCC markdown guidelines</h2>
+  <h2>IOCCC Markdown Guidelines</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->
@@ -389,7 +412,7 @@
 
 <!-- BEFORE: 1st line of markdown file: markdown.md -->
 <div id="guidelines">
-<h1 id="ioccc-markdown-guidelines">IOCCC markdown guidelines</h1>
+<h1 id="ioccc-markdown-guidelines">IOCCC Markdown Guidelines</h1>
 </div>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
 For example, when submitting to the IOCCC

--- a/news.html
+++ b/news.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 
@@ -1518,7 +1541,7 @@ aware that some people may use tab stop that is different than the common 8
 character tab stop.
 </p>
 <p class="leftbar">
-<strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC markdown guidelines</a>
+<strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC Markdown Guidelines</a>
 when forming your submission’s <code>remarks.md</code> file. And if your submission
 contains additional markdown files, please follow those same guidelines. See
 also <a href="rules.html#rule19">Rule 19</a>.

--- a/next/index.html
+++ b/next/index.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/next/rules.html
+++ b/next/rules.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="../bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="../markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="../bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="../inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 
@@ -401,6 +424,7 @@
 <li><a href="news.html">IOCCC News</a></li>
 <li><a href="status.html">Contest status</a></li>
 <li><a href="next/index.html">Rules and Guidelines</a></li>
+<li><a href="markdown.html">IOCCC markdown</a></li>
 </ul>
 <h2 id="faq">FAQ</h2>
 <ul>
@@ -417,7 +441,6 @@
 <li><a href="contact.html">Contacting the IOCCC</a></li>
 <li><a href="SECURITY.html">IOCCC Security Policy</a></li>
 <li><a href="thanks-for-help.html">Thanks for the help</a></li>
-<li><a href="markdown.html">IOCCC markdown</a></li>
 <li><a href="bin/index.html">Website scripts</a></li>
 <li><a href="inc/index.html">Script include files</a>
 <!-- AFTER: last line of markdown file: nojs-menu.md --></li>

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -12,6 +12,7 @@
 * [IOCCC News](news.html)
 * [Contest status](status.html)
 * [Rules and Guidelines](next/index.html)
+* [IOCCC markdown](markdown.html)
 
 ## FAQ
 
@@ -28,6 +29,5 @@
 * [Contacting the IOCCC](contact.html)
 * [IOCCC Security Policy](SECURITY.html)
 * [Thanks for the help](thanks-for-help.html)
-* [IOCCC markdown](markdown.html)
 * [Website scripts](bin/index.html)
 * [Script include files](inc/index.html)

--- a/status.html
+++ b/status.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 

--- a/years.html
+++ b/years.html
@@ -109,6 +109,12 @@
                 Rules and Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./markdown.html" class="sub-item-link">
+                IOCCC Markdown Guidelines
+              </a>
+            </div>
           </div>
         </div>
 
@@ -187,8 +193,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./markdown.html" class="sub-item-link">
-                IOCCC markdown guidelines
+              <a href="./bin/index.html" class="sub-item-link">
+                Website scripts
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./inc/index.html" class="sub-item-link">
+                Script include files
               </a>
             </div>
           </div>
@@ -267,6 +279,10 @@
               IOCCC News
             </a>
 
+            <a class="mobile-submenu-item" href="./markdown.html">
+              IOCCC Markdown Guidelines
+            </a>
+
           </div>
         </div>
 
@@ -321,6 +337,13 @@
               Thanks for the help
             </a>
 
+            <a class="mobile-submenu-item" href="./bin/index.html">
+              Website scripts
+            </a>
+
+            <a class="mobile-submenu-item" href="./inc/index.html">
+              Script include files
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION

The mobile About menu was missing the IOCCC markdown guidelines. This
has been added to the mobile menu but moved to 'Status' which is where
guidelines are (it has been renamed to be 'IOCCC Markdown Guidelines' to 
match the style of the other items in that menu).

The About menu now has two more links, one for the website tools and the
other for the include files of the tools. It might be, looking at the
generated html files, better to have another menu instead, but what that
should be is unclear. The reason it might be better is because the
'About' menu is rather long. In retrospect it might be better to not
have the script include files in the html files but this can be decided
and dealt with later.

The script bin/find-missing-links.sh now ignores the directory NOTES/. A
better approach might be using git ls-files --exclude but a quick test
did not work right. Another option, at least for NOTES/, might be to use
'git ls-files --exclude-standard'.

The bin/index.html file has been updated.

Run make www to rebuild all html files.
